### PR TITLE
Add Secret dialect

### DIFF
--- a/include/Dialect/Secret/IR/BUILD
+++ b/include/Dialect/Secret/IR/BUILD
@@ -1,0 +1,101 @@
+# Secret, a dialect defining secretnomials in a secretnomial ring and their operations.
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "SecretDialect.h",
+        "SecretOps.h",
+        "SecretTypes.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "SecretDialect.td",
+        "SecretOps.td",
+        "SecretTypes.td",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-dialect-decls"],
+            "SecretDialect.h.inc",
+        ),
+        (
+            ["-gen-dialect-defs"],
+            "SecretDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "SecretDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-typedef-decls"],
+            "SecretTypes.h.inc",
+        ),
+        (
+            ["-gen-typedef-defs"],
+            "SecretTypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "SecretTypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "SecretTypes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "SecretOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "SecretOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "SecretOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "SecretOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+    ],
+)

--- a/include/Dialect/Secret/IR/SecretDialect.h
+++ b/include/Dialect/Secret/IR/SecretDialect.h
@@ -1,0 +1,10 @@
+#ifndef HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETDIALECT_H_
+#define HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETDIALECT_H_
+
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Don't clobber include order
+#include "include/Dialect/Secret/IR/SecretDialect.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETDIALECT_H_

--- a/include/Dialect/Secret/IR/SecretDialect.td
+++ b/include/Dialect/Secret/IR/SecretDialect.td
@@ -1,0 +1,20 @@
+#ifndef HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETDIALECT_TD_
+#define HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def Secret_Dialect : Dialect {
+  let name = "secret";
+  let summary = "A dialect for computations that operate on encrypted secrets.";
+  let description = [{
+    Secret is intended to serve as a scheme-agnostic front-end for the HEIR
+    ecosystem of dialects. It is supposed to be fully interoperable with the
+    rest of MLIR via secret.generic, while lower-level HEIR dialects would have
+    custom types for arithmetic on secret integers of various bit widths.
+  }];
+
+  let cppNamespace = "::mlir::heir::secret";
+  let useDefaultTypePrinterParser = 1;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETDIALECT_TD_

--- a/include/Dialect/Secret/IR/SecretOps.h
+++ b/include/Dialect/Secret/IR/SecretOps.h
@@ -1,0 +1,18 @@
+#ifndef HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_H_
+#define HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_H_
+
+#include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/ControlFlowInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+// don't clobber import order
+#include "include/Dialect/Secret/IR/SecretDialect.h"
+#include "include/Dialect/Secret/IR/SecretTypes.h"
+
+#define GET_OP_CLASSES
+#include "include/Dialect/Secret/IR/SecretOps.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_H_

