### PR TITLE
Poly: replace get_coeff and extract_slice with to_tensor

### DIFF
--- a/include/Dialect/Poly/IR/PolyOps.td
+++ b/include/Dialect/Poly/IR/PolyOps.td
@@ -7,10 +7,6 @@ include "PolyTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-//===----------------------------------------------------------------------===//
-// Poly Operation definitions.
-//===----------------------------------------------------------------------===//
-
 class Poly_Op<string mnemonic, list<Trait> traits = []> :
         Op<Poly_Dialect, mnemonic, traits> {
   // See https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format
@@ -20,10 +16,6 @@ class Poly_Op<string mnemonic, list<Trait> traits = []> :
   }];
   let cppNamespace = "::mlir::heir::poly";
 }
-
-//===----------------------------------------------------------------------===//
-// Ring operations.
-//===----------------------------------------------------------------------===//
 
 class Poly_BinOp<string mnemonic, list<Trait> traits = [Pure, SameOperandsAndResultType, Commutative, ElementwiseMappable]> :
         Poly_Op<mnemonic, traits> {
@@ -57,55 +49,50 @@ def Poly_MulConstantOp : Poly_Op<"mul_constant", [ElementwiseMappable]> {
   );
 }
 
-//===----------------------------------------------------------------------===//
-// Poly extraction operations.
-//===----------------------------------------------------------------------===//
-
-def Poly_GetCoeffOp : Poly_Op<"get_coeff"> {
-  let summary = "Gets the coefficient of X^{index} from a polynomial.";
-
-  let arguments = (ins
-    Polynomial:$x,
-    Index:$index
-  );
-
-  // NOTE: This assumes the underlying type is an integer.
-  let results = (outs
-    AnyInteger:$output
-  );
-}
-
-def Poly_ExtractSliceOp : Poly_Op<"extract_slice", [Pure, InferTypeOpAdaptor]> {
-  let summary = "Extracts a slice of coefficients from X^i to X^j.";
-
+def Poly_FromTensorOp : Poly_Op<"from_tensor", [Pure]> {
+  let summary = "Creates a polynomial from integer coefficients stored in a tensor.";
   let description = [{
-    Extracts a slice of coefficients from X^i to X^j.
+    `poly.from_tensor` creates a polynomial value from a tensor of coefficients.
+    The input tensor must list the coefficients in degree-increasing order.
 
-    The included range includes `i`, but excludes `j`, similar to array slice
-    semantics.
-
-    The coefficients are returned in the order they appear in the polynomial,
-    from smallest degree to largest degree
-
+    The input one-dimensional tensor may have size at most the degree of the
+    ring's ideal generator polynomial, with smaller dimension implying that
+    all higher-degree terms have coefficient zero.
   }];
-  let arguments = (ins Polynomial:$input, Index:$i, Index:$j);
-  let results = (outs TensorOf<[AnyInteger]>:$output);
-}
-
-//===----------------------------------------------------------------------===//
-// Poly generation operations.
-//===----------------------------------------------------------------------===//
-
-def Poly_PolyFromCoeffsOp : Poly_Op<"from_coeffs", [Pure]> {
-  let summary = "Creates a Polynomial from integer coefficients stored in a tensor.";
-  let arguments = (ins TensorOf<[AnyInteger]>:$input);
+  let arguments = (ins RankedTensorOf<[AnyInteger]>:$input);
   let results = (outs Polynomial:$output);
+
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` qualified(type($output))";
 
   let builders = [
     // Builder that infers coefficient modulus from tensor bit width,
     // and uses whatever input ring is provided by the caller.
     OpBuilder<(ins "::mlir::Value":$input, "RingAttr":$ring)>
   ];
+
+  let hasVerifier = 1;
+}
+
+def Poly_ToTensorOp : Poly_Op<"to_tensor", [Pure]> {
+  let summary = "Creates a tensor containing the coefficients of a polynomial.";
+  let description = [{
+    `poly.to_tensor` creates a tensor value containing the coefficients of the
+    input polynomial. The output tensor contains the coefficients in
+    degree-increasing order.
+
+    Operations that act on the coefficients of a polynomial, such as extracting
+    a specific coefficient or extracting a range of coefficients, should be
+    implemented by composing `to_tensor` with the relevant `tensor` dialect
+    ops.
+
+    The output tensor has shape equal to the degree of the ring's ideal
+    generator polynomial, including zeroes.
+  }];
+  let arguments = (ins Polynomial:$input);
+  let results = (outs RankedTensorOf<[AnyInteger]>:$output);
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` type($output)";
+
+  let hasVerifier = 1;
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_POLY_IR_POLYOPS_TD_

--- a/include/Dialect/Poly/IR/PolyTypes.td
+++ b/include/Dialect/Poly/IR/PolyTypes.td
@@ -13,7 +13,7 @@ class Poly_Type<string name, string typeMnemonic>
   let mnemonic = typeMnemonic;
 }
 
-def Polynomial : Poly_Type<"Polynomial", "poly"> {
+def Polynomial : Poly_Type<"Poly", "poly"> {
   let summary = "An element of a polynomial quotient ring";
 
   let description = [{

--- a/lib/Conversion/BGVToPoly/BGVToPoly.cpp
+++ b/lib/Conversion/BGVToPoly/BGVToPoly.cpp
@@ -34,7 +34,7 @@ class CiphertextTypeConverter : public TypeConverter {
       assert(level < type.getRings().getRings().size());
 
       auto ring = type.getRings().getRings()[level];
-      auto polyTy = poly::PolynomialType::get(ctx, ring);
+      auto polyTy = poly::PolyType::get(ctx, ring);
 
       return RankedTensorType::get({type.getDim()}, polyTy);
     });

--- a/lib/Conversion/PolyToStandard/PolyToStandard.cpp
+++ b/lib/Conversion/PolyToStandard/PolyToStandard.cpp
@@ -21,7 +21,7 @@ class PolyToStandardTypeConverter : public TypeConverter {
  public:
   PolyToStandardTypeConverter(MLIRContext *ctx) {
     addConversion([](Type type) { return type; });
-    addConversion([ctx](PolynomialType type) -> Type {
+    addConversion([ctx](PolyType type) -> Type {
       RingAttr attr = type.getRing();
       uint32_t idealDegree = attr.ideal().getDegree();
       IntegerType elementTy =
@@ -40,14 +40,14 @@ class PolyToStandardTypeConverter : public TypeConverter {
   }
 };
 
-struct ConvertPolyFromCoeffs : public OpConversionPattern<PolyFromCoeffsOp> {
-  ConvertPolyFromCoeffs(mlir::MLIRContext *context)
-      : OpConversionPattern<PolyFromCoeffsOp>(context) {}
+struct ConvertFromTensor : public OpConversionPattern<FromTensorOp> {
+  ConvertFromTensor(mlir::MLIRContext *context)
+      : OpConversionPattern<FromTensorOp>(context) {}
 
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
-      PolyFromCoeffsOp op, OpAdaptor adaptor,
+      FromTensorOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOp(op, adaptor.getOperands()[0]);
     return success();
@@ -92,7 +92,7 @@ struct PolyToStandard : impl::PolyToStandardBase<PolyToStandard> {
     PolyToStandardTypeConverter typeConverter(context);
 
     // target.addIllegalDialect<PolyDialect>();
-    target.addIllegalOp<PolyFromCoeffsOp>();
+    target.addIllegalOp<FromTensorOp>();
     // target.addIllegalOp<AddOp>();
     // target.addIllegalOp<MulOp>();
 
@@ -100,7 +100,7 @@ struct PolyToStandard : impl::PolyToStandardBase<PolyToStandard> {
     // converters for func/call/return
 
     RewritePatternSet patterns(context);
-    patterns.add<ConvertPolyFromCoeffs>(typeConverter, context);
+    patterns.add<ConvertFromTensor>(typeConverter, context);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Dialect/Poly/IR/PolyOps.cpp
+++ b/lib/Dialect/Poly/IR/PolyOps.cpp
@@ -4,28 +4,42 @@ namespace mlir {
 namespace heir {
 namespace poly {
 
-LogicalResult ExtractSliceOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location,
-    ExtractSliceOpAdaptor adaptor, SmallVectorImpl<Type> &inferredReturnTypes) {
-  PolynomialType polyType =
-      llvm::dyn_cast<PolynomialType>(adaptor.getInput().getType());
-  RingAttr attr = polyType.getRing();
-  uint32_t idealDegree = attr.ideal().getDegree();
-  IntegerType elementTy =
-      IntegerType::get(context, attr.coefficientModulus().getBitWidth(),
-                       IntegerType::SignednessSemantics::Unsigned);
-  Type resultType = RankedTensorType::get({idealDegree}, elementTy, attr);
-  inferredReturnTypes.assign({resultType});
-  return success();
-}
-
-void PolyFromCoeffsOp::build(OpBuilder &builder, OperationState &result,
-                             Value input, RingAttr ring) {
+void FromTensorOp::build(OpBuilder &builder, OperationState &result,
+                         Value input, RingAttr ring) {
   TensorType tensorType = dyn_cast<TensorType>(input.getType());
   APInt cmod(APINT_BIT_WIDTH, 1);
   cmod = cmod << tensorType.getElementTypeBitWidth();
-  Type resultType = PolynomialType::get(builder.getContext(), ring);
+  Type resultType = PolyType::get(builder.getContext(), ring);
   build(builder, result, resultType, input);
+}
+
+LogicalResult FromTensorOp::verify() {
+  auto tensorShape = getInput().getType().getShape();
+  auto polyDegree = getOutput().getType().getRing().getIdeal().getDegree();
+  bool compatible = tensorShape.size() == 1 && tensorShape[0] <= polyDegree;
+  return compatible
+             ? success()
+             : emitOpError()
+                   << "input type " << getInput().getType()
+                   << " does not match output type " << getOutput().getType()
+                   << ". The input type must be a tensor of shape [d] where d "
+                      "is at most the degree of the polynomial generator of "
+                      "the output ring's ideal.";
+}
+
+LogicalResult ToTensorOp::verify() {
+  auto tensorShape = getOutput().getType().getShape();
+  auto polyDegree = getInput().getType().getRing().getIdeal().getDegree();
+  bool compatible = tensorShape.size() == 1 && tensorShape[0] == polyDegree;
+
+  return compatible
+             ? success()
+             : emitOpError()
+                   << "input type " << getInput().getType()
+                   << " does not match output type " << getOutput().getType()
+                   << ". The input type must be a tensor of shape [d] where d "
+                      "is exactly the degree of the polynomial generator of "
+                      "the output ring's ideal.";
 }
 
 }  // namespace poly

--- a/tests/poly/lower_poly.mlir
+++ b/tests/poly/lower_poly.mlir
@@ -4,12 +4,12 @@
 #cycl_2048 = #poly.polynomial<1 + x**1024>
 #ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
 module {
-  func.func @test_lower_from_coeffs() {
+  func.func @test_lower_from_tensor() {
     %c0 = arith.constant 0 : index
     // 2 + 2x + 5x^2
     %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
-    // CHECK-NOT: poly.from_coeffs
-    %poly = poly.from_coeffs(%coeffs) : (tensor<3xi32>) -> !poly.poly<#ring>
+    // CHECK-NOT: poly.from_tensor
+    %poly = poly.from_tensor %coeffs : tensor<3xi32> -> !poly.poly<#ring>
     return
   }
 }

--- a/tests/poly/poly_ops.mlir
+++ b/tests/poly/poly_ops.mlir
@@ -9,21 +9,20 @@
 #my_poly_4 = #poly.polynomial<t**3 + 4t + 2>
 #ring1 = #poly.ring<cmod=2837465, ideal=#my_poly>
 module {
-  func.func @test_multiply() -> i32 {
+  func.func @test_multiply() -> !poly.poly<#ring1> {
     %c0 = arith.constant 0 : index
     %two = arith.constant 2 : i32
     %five = arith.constant 5 : i32
     %coeffs1 = tensor.from_elements %two, %two, %five : tensor<3xi32>
     %coeffs2 = tensor.from_elements %five, %five, %two : tensor<3xi32>
 
-    %poly1 = poly.from_coeffs(%coeffs1) : (tensor<3xi32>) -> !poly.poly<#ring1>
-    %poly2 = poly.from_coeffs(%coeffs2) : (tensor<3xi32>) -> !poly.poly<#ring1>
+    %poly1 = poly.from_tensor %coeffs1 : tensor<3xi32> -> !poly.poly<#ring1>
+    %poly2 = poly.from_tensor %coeffs2 : tensor<3xi32> -> !poly.poly<#ring1>
 
     // CHECK: #poly.ring<cmod=2837465, ideal=#poly.polynomial<1 + x**1024>>
     %3 = poly.mul(%poly1, %poly2) {ring = #ring1} : !poly.poly<#ring1>
-    %4 = poly.get_coeff(%3, %c0) : (!poly.poly<#ring1>, index) -> i32
 
-    return %4 : i32
+    return %3 : !poly.poly<#ring1>
   }
 
   func.func @test_elementwise(%p0 : !poly.poly<#ring1>, %p1: !poly.poly<#ring1>) {
@@ -36,6 +35,18 @@ module {
     %add = poly.add(%tp0, %tp1) : tensor<2x!poly.poly<#ring1>>
     %sub = poly.sub(%tp0, %tp1) : tensor<2x!poly.poly<#ring1>>
     %mul = poly.mul(%tp0, %tp1) : tensor<2x!poly.poly<#ring1>>
+
+    return
+  }
+
+  func.func @test_to_from_tensor(%p0 : !poly.poly<#ring1>) {
+    %c0 = arith.constant 0 : index
+    %two = arith.constant 2 : i32
+    %coeffs1 = tensor.from_elements %two, %two : tensor<2xi32>
+    // CHECK: from_tensor
+    %poly = poly.from_tensor %coeffs1 : tensor<2xi32> -> !poly.poly<#ring1>
+    // CHECK: to_tensor
+    %tensor = poly.to_tensor %poly : !poly.poly<#ring1> -> tensor<1024xi32>
 
     return
   }


### PR DESCRIPTION
Also:

- add verifiers to to/from_tensor
- add more specific semantics to the docs
- simplify the assembly format
- rename PolynomialType to PolyType for more consistency (less name conflict with the Polynomial storage class in PolyAttr).