### PR TITLE
Add LWE dialect

### DIFF
--- a/include/Dialect/LWE/IR/BUILD
+++ b/include/Dialect/LWE/IR/BUILD
@@ -1,0 +1,134 @@
+# LWE, a dialect defining the LWE cryptosystem.
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "LWEDialect.h",
+        "LWEOps.h",
+        "LWETypes.h",
+        "LWEAttributes.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "LWEAttributes.td",
+        "LWEDialect.td",
+        "LWEOps.td",
+        "LWETypes.td",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "LWEDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "LWEDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWEDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-typedef-decls",
+            ],
+            "LWETypes.h.inc",
+        ),
+        (
+            [
+                "-gen-typedef-defs",
+            ],
+            "LWETypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "LWETypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWETypes.td",
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "LWEOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "LWEOps.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWEOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+    ],
+)
+
+gentbl_cc_library(
+    name = "attributes_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-attrdef-decls",
+            ],
+            "LWEAttributes.h.inc",
+        ),
+        (
+            [
+                "-gen-attrdef-defs",
+            ],
+            "LWEAttributes.cpp.inc",
+        ),
+        (
+            ["-gen-attrdef-doc"],
+            "LWEAttributes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWEAttributes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)

--- a/include/Dialect/LWE/IR/LWEAttributes.h
+++ b/include/Dialect/LWE/IR/LWEAttributes.h
@@ -1,0 +1,12 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_
+
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+
+// Required to pull in poly's Ring_Attr
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWEAttributes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_

--- a/include/Dialect/LWE/IR/LWEAttributes.td
+++ b/include/Dialect/LWE/IR/LWEAttributes.td
@@ -1,0 +1,74 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_
+
+include "LWEDialect.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/IR/OpBase.td"
+
+class LWE_Attr<string attrName, string attrMnemonic>
+    : AttrDef<LWE_Dialect, attrName> {
+  let mnemonic = attrMnemonic;
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+// TODO: should this live in a dedicated noise analysis dialect so it can be
+// easily reused?
+def GaussianAttr : LWE_Attr<"Gaussian", "gaussian"> {
+  let summary = "An attribute describing a Gaussian distribution over integers.";
+  let description = [{
+    This attribute describes a symmetric Gaussian distribution used in LWE
+    for generating random noise that hides messages.
+
+    The distribution is parameterized by a bit width $B$, representing the
+    domain of the distribution, the unsigned integers
+    $\mathbb{Z}/B\mathbb{Z}$, and an integer standard deviation. The
+    distribution is centered at zero.
+
+    Examples:
+
+    ```
+    #lwe_noise = #lwe.gaussian<domain_bitwidth=32, stdev=16384>
+    ```
+  }];
+
+  let parameters = (ins
+    "unsigned":$domain_bitwidth,
+    "unsigned":$stdev
+  );
+}
+
+def LWEEncodingSchemeAttr : LWE_Attr<"LWEEncodingScheme", "encoding_scheme"> {
+  let summary = "An attribute describing how cleartexts are encoded into LWE plaintexts.";
+  let description = [{
+    This attribute contains the parameters of an encoding scheme for LWE.
+    An encoding describes the bit width of the plaintext, the number of
+    high-order bits reserved for padding, the number of bits to reserve
+    for the message. The number of bits reserved for noise is equal to
+    the difference of the plaintext bitwidth and the sum of padding and
+    cleartext bitwidths, and is always stored in the least significant
+    bits of the plaintext.
+
+    Examples:
+
+    ```
+    #lwe_encoding = #lwe.encoding_scheme<
+      plaintext_bitwidth=32,
+      padding_bitwidth=1,
+      cleartext_bitwidth=3>
+    ```
+  }];
+  let parameters = (ins
+    "unsigned":$plaintext_bitwidth,
+    "unsigned":$padding_bitwidth,
+    "unsigned":$cleartext_bitwidth
+  );
+
+  // Verifier ensures plaintext is large enough to fit the padding and
+  // cleartext
+  let genVerifyDecl = 1;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_

--- a/include/Dialect/LWE/IR/LWEDialect.h
+++ b/include/Dialect/LWE/IR/LWEDialect.h
@@ -1,0 +1,12 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "include/Dialect/LWE/IR/LWEDialect.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_H_

--- a/include/Dialect/LWE/IR/LWEDialect.td
+++ b/include/Dialect/LWE/IR/LWEDialect.td
@@ -1,0 +1,23 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def LWE_Dialect : Dialect {
+  let name = "lwe";
+  let summary = "A dialect for the Learning With Errors (LWE) cryptosystem";
+  let description = [{
+    The `lwe` dialect defines the types and operations of the Learning With
+    Errors (LWE) cryptosystem.
+
+    See [Wikipedia](https://en.wikipedia.org/wiki/Learning_with_errors) for an
+    overview of LWE.
+  }];
+
+  let cppNamespace = "::mlir::heir::lwe";
+
+  let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_TD_

--- a/include/Dialect/LWE/IR/LWEOps.h
+++ b/include/Dialect/LWE/IR/LWEOps.h
@@ -1,0 +1,15 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_H_
+
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+#include "include/Dialect/LWE/IR/LWETypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "include/Dialect/LWE/IR/LWEOps.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_H_

--- a/include/Dialect/LWE/IR/LWEOps.td
+++ b/include/Dialect/LWE/IR/LWEOps.td
@@ -1,0 +1,109 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_TD_
+
+include "LWEDialect.td"
+include "LWETypes.td"
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+class LWE_Op<string mnemonic, list<Trait> traits = []> :
+        Op<LWE_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    `(` operands `)` attr-dict `:`  `(` qualified(type(operands)) `)` `->` qualified(type(results))
+  }];
+  let cppNamespace = "::mlir::heir::lwe";
+}
+
+class LWE_BinOp<string mnemonic> : LWE_Op<mnemonic, [Pure, Commutative, SameOperandsAndResultType]> {
+  let arguments = (ins Ciphertext:$lhs, Ciphertext:$rhs);
+  let results = (outs Ciphertext:$output);
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+}
+
+def LWE_AddOp : LWE_BinOp<"add"> { let summary = "Addition of two ciphertexts."; }
+def LWE_SubOp : LWE_BinOp<"sub"> { let summary = "Subition of two ciphertexts."; }
+
+def LWE_NegateOp : LWE_Op<"negate", [Pure, Involution, SameOperandsAndResultType]> {
+  let summary = "Negate the coefficients of the ciphertext.";
+  let arguments = (ins Ciphertext:$input);
+  let results = (outs Ciphertext:$output);
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+}
+
+def LWE_ScaleOP : LWE_Op<"scale", [Pure]> {
+  let summary = "Scale the input ciphertext by a constant.";
+  let arguments = (ins Ciphertext:$input, AnyInteger:$scale_by);
+  let results = (outs Ciphertext:$output);
+}
+
+def LWE_ModulusSwitchOp : LWE_Op<"modulus_switch", [Pure]> {
+  let summary = "Switch the modulus of the ciphertext.";
+  let description = [{
+  Switch the plaintext modulus of an LWE ciphertext.
+
+  This operation increases the noise in an LWE ciphertext relative to its new
+  modulus. The output ciphertext receives a different LWEEncodingScheme
+  attribute to reflect the new modulus.
+
+  For more details, see https://jeremykun.com/2022/07/16/modulus-switching-in-lwe/
+  }];
+  let arguments = (ins Ciphertext:$input, IndexAttr:$from_log_modulus, IndexAttr:$to_log_modulus);
+  let results = (outs Ciphertext:$output);
+  let assemblyFormat = "`(` $input `)` attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+  let hasVerifier = 1;
+}
+
+def LWE_KeySwitchOp : LWE_Op<"key_switch", [Pure]> {
+  let summary = "Switch the secret key of an LWE ciphertext.";
+  let description = [{
+  Switch the secret key of an LWE ciphertext.
+
+  This operation increases the noise in an LWE ciphertext. The keys to switch
+  between are inferred from the input and output attributes. The output may
+  receive a different LWEEncodingScheme attribute to reflect the parameters of
+  the encoding scheme of the output secret key.
+
+  For more details, see https://jeremykun.com/2022/08/29/key-switching-in-lwe/
+  }];
+
+  let arguments = (ins Ciphertext:$input);
+  let results = (outs Ciphertext:$output);
+  let assemblyFormat = "`(` $input `)` attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+}
+
+def LWE_EncodeOp : LWE_Op<"encode", [Pure]> {
+  let summary = "Encode the input cleartext as an LWE plaintext";
+  let arguments = (ins AnyInteger:$input);
+  let results = (outs Plaintext:$output);
+  let assemblyFormat = "`(` $input `)` attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+}
+
+def LWE_DecodeOp : LWE_Op<"decode", [Pure]> {
+  let summary = "Decode the input LWE plaintext as a cleartext";
+  let arguments = (ins Plaintext:$input);
+  let results = (outs AnyInteger:$output);
+  let assemblyFormat = "`(` $input `)` attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+}
+
+def LWE_EncryptOp : LWE_Op<"encrypt", [Pure]> {
+  let summary = "Encrypt an LWE plaintext";
+  let description = [{
+  Encrypt an LWE plaintext.
+
+  The secret key to encrypt with is inferred from the output type.
+  }];
+
+  let arguments = (ins Plaintext:$input);
+  let results = (outs Ciphertext:$output);
+  let assemblyFormat = "`(` $input `)` attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+}
+
+def LWE_DecryptOp : LWE_Op<"decrypt", [Pure]> {
+  let summary = "Decrypt an LWE ciphertext";
+  let arguments = (ins Ciphertext:$input);
+  let results = (outs Plaintext:$output);
+  let assemblyFormat = "`(` $input `)` attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_TD_

--- a/include/Dialect/LWE/IR/LWETypes.h
+++ b/include/Dialect/LWE/IR/LWETypes.h
@@ -1,0 +1,13 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_H_
+
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+
+// Required to pull in poly's Ring_Attr
+#include "include/Dialect/Poly/IR/PolyAttributes.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWETypes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_H_

--- a/include/Dialect/LWE/IR/LWETypes.td
+++ b/include/Dialect/LWE/IR/LWETypes.td
@@ -1,0 +1,73 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_
+
+include "LWEDialect.td"
+include "LWEAttributes.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class LWE_Type<string name, string typeMnemonic> : TypeDef<LWE_Dialect, name> {
+  let mnemonic = typeMnemonic;
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+def Plaintext : LWE_Type<"Plaintext", "plaintext"> {
+  let summary = "A type for an encoded LWE plaintext";
+  let description = [{
+    `lwe.plaintext` represents a plaintext value encoding a cleartext.
+
+    Example:
+
+    ```
+    #encoding = #lwe.encoding_scheme<
+      plaintext_bitwidth=32,
+      padding_bitwidth=1,
+      cleartext_bitwidth=3>
+    %0 = !lwe.plaintext<encoing_scheme=#encoding>
+    ```
+  }];
+  let parameters = (ins LWEEncodingSchemeAttr:$encoding_scheme);
+}
+
+// TODO: add an optional noise attribute to track noise
+def Ciphertext : LWE_Type<"Ciphertext", "ciphertext"> {
+  let summary = "A type for LWE Ciphertext";
+
+  let description = [{
+    `lwe.ciphertext` represents an encrypted LWE ciphertext.
+
+    This type tracks the LWE ciphertext parameters, including the ciphertext
+    dimension (the number of LWE samples) and the underlying encoding scheme of
+    the plaintext. This type lowers to a 1-dimensional tensor of size
+    `dimension + 1`, where the extra value is the bias
+    $b = \sum_{i=1}^\textup{dimension} a_i s_i$.
+
+    The type is also parameterized by the secret key, as represented by a
+    program-unique integer attribute.
+
+    Example:
+
+    ```
+    #encoding = #lwe.encoding_scheme<
+      plaintext_bitwidth=32,
+      padding_bitwidth=1,
+      cleartext_bitwidth=3>
+    %0 = !lwe.ciphertext<encoing_scheme=#encoding, dimension=1024, secret_key=0>
+    ```
+  }];
+
+  let parameters = (ins
+    LWEEncodingSchemeAttr:$encoding_scheme,
+    "unsigned":$dimension,
+    // TODO: what else is needed to ensure secret key attributes are unique?
+    // e.g., should we have a verifier that ensures any two ciphertexts
+    // that have the same secretKey attribute have matching dimensions?
+    "unsigned":$secret_key
+  );
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -1,0 +1,29 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "LWEDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/LWE/IR:LWEAttributes.h",
+        "@heir//include/Dialect/LWE/IR:LWEDialect.h",
+        "@heir//include/Dialect/LWE/IR:LWEOps.h",
+        "@heir//include/Dialect/LWE/IR:LWETypes.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/LWE/IR:attributes_inc_gen",
+        "@heir//include/Dialect/LWE/IR:dialect_inc_gen",
+        "@heir//include/Dialect/LWE/IR:ops_inc_gen",
+        "@heir//include/Dialect/LWE/IR:types_inc_gen",
+        "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
+        "@heir//lib/Dialect/Poly/IR:PolyAttributes",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)

--- a/lib/Dialect/LWE/IR/LWEDialect.cpp
+++ b/lib/Dialect/LWE/IR/LWEDialect.cpp
@@ -1,0 +1,83 @@
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "include/Dialect/LWE/IR/LWEOps.h"
+#include "include/Dialect/LWE/IR/LWETypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated definitions
+#include "include/Dialect/LWE/IR/LWEDialect.cpp.inc"
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWEAttributes.cpp.inc"
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWETypes.cpp.inc"
+#define GET_OP_CLASSES
+#include "include/Dialect/LWE/IR/LWEOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+//===----------------------------------------------------------------------===//
+// LWE dialect.
+//===----------------------------------------------------------------------===//
+
+// Dialect construction: there is one instance per context and it registers its
+// operations, types, and interfaces here.
+void LWEDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "include/Dialect/LWE/IR/LWEAttributes.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "include/Dialect/LWE/IR/LWETypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "include/Dialect/LWE/IR/LWEOps.cpp.inc"
+      >();
+}
+
+LogicalResult LWEEncodingSchemeAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    unsigned int plaintextBitwidth, unsigned int paddingBitwidth,
+    unsigned int cleartextBitwidth) {
+  // It may be worth adding some sort of warning notification if the attribute
+  // allocates no bits for noise.
+  if (plaintextBitwidth < paddingBitwidth + cleartextBitwidth)
+    return emitError() << "Attribute's designated plaintext bitwidth ("
+                       << plaintextBitwidth
+                       << ") is too small to store both the cleartext ("
+                       << cleartextBitwidth << ") and padding ("
+                       << paddingBitwidth << ")";
+  return success();
+}
+
+LogicalResult ModulusSwitchOp::verify() {
+  uint64_t attrFromLogModulus = getFromLogModulus().getZExtValue();
+  uint64_t inputFromLogModulus =
+      getInput().getType().getEncodingScheme().getPlaintextBitwidth();
+  uint64_t attrToLogModulus = getToLogModulus().getZExtValue();
+  uint64_t inputToLogModulus =
+      getOutput().getType().getEncodingScheme().getPlaintextBitwidth();
+
+  if (attrFromLogModulus != inputFromLogModulus)
+    return emitOpError() << "Modulus switch input has plaintext bitwidth "
+                         << inputFromLogModulus
+                         << " but the from_log_modulus attr is "
+                         << attrFromLogModulus;
+
+  if (attrToLogModulus != inputToLogModulus)
+    return emitOpError() << "Modulus switch output has plaintext bitwidth "
+                         << inputToLogModulus
+                         << " but the to_log_modulus attr is "
+                         << attrToLogModulus;
+  return success();
+}
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/lwe/BUILD
+++ b/tests/lwe/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/lwe/syntax.mlir
+++ b/tests/lwe/syntax.mlir
@@ -1,0 +1,31 @@
+// RUN: heir-opt %s > %t
+
+// This simply tests for syntax.
+
+#lwe_noise = #lwe.gaussian<domain_bitwidth=32, stdev=16384>
+#encoding = #lwe.encoding_scheme<
+  plaintext_bitwidth=32,
+  padding_bitwidth=1,
+  cleartext_bitwidth=3>
+#mod_switched_encoding = #lwe.encoding_scheme<
+  plaintext_bitwidth=16,
+  padding_bitwidth=1,
+  cleartext_bitwidth=3>
+module {
+  func.func @test_syntax(
+      %arg0 : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>) {
+    %c_4 = arith.constant 4 : i32
+    %cleartext = arith.constant 6 : i3
+    %plaintext = lwe.encode(%cleartext) : i3 -> !lwe.plaintext<encoding_scheme=#encoding>
+    %arg1 = lwe.encrypt(%plaintext) : !lwe.plaintext<encoding_scheme=#encoding> -> !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>
+    %0 = lwe.add(%arg0, %arg1) : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>
+    %1 = lwe.sub(%arg0, %arg1) : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>
+    %2 = lwe.negate(%arg0) : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>
+    %3 = lwe.scale(%arg0, %c_4) : (!lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>, i32) -> !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0>
+    %4 = lwe.modulus_switch(%arg0) {from_log_modulus = 32 : index, to_log_modulus = 16 : index} : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0> -> !lwe.ciphertext<encoding_scheme=#mod_switched_encoding, dimension=1024, secret_key=0>
+    %5 = lwe.key_switch(%arg0) : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0> -> !lwe.ciphertext<encoding_scheme=#encoding, dimension=512, secret_key=1>
+    %6 = lwe.decrypt(%1) : !lwe.ciphertext<encoding_scheme=#encoding, dimension=1024, secret_key=0> -> !lwe.plaintext<encoding_scheme=#encoding>
+    %7 = lwe.decode(%6) : !lwe.plaintext<encoding_scheme=#encoding> -> i3
+    return
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,6 +17,7 @@ cc_binary(
         "@heir//lib/Conversion/PolyToStandard",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/EncryptedArith/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Poly/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/Secret/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -3,6 +3,7 @@
 #include "include/Conversion/PolyToStandard/PolyToStandard.h"
 #include "include/Dialect/BGV/IR/BGVDialect.h"
 #include "include/Dialect/EncryptedArith/IR/EncryptedArithDialect.h"
+#include "include/Dialect/LWE/IR/LWEDialect.h"
 #include "include/Dialect/Poly/IR/PolyDialect.h"
 #include "include/Dialect/Secret/IR/SecretDialect.h"
 #include "include/Dialect/Secret/Transforms/Passes.h"
@@ -76,6 +77,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registry.insert<mlir::heir::EncryptedArithDialect>();
   registry.insert<mlir::heir::bgv::BGVDialect>();
+  registry.insert<mlir::heir::lwe::LWEDialect>();
   registry.insert<mlir::heir::poly::PolyDialect>();
   registry.insert<mlir::heir::secret::SecretDialect>();
 


### PR DESCRIPTION
Branching off from the CGGI dialect, it felt too strange to implement all these types as CGGI specific. Plus, we want this too be a general toolchain for FHE writ large, so tying LWE to CGGI feels like a bad design decision.

Probably we will need to have the secret key be a proper type in this dialect. As I prototype it I'm putting the SK as an opaque integer attribute.