### PR TITLE
Add a polynomial attribute

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 build --action_env=BAZEL_CXXOPTS=-std=c++17
 build --cxxopt='-std=c++17'
+build --features=layering_check
 test --test_output=errors

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/assets/jsconfig.json
 docs/node_modules/
 .hugo_build.lock
 hugo_stats.json
+
+# for python dependencies
+venv

--- a/include/Dialect/Poly/IR/BUILD
+++ b/include/Dialect/Poly/IR/BUILD
@@ -9,15 +9,19 @@ package(
 
 exports_files(
     [
+        "PolyAttributes.h",
         "PolyDialect.h",
         "PolyOps.h",
         "PolyTypes.h",
+        "Polynomial.h",
+        "PolynomialDetail.h",
     ],
 )
 
 td_library(
     name = "td_files",
     srcs = [
+        "PolyAttributes.td",
         "PolyDialect.td",
         "PolyOps.td",
         "PolyTypes.td",
@@ -48,6 +52,34 @@ gentbl_cc_library(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "PolyDialect.td",
     deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "attributes_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-attrdef-decls",
+            ],
+            "PolyAttributes.h.inc",
+        ),
+        (
+            [
+                "-gen-attrdef-defs",
+            ],
+            "PolyAttributes.cpp.inc",
+        ),
+        (
+            ["-gen-attrdef-doc"],
+            "PolyAttributes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "PolyAttributes.td",
+    deps = [
+        ":dialect_inc_gen",
         ":td_files",
     ],
 )

--- a/include/Dialect/Poly/IR/PolyAttributes.h
+++ b/include/Dialect/Poly/IR/PolyAttributes.h
@@ -1,0 +1,10 @@
+#ifndef HEIR_INCLUDE_DIALECT_POLY_IR_POLYATTRIBUTES_H_
+#define HEIR_INCLUDE_DIALECT_POLY_IR_POLYATTRIBUTES_H_
+
+#include "include/Dialect/Poly/IR/PolyDialect.h"
+#include "include/Dialect/Poly/IR/Polynomial.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/Poly/IR/PolyAttributes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYATTRIBUTES_H_

--- a/include/Dialect/Poly/IR/PolyAttributes.td
+++ b/include/Dialect/Poly/IR/PolyAttributes.td
@@ -1,0 +1,66 @@
+#ifndef HEIR_INCLUDE_DIALECT_POLY_IR_POLYATTRIBUTES_TD_
+#define HEIR_INCLUDE_DIALECT_POLY_IR_POLYATTRIBUTES_TD_
+
+include "PolyDialect.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class Poly_Attr<string name, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<Poly_Dialect, name, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+def Polynomial_Attr : Poly_Attr<"Polynomial", "polynomial"> {
+  let summary = "An attribute containing a single-variable polynomial.";
+  let description = [{
+     #poly = #poly.poly<x**1024 + 1>
+  }];
+
+  let parameters = (ins "Polynomial":$value);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "Polynomial":$value), [{
+      return $_get(value.getContext(), value);
+    }]>
+  ];
+  let extraClassDeclaration = [{
+    using ValueType = Polynomial;
+    Polynomial getPolynomial() const { return getValue(); }
+  }];
+
+  let skipDefaultBuilders = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def Ring_Attr : Poly_Attr<"Ring", "ring"> {
+  let summary = "An attribute specifying a ring.";
+  let description = [{
+    An attribute specifying a polynomial quotient ring with integer
+    coefficients, $\mathbb{Z}/n\mathbb{Z}[x] / (p(x))$.
+
+    `cmod` is the coefficient modulus $n$, and `ideal` is the ring ideal
+    $(p(x))$. Because all ideals in a single-variable polynomial ring are
+    principal, the ideal is defined by a single polynomial.
+
+      #ring = #poly.ring<cmod=1234, ideal=#poly.polynomial<x**1024 + 1>>
+  }];
+
+  let parameters = (ins "APInt": $cmod, "Polynomial":$ideal);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "APInt": $cmod, "Polynomial":$ideal), [{
+      return $_get(ideal.getContext(), cmod, ideal);
+    }]>
+  ];
+  let extraClassDeclaration = [{
+    Polynomial ideal() const { return getIdeal(); }
+    APInt coefficientModulus() const { return getCmod(); }
+  }];
+
+  let skipDefaultBuilders = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+
+#endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYATTRIBUTES_TD_

