### PR TITLE
Add `SameOperandsAndResultRings` trait to BGV ops

### DIFF
--- a/include/Dialect/BGV/IR/BGVOps.h
+++ b/include/Dialect/BGV/IR/BGVOps.h
@@ -3,6 +3,7 @@
 
 #include "include/Dialect/BGV/IR/BGVAttributes.h"
 #include "include/Dialect/BGV/IR/BGVDialect.h"
+#include "include/Dialect/BGV/IR/BGVTraits.h"
 #include "include/Dialect/BGV/IR/BGVTypes.h"
 #include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project

--- a/include/Dialect/BGV/IR/BGVOps.td
+++ b/include/Dialect/BGV/IR/BGVOps.td
@@ -8,6 +8,9 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 // TODO(https://github.com/google/heir/issues/101): Add verifiers for BGV ops.
+def SameOperandsAndResultRings:  NativeOpTrait<"SameOperandsAndResultRings"> {
+  let cppNamespace = "::mlir::heir::bgv";
+}
 
 class BGV_Op<string mnemonic, list<Trait> traits = []> :
         Op<BGV_Dialect, mnemonic, traits> {
@@ -52,7 +55,7 @@ def BGV_SubOp : BGV_Op<"sub", [SameOperandsAndResultType]> {
   let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
 }
 
-def BGV_MulOp : BGV_Op<"mul", [Commutative]> {
+def BGV_MulOp : BGV_Op<"mul", [Commutative, SameOperandsAndResultRings, SameTypeOperands]> {
   let summary = "Multiplication operation between ciphertexts.";
 
   let arguments = (ins
@@ -64,10 +67,10 @@ def BGV_MulOp : BGV_Op<"mul", [Commutative]> {
     Ciphertext:$output
   );
 
-  let assemblyFormat = "`(` operands `)` attr-dict `:` type($x)`,` type($y) `->` type($output)" ;
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($x) `->` type($output)" ;
 }
 
-def BGV_Rotate : BGV_Op<"rotate"> {
+def BGV_Rotate : BGV_Op<"rotate", [SameOperandsAndResultRings]> {
   let summary = "Rotate the coefficients of the ciphertext using a Galois automorphism.";
 
   let arguments = (ins
@@ -90,9 +93,11 @@ def BGV_Negate : BGV_Op<"negate", [SameOperandsAndResultType]> {
   let results = (outs
     Ciphertext:$output
   );
+
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
 }
 
-def BGV_Relinearize : BGV_Op<"relinearize"> {
+def BGV_Relinearize : BGV_Op<"relinearize", [SameOperandsAndResultRings]> {
   let summary = "Relinearize the ciphertext.";
 
   let description = [{
@@ -116,7 +121,7 @@ def BGV_Relinearize : BGV_Op<"relinearize"> {
   );
 }
 
-def BGV_ModulusSwitch : BGV_Op<"modulus_switch"> {
+def BGV_ModulusSwitch : BGV_Op<"modulus_switch", [SameOperandsAndResultRings]> {
   // This must be validated against the BGV ring parameter.
   let summary = "Lower the modulus level of the ciphertext.";
 

--- a/include/Dialect/BGV/IR/BGVTraits.h
+++ b/include/Dialect/BGV/IR/BGVTraits.h
@@ -1,0 +1,51 @@
+#ifndef HEIR_INCLUDE_DIALECT_BGV_IR_BGVTRAITS_H_
+#define HEIR_INCLUDE_DIALECT_BGV_IR_BGVTRAITS_H_
+
+#include "include/Dialect/BGV/IR/BGVAttributes.h"
+#include "include/Dialect/BGV/IR/BGVTypes.h"
+#include "mlir/include/mlir/IR/OpDefinition.h"  // from @llvm-project
+
+namespace mlir::heir::bgv {
+
+// Trait that ensures that all operands and results ciphertext have the same set
+// of rings.
+template <typename ConcreteType>
+class SameOperandsAndResultRings
+    : public OpTrait::TraitBase<ConcreteType, SameOperandsAndResultRings> {
+ public:
+  static LogicalResult verifyTrait(Operation *op) {
+    BGVRingsAttr rings = nullptr;
+    for (auto rTy : op->getResultTypes()) {
+      auto ct = dyn_cast<CiphertextType>(rTy);
+      if (!ct) continue;
+      if (rings == nullptr) {
+        rings = ct.getRings();
+        continue;
+      }
+      if (rings != ct.getRings()) {
+        return op->emitOpError()
+               << "requires all operands and results to have the same rings";
+      }
+    }
+
+    for (auto oTy : op->getOperandTypes()) {
+      auto ct = dyn_cast<CiphertextType>(oTy);
+      if (!ct) continue;  // Check only ciphertexts
+
+      if (rings == nullptr) {
+        rings = ct.getRings();
+        continue;
+      }
+
+      if (rings != ct.getRings()) {
+        return op->emitOpError()
+               << "requires all operands and results to have the same rings";
+      }
+    }
+    return success();
+  }
+};
+
+}  // namespace mlir::heir::bgv
+
+#endif  // HEIR_INCLUDE_DIALECT_BGV_IR_BGVTRAITS_H_

--- a/include/Dialect/BGV/IR/BUILD
+++ b/include/Dialect/BGV/IR/BUILD
@@ -13,6 +13,7 @@ exports_files(
         "BGVOps.h",
         "BGVTypes.h",
         "BGVAttributes.h",
+        "BGVTraits.h",
     ],
 )
 

--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "@heir//include/Dialect/BGV/IR:BGVAttributes.h",
         "@heir//include/Dialect/BGV/IR:BGVDialect.h",
         "@heir//include/Dialect/BGV/IR:BGVOps.h",
+        "@heir//include/Dialect/BGV/IR:BGVTraits.h",
         "@heir//include/Dialect/BGV/IR:BGVTypes.h",
     ],
     includes = ["@heir//include"],

--- a/tests/bgv/ops.mlir
+++ b/tests/bgv/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s > %t
+// RUN: heir-opt --color %s > %t
 // RUN: FileCheck %s < %t
 
 // This simply tests for syntax.
@@ -7,11 +7,16 @@
 #ring1 = #poly.ring<cmod=463187969, ideal=#my_poly>
 #ring2 = #poly.ring<cmod=33538049, ideal=#my_poly>
 #rings = #bgv.rings<#ring1, #ring2>
+#otherrings = #bgv.rings<#ring1>
 
 // CHECK: module
 module {
   func.func @test_multiply(%arg0 : !bgv.ciphertext<rings=#rings>, %arg1: !bgv.ciphertext<rings=#rings>) -> !bgv.ciphertext<rings=#rings> {
-    %0 = bgv.mul(%arg0, %arg1) : !bgv.ciphertext<rings=#rings>, !bgv.ciphertext<rings=#rings> -> !bgv.ciphertext<rings=#rings, dim=3>
+    %add = bgv.add(%arg0, %arg1) : !bgv.ciphertext<rings=#rings>
+    %sub = bgv.sub(%arg0, %arg1) : !bgv.ciphertext<rings=#rings>
+    %neg = bgv.negate(%arg0) : !bgv.ciphertext<rings=#rings>
+
+    %0 = bgv.mul(%arg0, %arg1) : !bgv.ciphertext<rings=#rings> -> !bgv.ciphertext<rings=#rings, dim=3>
     %1 = bgv.relinearize(%0) {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!bgv.ciphertext<rings=#rings, dim=3>) -> !bgv.ciphertext<rings=#rings>
     %2 = bgv.modulus_switch(%1) {from_level = 1, to_level=0} : (!bgv.ciphertext<rings=#rings>) -> !bgv.ciphertext<rings=#rings, dim=2, level=0>
     // CHECK: <<cmod=463187969, ideal=#poly.polynomial<1 + x**1024>>, <cmod=33538049, ideal=#poly.polynomial<1 + x**1024>>>

--- a/tests/bgv/to_poly.mlir
+++ b/tests/bgv/to_poly.mlir
@@ -26,7 +26,7 @@ module {
     %sub = bgv.sub(%x, %y) : !ct1
     // CHECK: [[C:%.+]] = arith.constant -1 : [[I:.+]]
     // CHECK: poly.mul_constant([[X]], [[C]]) : ([[T]], [[I]]) -> [[T]]
-    %negate = bgv.negate(%x) : (!ct1) -> !ct1
+    %negate = bgv.negate(%x) : !ct1
 
     // CHECK: [[I0:%.+]] = arith.constant 0 : index
     // CHECK: [[I1:%.+]] = arith.constant 1 : index
@@ -40,7 +40,7 @@ module {
     // CHECK: [[Z1:%.+]] = poly.add([[X0Y1]], [[X1Y0]]) : [[P]]
     // CHECK: [[Z2:%.+]] = poly.mul([[X1]], [[Y1]]) : [[P]]
     // CHECK: [[Z:%.+]] = tensor.from_elements [[Z0]], [[Z1]], [[Z2]] : tensor<3x[[P]]>
-    %mul = bgv.mul(%x, %y) : !ct1, !ct1 -> !bgv.ciphertext<rings=#rings, dim=3, level=1>
+    %mul = bgv.mul(%x, %y) : !ct1 -> !bgv.ciphertext<rings=#rings, dim=3, level=1>
     return
   }
 }


### PR DESCRIPTION
* Add `SameOperandsAndResultRings` trait to BGV ops;
* Simplify some assembly formats;
* Add `SameTypeOperands` trait to `BGV_MulOp`.

**Follow up:** come up with format that takes advantage of `SameOperandsAndResultRings`.