### PR TITLE
Improve poly types and add a starter lowering pass

### DIFF
--- a/include/Conversion/PolyToStandard/BUILD
+++ b/include/Conversion/PolyToStandard/BUILD
@@ -1,0 +1,35 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "PolyToStandard.h",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=PolyToStandard",
+            ],
+            "PolyToStandard.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "PolyToStandard.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "PolyToStandard.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/include/Conversion/PolyToStandard/PolyToStandard.h
+++ b/include/Conversion/PolyToStandard/PolyToStandard.h
@@ -1,0 +1,20 @@
+#ifndef INCLUDE_CONVERSION_POLYTOSTANDARD_POLYTOSTANDARD_H_
+#define INCLUDE_CONVERSION_POLYTOSTANDARD_POLYTOSTANDARD_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace poly {
+
+#define GEN_PASS_DECL
+#include "include/Conversion/PolyToStandard/PolyToStandard.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "include/Conversion/PolyToStandard/PolyToStandard.h.inc"
+
+}  // namespace poly
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_CONVERSION_POLYTOSTANDARD_POLYTOSTANDARD_H_

--- a/include/Conversion/PolyToStandard/PolyToStandard.td
+++ b/include/Conversion/PolyToStandard/PolyToStandard.td
@@ -1,0 +1,19 @@
+#ifndef INCLUDE_CONVERSION_POLYTOSTANDARD_POLYTOSTANDARD_TD_
+#define INCLUDE_CONVERSION_POLYTOSTANDARD_POLYTOSTANDARD_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def PolyToStandard : Pass<"lower-poly"> {
+  let summary = "Lower `poly` to standard MLIR dialects.";
+
+  let description = [{
+    This pass lowers the `poly` dialect to standard MLIR, a mixture of affine,
+    tensor, and arith.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::heir::poly::PolyDialect",
+  ];
+}
+
+#endif  // INCLUDE_CONVERSION_POLYTOSTANDARD_POLYTOSTANDARD_TD_

--- a/include/Dialect/Poly/IR/BUILD
+++ b/include/Dialect/Poly/IR/BUILD
@@ -30,6 +30,7 @@ td_library(
     deps = [
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
     ],
 )
 

--- a/include/Dialect/Poly/IR/PolyOps.td
+++ b/include/Dialect/Poly/IR/PolyOps.td
@@ -5,6 +5,7 @@ include "PolyAttributes.td"
 include "PolyDialect.td"
 include "PolyTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Poly Operation definitions.