--- a/include/Dialect/Poly/IR/PolyDialect.td
+++ b/include/Dialect/Poly/IR/PolyDialect.td
@@ -33,6 +33,7 @@ def Poly_Dialect : Dialect {
   let cppNamespace = "::mlir::heir::poly";
 
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYDIALECT_TD_

--- a/include/Dialect/Poly/IR/PolyOps.td
+++ b/include/Dialect/Poly/IR/PolyOps.td
@@ -1,6 +1,7 @@
 #ifndef HEIR_INCLUDE_DIALECT_POLY_IR_POLYOPS_TD_
 #define HEIR_INCLUDE_DIALECT_POLY_IR_POLYOPS_TD_
 
+include "PolyAttributes.td"
 include "PolyDialect.td"
 include "PolyTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -56,7 +57,9 @@ def Poly_MulOp : Poly_Op<"mul", [SameOperandsAndResultType]> {
   let summary = "Multiplication operation between polynomials.";
 
   let arguments = (ins
-    Variadic<Poly>:$x
+    Poly:$lhs,
+    Poly:$rhs,
+    Ring_Attr:$ring
   );
 
   let results = (outs

--- a/include/Dialect/Poly/IR/PolyTypes.h
+++ b/include/Dialect/Poly/IR/PolyTypes.h
@@ -1,6 +1,7 @@
 #ifndef HEIR_INCLUDE_DIALECT_POLY_IR_POLYTYPES_H_
 #define HEIR_INCLUDE_DIALECT_POLY_IR_POLYTYPES_H_
 
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
 #include "include/Dialect/Poly/IR/PolyDialect.h"
 
 #define GET_TYPEDEF_CLASSES

--- a/include/Dialect/Poly/IR/PolyTypes.td
+++ b/include/Dialect/Poly/IR/PolyTypes.td
@@ -2,13 +2,10 @@
 #define HEIR_INCLUDE_DIALECT_POLY_IR_POLYTYPES_TD_
 
 include "PolyDialect.td"
+include "PolyAttributes.td"
 
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/AttrTypeBase.td"
-
-//===----------------------------------------------------------------------===//
-// Poly type definitions
-//===----------------------------------------------------------------------===//
 
 // A base class for all types in this dialect
 class Poly_Type<string name, string typeMnemonic>
@@ -21,10 +18,8 @@ def Poly : Poly_Type<"Polynomial", "poly"> {
 
   let description = [{
     A type for polynomials in a polynomial quotient ring.
-
-    The type is parametrized by the degree of the polynomial
-
   }];
+
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYTYPES_TD_

--- a/include/Dialect/Poly/IR/Polynomial.h
+++ b/include/Dialect/Poly/IR/Polynomial.h
@@ -1,0 +1,139 @@
+#ifndef HEIR_INCLUDE_DIALECT_POLY_IR_POLYNOMIAL_H_
+#define HEIR_INCLUDE_DIALECT_POLY_IR_POLYNOMIAL_H_
+
+#include "llvm/include/llvm/ADT/APInt.h"         // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMapInfo.h"  // from @llvm-project
+#include "llvm/include/llvm/ADT/Hashing.h"       // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"      // from @llvm-project
+
+namespace mlir {
+
+class MLIRContext;
+
+namespace heir {
+namespace poly {
+
+constexpr unsigned APINT_BIT_WIDTH = 64;
+
+namespace detail {
+struct PolynomialStorage;
+}  // namespace detail
+
+class Monomial {
+ public:
+  Monomial(int64_t coeff, uint64_t expo)
+      : coefficient(APINT_BIT_WIDTH, coeff), exponent(APINT_BIT_WIDTH, expo) {}
+
+  Monomial(APInt coeff, APInt expo) : coefficient(coeff), exponent(expo) {}
+
+  Monomial() : coefficient(APINT_BIT_WIDTH, 0), exponent(APINT_BIT_WIDTH, 0) {}
+
+  bool operator==(Monomial other) const {
+    return other.coefficient == coefficient && other.exponent == exponent;
+  }
+  bool operator!=(Monomial other) const {
+    return other.coefficient != coefficient || other.exponent != exponent;
+  }
+
+  /// Monomials are ordered by exponent.
+  bool operator<(const Monomial &other) const {
+    return (exponent.ule(other.exponent));
+  }
+
+  // Prints polynomial to 'os'.
+  void print(raw_ostream &os) const;
+
+  friend ::llvm::hash_code hash_value(Monomial arg);
+
+ public:
+  APInt coefficient;
+
+  // Always unsigned
+  APInt exponent;
+};
+
+/// A single-variable polynomial with integer coefficients. Polynomials are
+/// immutable and uniqued.
+///
+/// Eg: x^1024 + x + 1
+///
+/// The symbols used as the polynomial's indeterminate don't matter, so long as
+/// it is used consistently throughout the polynomial.
+class Polynomial {
+ public:
+  using ImplType = detail::PolynomialStorage;
+
+  constexpr Polynomial() = default;
+  explicit Polynomial(ImplType *terms) : terms(terms) {}
+
+  static Polynomial fromMonomials(ArrayRef<Monomial> monomials,
+                                  MLIRContext *context);
+  /// Returns a polynomial with coefficients given by `coeffs`
+  static Polynomial fromCoefficients(ArrayRef<int64_t> coeffs,
+                                     MLIRContext *context);
+
+  MLIRContext *getContext() const;
+
+  explicit operator bool() const { return terms != nullptr; }
+  bool operator==(Polynomial other) const { return other.terms == terms; }
+  bool operator!=(Polynomial other) const { return !(other.terms == terms); }
+
+  // Prints polynomial to 'os'.
+  void print(raw_ostream &os) const;
+  void dump() const;
+
+  ArrayRef<Monomial> getTerms() const;
+
+  unsigned getDegree() const;
+
+  friend ::llvm::hash_code hash_value(Polynomial arg);
+
+ private:
+  ImplType *terms{nullptr};
+};
+
+// Make Polynomial hashable.
+inline ::llvm::hash_code hash_value(Polynomial arg) {
+  return ::llvm::hash_value(arg.terms);
+}
+
+inline ::llvm::hash_code hash_value(Monomial arg) {
+  return ::llvm::hash_value(arg.coefficient) ^ ::llvm::hash_value(arg.exponent);
+}
+
+inline raw_ostream &operator<<(raw_ostream &os, Polynomial polynomial) {
+  polynomial.print(os);
+  return os;
+}
+
+}  // namespace poly
+}  // namespace heir
+}  // namespace mlir
+
+namespace llvm {
+
+// Polynomials hash just like pointers
+template <>
+struct DenseMapInfo<mlir::heir::poly::Polynomial> {
+  static mlir::heir::poly::Polynomial getEmptyKey() {
+    auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
+    return mlir::heir::poly::Polynomial(
+        static_cast<mlir::heir::poly::Polynomial::ImplType *>(pointer));
+  }
+  static mlir::heir::poly::Polynomial getTombstoneKey() {
+    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
+    return mlir::heir::poly::Polynomial(
+        static_cast<mlir::heir::poly::Polynomial::ImplType *>(pointer));
+  }
+  static unsigned getHashValue(mlir::heir::poly::Polynomial val) {
+    return mlir::heir::poly::hash_value(val);
+  }
+  static bool isEqual(mlir::heir::poly::Polynomial LHS,
+                      mlir::heir::poly::Polynomial RHS) {
+    return LHS == RHS;
+  }
+};
+
+}  // namespace llvm
+
+#endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYNOMIAL_H_

--- a/include/Dialect/Poly/IR/PolynomialDetail.h
+++ b/include/Dialect/Poly/IR/PolynomialDetail.h
@@ -1,0 +1,58 @@
+#ifndef HEIR_INCLUDE_DIALECT_POLY_IR_POLYNOMIALDETAIL_H_
+#define HEIR_INCLUDE_DIALECT_POLY_IR_POLYNOMIALDETAIL_H_
+
+#include "include/Dialect/Poly/IR/Polynomial.h"
+#include "llvm/include/llvm/ADT/ArrayRef.h"             // from @llvm-project
+#include "llvm/include/llvm/Support/TrailingObjects.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/StorageUniquer.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/TypeID.h"           // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace poly {
+namespace detail {
+
+// A Polynomial is stored as an ordered list of monomial terms, each of which
+// is a tuple of coefficient and exponent.
+struct PolynomialStorage final
+    : public StorageUniquer::BaseStorage,
+      public llvm::TrailingObjects<PolynomialStorage, Monomial> {
+  /// The hash key used for uniquing.
+  using KeyTy = std::tuple<unsigned, ArrayRef<Monomial>>;
+
+  unsigned numTerms;
+
+  MLIRContext *context;
+
+  /// The monomial terms for this polynomial.
+  ArrayRef<Monomial> terms() const {
+    return {getTrailingObjects<Monomial>(), numTerms};
+  }
+
+  bool operator==(const KeyTy &key) const {
+    return std::get<0>(key) == numTerms && std::get<1>(key) == terms();
+  }
+
+  // Constructs a PolynomialStorage from a key. The context must be set by the
+  // caller.
+  static PolynomialStorage *construct(
+      StorageUniquer::StorageAllocator &allocator, const KeyTy &key) {
+    auto terms = std::get<1>(key);
+    auto byteSize = PolynomialStorage::totalSizeToAlloc<Monomial>(terms.size());
+    auto *rawMem = allocator.allocate(byteSize, alignof(PolynomialStorage));
+    auto *res = new (rawMem) PolynomialStorage();
+    res->numTerms = std::get<0>(key);
+    std::uninitialized_copy(terms.begin(), terms.end(),
+                            res->getTrailingObjects<Monomial>());
+    return res;
+  }
+};
+
+}  // namespace detail
+}  // namespace poly
+}  // namespace heir
+}  // namespace mlir
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::heir::poly::detail::PolynomialStorage)
+
+#endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYNOMIALDETAIL_H_

