### PR TITLE
poly: add lowering for to_tensor and fixup poly type lowering

### DIFF
--- a/include/Conversion/PolyToStandard/PolyToStandard.td
+++ b/include/Conversion/PolyToStandard/PolyToStandard.td
@@ -13,6 +13,7 @@ def PolyToStandard : Pass<"lower-poly"> {
   let dependentDialects = [
     "mlir::arith::ArithDialect",
     "mlir::heir::poly::PolyDialect",
+    "mlir::tensor::TensorDialect",
   ];
 }
 

--- a/tests/poly/lower_poly.mlir
+++ b/tests/poly/lower_poly.mlir
@@ -4,13 +4,47 @@
 #cycl_2048 = #poly.polynomial<1 + x**1024>
 #ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
 module {
+  // CHECK-label: test_lower_from_tensor
   func.func @test_lower_from_tensor() {
     %c0 = arith.constant 0 : index
     // 2 + 2x + 5x^2
     %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
     // CHECK-NOT: poly.from_tensor
+    // CHECK: [[COEFFS:%.+]] = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
+    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] : tensor<3xi32> to tensor<3xi64>
+    // CHECK: [[PAD:%.+]] = tensor.pad [[EXT]] low[0] high[1021]
+    // CHECK: tensor<3xi64> to tensor<1024xi64>
     %poly = poly.from_tensor %coeffs : tensor<3xi32> -> !poly.poly<#ring>
+    // CHECK: return
     return
+  }
+
+  // CHECK-label: test_lower_to_tensor
+  func.func @test_lower_to_tensor() -> tensor<1024xi64> {
+    // CHECK: [[COEFFS:%.+]] = arith.constant
+    %coeffs = arith.constant dense<2> : tensor<1024xi32>
+    // CHECK-NOT: poly.from_tensor
+    %poly = poly.from_tensor %coeffs : tensor<1024xi32> -> !poly.poly<#ring>
+    // CHECK-NOT: poly.to_tensor
+    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] :  tensor<1024xi32> to  tensor<1024xi64>
+    %tensor = poly.to_tensor %poly : !poly.poly<#ring> -> tensor<1024xi64>
+    // CHECK: return [[EXT]]
+    return %tensor : tensor<1024xi64>
+  }
+
+  // CHECK-label: test_lower_to_tensor_small_coeffs
+  func.func @test_lower_to_tensor_small_coeffs() -> tensor<1024xi64> {
+    // CHECK-NOT: poly.from_tensor
+    // CHECK-NOT: poly.to_tensor
+    // CHECK: [[COEFFS:%.+]] = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
+    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] : tensor<3xi32> to tensor<3xi64>
+    // CHECK: [[PAD:%.+]] = tensor.pad [[EXT]] low[0] high[1021]
+    // CHECK: tensor<3xi64> to tensor<1024xi64>
+    %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
+    %poly = poly.from_tensor %coeffs : tensor<3xi32> -> !poly.poly<#ring>
+    %tensor = poly.to_tensor %poly : !poly.poly<#ring> -> tensor<1024xi64>
+    // CHECK: return [[PAD]]
+    return %tensor : tensor<1024xi64>
   }
 
   // CHECK-label: f0


### PR DESCRIPTION
* Change poly element type conversion to signless: otherwise, we fail to materialize the conversion from the `tensor<1024xi64> ` (the original coeffs) to `tensor<1024xui64>` (type converted). [I could have changed the test, but I know we'll want signless for the arith ops]
* Remove ring attribute on the lowered tensor, to prevent unrealized cast conversions from the converted type with the attrs to the base tensor types. 