### PR TITLE
[draft] poly: support tensor of poly lowering to standard

### DIFF
--- a/tests/poly/tensor_poly.mlir
+++ b/tests/poly/tensor_poly.mlir
@@ -1,0 +1,32 @@
+// RUN: heir-opt --lower-poly %s > %t
+// RUN: FileCheck %s < %t
+
+#cycl_2048 = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
+module {
+  // CHECK-label: f0
+  // CHECK %arg0: tensor<2x1024xui64, #poly.ring<cmod=4294967296, ideal=#poly.polynomial<1 + x**1024>>>
+  func.func @f0(%arg: tensor<2x!poly.poly<#ring>>) -> tensor<2x!poly.poly<#ring>> {
+    return %arg : tensor<2x!poly.poly<#ring>>
+  }
+
+  // CHECK-label: test_lower_fn_and_call
+  // CHECK-NOT: poly.poly<#ring>
+  func.func @test_lower_fn_and_call(%arg: tensor<2x!poly.poly<#ring>>) {
+    func.call @f0(%arg) : (tensor<2x!poly.poly<#ring>>) -> tensor<2x!poly.poly<#ring>>
+    return
+  }
+
+  // CHECK-label: test_lower_tensor_poly_to_tensor
+  func.func @test_lower_tensor_poly_to_tensor() -> (tensor<2x!poly.poly<#ring>>) {
+    // CHECK: [[COEFFS:%.+]] = arith.constant
+    %coeffs = arith.constant dense<2> : tensor<1024xi32>
+    // CHECK-NOT: poly.from_tensor
+    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] :  tensor<1024xi32> to  tensor<1024xi64>
+    %poly = poly.from_tensor %coeffs : tensor<1024xi32> -> !poly.poly<#ring>
+    // CHECK: [[TENSOR:%.+]] = tensor.from_elements [[EXT]], [[EXT]] : tensor<2x1024xi64>
+    %tensor_poly = tensor.from_elements %poly, %poly : tensor<2x!poly.poly<#ring>>
+    // CHECK: return [[TENSOR]] : tensor<2x1024xi64>
+    return %tensor_poly : tensor<2x!poly.poly<#ring>>
+  }
+}


### PR DESCRIPTION
draft, since I'm struggling with getting MLIR to translate the `tensor.from_elements` directly. For context, with this testcase:

```
  // CHECK-label: test_lower_tensor_poly_to_tensor
  func.func @test_lower_tensor_poly_to_tensor() -> (tensor<2x!poly.poly<#ring>>) {
    // CHECK: [[COEFFS:%.+]] = arith.constant
    %coeffs = arith.constant dense<2> : tensor<1024xi32>
    // CHECK-NOT: poly.from_tensor
    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] :  tensor<1024xi32> to  tensor<1024xi64>
    %poly = poly.from_tensor %coeffs : tensor<1024xi32> -> !poly.poly<#ring>
    // CHECK: [[TENSOR:%.+]] = tensor.from_elements [[EXT]], [[EXT]] : tensor<2x1024xi64>
    %tensor_poly = tensor.from_elements %poly, %poly : tensor<2x!poly.poly<#ring>>
    // CHECK: return [[TENSOR]] : tensor<2x1024xi64>
    return %tensor_poly : tensor<2x!poly.poly<#ring>>
  }
```

I would expect that the `tensor.from_elements` would automatically be converted to using the converted types and return a converted result. However, it does not, it performs a conversion cast on the result:

```
func.func @test_lower_tensor_poly_to_tensor() -> tensor<2x1024xi64> {
  %cst = arith.constant dense<2> : tensor<1024xi32>
  %0 = arith.extui %cst : tensor<1024xi32> to tensor<1024xi64>
  %1 = poly.from_tensor %cst : tensor<1024xi32> -> !poly.poly<<cmod=4294967296, ideal=#poly.polynomial<1 + x**1024>>>
  %from_elements = tensor.from_elements %1, %1 : tensor<2x!poly.poly<<cmod=4294967296, ideal=#poly.polynomial<1 + x**1024>>>>
  %2 = builtin.unrealized_conversion_cast %from_elements : tensor<2x!poly.poly<<cmod=4294967296, ideal=#poly.polynomial<1 + x**1024>>>> to tensor<2x1024xi64>
  return %2 : tensor<2x1024xi64>
}
```

Then I thought it seems like we want to treat `tensor.from_elements` similar to `func.call` interfaces (where the args and return value are all converted).

I tried 
* `target.markUknownOpDynamicallyLegal` for any op with an illegal type for operands or results, but this didn't trigger anything


Still brainstorming, let me know if there's simple boilerplate that's supposed to do this.

EDIT: I see what's going on - I added a generic op converter that converts inputs and outputs, but because the expected behavior of `tensor.from_elements` is to add an extra dimension, this isn't out of the box behavior from `tensor.from_elements`. It needs a custom converter that re-shapes the args.