--- a/lib/Dialect/Poly/IR/BUILD
+++ b/lib/Dialect/Poly/IR/BUILD
@@ -11,17 +11,70 @@ cc_library(
         "PolyDialect.cpp",
     ],
     hdrs = [
+        "@heir//include/Dialect/Poly/IR:PolyAttributes.h",
         "@heir//include/Dialect/Poly/IR:PolyDialect.h",
         "@heir//include/Dialect/Poly/IR:PolyOps.h",
         "@heir//include/Dialect/Poly/IR:PolyTypes.h",
     ],
     includes = ["@heir//include"],
     deps = [
+        ":PolyAttributes",
+        ":Polynomial",
+        "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
         "@heir//include/Dialect/Poly/IR:dialect_inc_gen",
         "@heir//include/Dialect/Poly/IR:ops_inc_gen",
         "@heir//include/Dialect/Poly/IR:types_inc_gen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)
+
+cc_library(
+    name = "PolyAttributes",
+    srcs = [
+        "PolyAttributes.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Poly/IR:PolyAttributes.h",
+        "@heir//include/Dialect/Poly/IR:PolyDialect.h",
+    ],
+    deps = [
+        ":Polynomial",
+        "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
+        "@heir//include/Dialect/Poly/IR:dialect_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AsmParser",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "Polynomial",
+    srcs = [
+        "Polynomial.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Poly/IR:Polynomial.h",
+        "@heir//include/Dialect/Poly/IR:PolynomialDetail.h",
+    ],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "PolynomialTest",
+    size = "small",
+    srcs = ["PolynomialTest.cpp"],
+    deps = [
+        ":Polynomial",
+        "@googletest//:gtest_main",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
     ],
 )

--- a/lib/Dialect/Poly/IR/PolyAttributes.cpp
+++ b/lib/Dialect/Poly/IR/PolyAttributes.cpp
@@ -1,0 +1,182 @@
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+
+#include "include/Dialect/Poly/IR/Polynomial.h"
+#include "llvm/include/llvm/ADT/SmallSet.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/StringExtras.h"       // from @llvm-project
+#include "llvm/include/llvm/ADT/StringRef.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace poly {
+
+void PolynomialAttr::print(AsmPrinter &p) const {
+  p << '<';
+  p << getPolynomial();
+  p << '>';
+}
+
+/// Try to parse a monomial. If successful, populate the fields of the outparam
+/// `monomial` with the results, and the `variable` outparam with the parsed
+/// variable name.
+ParseResult parseMonomial(AsmParser &parser, Monomial &monomial,
+                          llvm::StringRef *variable, bool *isConstantTerm) {
+  APInt parsedCoeff(APINT_BIT_WIDTH, 1);
+  auto result = parser.parseOptionalInteger(parsedCoeff);
+  if (result.has_value()) {
+    if (failed(*result)) {
+      parser.emitError(parser.getCurrentLocation(),
+                       "Invalid integer coefficient.");
+      return failure();
+    }
+  }
+
+  // Variable name
+  result = parser.parseOptionalKeyword(variable);
+  if (!result.has_value() || failed(*result)) {
+    // we allow "failed" because it triggers when the next token is a +,
+    // which is allowed when the input is the constant term.
+    monomial.coefficient = parsedCoeff;
+    monomial.exponent = APInt(APINT_BIT_WIDTH, 0);
+    *isConstantTerm = true;
+    return success();
+  }
+
+  // Parse exponentiation symbol as **
+  // We can't use caret because it's reserved for basic block identifiers
+  // If no star is present, it's treated as a polynomial with exponent 1
+  if (failed(parser.parseOptionalStar())) {
+    monomial.coefficient = parsedCoeff;
+    monomial.exponent = APInt(APINT_BIT_WIDTH, 1);
+    return success();
+  }
+
+  // If there's one * there must be two
+  if (failed(parser.parseStar())) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "Exponents must be specified as a double-asterisk `**`.");
+    return failure();
+  }
+
+  // If there's a **, then the integer exponent is required.
+  APInt parsedExponent(APINT_BIT_WIDTH, 0);
+  if (failed(parser.parseInteger(parsedExponent))) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "Found invalid integer exponent.");
+    return failure();
+  }
+
+  monomial.coefficient = parsedCoeff;
+  monomial.exponent = parsedExponent;
+  return success();
+}
+
+mlir::Attribute mlir::heir::poly::PolynomialAttr::parse(AsmParser &parser,
+                                                        Type type) {
+  if (failed(parser.parseLess())) return {};
+
+  std::vector<Monomial> monomials;
+  llvm::SmallSet<std::string, 2> variables;
+  llvm::DenseSet<APInt> exponents;
+
+  while (true) {
+    Monomial parsedMonomial;
+    llvm::StringRef parsedVariableRef;
+    bool isConstantTerm = false;
+    if (failed(parseMonomial(parser, parsedMonomial, &parsedVariableRef,
+                             &isConstantTerm))) {
+      return {};
+    }
+
+    if (!isConstantTerm) {
+      std::string parsedVariable = parsedVariableRef.str();
+      variables.insert(parsedVariable);
+    }
+    monomials.push_back(parsedMonomial);
+
+    if (exponents.count(parsedMonomial.exponent) > 0) {
+      llvm::SmallString<512> coeff_string;
+      parsedMonomial.exponent.toStringSigned(coeff_string);
+      parser.emitError(parser.getCurrentLocation(),
+                       "At most one monomial may have exponent " +
+                           coeff_string + ", but found multiple.");
+      return {};
+    }
+    exponents.insert(parsedMonomial.exponent);
+
+    // Parse optional +. If a + is absent, require > and break, otherwise forbid
+    // > and continue with the next monomial.
+    // ParseOptional{Plus, Greater} does not return an OptionalParseResult, so
+    // failed means that the token was not found.
+    if (failed(parser.parseOptionalPlus())) {
+      if (succeeded(parser.parseGreater())) {
+        break;
+      } else {
+        parser.emitError(
+            parser.getCurrentLocation(),
+            "Expected + and more monomials, or > to end polynomial attribute.");
+        return {};
+      }
+    } else if (succeeded(parser.parseOptionalGreater())) {
+      parser.emitError(
+          parser.getCurrentLocation(),
+          "Expected another monomial after +, but found > ending attribute.");
+      return {};
+    }
+  }
+
+  if (variables.size() > 1) {
+    std::string vars = llvm::join(variables.begin(), variables.end(), ", ");
+    parser.emitError(
+        parser.getCurrentLocation(),
+        "Polynomials must have one indeterminate, but there were multiple: " +
+            vars);
+  }
+
+  Polynomial poly =
+      Polynomial::fromMonomials(std::move(monomials), parser.getContext());
+  return PolynomialAttr::get(poly);
+}
+
+void RingAttr::print(AsmPrinter &p) const {
+  p << "<cmod=";
+  p << coefficientModulus();
+  p << ", ideal=";
+  p << PolynomialAttr::get(ideal());
+  p << '>';
+}
+
+mlir::Attribute mlir::heir::poly::RingAttr::parse(AsmParser &parser,
+                                                  Type type) {
+  if (failed(parser.parseLess())) return {};
+
+  if (failed(parser.parseKeyword("cmod"))) return {};
+
+  if (failed(parser.parseEqual())) return {};
+
+  APInt cmod(APINT_BIT_WIDTH, 0);
+  auto result = parser.parseInteger(cmod);
+  if (failed(result)) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "Invalid coefficient modulus.");
+    return {};
+  }
+
+  if (failed(parser.parseComma())) return {};
+
+  if (failed(parser.parseKeyword("ideal"))) return {};
+
+  if (failed(parser.parseEqual())) return {};
+
+  PolynomialAttr polyAttr;
+  if (failed(parser.parseAttribute<PolynomialAttr>(polyAttr))) return {};
+
+  if (failed(parser.parseGreater())) return {};
+
+  return RingAttr::get(cmod, polyAttr.getPolynomial());
+}
+
+}  // namespace poly
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Poly/IR/PolyDialect.cpp
+++ b/lib/Dialect/Poly/IR/PolyDialect.cpp
@@ -1,15 +1,19 @@
 #include "include/Dialect/Poly/IR/PolyDialect.h"
 