@@ -12,7 +13,6 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 
 class Poly_Op<string mnemonic, list<Trait> traits = []> :
         Op<Poly_Dialect, mnemonic, traits> {
-
   // See https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format
   // TODO(b/291601096): Simplify this format by adding type constraints.
   let assemblyFormat = [{
@@ -25,60 +25,35 @@ class Poly_Op<string mnemonic, list<Trait> traits = []> :
 // Ring operations.
 //===----------------------------------------------------------------------===//
 
-def Poly_AddOp : Poly_Op<"add", [SameOperandsAndResultType]> {
+class Poly_BinOp<string mnemonic, list<Trait> traits = [Pure, SameOperandsAndResultType, Commutative]> :
+        Poly_Op<mnemonic, traits> {
+  let arguments = (ins Polynomial:$lhs, Polynomial:$rhs);
+  let results = (outs Polynomial:$output);
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+}
+
+def Poly_AddOp : Poly_BinOp<"add"> {
   let summary = "Addition operation between polynomials.";
-
-  let arguments = (ins
-    Variadic<Poly>:$x
-  );
-
-  let results = (outs
-    Poly:$output
-  );
-
-   let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
 }
 
-def Poly_SubOp : Poly_Op<"sub", [SameOperandsAndResultType]> {
+def Poly_SubOp : Poly_BinOp<"sub"> {
   let summary = "Subtraction operation between polynomials.";
-
-  let arguments = (ins
-    Variadic<Poly>:$x
-  );
-
-  let results = (outs
-    Poly:$output
-  );
-
-  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
 }
 
-def Poly_MulOp : Poly_Op<"mul", [SameOperandsAndResultType]> {
+def Poly_MulOp : Poly_BinOp<"mul"> {
   let summary = "Multiplication operation between polynomials.";
-
-  let arguments = (ins
-    Poly:$lhs,
-    Poly:$rhs,
-    Ring_Attr:$ring
-  );
-
-  let results = (outs
-    Poly:$output
-  );
-
-  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
 }
 
 def Poly_MulConstantOp : Poly_Op<"mul_constant"> {
   let summary = "Multiplication by a constant of the field.";
 
   let arguments = (ins
-    Poly:$x,
+    Polynomial:$x,
     AnyInteger:$constant
   );
 
   let results = (outs
-    Poly:$output
+    Polynomial:$output
   );
 }
 
@@ -90,7 +65,7 @@ def Poly_GetCoeffOp : Poly_Op<"get_coeff"> {
   let summary = "Gets the coefficient of X^{index} from a polynomial.";
 
   let arguments = (ins
-    Poly:$x,
+    Polynomial:$x,
     Index:$index
   );
 
@@ -100,34 +75,37 @@ def Poly_GetCoeffOp : Poly_Op<"get_coeff"> {
   );
 }
 
-def Poly_ExtractSliceOp : Poly_Op<"extract_slice"> {
-  let summary = "Extracts a slice of coefficients from X^i to X^j inclusive.";
+def Poly_ExtractSliceOp : Poly_Op<"extract_slice", [Pure, InferTypeOpAdaptor]> {
+  let summary = "Extracts a slice of coefficients from X^i to X^j.";
 
-  let arguments = (ins
-    Poly:$x,
-    Index:$i,
-    Index:$j
-  );
+  let description = [{
+    Extracts a slice of coefficients from X^i to X^j.
 
-  let results = (outs
-    TensorOf<[AnyInteger]>:$output
-  );
+    The included range includes `i`, but excludes `j`, similar to array slice
+    semantics.
+
+    The coefficients are returned in the order they appear in the polynomial,
+    from smallest degree to largest degree
+
+  }];
+  let arguments = (ins Polynomial:$input, Index:$i, Index:$j);
+  let results = (outs TensorOf<[AnyInteger]>:$output);
 }
 
 //===----------------------------------------------------------------------===//
 // Poly generation operations.
 //===----------------------------------------------------------------------===//
 
-def Poly_PolyFromCoeffsOp : Poly_Op<"from_coeffs"> {
-  let summary = "Creates a Polynomial from integer coeffs.";
+def Poly_PolyFromCoeffsOp : Poly_Op<"from_coeffs", [Pure]> {
+  let summary = "Creates a Polynomial from integer coefficients stored in a tensor.";
+  let arguments = (ins TensorOf<[AnyInteger]>:$input);
+  let results = (outs Polynomial:$output);
 
-  let arguments = (ins
-    TensorOf<[AnyInteger]>:$x
-  );
-
-  let results = (outs
-    Poly:$output
-  );
+  let builders = [
+    // Builder that infers coefficient modulus from tensor bit width,
+    // and uses whatever input ring is provided by the caller.
+    OpBuilder<(ins "::mlir::Value":$input, "RingAttr":$ring)>
+  ];
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYOPS_TD_

--- a/include/Dialect/Poly/IR/PolyTypes.td
+++ b/include/Dialect/Poly/IR/PolyTypes.td
@@ -13,13 +13,15 @@ class Poly_Type<string name, string typeMnemonic>
   let mnemonic = typeMnemonic;
 }
 
-def Poly : Poly_Type<"Polynomial", "poly"> {
-  let summary = "Polynomial represents an element of a polynomial quotient ring";
+def Polynomial : Poly_Type<"Polynomial", "poly"> {
+  let summary = "An element of a polynomial quotient ring";
 
   let description = [{
     A type for polynomials in a polynomial quotient ring.
   }];
 
+  let parameters = (ins Ring_Attr:$ring);
+  let assemblyFormat = "`<` $ring `>`";
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYTYPES_TD_

--- a/lib/Conversion/PolyToStandard/BUILD
+++ b/lib/Conversion/PolyToStandard/BUILD
@@ -1,0 +1,26 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "PolyToStandard",
+    srcs = ["PolyToStandard.cpp"],
+    hdrs = [
+        "@heir//include/Conversion/PolyToStandard:PolyToStandard.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Conversion/PolyToStandard:pass_inc_gen",
+        "@heir//lib/Dialect/Poly/IR:PolyOps",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:FuncTransforms",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)

--- a/lib/Conversion/PolyToStandard/PolyToStandard.cpp
+++ b/lib/Conversion/PolyToStandard/PolyToStandard.cpp
@@ -1,0 +1,113 @@
+#include "include/Conversion/PolyToStandard/PolyToStandard.h"
+
+#include "include/Dialect/Poly/IR/PolyOps.h"
+#include "include/Dialect/Poly/IR/PolyTypes.h"
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Utils/StructuredOpsUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace poly {
+
+#define GEN_PASS_DEF_POLYTOSTANDARD
+#include "include/Conversion/PolyToStandard/PolyToStandard.h.inc"
+
+class PolyToStandardTypeConverter : public TypeConverter {
+ public:
+  PolyToStandardTypeConverter(MLIRContext *ctx) {
+    addConversion([](Type type) { return type; });
+    addConversion([ctx](PolynomialType type) -> Type {
+      RingAttr attr = type.getRing();
+      uint32_t idealDegree = attr.ideal().getDegree();
+      IntegerType elementTy =
+          IntegerType::get(ctx, attr.coefficientModulus().getBitWidth(),
+                           IntegerType::SignednessSemantics::Unsigned);
+      return RankedTensorType::get({idealDegree}, elementTy, attr);
+    });
+
+    // We don't include any custom materialization ops because this lowering is
+    // all done in a single pass. The dialect conversion framework works by
+    // resolving intermediate (mid-pass) type conflicts by inserting
+    // unrealized_conversion_cast ops, and only converting those to custom
+    // materializations if they persist at the end of the pass. In our case,
+    // we'd only need to use custom materializations if we split this lowering
+    // across multiple passes.
+  }
+};
+
+struct ConvertPolyFromCoeffs : public OpConversionPattern<PolyFromCoeffsOp> {
+  ConvertPolyFromCoeffs(mlir::MLIRContext *context)
+      : OpConversionPattern<PolyFromCoeffsOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      PolyFromCoeffsOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, adaptor.getOperands()[0]);
+    return success();
+  }
+};
+
+struct ConvertAdd : public OpConversionPattern<AddOp> {
+  ConvertAdd(mlir::MLIRContext *context)
+      : OpConversionPattern<AddOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      AddOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // TODO(https://github.com/google/heir/issues/104): implement
+    return failure();
+  }
+};
+
+struct ConvertMul : public OpConversionPattern<MulOp> {
+  ConvertMul(mlir::MLIRContext *context)
+      : OpConversionPattern<MulOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      MulOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // TODO(https://github.com/google/heir/issues/104): implement
+    return success();
+  }
+};
+
+struct PolyToStandard : impl::PolyToStandardBase<PolyToStandard> {
+  using PolyToStandardBase::PolyToStandardBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto *module = getOperation();
+    ConversionTarget target(*context);
+    PolyToStandardTypeConverter typeConverter(context);
+
+    // target.addIllegalDialect<PolyDialect>();
+    target.addIllegalOp<PolyFromCoeffsOp>();
+    // target.addIllegalOp<AddOp>();
+    // target.addIllegalOp<MulOp>();
+
+    // TODO(https://github.com/google/heir/issues/105): add upstream type
+    // converters for func/call/return
+
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertPolyFromCoeffs>(typeConverter, context);
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace poly
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Poly/IR/BUILD
+++ b/lib/Dialect/Poly/IR/BUILD
@@ -19,6 +19,7 @@ cc_library(
     includes = ["@heir//include"],
     deps = [
         ":PolyAttributes",
+        ":PolyOps",
         ":Polynomial",
         "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
         "@heir//include/Dialect/Poly/IR:dialect_inc_gen",
@@ -47,6 +48,27 @@ cc_library(
         "@llvm-project//mlir:AsmParser",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "PolyOps",
+    srcs = [
+        "PolyOps.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Poly/IR:PolyDialect.h",
+        "@heir//include/Dialect/Poly/IR:PolyOps.h",
+        "@heir//include/Dialect/Poly/IR:PolyTypes.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        ":PolyAttributes",
+        "@heir//include/Dialect/Poly/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Poly/IR:ops_inc_gen",
+        "@heir//include/Dialect/Poly/IR:types_inc_gen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
     ],
 )
 

--- a/lib/Dialect/Poly/IR/PolyAttributes.cpp
+++ b/lib/Dialect/Poly/IR/PolyAttributes.cpp
@@ -126,6 +126,7 @@ mlir::Attribute mlir::heir::poly::PolynomialAttr::parse(AsmParser &parser,
     }
   }
 
+  // insert necessary constant ops to give as input to extract_slice.
   if (variables.size() > 1) {
     std::string vars = llvm::join(variables.begin(), variables.end(), ", ");
     parser.emitError(

--- a/lib/Dialect/Poly/IR/PolyOps.cpp
+++ b/lib/Dialect/Poly/IR/PolyOps.cpp
@@ -1,0 +1,33 @@
+#include "include/Dialect/Poly/IR/PolyOps.h"
+
+namespace mlir {
+namespace heir {
+namespace poly {
+
+LogicalResult ExtractSliceOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location,
+    ExtractSliceOpAdaptor adaptor, SmallVectorImpl<Type> &inferredReturnTypes) {
+  PolynomialType polyType =
+      llvm::dyn_cast<PolynomialType>(adaptor.getInput().getType());
+  RingAttr attr = polyType.getRing();
+  uint32_t idealDegree = attr.ideal().getDegree();
+  IntegerType elementTy =
+      IntegerType::get(context, attr.coefficientModulus().getBitWidth(),
+                       IntegerType::SignednessSemantics::Unsigned);
+  Type resultType = RankedTensorType::get({idealDegree}, elementTy, attr);
+  inferredReturnTypes.assign({resultType});
+  return success();
+}
+
+void PolyFromCoeffsOp::build(OpBuilder &builder, OperationState &result,
+                             Value input, RingAttr ring) {
+  TensorType tensorType = dyn_cast<TensorType>(input.getType());
+  APInt cmod(APINT_BIT_WIDTH, 1);
+  cmod = cmod << tensorType.getElementTypeBitWidth();
+  Type resultType = PolynomialType::get(builder.getContext(), ring);
+  build(builder, result, resultType, input);
+}
+
+}  // namespace poly
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Poly/IR/Polynomial.cpp
+++ b/lib/Dialect/Poly/IR/Polynomial.cpp
@@ -21,49 +21,53 @@ Polynomial Polynomial::fromMonomials(ArrayRef<Monomial> monomials,
   };
 
   // A polynomial's terms are canonically stored in order of increasing degree.
-  llvm::OwningArrayRef<Monomial> monomials_copy =
+  llvm::OwningArrayRef<Monomial> monomialsCopy =
       llvm::OwningArrayRef<Monomial>(monomials);
-  std::sort(monomials_copy.begin(), monomials_copy.end());
+  std::sort(monomialsCopy.begin(), monomialsCopy.end());
 
   StorageUniquer &uniquer = context->getAttributeUniquer();
   return Polynomial(uniquer.get<detail::PolynomialStorage>(
-      assignCtx, monomials.size(), monomials_copy));
+      assignCtx, monomials.size(), monomialsCopy));
 }
 
 Polynomial Polynomial::fromCoefficients(ArrayRef<int64_t> coeffs,
                                         MLIRContext *context) {
   std::vector<Monomial> monomials;
   for (size_t i = 0; i < coeffs.size(); i++) {
-    monomials.push_back(Monomial(coeffs[i], i));
+    monomials.emplace_back(coeffs[i], i);
   }
-  return Polynomial::fromMonomials(std::move(monomials), context);
+  return Polynomial::fromMonomials(monomials, context);
 }
 
 void Polynomial::print(raw_ostream &os) const {
   bool first = true;
-  for (auto term : terms->terms()) {
+  for (const auto &term : terms->terms()) {
     if (first) {
       first = false;
     } else {
       os << " + ";
     }
-    std::string coeff_to_print;
+    std::string coeffToPrint;
     if (term.coefficient == 1 && term.exponent.uge(1)) {
-      coeff_to_print = "";
+      coeffToPrint = "";
     } else {
-      llvm::SmallString<512> coeff_string;
-      term.coefficient.toStringSigned(coeff_string);
-      coeff_to_print = coeff_string.str();
+      llvm::SmallString<512> coeffString;
+      term.coefficient.toStringSigned(coeffString);
+      coeffToPrint = coeffString.str();
     }
 
     if (term.exponent == 0) {
-      os << coeff_to_print;
+      os << coeffToPrint;
     } else if (term.exponent == 1) {
-      os << coeff_to_print << "x";
+      os << coeffToPrint << "x";
     } else {
-      os << coeff_to_print << "x**" << term.exponent;
+      os << coeffToPrint << "x**" << term.exponent;
     }
   }
+}
+
+unsigned Polynomial::getDegree() const {
+  return terms->terms().back().exponent.getSExtValue();
 }
 
 }  // end namespace poly

--- a/tests/poly/BUILD
+++ b/tests/poly/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/poly/lower_poly.mlir
+++ b/tests/poly/lower_poly.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --lower-poly %s > %t
+// RUN: FileCheck %s < %t
+
+#cycl_2048 = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
+module {
+  func.func @test_lower_from_coeffs() {
+    %c0 = arith.constant 0 : index
+    // 2 + 2x + 5x^2
+    %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
+    // CHECK-NOT: poly.from_coeffs
+    %poly = poly.from_coeffs(%coeffs) : (tensor<3xi32>) -> !poly.poly<#ring>
+    return
+  }
+}

--- a/tests/poly/poly_ops.mlir
+++ b/tests/poly/poly_ops.mlir
@@ -16,12 +16,12 @@ module {
     %coeffs1 = tensor.from_elements %two, %two, %five : tensor<3xi32>
     %coeffs2 = tensor.from_elements %five, %five, %two : tensor<3xi32>
 
-    %poly1 = poly.from_coeffs(%coeffs1) : (tensor<3xi32>) -> !poly.poly
-    %poly2 = poly.from_coeffs(%coeffs2) : (tensor<3xi32>) -> !poly.poly
+    %poly1 = poly.from_coeffs(%coeffs1) : (tensor<3xi32>) -> !poly.poly<#ring1>
+    %poly2 = poly.from_coeffs(%coeffs2) : (tensor<3xi32>) -> !poly.poly<#ring1>
 
     // CHECK: #poly.ring<cmod=2837465, ideal=#poly.polynomial<1 + x**1024>>
-    %3 = poly.mul(%poly1, %poly2) {ring = #ring1} : !poly.poly
-    %4 = poly.get_coeff(%3, %c0) : (!poly.poly, index) -> i32
+    %3 = poly.mul(%poly1, %poly2) {ring = #ring1} : !poly.poly<#ring1>
+    %4 = poly.get_coeff(%3, %c0) : (!poly.poly<#ring1>, index) -> i32
 
     return %4 : i32
   }

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -13,6 +13,7 @@ cc_binary(
     deps = [
         "@heir//lib/Conversion/MemrefToArith:ExpandCopy",
         "@heir//lib/Conversion/MemrefToArith:MemrefToArithRegistration",
+        "@heir//lib/Conversion/PolyToStandard",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/EncryptedArith/IR:Dialect",
         "@heir//lib/Dialect/Poly/IR:Dialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -1,4 +1,5 @@
 #include "include/Conversion/MemrefToArith/MemrefToArith.h"
+#include "include/Conversion/PolyToStandard/PolyToStandard.h"
 #include "include/Dialect/BGV/IR/BGVDialect.h"
 #include "include/Dialect/EncryptedArith/IR/EncryptedArithDialect.h"
 #include "include/Dialect/Poly/IR/PolyDialect.h"
@@ -86,6 +87,9 @@ int main(int argc, char **argv) {
 
   // Register MLIR core passes to build pipeline.
   mlir::registerAllPasses();
+
+  // Custom passes in HEIR
+  mlir::heir::poly::registerPolyToStandardPasses();
 
   mlir::PassPipelineRegistration<>(
       "heir-tosa-to-arith",


### PR DESCRIPTION
This PR makes slight improvements to the poly types by adding a ring attribute, makes small modifications to the poly ops by changing them to binary ops instead of variadic, and then implements the shell of a `lower-poly` pass that will lower to linalg + standard MLIR, with an eye towards lowering fully to LLVM.

I want to get this incomplete shell checked in to ease the review burden, and start collaborating with the details of the pass with other contributors.