### PR TITLE
bgv: add a bgv dialect definition

### DIFF
--- a/include/Dialect/BGV/IR/BGVAttributes.h
+++ b/include/Dialect/BGV/IR/BGVAttributes.h
@@ -1,0 +1,12 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVATTRIBUTES_H_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVATTRIBUTES_H_
+
+#include "include/Dialect/BGV/IR/BGVDialect.h"
+
+// Required to pull in poly's Ring_Attr
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/BGV/IR/BGVAttributes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVATTRIBUTES_H_

--- a/include/Dialect/BGV/IR/BGVAttributes.td
+++ b/include/Dialect/BGV/IR/BGVAttributes.td
@@ -1,0 +1,17 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
+
+include "BGVDialect.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/IR/OpBase.td"
+
+def BGVRingArrayAttr : AttrDef<BGV_Dialect, "BGVRings"> {
+  let mnemonic = "rings";
+  let parameters = (ins ArrayRefParameter<"::mlir::heir::poly::RingAttr">:$rings);
+  let assemblyFormat = "`<` $rings `>`";
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVATTRIBUTES_TD_

--- a/include/Dialect/BGV/IR/BGVDialect.h
+++ b/include/Dialect/BGV/IR/BGVDialect.h
@@ -1,0 +1,12 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVDIALECT_H_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "include/Dialect/BGV/IR/BGVDialect.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVDIALECT_H_

--- a/include/Dialect/BGV/IR/BGVDialect.td
+++ b/include/Dialect/BGV/IR/BGVDialect.td
@@ -1,0 +1,22 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVDIALECT_TD_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def BGV_Dialect : Dialect {
+  // The namespace of the dialect.
+  // This corresponds to the string provided in `getDialectNamespace`.
+  let name = "bgv";
+
+  let summary = "A dialect for types and operations in the BGV cryptosystem";
+  let description = [{
+    The BGV dialect defines the types and operations of the BGV cryptosystem
+  }];
+
+  let cppNamespace = "::mlir::heir::bgv";
+
+  let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVDIALECT_TD_

--- a/include/Dialect/BGV/IR/BGVOps.h
+++ b/include/Dialect/BGV/IR/BGVOps.h
@@ -1,0 +1,15 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_H_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_H_
+
+#include "include/Dialect/BGV/IR/BGVAttributes.h"
+#include "include/Dialect/BGV/IR/BGVDialect.h"
+#include "include/Dialect/BGV/IR/BGVTypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "include/Dialect/BGV/IR/BGVOps.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_H_

--- a/include/Dialect/BGV/IR/BGVOps.td
+++ b/include/Dialect/BGV/IR/BGVOps.td
@@ -1,0 +1,136 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_TD_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_TD_
+
+include "BGVDialect.td"
+include "BGVTypes.td"
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+// TODO(https://github.com/google/heir/issues/101): Add verifiers for BGV ops.
+
+class BGV_Op<string mnemonic, list<Trait> traits = []> :
+        Op<BGV_Dialect, mnemonic, traits> {
+
+  // See https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format
+  // TODO(https://github.com/google/heir/issues/106): Simplify this format by adding type constraints.
+  let assemblyFormat = [{
+    `(` operands `)` attr-dict `:`  `(` type(operands) `)` `->` type(results)
+  }];
+  let cppNamespace = "::mlir::heir::bgv";
+}
+
+// TODO(https://github.com/google/heir/issues/100): Add plaintext-ciphertext operations.
+
+def BGV_AddOp : BGV_Op<"add", [Commutative, SameOperandsAndResultType]> {
+  let summary = "Addition operation between ciphertexts.";
+
+  let arguments = (ins
+    Ciphertext:$x,
+    Ciphertext:$y
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+}
+
+def BGV_SubOp : BGV_Op<"sub", [SameOperandsAndResultType]> {
+  let summary = "Subtraction operation between ciphertexts.";
+
+  let arguments = (ins
+    Ciphertext:$x,
+    Ciphertext:$y
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+}
+
+def BGV_MulOp : BGV_Op<"mul", [Commutative]> {
+  let summary = "Multiplication operation between ciphertexts.";
+
+  let arguments = (ins
+    Ciphertext:$x,
+    Ciphertext:$y
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($x)`,` type($y) `->` type($output)" ;
+}
+
+def BGV_Rotate : BGV_Op<"rotate"> {
+  let summary = "Rotate the coefficients of the ciphertext using a Galois automorphism.";
+
+  let arguments = (ins
+    Ciphertext:$x,
+    I64Attr:$offset
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+}
+
+def BGV_Negate : BGV_Op<"negate", [SameOperandsAndResultType]> {
+  let summary = "Negate the coefficients of the ciphertext.";
+
+  let arguments = (ins
+    Ciphertext:$x
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+}
+
+def BGV_Relinearize : BGV_Op<"relinearize"> {
+  let summary = "Relinearize the ciphertext.";
+
+  let description = [{
+    This op takes integer array attributes `from_basis` and `to_basis` that are
+    used to indicate the key basis from which and to which the ciphertext is
+    encrypted against. A ciphertext is canonically encrypted against key basis
+    `(1, s)`. After a multiplication, its size will increase and the basis will be
+    `(1, s, s^2)`. The array that represents the key basis is constructed by
+    listing the powers of `s` at each position of the array. For example, `(1, s,
+    s^2)` corresponds to `[0, 1, 2]`, while `(1, s^2)` corresponds to `[0, 2]`.
+  }];
+
+  let arguments = (ins
+    Ciphertext:$x,
+    DenseI32ArrayAttr:$from_basis,
+    DenseI32ArrayAttr:$to_basis
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+}
+
+def BGV_ModulusSwitch : BGV_Op<"modulus_switch", [SameOperandsAndResultType]> {
+  // This must be validated against the BGV ring parameter.
+  let summary = "Lower the modulus level of the ciphertext.";
+
+  let arguments = (ins
+    Ciphertext:$x,
+    I64Attr:$from_level,
+    I64Attr:$to_level
+  );
+
+  let results = (outs
+    Ciphertext:$output
+  );
+
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_TD_

--- a/include/Dialect/BGV/IR/BGVTypes.h
+++ b/include/Dialect/BGV/IR/BGVTypes.h
@@ -1,0 +1,13 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_H_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_H_
+
+#include "include/Dialect/BGV/IR/BGVAttributes.h"
+#include "include/Dialect/BGV/IR/BGVDialect.h"
+
+// Required to pull in poly's Ring_Attr
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/BGV/IR/BGVTypes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_H_

--- a/include/Dialect/BGV/IR/BGVTypes.td
+++ b/include/Dialect/BGV/IR/BGVTypes.td
@@ -1,0 +1,46 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_TD_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_TD_
+
+include "BGVDialect.td"
+include "BGVAttributes.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+
+// TODO(https://github.com/google/heir/issues/100): Add a plaintext type.
+
+// A base class for all types in this dialect
+class BGV_Type<string name, string typeMnemonic>
+    : TypeDef<BGV_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+def Ciphertext : BGV_Type<"Ciphertext", "ciphertext"> {
+  let summary = "A type for BGV Ciphertext";
+
+  let description = [{
+    A type for BGV Ciphertexts.
+
+    This type tracks the BGV ciphertext parameters, including the ciphertext
+    dimension (number of polynomials) and the set of rings that were used for
+    the particular BGV scheme instance. The default dimension is 2, representing
+    a ciphertext that is canonically encrypted against the key basis `(1, s)`.
+
+    The type also includes a ring parameter specification.
+
+    For example, `bgv.ciphertext<rings=#rings, dim=3>` is a ciphertext with 3
+    polynomials (c_0, c_1, c_2).
+  }];
+
+  // TODO(https://github.com/google/heir/issues/99): Add # of plaintext bits.
+  let parameters = (ins
+    BGVRingArrayAttr:$rings,
+    DefaultValuedParameter<"unsigned", "2">:$dim
+  );
+
+  let assemblyFormat = "`<` `rings` `=` $rings (`,` `dim` `=` $dim^ )? `>`";
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_TD_

--- a/include/Dialect/BGV/IR/BUILD
+++ b/include/Dialect/BGV/IR/BUILD
@@ -1,0 +1,133 @@
+# BGV, a dialect defining the BGV cryptosystem.
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "BGVDialect.h",
+        "BGVOps.h",
+        "BGVTypes.h",
+        "BGVAttributes.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "BGVAttributes.td",
+        "BGVDialect.td",
+        "BGVOps.td",
+        "BGVTypes.td",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "BGVDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "BGVDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "BGVDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-typedef-decls",
+            ],
+            "BGVTypes.h.inc",
+        ),
+        (
+            [
+                "-gen-typedef-defs",
+            ],
+            "BGVTypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "BGVTypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "BGVTypes.td",
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "BGVOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "BGVOps.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "BGVOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+    ],
+)
+
+gentbl_cc_library(
+    name = "attributes_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-attrdef-decls",
+            ],
+            "BGVAttributes.h.inc",
+        ),
+        (
+            [
+                "-gen-attrdef-defs",
+            ],
+            "BGVAttributes.cpp.inc",
+        ),
+        (
+            ["-gen-attrdef-doc"],
+            "BGVAttributes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "BGVAttributes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -1,0 +1,46 @@
+#include "include/Dialect/BGV/IR/BGVDialect.h"
+
+#include "include/Dialect/BGV/IR/BGVAttributes.h"
+#include "include/Dialect/BGV/IR/BGVOps.h"
+#include "include/Dialect/BGV/IR/BGVTypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated definitions
+#include "include/Dialect/BGV/IR/BGVDialect.cpp.inc"
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/BGV/IR/BGVAttributes.cpp.inc"
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/BGV/IR/BGVTypes.cpp.inc"
+#define GET_OP_CLASSES
+#include "include/Dialect/BGV/IR/BGVOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace bgv {
+
+//===----------------------------------------------------------------------===//
+// BGV dialect.
+//===----------------------------------------------------------------------===//
+
+// Dialect construction: there is one instance per context and it registers its
+// operations, types, and interfaces here.
+void BGVDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "include/Dialect/BGV/IR/BGVAttributes.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "include/Dialect/BGV/IR/BGVTypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "include/Dialect/BGV/IR/BGVOps.cpp.inc"
+      >();
+}
+
+}  // namespace bgv
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -1,0 +1,31 @@
+# BGV dialect
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "BGVDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/BGV/IR:BGVAttributes.h",
+        "@heir//include/Dialect/BGV/IR:BGVDialect.h",
+        "@heir//include/Dialect/BGV/IR:BGVOps.h",
+        "@heir//include/Dialect/BGV/IR:BGVTypes.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/BGV/IR:attributes_inc_gen",
+        "@heir//include/Dialect/BGV/IR:dialect_inc_gen",
+        "@heir//include/Dialect/BGV/IR:ops_inc_gen",
+        "@heir//include/Dialect/BGV/IR:types_inc_gen",
+        "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
+        "@heir//lib/Dialect/Poly/IR:PolyAttributes",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)

--- a/tests/bgv_ops.mlir
+++ b/tests/bgv_ops.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt %s > %t
+// RUN: FileCheck %s < %t
+
+// This simply tests for syntax.
+
+#my_poly = #poly.polynomial<1 + x**1024>
+#ring1 = #poly.ring<cmod=463187969, ideal=#my_poly>
+#ring2 = #poly.ring<cmod=33538049, ideal=#my_poly>
+#rings = #bgv.rings<#ring1, #ring2>
+
+// CHECK: module
+module {
+  func.func @test_multiply(%arg0 : !bgv.ciphertext<rings=#rings>, %arg1: !bgv.ciphertext<rings=#rings>) -> !bgv.ciphertext<rings=#rings> {
+    %0 = bgv.mul(%arg0, %arg1) : !bgv.ciphertext<rings=#rings>, !bgv.ciphertext<rings=#rings> -> !bgv.ciphertext<rings=#rings, dim=3>
+    %1 = bgv.relinearize(%0) {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!bgv.ciphertext<rings=#rings, dim=3>) -> !bgv.ciphertext<rings=#rings>
+    %2 = bgv.modulus_switch(%1) {from_level = 1, to_level=0} : !bgv.ciphertext<rings=#rings>
+    // CHECK: <<cmod=463187969, ideal=#poly.polynomial<1 + x**1024>>, <cmod=33538049, ideal=#poly.polynomial<1 + x**1024>>>
+    return %arg0 : !bgv.ciphertext<rings=#rings>
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -13,6 +13,7 @@ cc_binary(
     deps = [
         "@heir//lib/Conversion/MemrefToArith:ExpandCopy",
         "@heir//lib/Conversion/MemrefToArith:MemrefToArithRegistration",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/EncryptedArith/IR:Dialect",
         "@heir//lib/Dialect/Poly/IR:Dialect",
         "@llvm-project//mlir:AffineDialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -1,4 +1,5 @@
 #include "include/Conversion/MemrefToArith/MemrefToArith.h"
+#include "include/Dialect/BGV/IR/BGVDialect.h"
 #include "include/Dialect/EncryptedArith/IR/EncryptedArithDialect.h"
 #include "include/Dialect/Poly/IR/PolyDialect.h"
 #include "mlir/include/mlir/Conversion/TosaToLinalg/TosaToLinalg.h"  // from @llvm-project
@@ -71,6 +72,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registry.insert<mlir::heir::poly::PolyDialect>();
   registry.insert<mlir::heir::EncryptedArithDialect>();
+  registry.insert<mlir::heir::bgv::BGVDialect>();
 
   // Add expected MLIR dialects to the registry.
   registry.insert<mlir::func::FuncDialect>();


### PR DESCRIPTION
This is a first iteration of a BGV dialect, with a few follow-ups posted as issues (that would benefit from individual PR discussion).

The BGV ciphertext includes:
* The number of polynomials, or "dim" of the ciphertext. (this may change after an operation like multiplication or relinearize). default is 2.
* The **list** of rings of the scheme that the BGV ciphertext was instantiated with. An operation that changes these rings, like `modulus_switch` will reference the index from which and to which the operation moves the ciphertext.

Noteworthy things:
* The `key_basis` attribute describes the key basis relative to which a ciphertext is encrypted. A basis of `(1, s)` is represented with `[0, 1]` - these correspond to the exponents of the secret key. After a rotation, it may be `[0, 2`] representing `(1, s^2)`. Or it may be `[0, 1, 2]` representing `(1, s, s^2)` after a `mul`.
* `bgv.relinearize` generalizes relinearization from galois automorphisms and from multiplications, the `from_basis` and `to_basis` describe the key basis change.
* With this particular approach, parameter selection would need to occur while lowering from FHE. It is possible that we could generalize and unspecialize the rings if needed. But that can be a follow-up. Or perhaps an parameter tuning pass can simply just make the params better later.

There are follow-up issues and `TODO`s in the code posted for:
* Adding an attribute for underlying plaintext bits to help with analysis
* Adding a `Plaintext` type and ops
* Adding verifiers / validations for ops.