-// NOLINTNEXTLINE(misc-include-cleaner): Required to define PolyOps
-#include "include/Dialect/Poly/IR/PolyOps.h"
-#include "include/Dialect/Poly/IR/PolyTypes.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 
+// NOLINTNEXTLINE(misc-include-cleaner): Required to define PolyOps
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+#include "include/Dialect/Poly/IR/PolyOps.h"
+#include "include/Dialect/Poly/IR/PolyTypes.h"
+#include "include/Dialect/Poly/IR/PolynomialDetail.h"
+
 // Generated definitions
 #include "include/Dialect/Poly/IR/PolyDialect.cpp.inc"
-
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/Poly/IR/PolyAttributes.cpp.inc"
 #define GET_TYPEDEF_CLASSES
 #include "include/Dialect/Poly/IR/PolyTypes.cpp.inc"
 #define GET_OP_CLASSES
@@ -26,6 +30,10 @@ namespace poly {
 // Dialect construction: there is one instance per context and it registers its
 // operations, types, and interfaces here.
 void PolyDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "include/Dialect/Poly/IR/PolyAttributes.cpp.inc"
+      >();
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "include/Dialect/Poly/IR/PolyTypes.cpp.inc"
@@ -34,6 +42,10 @@ void PolyDialect::initialize() {
 #define GET_OP_LIST
 #include "include/Dialect/Poly/IR/PolyOps.cpp.inc"
       >();
+
+  getContext()
+      ->getAttributeUniquer()
+      .registerParametricStorageType<detail::PolynomialStorage>();
 }
 
 }  // namespace poly

