### PR TITLE
Only run CI if PR is ready for review

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - ready_for_review
+      - review_requested
     branches:
       - main
 jobs:


### PR DESCRIPTION
This PR is a simple tweak to only run the (possibly expensive) CI once a PR is marked as ready for review or a review is requested.

Got this idea from https://some-natalie.dev/blog/scanning-code-on-every-push/