### PR TITLE
Add BGVToPoly converter

### DIFF
--- a/include/Conversion/BGVToPoly/BGVToPoly.h
+++ b/include/Conversion/BGVToPoly/BGVToPoly.h
@@ -1,0 +1,16 @@
+#ifndef HEIR_INCLUDE_CONVERSION_BGVTOPOLY_BGVTOPOLY_H_
+#define HEIR_INCLUDE_CONVERSION_BGVTOPOLY_BGVTOPOLY_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir::heir::bgv {
+
+#define GEN_PASS_DECL
+#include "include/Conversion/BGVToPoly/BGVToPoly.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "include/Conversion/BGVToPoly/BGVToPoly.h.inc"
+
+}  // namespace mlir::heir::bgv
+
+#endif  // HEIR_INCLUDE_CONVERSION_BGVTOPOLY_BGVTOPOLY_H_

--- a/include/Conversion/BGVToPoly/BGVToPoly.td
+++ b/include/Conversion/BGVToPoly/BGVToPoly.td
@@ -1,0 +1,20 @@
+#ifndef HEIR_INCLUDE_CONVERSION_BGVTOPOLY_BGVTOPOLY_TD_
+#define HEIR_INCLUDE_CONVERSION_BGVTOPOLY_BGVTOPOLY_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def BGVToPoly : Pass<"bgv-to-poly"> {
+  let summary = "Lower `bgv` to `poly` dialect.";
+
+  let description = [{
+    This pass lowers the `bgv` dialect to `poly` dialect.
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::bgv::BGVDialect",
+    "mlir::heir::poly::PolyDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
+#endif  // HEIR_INCLUDE_CONVERSION_BGVTOPOLY_BGVTOPOLY_TD_

--- a/include/Conversion/BGVToPoly/BUILD
+++ b/include/Conversion/BGVToPoly/BUILD
@@ -1,0 +1,37 @@
+# BGVToPoly tablegen and headers.
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "BGVToPoly.h",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=BGVToPoly",
+            ],
+            "BGVToPoly.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "BGVToPoly.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "BGVToPoly.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/include/Dialect/BGV/IR/BGVOps.td
+++ b/include/Dialect/BGV/IR/BGVOps.td
@@ -116,7 +116,7 @@ def BGV_Relinearize : BGV_Op<"relinearize"> {
   );
 }
 