--- a/lib/Dialect/Poly/IR/Polynomial.cpp
+++ b/lib/Dialect/Poly/IR/Polynomial.cpp
@@ -1,0 +1,73 @@
+#include "include/Dialect/Poly/IR/Polynomial.h"
+
+#include "include/Dialect/Poly/IR/PolynomialDetail.h"
+#include "llvm/include/llvm/ADT/APInt.h"            // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallString.h"      // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"       // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace poly {
+
+MLIRContext *Polynomial::getContext() const { return terms->context; }
+
+ArrayRef<Monomial> Polynomial::getTerms() const { return terms->terms(); }
+
+Polynomial Polynomial::fromMonomials(ArrayRef<Monomial> monomials,
+                                     MLIRContext *context) {
+  auto assignCtx = [context](detail::PolynomialStorage *storage) {
+    storage->context = context;
+  };
+
+  // A polynomial's terms are canonically stored in order of increasing degree.
+  llvm::OwningArrayRef<Monomial> monomials_copy =
+      llvm::OwningArrayRef<Monomial>(monomials);
+  std::sort(monomials_copy.begin(), monomials_copy.end());
+
+  StorageUniquer &uniquer = context->getAttributeUniquer();
+  return Polynomial(uniquer.get<detail::PolynomialStorage>(
+      assignCtx, monomials.size(), monomials_copy));
+}
+
+Polynomial Polynomial::fromCoefficients(ArrayRef<int64_t> coeffs,
+                                        MLIRContext *context) {
+  std::vector<Monomial> monomials;
+  for (size_t i = 0; i < coeffs.size(); i++) {
+    monomials.push_back(Monomial(coeffs[i], i));
+  }
+  return Polynomial::fromMonomials(std::move(monomials), context);
+}
+
+void Polynomial::print(raw_ostream &os) const {
+  bool first = true;
+  for (auto term : terms->terms()) {
+    if (first) {
+      first = false;
+    } else {
+      os << " + ";
+    }
+    std::string coeff_to_print;
+    if (term.coefficient == 1 && term.exponent.uge(1)) {
+      coeff_to_print = "";
+    } else {
+      llvm::SmallString<512> coeff_string;
+      term.coefficient.toStringSigned(coeff_string);
+      coeff_to_print = coeff_string.str();
+    }
+
+    if (term.exponent == 0) {
+      os << coeff_to_print;
+    } else if (term.exponent == 1) {
+      os << coeff_to_print << "x";
+    } else {
+      os << coeff_to_print << "x**" << term.exponent;
+    }
+  }
+}
+
+}  // end namespace poly
+}  // end namespace heir
+}  // end namespace mlir
+
+MLIR_DEFINE_EXPLICIT_TYPE_ID(mlir::heir::poly::detail::PolynomialStorage);

