### PR TITLE
Remove hard-coded tests dir from lit runner macro

### DIFF
--- a/bazel/lit.bzl
+++ b/bazel/lit.bzl
@@ -1,7 +1,6 @@
 """Macros for defining lit tests."""
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
-# TODO: try replacing this with a lit.cfg.py config (test_exec_root? test_src_root?)
-_TESTS_DIR = "tests"
 _DEFAULT_FILE_EXTS = ["mlir"]
 
 def lit_test(name = None, src = None, size = "small", tags = None):
@@ -35,14 +34,19 @@ def lit_test(name = None, src = None, size = "small", tags = None):
     if not src:
         fail("src must be specified")
     name = name or src + ".test"
-    rel_target = ":" + src
+
+    filegroup_name = name + ".filegroup"
+    native.filegroup(
+      name = filegroup_name,
+      srcs = [src],
+    )
 
     native.py_test(
         name = name,
         size = size,
         # -v ensures lit outputs useful info during test failures
-        args = ["-v", _TESTS_DIR + "/" + src],
-        data = ["@heir//tests:test_utilities", rel_target],
+        args = ["-v", paths.join(native.package_name(), src)],
+        data = ["@heir//tests:test_utilities", filegroup_name],
         srcs = ["@llvm-project//llvm:lit"],
         main = "lit.py",
         tags = tags,


### PR DESCRIPTION
The micro_speech test in the tests/micro_speech subdirectory were failing due to the path missing the subdirectory

https://github.com/google/heir/actions/runs/5281122239/jobs/9554255008

Added `native.package_name` to get the relative path from the project root to the package, so it can all be inferred.

Also used a filegroup instead of `":" + src` to make the source data dependency smarter.

Now the test still fails, but it fails for a C++ reason, not a build system reason.