### PR TITLE
Add MathJax to docs

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -167,6 +167,11 @@ enable = false
   icon = "fab fa-github"
   desc = "Development takes place here!"
 
+
+[params.katex]
+  # Disable KaTeX in favor of MathJax
+  enable = false
+
 # hugo module configuration
 
 [module]

--- a/docs/layouts/partials/hooks/head-end.html
+++ b/docs/layouts/partials/hooks/head-end.html
@@ -1,0 +1,10 @@
+<!-- Import MathJax -->
+<script>
+window.MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']]
+  }
+};
+</script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
* Use Docsy hook to include MathJax3 script and configure it to handle `$inline$` math.
* Explicitly disable KaTeX rendering to avoid mixing both.

Fixes: #120 

Docsy [supports](https://www.docsy.dev/docs/adding-content/diagrams-and-formulae/ ) KaTeX out of the box. The matter of enabling it is just adding `math: true` to page front matter or enabling it site-wise.

<img width="897" alt="Screenshot 2023-09-01 at 1 35 36 PM" src="https://github.com/google/heir/assets/1387442/eb1157da-e500-4d5b-95e6-44986bf8dfe0">