--- a/lib/Dialect/Poly/IR/PolynomialTest.cpp
+++ b/lib/Dialect/Poly/IR/PolynomialTest.cpp
@@ -1,0 +1,63 @@
+#include "gmock/gmock.h"  // from @googletest
+#include "gtest/gtest.h"  // from @googletest
+#include "include/Dialect/Poly/IR/Polynomial.h"
+#include "include/Dialect/Poly/IR/PolynomialDetail.h"
+#include "llvm/include/llvm/Support/raw_ostream.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/StorageUniquer.h"  // from @llvm-project
+
+namespace mlir::heir::poly {
+namespace {
+
+using ::testing::ElementsAre;
+
+TEST(PolynomialTest, TestBuilder) {
+  mlir::MLIRContext context;
+  context.getAttributeUniquer()
+      .registerParametricStorageType<detail::PolynomialStorage>();
+  auto poly = Polynomial::fromCoefficients({1, 2, 3}, &context);
+  std::string result;
+  llvm::raw_string_ostream stream(result);
+  poly.print(stream);
+
+  EXPECT_EQ(result, "1 + 2x + 3x**2");
+}
+
+TEST(PolynomialTest, TestBuilderFromMonomials) {
+  mlir::MLIRContext context;
+  context.getAttributeUniquer()
+      .registerParametricStorageType<detail::PolynomialStorage>();
+  std::vector<Monomial> monomials;
+  monomials.push_back(Monomial(1, 1024));
+  monomials.push_back(Monomial(1, 0));
+  auto poly = Polynomial::fromMonomials(monomials, &context);
+
+  std::string result;
+  llvm::raw_string_ostream stream(result);
+  poly.print(stream);
+
+  EXPECT_EQ(result, "1 + x**1024");
+}
+
+TEST(PolynomialTest, TestSortedDegree) {
+  mlir::MLIRContext context;
+  context.getAttributeUniquer()
+      .registerParametricStorageType<detail::PolynomialStorage>();
+  std::vector<Monomial> monomials;
+  monomials.push_back(Monomial(1, 9));
+  monomials.push_back(Monomial(1, 1));
+  monomials.push_back(Monomial(1, 3));
+  monomials.push_back(Monomial(1, 0));
+
+  auto poly = Polynomial::fromMonomials(monomials, &context);
+
+  std::vector<uint64_t> actualDegrees;
+  for (auto term : poly.getTerms()) {
+    actualDegrees.push_back(term.exponent.getZExtValue());
+  }
+
+  EXPECT_THAT(actualDegrees, ElementsAre(0, 1, 3, 9));
+}
+
+}  // namespace
+}  // namespace mlir::heir::poly

