### PR TITLE
ci: add pull_ready label on PR approval for internal migration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
 # This is used by .github/workflows/pr_review.yml to apply the `pull_ready`
 # label to any root change when it has approval.
 pull_ready:
-- '*'
+- '**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# This is used by .github/workflows/pr_review.yml to apply the `pull_ready`
+# label to any root change when it has approval.
+pull_ready:
+- '*'

--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -34,3 +34,5 @@ jobs:
     steps:
       - name: Apply `pull ready` label
         uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # pin@v4
+        with:
+          dot: true

--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -1,0 +1,36 @@
+name: PR review status and labelling
+permissions: read-all
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  # We require a single commit, but only after the review process is complete and
+  # the PR has an Approval.
+  # This fails if there are multiple commits and the PR is approved.
+  # Otherwise, the PR is ready for internal migration, apply the `pull ready` label.
+  require-single-commit-on-approval:
+    if: ${{ github.event.review.state == 'approved' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+
+      - name: Assert single commit
+        env:
+          commits: ${{ github.event.pull_request.commits }}
+        run: |
+          if (( commits > 1 )); then
+            echo "::error::Expected approved PR to have a single commit, but found $commits. google/heir requires a single commit per PR because Google's internal/external synchronization tooling does not support squashing, and instead would rebase all commits into the main branch."
+            exit 1
+          fi
+
+  apply-pull-ready-label:
+    if: ${{ github.event.review.state == 'approved' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply `pull ready` label
+        uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # pin@v4

--- a/.github/workflows/pr_style.yml
+++ b/.github/workflows/pr_style.yml
@@ -4,22 +4,8 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
-  require-single-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
-
-      - name: Assert single commit
-        env:
-          commits: ${{ github.event.pull_request.commits }}
-        run: |
-          if (( commits > 1 )); then
-            echo "::error::Expected PR to have a single commit, but found $commits. google/heir requires a single commit per PR because Google's internal/external synchronization tooling does not support squashing, and instead would rebase all commits into the main branch."
-            exit 1
-          fi
-
   pre-commit-style:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/127

This PR adds a workflow that auto adds the `pull_ready` label on PR approval. The workflow will indicate failure if the PR is approved and not squashed into a single commit - this way, we don't check single commit until after the review is complete (I'm not sure we need the `squash ready` label since CI failure indicates this, so I'll update the docs once we test this process)