--- a/include/Dialect/Secret/IR/SecretOps.td
+++ b/include/Dialect/Secret/IR/SecretOps.td
@@ -1,0 +1,171 @@
+#ifndef HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_TD_
+#define HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_TD_
+
+include "SecretDialect.td"
+include "SecretTypes.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class Secret_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Secret_Dialect, mnemonic, traits> {
+  let cppNamespace = "::mlir::heir::secret";
+}
+
+def Secret_ConcealOp : Secret_Op<"conceal", [Pure]> {
+  let summary = "Convert a non-secret value into a secret";
+  let description = [{
+    Convert a value to a secret containing the same value.
+
+    This op represents a scheme-agnostic encryption operation, as well as a
+    "trivial encryption" operation which is needed for some FHE schemes. This
+    op is also useful for type materialization in the dialect conversion
+    framework.
+
+    Examples:
+
+    ```
+    %Y = secret.conceal %value : i32 -> !secret.secret<i32>
+    ```
+  }];
+
+  let arguments = (ins AnyType:$cleartext);
+  let results = (outs Secret:$output);
+  let assemblyFormat = "$cleartext attr-dict `:` type($cleartext) `->` type($output)";
+
+  let builders = [
+    // Builder to infer output type from the input type
+    OpBuilder<(ins "Value":$cleartext)>
+  ];
+
+  // TODO(https://github.com/google/heir/issues/108): add a folder that
+  // collapses secret<secret<T>> into secret<T> and removes intermediate
+  // conceal ops.
+  // let hasFolder = 1;
+}
+
+def Secret_RevealOp : Secret_Op<"reveal", [Pure]> {
+  let summary = "Convert a secret value into a non-secret";
+  let description = [{
+    Convert a secret into a non-secret containing the same value.
+
+    This op represents a scheme-agnostic decryption operation. This op is also
+    useful for target materialization in the dialect conversion framework.
+
+    Examples:
+
+    ```
+    %Y = secret.reveal %secret_value : !secret.secret<i32> -> i32
+    ```
+  }];
+
+  let arguments = (ins Secret:$input);
+  let results = (outs AnyType:$cleartext);
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($cleartext)";
+
+  let builders = [
+    // Builder to infer output type from the input type
+    OpBuilder<(ins "Value":$secret)>
+  ];
+}
+
+
+def Secret_YieldOp : Secret_Op<"yield", [Pure, ReturnLike, Terminator]>,
+  Arguments<(ins Variadic<AnyType>:$values)> {
+  let summary = "Secret yield operation";
+  let description = [{
+    `secret.yield` is a special terminator operation for blocks inside regions
+    in `secret` generic ops. It returns the cleartext value of the
+    corresponding private computation to the immediately enclosing `secret`
+    generic op.
+  }];
+  let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
+  let hasCustomAssemblyFormat = 1;
+
+  // TODO(https://github.com/google/heir/issues/108): add a verifier that
+  // ensures the yield op is inside a generic op, that the return type of the
+  // yield op matches the enclosing generic, and any other similar
+  // verifications that linalg.generic has that would be applicable here. Maybe
+  // there are some generic interfaces that produce these verifiers for free,
+  // like SingleBlockImplicitTerminator?
+  // let hasVerifier = 1;
+}
+
+def Secret_GenericOp : Secret_Op<"generic", [
+       SingleBlockImplicitTerminator<"YieldOp">]> {
+  let summary = "Lift a plaintext computation to operate on secrets.";
+  let description = [{
+    `secret.generic` lifts a plaintext computation to operate on one or more
+    secrets. The lifted computation is represented as a region containing a
+    single block terminated by `secret.yield`. The arguments of the `secret.generic`
+    may include one or more `!secret.secret` types. The arguments of the block
+    in the op's body correspond to the underlying plaintext types of the secrets.
+
+    Basic examples:
+
+    Add two secret integers together
+
+    ```
+    %Z = secret.generic ins(%X, %Y : !secret.secret<i32>, !secret.secret<i32>) {
+      ^bb0(%x: i32, %y: i32) :
+        %z = arith.addi %x, %y: i32
+        secret.yield %z : i32
+      } -> (!secret.secret<i32>)
+    ```
+
+    Add a secret value with a plaintext value. I.e., not all arguments to the
+    op need be secret.
+
+    ```
+    %Z = secret.generic ins(%X, %Y : i32, !secret.secret<i32>) {
+      ^bb0(%x: i32, %y: i32) :
+        %z = arith.addi %x, %y: i32
+        secret.yield %z : i32
+      } -> (!secret.secret<i32>)
+    ```
+
+    A `secret.generic` op also has a corresponding `library_name` attribute
+    that provides semantic information about what op is computed inside the
+    region. This can be used by lowering passes to target specific
+    instructions in lower level dialects that support them. For example, an FHE
+    dialect may have special support for an encrypted matmul op.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$inputs,
+                       OptionalAttr<StrAttr>:$library_call);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region AnyRegion:$region);
+
+  let builders = [
+    OpBuilder<(ins "ValueRange":$inputs, "StringAttr":$libraryCall,
+      CArg<"function_ref<void(OpBuilder &, Location, ValueRange)>", "nullptr">)>
+  ];
+
+  let extraClassDeclaration = [{
+    std::string getLibraryCallName() {
+      return getLibraryCall() ?
+        getLibraryCall()->str() : "op_has_no_registered_library_name";
+    }
+
+    static std::function<void(ImplicitLocOpBuilder &,
+                              Block &, ArrayRef<NamedAttribute>)>
+    getRegionBuilder() {
+      return nullptr;
+    }
+  }];
+
+  // let hasCanonicalizer = 1;
+  let hasCustomAssemblyFormat = 1;
+
+  // TODO(https://github.com/google/heir/issues/108): add a folder that removes
+  // the op if there are no secret inputs.
+  // let hasFolder = 1;
+
+  // TODO(https://github.com/google/heir/issues/108): add a verifier that
+  // ensures the arguments to the op match the arguments of the block.
+  // let hasVerifier = 1;
+}
+
+
+#endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_TD_