--- a/tests/poly_ops.mlir
+++ b/tests/poly_ops.mlir
@@ -1,25 +1,28 @@
-// RUN: heir-opt %s | FileCheck %s
+// RUN: heir-opt %s > %t
+// RUN: FileCheck %s < %t
 
 // This simply tests for syntax.
 
+#my_poly = #poly.polynomial<1 + x**1024>
+#my_poly_2 = #poly.polynomial<2>
+#my_poly_3 = #poly.polynomial<3x>
+#my_poly_4 = #poly.polynomial<t**3 + 4t + 2>
+#ring1 = #poly.ring<cmod=2837465, ideal=#my_poly>
 module {
-// CHECK-LABEL: func @fooFunc
-  func.func @fooFunc(%arg0: !poly.poly, %arg1: !poly.poly) -> !poly.poly {
+  func.func @test_multiply() -> i32 {
     %c0 = arith.constant 0 : index
-    %c3 = arith.constant 3 : index
-    %c1_i32 = arith.constant 1 : i32
-    // CHECK: poly.mul
-    %0 = poly.mul(%arg0, %arg1) : !poly.poly
-    // CHECK: poly.extract_slice
-    %1 = poly.extract_slice(%0, %c0, %c3) : (!poly.poly, index, index) -> tensor<3xi32>
-    // CHECK: poly.from_coeffs
-    %2 = poly.from_coeffs(%1) : (tensor<3xi32>) -> !poly.poly
-    // CHECK: poly.add
-    %3 = poly.add(%arg0, %arg1, %2) : !poly.poly
-    // CHECK: poly.get_coeff
+    %two = arith.constant 2 : i32
+    %five = arith.constant 5 : i32
+    %coeffs1 = tensor.from_elements %two, %two, %five : tensor<3xi32>
+    %coeffs2 = tensor.from_elements %five, %five, %two : tensor<3xi32>
+
+    %poly1 = poly.from_coeffs(%coeffs1) : (tensor<3xi32>) -> !poly.poly
+    %poly2 = poly.from_coeffs(%coeffs2) : (tensor<3xi32>) -> !poly.poly
+
+    // CHECK: #poly.ring<cmod=2837465, ideal=#poly.polynomial<1 + x**1024>>
+    %3 = poly.mul(%poly1, %poly2) {ring = #ring1} : !poly.poly
     %4 = poly.get_coeff(%3, %c0) : (!poly.poly, index) -> i32
-    // CHECK: poly.mul_constant
-    %5 = poly.mul_constant(%3, %4) : (!poly.poly, i32) -> !poly.poly
-    return %5 : !poly.poly
+
+    return %4 : i32
   }
 }


### PR DESCRIPTION
This PR adds a polynomial attribute definition to the poly dialect, which can be used to annotate types or ops with information about the polynomial ring in which the operation occurs.

~~An example attribute is added to `poly.mul` for demonstration, with a TODO left to remove it, and the poly_ops.mlir test updated to check for it.~~ Update: I had time to add `#poly.ring` so I went ahead and did it.

Notable aspects of this PR:

- Polynomial is an internal representation of a polynomial as a list of Monomials, using the llvm::TrailingObjects storage paradigm. Polynomial is not meant to be used for polynomial arithmetic _per se_ (i.e., we shouldn't be doing large computations with it). I had originally added `Polynomial::operator+` expecting to do some simple operations with it, and then removed it when I realized it was unnecessary and we can just use `fromMonomials` and construct the monomials directly.
- The underlying coefficient/exponent types are all APInt with a 64-bit width, the idea being that if we need to increase it later we can do so easily. I also saw [MPInt](https://github.com/llvm/llvm-project/blob/b299ec16661f653df66cdaf161cdc5441bc9803c/mlir/include/mlir/Analysis/Presburger/MPInt.h#L87) in the Presburger library, and I think that might be a better type to use for this because it doesn't assert that the bit width of the two operands to be the same. But since it's hidden inside Presburger I wasn't sure if it is sensible/stable to depend on. I asked @groverkss in the mlir chat about this.