-def BGV_ModulusSwitch : BGV_Op<"modulus_switch", [SameOperandsAndResultType]> {
+def BGV_ModulusSwitch : BGV_Op<"modulus_switch"> {
   // This must be validated against the BGV ring parameter.
   let summary = "Lower the modulus level of the ciphertext.";
 
@@ -129,8 +129,6 @@ def BGV_ModulusSwitch : BGV_Op<"modulus_switch", [SameOperandsAndResultType]> {
   let results = (outs
     Ciphertext:$output
   );
-
-  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVOPS_TD_

--- a/include/Dialect/BGV/IR/BGVTypes.td
+++ b/include/Dialect/BGV/IR/BGVTypes.td
@@ -32,15 +32,18 @@ def Ciphertext : BGV_Type<"Ciphertext", "ciphertext"> {
 
     For example, `bgv.ciphertext<rings=#rings, dim=3>` is a ciphertext with 3
     polynomials (c_0, c_1, c_2).
+
+    The optional attribute `level` specifies the "current ring".
   }];
 
   // TODO(https://github.com/google/heir/issues/99): Add # of plaintext bits.
   let parameters = (ins
     BGVRingArrayAttr:$rings,
-    DefaultValuedParameter<"unsigned", "2">:$dim
+    DefaultValuedParameter<"unsigned", "2">:$dim,
+    OptionalParameter<"std::optional<uint64_t>">:$level
   );
 
-  let assemblyFormat = "`<` `rings` `=` $rings (`,` `dim` `=` $dim^ )? `>`";
+  let assemblyFormat = "`<` `rings` `=` $rings (`,` `dim` `=` $dim^ )? (`,` `level` `=` $level^ )? `>`";
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVTYPES_TD_

--- a/lib/Conversion/BGVToPoly/BGVToPoly.cpp
+++ b/lib/Conversion/BGVToPoly/BGVToPoly.cpp
@@ -1,0 +1,86 @@
+#include "include/Conversion/BGVToPoly/BGVToPoly.h"
+
+#include <cstddef>
+#include <optional>
+
+#include "include/Dialect/BGV/IR/BGVDialect.h"
+#include "include/Dialect/BGV/IR/BGVTypes.h"
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+#include "include/Dialect/Poly/IR/PolyTypes.h"
+#include "include/Dialect/Poly/IR/Polynomial.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/OneToNFuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+namespace mlir::heir::bgv {
+
+#define GEN_PASS_DEF_BGVTOPOLY
+#include "include/Conversion/BGVToPoly/BGVToPoly.h.inc"
+
+class CiphertextTypeConverter : public TypeConverter {
+ public:
+  // Convert ciphertext to tensor<#dim x !poly.poly<#rings[#level]>>
+  CiphertextTypeConverter(MLIRContext *ctx) {
+    addConversion([](Type type) { return type; });
+    addConversion([ctx](CiphertextType type) -> Type {
+      assert(type.getLevel().has_value());
+      auto level = type.getLevel().value();
+      assert(level < type.getRings().getRings().size());
+
+      auto ring = type.getRings().getRings()[level];
+      auto polyTy = poly::PolynomialType::get(ctx, ring);
+
+      return RankedTensorType::get({type.getDim()}, polyTy);
+    });
+  }
+  // We don't include any custom materialization ops because this lowering is
+  // all done in a single pass. The dialect conversion framework works by
+  // resolving intermediate (mid-pass) type conflicts by inserting
+  // unrealized_conversion_cast ops, and only converting those to custom
+  // materializations if they persist at the end of the pass. In our case,
+  // we'd only need to use custom materializations if we split this lowering
+  // across multiple passes.
+};
+
+struct BGVToPoly : public impl::BGVToPolyBase<BGVToPoly> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto *module = getOperation();
+    CiphertextTypeConverter typeConverter(context);
+
+    ConversionTarget target(*context);
+    target.addLegalOp<ModuleOp>();
+
+    RewritePatternSet patterns(context);
+
+    // Add "standard" set of conversions and constraints for full dialect
+    // conversion. See Dialect/Func/Transforms/FuncBufferize.cpp for example.
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+             typeConverter.isLegal(&op.getBody());
+    });
+    populateCallOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::CallOp>(
+        [&](func::CallOp op) { return typeConverter.isLegal(op); });
+
+    populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
+    populateReturnOpTypeConversionPattern(patterns, typeConverter);
+    target.markUnknownOpDynamicallyLegal([&](Operation *op) {
+      return isNotBranchOpInterfaceOrReturnLikeOp(op) ||
+             isLegalForBranchOpInterfaceTypeConversionPattern(op,
+                                                              typeConverter) ||
+             isLegalForReturnOpTypeConversionPattern(op, typeConverter);
+    });
+
+    // Run full conversion, if any BGV ops were missed out the pass will fail.
+    if (failed(applyFullConversion(module, target, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace mlir::heir::bgv

--- a/lib/Conversion/BGVToPoly/BUILD
+++ b/lib/Conversion/BGVToPoly/BUILD
@@ -1,0 +1,26 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "BGVToPoly",
+    srcs = ["BGVToPoly.cpp"],
+    hdrs = [
+        "@heir//include/Conversion/BGVToPoly:BGVToPoly.h",
+    ],
+    deps = [
+        "@heir//include/Conversion/BGVToPoly:pass_inc_gen",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/Poly/IR:Dialect",
+        "@heir//lib/Dialect/Poly/IR:Polynomial",
+        "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:FuncTransforms",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)

--- a/tests/bgv_ops.mlir
+++ b/tests/bgv_ops.mlir
@@ -13,7 +13,7 @@ module {
   func.func @test_multiply(%arg0 : !bgv.ciphertext<rings=#rings>, %arg1: !bgv.ciphertext<rings=#rings>) -> !bgv.ciphertext<rings=#rings> {
     %0 = bgv.mul(%arg0, %arg1) : !bgv.ciphertext<rings=#rings>, !bgv.ciphertext<rings=#rings> -> !bgv.ciphertext<rings=#rings, dim=3>
     %1 = bgv.relinearize(%0) {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!bgv.ciphertext<rings=#rings, dim=3>) -> !bgv.ciphertext<rings=#rings>
-    %2 = bgv.modulus_switch(%1) {from_level = 1, to_level=0} : !bgv.ciphertext<rings=#rings>
+    %2 = bgv.modulus_switch(%1) {from_level = 1, to_level=0} : (!bgv.ciphertext<rings=#rings>) -> !bgv.ciphertext<rings=#rings, dim=2, level=0>
     // CHECK: <<cmod=463187969, ideal=#poly.polynomial<1 + x**1024>>, <cmod=33538049, ideal=#poly.polynomial<1 + x**1024>>>
     return %arg0 : !bgv.ciphertext<rings=#rings>
   }

--- a/tests/bgv_to_poly.mlir
+++ b/tests/bgv_to_poly.mlir
@@ -1,0 +1,18 @@
+// RUN: heir-opt --bgv-to-poly %s > %t
+// RUN: FileCheck %s < %t
+
+// This simply tests for syntax.
+
+#my_poly = #poly.polynomial<1 + x**1024>
+#ring1 = #poly.ring<cmod=463187969, ideal=#my_poly>
+#ring2 = #poly.ring<cmod=33538049, ideal=#my_poly>
+#rings = #bgv.rings<#ring1, #ring2>
+
+// CHECK: module
+module {
+  // CHECK: func.func @test_fn([[X:%.+]]: [[T:tensor<2x!poly.*33538049.*]]) -> [[T]] {
+  func.func @test_fn(%x : !bgv.ciphertext<rings=#rings, dim=2, level=1>) -> !bgv.ciphertext<rings=#rings, dim=2, level=1> {
+    // CHECK: return [[X]] : [[T]]
+    return %x : !bgv.ciphertext<rings=#rings, dim=2, level=1>
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -11,6 +11,7 @@ cc_binary(
     srcs = ["heir-opt.cpp"],
     includes = ["include"],
     deps = [
+        "@heir//lib/Conversion/BGVToPoly",
         "@heir//lib/Conversion/MemrefToArith:ExpandCopy",
         "@heir//lib/Conversion/MemrefToArith:MemrefToArithRegistration",
         "@heir//lib/Conversion/PolyToStandard",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -1,3 +1,4 @@
+#include "include/Conversion/BGVToPoly/BGVToPoly.h"
 #include "include/Conversion/MemrefToArith/MemrefToArith.h"
 #include "include/Conversion/PolyToStandard/PolyToStandard.h"
 #include "include/Dialect/BGV/IR/BGVDialect.h"
@@ -94,6 +95,7 @@ int main(int argc, char **argv) {
 
   // Custom passes in HEIR
   mlir::heir::poly::registerPolyToStandardPasses();
+  mlir::heir::bgv::registerBGVToPolyPasses();
 
   mlir::PassPipelineRegistration<>(
       "heir-tosa-to-arith",


### PR DESCRIPTION
Add BGVToPoly converter

Add BGVToPoly one-shot-pass.
Add optional ciphertext attribute `level` to specify "current ring".
Convert BGV ciphertext to `tensor<#dim x !poly.poly<#rings[#level]>>`.
Perform only function signature conversion.

**Before** implementation of `BGV_Op` conversion the `ElementwiseMappable`
trait will need to be added to some `Poly_Op` to simpify converted IR.
Will be done as a follow up action.