--- a/include/Dialect/Secret/IR/SecretTypes.h
+++ b/include/Dialect/Secret/IR/SecretTypes.h
@@ -1,0 +1,9 @@
+#ifndef HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETTYPES_H_
+#define HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETTYPES_H_
+
+#include "include/Dialect/Secret/IR/SecretDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/Secret/IR/SecretTypes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETTYPES_H_

--- a/include/Dialect/Secret/IR/SecretTypes.td
+++ b/include/Dialect/Secret/IR/SecretTypes.td
@@ -1,0 +1,35 @@
+#ifndef HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETTYPES_TD_
+#define HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETTYPES_TD_
+
+include "SecretDialect.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+// A base class for all types in this dialect
+class Secret_Type<string name, string typeMnemonic>
+    : TypeDef<Secret_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+def Secret : Secret_Type<"Secret", "secret"> {
+  let summary = "A secret value";
+
+  let description = [{
+    A generic wrapper around another MLIR type, representing an encrypted value
+    but not specifying the manner of encryption. This is useful in HEIR because
+    the compiler may choose various details of the FHE scheme based on the
+    properties of the input program, the backend target hardware, and cost
+    models of the various passes.
+  }];
+
+  let parameters = (ins "Type":$valueType);
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$valueType), [{
+      return $_get(valueType.getContext(), valueType);
+    }]>
+  ];
+  let assemblyFormat = "`<` $valueType `>`";
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETTYPES_TD_

--- a/include/Dialect/Secret/Transforms/BUILD
+++ b/include/Dialect/Secret/Transforms/BUILD
@@ -1,0 +1,34 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=Secret",
+            ],
+            "Passes.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "SecretPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+exports_files([
+    "Passes.h",
+    "ForgetSecrets.h",
+])

--- a/include/Dialect/Secret/Transforms/ForgetSecrets.h
+++ b/include/Dialect/Secret/Transforms/ForgetSecrets.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_DIALECT_SECRET_TRANSFORMS_FORGETSECRETS_H_
+#define INCLUDE_DIALECT_SECRET_TRANSFORMS_FORGETSECRETS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+#define GEN_PASS_DECL
+#include "include/Dialect/Secret/Transforms/Passes.h.inc"
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_DIALECT_SECRET_TRANSFORMS_FORGETSECRETS_H_

--- a/include/Dialect/Secret/Transforms/Passes.h
+++ b/include/Dialect/Secret/Transforms/Passes.h
@@ -1,0 +1,18 @@
+#ifndef INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_H_
+#define INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_H_
+
+#include "include/Dialect/Secret/IR/SecretDialect.h"
+#include "include/Dialect/Secret/Transforms/ForgetSecrets.h"
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+#define GEN_PASS_REGISTRATION
+#include "include/Dialect/Secret/Transforms/Passes.h.inc"
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_H_

--- a/include/Dialect/Secret/Transforms/Passes.td
+++ b/include/Dialect/Secret/Transforms/Passes.td
@@ -1,0 +1,15 @@
+#ifndef INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_TD_
+#define INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def SecretForgetSecrets : Pass<"secret-forget-secrets"> {
+  let summary = "Convert secret types to standard types";
+  let description = [{
+    Drop the `secret<...>` type from the IR, replacing it with the contained
+    type and the corresponding cleartext computation.
+  }];
+  let dependentDialects = ["mlir::heir::secret::SecretDialect"];
+}
+
+#endif  // INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_TD_

