### PR TITLE
ci: remove pull ready labelling workflow

### DIFF
--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -1,14 +1,14 @@
-name: PR review status and labelling
+name: PR review status
 permissions: read-all
 on:
   pull_request_review:
     types: [submitted]
 
 jobs:
-  # We require a single commit, but only after the review process is complete and
-  # the PR has an Approval.
-  # This fails if there are multiple commits and the PR is approved.
-  # Otherwise, the PR is ready for internal migration, apply the `pull ready` label.
+  # We require a single commit, but only after the review process is complete
+  # and the PR has an Approval. This fails if there are multiple commits and the
+  # PR is approved. Otherwise, the PR is ready for internal migration, the
+  # maintainer may apply the the `pull ready` label.
   require-single-commit-on-approval:
     if: ${{ github.event.review.state == 'approved' }}
     runs-on: ubuntu-latest
@@ -24,15 +24,3 @@ jobs:
             echo "::error::Expected approved PR to have a single commit, but found $commits. google/heir requires a single commit per PR because Google's internal/external synchronization tooling does not support squashing, and instead would rebase all commits into the main branch."
             exit 1
           fi
-
-  apply-pull-ready-label:
-    if: ${{ github.event.review.state == 'approved' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Apply `pull ready` label
-        uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # pin@v4
-        with:
-          dot: true

--- a/docs/content/en/docs/contributing.md
+++ b/docs/content/en/docs/contributing.md
@@ -106,15 +106,15 @@ at the [pull request review stage](#pull-request-review-flow).
 3. **Approved**
 
 - **At this stage, you must squash your commits into a single commit.**
-- Once the PR is approved, you will see a `squash ready` label applied if your
-  PR requires you to squash together multiple commits. You may use the
-  `git rebase -i`. Pull requests must comprise of a single git commit before
-  merging.
+- Once the PR is approved, a GitHub workflow will
+  [check](https://github.com/google/heir/blob/main/.github/workflows/pr_review.yml)
+  your PR for multiple commits. You may use the `git rebase -i` to squash the
+  commits. Pull requests must comprise of a single git commit before merging.
 
 4. **Pull Ready**
 
-- Once the PR is squashed into a single git commit, the `pull ready` label is
-  applied.
+- Once the PR is squashed into a single git commit, a maintainer will apply the
+  `pull ready` label.
 - This initiates the internal code migration and presubmits.
 - If needed, we may come to you to make some minor changes in case tests fail at
   this stage. If so, we will request changes from the GitHub UI and the PR must


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/127