--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -1,0 +1,65 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "SecretDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Secret/IR:SecretDialect.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        ":SecretOps",
+        ":SecretTypes",
+        "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Secret/IR:ops_inc_gen",
+        "@heir//include/Dialect/Secret/IR:types_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "SecretTypes",
+    srcs = [
+        "SecretTypes.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Secret/IR:SecretDialect.h",
+        "@heir//include/Dialect/Secret/IR:SecretTypes.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Secret/IR:types_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)
+
+cc_library(
+    name = "SecretOps",
+    srcs = [
+        "SecretOps.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Secret/IR:SecretDialect.h",
+        "@heir//include/Dialect/Secret/IR:SecretOps.h",
+        "@heir//include/Dialect/Secret/IR:SecretTypes.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Secret/IR:ops_inc_gen",
+        "@heir//include/Dialect/Secret/IR:types_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ControlFlowInterfaces",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)

--- a/lib/Dialect/Secret/IR/SecretDialect.cpp
+++ b/lib/Dialect/Secret/IR/SecretDialect.cpp
@@ -1,0 +1,37 @@
+#include "include/Dialect/Secret/IR/SecretDialect.h"
+
+#include "include/Dialect/Secret/IR/SecretDialect.cpp.inc"
+#include "include/Dialect/Secret/IR/SecretOps.h"
+#include "include/Dialect/Secret/IR/SecretTypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/Secret/IR/SecretTypes.cpp.inc"
+#define GET_OP_CLASSES
+#include "include/Dialect/Secret/IR/SecretOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+//===----------------------------------------------------------------------===//
+// Secret dialect.
+//===----------------------------------------------------------------------===//
+
+// Dialect construction: there is one instance per context and it registers its
+// operations, types, and interfaces here.
+void SecretDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "include/Dialect/Secret/IR/SecretTypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "include/Dialect/Secret/IR/SecretOps.cpp.inc"
+      >();
+}
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Secret/IR/SecretOps.cpp
+++ b/lib/Dialect/Secret/IR/SecretOps.cpp
@@ -1,0 +1,117 @@
+#include "include/Dialect/Secret/IR/SecretOps.h"
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+void YieldOp::print(OpAsmPrinter &p) {
+  if (getNumOperands() > 0) p << ' ' << getOperands();
+  p.printOptionalAttrDict((*this)->getAttrs());
+  if (getNumOperands() > 0) p << " : " << getOperandTypes();
+}
+
+ParseResult YieldOp::parse(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand, 2> opInfo;
+  SmallVector<Type, 2> types;
+  SMLoc loc = parser.getCurrentLocation();
+  return failure(parser.parseOperandList(opInfo) ||
+                 parser.parseOptionalAttrDict(result.attributes) ||
+                 (!opInfo.empty() && parser.parseColonTypeList(types)) ||
+                 parser.resolveOperands(opInfo, types, loc, result.operands));
+}
+
+void GenericOp::print(OpAsmPrinter &p) {
+  ValueRange inputs = getInputs();
+  if (!inputs.empty())
+    p << " ins(" << inputs << " : " << inputs.getTypes() << ")";
+
+  ArrayRef<NamedAttribute> attrs = (*this)->getAttrs();
+  if (!attrs.empty()) {
+    p << " attrs =";
+    p.printOptionalAttrDict(attrs);
+  }
+
+  if (!getRegion().empty()) {
+    p << ' ';
+    p.printRegion(getRegion());
+  }
+
+  TypeRange resultTypes = getResults().getTypes();
+  if (resultTypes.empty()) return;
+  p.printOptionalArrowTypeList(resultTypes);
+}
+
+static ParseResult parseCommonStructuredOpParts(
+    OpAsmParser &parser, OperationState &result,
+    SmallVectorImpl<Type> &inputTypes) {
+  SMLoc attrsLoc, inputsOperandsLoc;
+  SmallVector<OpAsmParser::UnresolvedOperand, 4> inputsOperands;
+
+  if (succeeded(parser.parseOptionalLess())) {
+    if (parser.parseAttribute(result.propertiesAttr) || parser.parseGreater())
+      return failure();
+  }
+  attrsLoc = parser.getCurrentLocation();
+  if (parser.parseOptionalAttrDict(result.attributes)) return failure();
+
+  if (succeeded(parser.parseOptionalKeyword("ins"))) {
+    if (parser.parseLParen()) return failure();
+
+    inputsOperandsLoc = parser.getCurrentLocation();
+    if (parser.parseOperandList(inputsOperands) ||
+        parser.parseColonTypeList(inputTypes) || parser.parseRParen())
+      return failure();
+  }
+
+  if (parser.resolveOperands(inputsOperands, inputTypes, inputsOperandsLoc,
+                             result.operands))
+    return failure();
+  return success();
+}
+
+ParseResult GenericOp::parse(OpAsmParser &parser, OperationState &result) {
+  DictionaryAttr dictAttr;
+  if (parser.parseAttribute(dictAttr, "_", result.attributes)) return failure();
+  result.attributes.assign(dictAttr.getValue().begin(),
+                           dictAttr.getValue().end());
+
+  SmallVector<Attribute> iteratorTypeAttrs;
+
+  // Parsing is shared with named ops, except for the region.
+  SmallVector<Type, 1> inputTypes;
+  if (parseCommonStructuredOpParts(parser, result, inputTypes))
+    return failure();
+
+  // Optional attributes may be added.
+  if (succeeded(parser.parseOptionalKeyword("attrs")))
+    if (failed(parser.parseEqual()) ||
+        failed(parser.parseOptionalAttrDict(result.attributes)))
+      return failure();
+
+  std::unique_ptr<Region> region = std::make_unique<Region>();
+  if (parser.parseRegion(*region, {})) return failure();
+  result.addRegion(std::move(region));
+
+  SmallVector<Type, 1> outputTypes;
+  if (parser.parseOptionalArrowTypeList(outputTypes)) return failure();
+  result.addTypes(outputTypes);
+
+  return success();
+}
+
+void ConcealOp::build(OpBuilder &builder, OperationState &result,
+                      Value cleartextValue) {
+  Type resultType = SecretType::get(cleartextValue.getType());
+  build(builder, result, resultType, cleartextValue);
+}
+
+void RevealOp::build(OpBuilder &builder, OperationState &result,
+                     Value secretValue) {
+  Type resultType =
+      llvm::dyn_cast<SecretType>(secretValue.getType()).getValueType();
+  build(builder, result, resultType, secretValue);
+}
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Secret/IR/SecretTypes.cpp
+++ b/lib/Dialect/Secret/IR/SecretTypes.cpp
@@ -1,0 +1,11 @@
+#include "include/Dialect/Secret/IR/SecretTypes.h"
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+// Placeholder for secret dialect implementation code
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Secret/Transforms/BUILD
+++ b/lib/Dialect/Secret/Transforms/BUILD
@@ -1,0 +1,36 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = [
+        "@heir//include/Dialect/Secret/Transforms:Passes.h",
+    ],
+    deps = [
+        ":ForgetSecrets",
+        "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "ForgetSecrets",
+    srcs = ["ForgetSecrets.cpp"],
+    hdrs = [
+        "@heir//include/Dialect/Secret/Transforms:ForgetSecrets.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:SecretOps",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:FuncTransforms",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)

--- a/lib/Dialect/Secret/Transforms/ForgetSecrets.cpp
+++ b/lib/Dialect/Secret/Transforms/ForgetSecrets.cpp
@@ -1,0 +1,137 @@
+#include "include/Dialect/Secret/Transforms/ForgetSecrets.h"
+
+#include "include/Dialect/Secret/IR/SecretOps.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+#define GEN_PASS_DEF_SECRETFORGETSECRETS
+#include "include/Dialect/Secret/Transforms/Passes.h.inc"
+
+using ::mlir::func::CallOp;
+using ::mlir::func::FuncOp;
+using ::mlir::func::ReturnOp;
+
+class ForgetSecretsTypeConverter : public TypeConverter {
+ public:
+  ForgetSecretsTypeConverter() {
+    addConversion([](Type type) { return type; });
+    addConversion([](SecretType secretType) -> Type {
+      return secretType.getValueType();
+    });
+  }
+};
+
+struct ConvertGeneric : public OpConversionPattern<GenericOp> {
+  ConvertGeneric(mlir::MLIRContext *context)
+      : OpConversionPattern<GenericOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      GenericOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Block *originalBlock = op->getBlock();
+    Block &opEntryBlock = op.getRegion().front();
+    YieldOp yieldOp = dyn_cast<YieldOp>(op.getRegion().back().getTerminator());
+
+    // Inline the op's (unique) block, including the yield op. This also
+    // requires splitting the parent block of the generic op, so that we have a
+    // clear insertion point for inlining.
+    Block *newBlock = rewriter.splitBlock(originalBlock, Block::iterator(op));
+    rewriter.inlineRegionBefore(op.getRegion(), newBlock);
+
+    // Now that op's region is inlined, the operands of its YieldOp are mapped
+    // to the materialized target values. Therefore, we can replace the op's
+    // uses with those of its YieldOp's operands.
+    rewriter.replaceOp(op, yieldOp->getOperands());
+
+    // No need for these intermediate blocks, merge them into 1.
+    rewriter.mergeBlocks(&opEntryBlock, originalBlock, adaptor.getOperands());
+    rewriter.mergeBlocks(newBlock, originalBlock, {});
+
+    rewriter.eraseOp(yieldOp);
+    return success();
+  }
+};
+
+struct ConvertConceal : public OpConversionPattern<ConcealOp> {
+  ConvertConceal(mlir::MLIRContext *context)
+      : OpConversionPattern<ConcealOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ConcealOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (op.getOutput().use_empty()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    rewriter.replaceOp(op, adaptor.getCleartext());
+    return success();
+  }
+};
+
+struct ConvertReveal : public OpConversionPattern<RevealOp> {
+  ConvertReveal(mlir::MLIRContext *context)
+      : OpConversionPattern<RevealOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      RevealOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (op.getCleartext().use_empty()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    rewriter.replaceOp(op, adaptor.getInput());
+    return success();
+  }
+};
+
+struct ForgetSecrets : impl::SecretForgetSecretsBase<ForgetSecrets> {
+  using SecretForgetSecretsBase::SecretForgetSecretsBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto *func = getOperation();
+    ConversionTarget target(*context);
+    ForgetSecretsTypeConverter typeConverter;
+
+    target.addIllegalDialect<SecretDialect>();
+    target.addDynamicallyLegalOp<mlir::func::FuncOp>(
+        [&](mlir::func::FuncOp op) {
+          return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+                 typeConverter.isLegal(&op.getBody());
+        });
+    target.addDynamicallyLegalOp<mlir::func::CallOp>(
+        [&](mlir::func::CallOp op) { return typeConverter.isLegal(op); });
+    target.addDynamicallyLegalOp<mlir::func::ReturnOp>(
+        [&](mlir::func::ReturnOp op) { return typeConverter.isLegal(op); });
+
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertGeneric, ConvertConceal, ConvertReveal>(typeConverter,
+                                                                context);
+    populateFunctionOpInterfaceTypeConversionPattern<FuncOp>(patterns,
+                                                             typeConverter);
+    populateReturnOpTypeConversionPattern(patterns, typeConverter);
+    populateCallOpTypeConversionPattern(patterns, typeConverter);
+
+    if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir

--- a/tests/secret/BUILD
+++ b/tests/secret/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/secret/forget_secrets.mlir
+++ b/tests/secret/forget_secrets.mlir
@@ -1,0 +1,115 @@
+// RUN: heir-opt --secret-forget-secrets --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: test_erase_unused_conceal
+func.func @test_erase_unused_conceal(%value : i32) {
+  // CHECK-NOT: secret
+  %Y = secret.conceal %value : i32 -> !secret.secret<i32>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: test_conceal_then_generic
+// CHECK-SAME:     %[[ARG:.*]]: i32
+// CHECK-SAME:  ) {
+// CHECK:         %[[C7:.*]] = arith.constant 7 : i32
+// CHECK:         %[[V0:.*]] = arith.addi %[[C7]], %[[ARG]] : i32
+// CHECK:         return
+// CHECK:       }
+func.func @test_conceal_then_generic(%value : i32) {
+  %X = arith.constant 7 : i32
+  %Y = secret.conceal %value : i32 -> !secret.secret<i32>
+  %Z = secret.generic {library_name = "foo"}
+    ins(%X, %Y : i32, !secret.secret<i32>) {
+    ^bb0(%x: i32, %y: i32) :
+      %d = arith.addi %x, %y: i32
+      secret.yield %d : i32
+    } -> (!secret.secret<i32>)
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_function_signature(
+// CHECK-SAME:     %[[ARG:.*]]: i32
+// CHECK-SAME:  ) -> i32 {
+// CHECK: return %[[ARG]] : i32
+func.func @test_function_signature(%Y : !secret.secret<i32>) -> !secret.secret<i32> {
+  func.return %Y : !secret.secret<i32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_add_two_secrets(
+// CHECK-SAME:     %[[S1:.*]]: i32,
+// CHECK-SAME:     %[[S2:.*]]: i32
+// CHECK-SAME:  ) -> i32 {
+// CHECK: %[[V0:.*]] = arith.addi %[[S1]], %[[S2]] : i32
+// CHECK: return %[[V0]] : i32
+func.func @test_add_two_secrets(
+    %s1 : !secret.secret<i32>,
+    %s2 : !secret.secret<i32>) -> !secret.secret<i32> {
+  %out = secret.generic {library_name = "foo"}
+    ins(%s1, %s2 : !secret.secret<i32>, !secret.secret<i32>) {
+    ^bb0(%x: i32, %y: i32) :
+      %d = arith.addi %x, %y: i32
+      secret.yield %d : i32
+    } -> (!secret.secret<i32>)
+  func.return %out : !secret.secret<i32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_compose_generic(
+// CHECK-SAME:     %[[S1:.*]]: i32,
+// CHECK-SAME:     %[[S2:.*]]: i32
+// CHECK-SAME:  ) -> i32 {
+// CHECK: %[[V0:.*]] = arith.addi %[[S1]], %[[S2]] : i32
+// CHECK: %[[V1:.*]] = arith.muli %[[S1]], %[[V0]] : i32
+// CHECK: return %[[V1]] : i32
+func.func @test_compose_generic(
+    %s1 : !secret.secret<i32>,
+    %s2 : !secret.secret<i32>) -> !secret.secret<i32> {
+  %0 = secret.generic {library_name = "addi"}
+    ins(%s1, %s2 : !secret.secret<i32>, !secret.secret<i32>) {
+    ^bb0(%x: i32, %y: i32) :
+      %d = arith.addi %x, %y: i32
+      secret.yield %d : i32
+    } -> (!secret.secret<i32>)
+  %1 = secret.generic {library_name = "muli"}
+    ins(%s1, %0 : !secret.secret<i32>, !secret.secret<i32>) {
+    ^bb0(%x: i32, %y: i32) :
+      %d = arith.muli %x, %y: i32
+      secret.yield %d : i32
+    } -> (!secret.secret<i32>)
+  func.return %1 : !secret.secret<i32>
+}
+
+func.func @test_convert_call() {
+  %0 = arith.constant 7 : i32
+  %1 = arith.constant 8 : i32
+  %2 = secret.conceal %0 : i32 -> !secret.secret<i32>
+  %3 = secret.conceal %1 : i32 -> !secret.secret<i32>
+  %4 = func.call @test_compose_generic(%2, %3) : (!secret.secret<i32>, !secret.secret<i32>) -> !secret.secret<i32>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: test_convert_call_2
+// CHECK-NOT: secret
+func.func @example_fn(
+    %s1 : !secret.secret<i32>,
+    %s2 : !secret.secret<i32>) -> !secret.secret<i32> {
+  func.return %s1 : !secret.secret<i32>
+}
+
+func.func @test_convert_call_2() -> i32 {
+  %0 = arith.constant 7 : i32
+  %1 = arith.constant 8 : i32
+  %2 = secret.conceal %0 : i32 -> !secret.secret<i32>
+  %3 = secret.conceal %1 : i32 -> !secret.secret<i32>
+  %4 = func.call @example_fn(%2, %3) : (!secret.secret<i32>, !secret.secret<i32>) -> !secret.secret<i32>
+  %5 = secret.reveal %4 : !secret.secret<i32> -> i32
+  func.return %5 : i32
+}

--- a/tests/secret/generic.mlir
+++ b/tests/secret/generic.mlir
@@ -1,0 +1,17 @@
+// RUN: heir-opt %s > %t
+// RUN: FileCheck %s < %t
+
+module {
+  func.func @main(%value : i32) {
+    %X = arith.constant 7 : i32
+    %Y = secret.conceal %value : i32 -> !secret.secret<i32>
+    // CHECK: secret.generic
+    %Z = secret.generic {library_name = "foo"}
+      ins(%X, %Y : i32, !secret.secret<i32>) {
+      ^bb0(%x: i32, %y: i32) :
+        %d = arith.addi %x, %y: i32
+        secret.yield %d : i32
+      } -> (!secret.secret<i32>)
+    func.return
+  }
+}

--- a/tests/secret/syntax.mlir
+++ b/tests/secret/syntax.mlir
@@ -1,0 +1,11 @@
+// RUN: heir-opt %s > %t
+// RUN: FileCheck %s < %t
+
+// This simply tests for syntax.
+
+module {
+  // CHECK-LABEL: func @fooFunc
+  func.func @fooFunc(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+    return %arg0 : !secret.secret<i32>
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -16,6 +16,8 @@ cc_binary(
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/EncryptedArith/IR:Dialect",
         "@heir//lib/Dialect/Poly/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/Secret/Transforms",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:AllPassesAndDialects",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -2,6 +2,8 @@
 #include "include/Dialect/BGV/IR/BGVDialect.h"
 #include "include/Dialect/EncryptedArith/IR/EncryptedArithDialect.h"
 #include "include/Dialect/Poly/IR/PolyDialect.h"
+#include "include/Dialect/Secret/IR/SecretDialect.h"
+#include "include/Dialect/Secret/Transforms/Passes.h"
 #include "mlir/include/mlir/Conversion/TosaToLinalg/TosaToLinalg.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/Passes.h"   // from @llvm-project
@@ -70,22 +72,24 @@ void tosaPipelineBuilder(mlir::OpPassManager &manager) {
 
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
-  registry.insert<mlir::heir::poly::PolyDialect>();
   registry.insert<mlir::heir::EncryptedArithDialect>();
   registry.insert<mlir::heir::bgv::BGVDialect>();
+  registry.insert<mlir::heir::poly::PolyDialect>();
+  registry.insert<mlir::heir::secret::SecretDialect>();
 
   // Add expected MLIR dialects to the registry.
+  registry.insert<mlir::affine::AffineDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
-  registry.insert<mlir::arith::ArithDialect>();
-  registry.insert<mlir::affine::AffineDialect>();
   registry.insert<mlir::scf::SCFDialect>();
-  mlir::registerAllDialects(registry);
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::tosa::TosaDialect>();
+  mlir::registerAllDialects(registry);
 
   // Register MLIR core passes to build pipeline.
   mlir::registerAllPasses();
+  mlir::heir::secret::registerSecretPasses();
 
   mlir::PassPipelineRegistration<>(
       "heir-tosa-to-arith",


### PR DESCRIPTION
This PR implements a `secret` dialect to represent generic, high level computation on encrypted data, along with a demonstration lowering pass that drops the secret types.

It defines a single new type, `secret.secret<AnyType>` which wraps a non-secret type, and centers around the `secret.generic` op, which "lifts" a computation on the plaintext types to a computation on the corresponding secret types, with some metadata attached to the high level operation encapsulated by a `secret.generic` so that it can be lowered to custom ops in specific dialects.

I also defined a pass, `--secret-forget-secrets`, which simply drops the secrets from all types and returns an equivalent program that operates on plaintext data.

Some notes:

- In my examples I have `secret.generic`'s body containing a single op, but I think more realistically we will have front ends that convert large regions of code into a large `secret.generic`, and then passes in this dialect that transform it by doing things like extracting loops with static bounds outside of the body of a `secret.generic` and only having the inner-most loop body contain `secret.generic` ops (which could then be further analyzed/optimized with partial loop unrolling and fusing), or something like transforming the body of a `secret.generic` into a combinational circuit, then applying a circuit optimizer to it.
- Forgetting secrets is only intended to be useful for testing, e.g, to ensure a program is functionally equivalent before and after any FHE passes are applied. But it also helps me understand how to write passes that operate on the mildly complex IR I've defined for `secret.generic`.
- I'd like to eventually generalize the forget-secrets pass to operate on an interface(s), and then apply that interface to lower level dialects, so that at any point during a program's compilation lifecycle, we can exit the "encrypted" part of the pipeline and test functional equivalence.