### PR TITLE
Add LWE toolbox dialect and CGGI-style lwe bitfield encoding attribute

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=500000'] # 500MB
 
+# Custom search and replace rules for HEIR
+- repo: https://github.com/mattlqx/pre-commit-search-and-replace
+  rev: v1.0.5
+  hooks:
+  - id: search-and-replace
+    files: \.(cpp|h)$
+
 # clang-format
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: "v16.0.6"
@@ -21,7 +28,7 @@ repos:
 
 # Starlark
 -   repo: https://github.com/keith/pre-commit-buildifier
-    rev: "6.1.0"
+    rev: "6.3.3"
     hooks:
       - id: buildifier
       - id: buildifier-lint
@@ -34,7 +41,7 @@ repos:
 
 # Changes tabs to spaces
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: "v1.5.1"
+    rev: "v1.5.4"
     hooks:
       - id: remove-tabs
 

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,0 +1,5 @@
+# Force all C++ mlir include paths to be prefixed with "mlir/include/mlir",
+# instead of just "mlir/", as the latter is incompatible with Google's internal
+# filesystem.
+- search: '/^#include "mlir\/(?!include\/mlir\/)/'
+  replacement: '#include "mlir/include/mlir/'

--- a/include/Dialect/LWE/IR/BUILD
+++ b/include/Dialect/LWE/IR/BUILD
@@ -1,0 +1,80 @@
+# LWE, a dialect defining the LWE cryptosystem.
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "LWEDialect.h",
+        "LWEAttributes.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "LWEAttributes.td",
+        "LWEDialect.td",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "LWEDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "LWEDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWEDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "attributes_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-attrdef-decls",
+            ],
+            "LWEAttributes.h.inc",
+        ),
+        (
+            [
+                "-gen-attrdef-defs",
+            ],
+            "LWEAttributes.cpp.inc",
+        ),
+        (
+            ["-gen-attrdef-doc"],
+            "LWEAttributes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWEAttributes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)

--- a/include/Dialect/LWE/IR/LWEAttributes.h
+++ b/include/Dialect/LWE/IR/LWEAttributes.h
@@ -1,0 +1,10 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_
+
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+#include "mlir/include/mlir/IR/TensorEncoding.h"  // from @llvm-project
+
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWEAttributes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_

--- a/include/Dialect/LWE/IR/LWEAttributes.td
+++ b/include/Dialect/LWE/IR/LWEAttributes.td
@@ -1,0 +1,64 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_
+
+include "LWEDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/TensorEncoding.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+class LWE_EncodingAttr<string attrName, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<LWE_Dialect, attrName, traits # [
+    // All encoding attributes are required to be compatible with a tensor
+    // with an element type relevant to that encoding.
+    DeclareAttrInterfaceMethods<VerifiableTensorEncoding>
+]> {
+  let mnemonic = attrMnemonic;
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+def LWE_BitFieldEncoding: LWE_EncodingAttr<"BitFieldEncoding", "bit_field_encoding"> {
+  let summary = "An attribute describing encoded LWE plaintexts using bit fields.";
+  let description = [{
+    A bit field encoding of an integer describes which contiguous region
+    of bits a small integer occupies within a larger integer.
+
+    In LWE the plaintexts are integers of a given bit width, and the cleartext
+    messages are integers of a smaller bit width. A common example might be
+    3-bit cleartexts inside a 32-bit plaintext. In the CGGI FHE scheme, the
+    3-bit cleartext might be stored as follows, where 0 denotes a 0 bit, `b`
+    denotes a bit of the cleartext, `n` denotes a bit reserved for noise, and
+    `|` is a visual aid to show where the bit fields begin and end.
+
+
+    ```
+       0|bbb|nn...n
+    MSB^          ^LSB
+    ```
+
+    The data describing the encoding consists of the starting bit positions of
+    the cleartext bit field and its width, where the LSB is bit 0 and the MSB
+    is bit `bit_width-1`. So the above example would have starting bit `30` and
+    width `3`. The bits preceding (more significant than) the starting bit are
+    reserved for padding, and the bits following (less significant than) the
+    ending bit are reserved for noise.
+
+    The presence of this attribute as the `encoding` attribute of a tensor
+    indicates that the tensor is an LWE ciphertext.
+
+    Example:
+
+    ```
+    #lwe_encoding = #lwe.poly_coefficient_encoding<cleartext_start=30, cleartext_bitwidth=3>
+    %lwe_ciphertext = arith.constant <[1,2,3,4]> : tensor<4xi32, #lwe_encoding>
+    ```
+  }];
+
+  let parameters = (ins
+    "unsigned":$cleartext_start,
+    "unsigned":$cleartext_bitwidth
+  );
+}
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_

--- a/include/Dialect/LWE/IR/LWEDialect.h
+++ b/include/Dialect/LWE/IR/LWEDialect.h
@@ -1,0 +1,10 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"   // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "include/Dialect/LWE/IR/LWEDialect.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_H_

--- a/include/Dialect/LWE/IR/LWEDialect.td
+++ b/include/Dialect/LWE/IR/LWEDialect.td
@@ -1,0 +1,31 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def LWE_Dialect : Dialect {
+  let name = "lwe";
+  let description = [{
+    The `lwe` dialect is a dialect for concepts related to cryptosystems
+    in the Learning With Errors (LWE) family.
+
+    See [Wikipedia](https://en.wikipedia.org/wiki/Learning_with_errors)
+    for an overview of LWE and the related
+    [RLWE](https://en.wikipedia.org/wiki/Ring_learning_with_errors)
+    problem.
+
+    While one might expect this dialect to contain types along the lines
+    of LWE and RLWE ciphertexts, and operations like encryption, decryption,
+    adding and multiplying ciphertexts, these concepts are not centralized
+    here because they are too scheme-specific.
+
+    Instead, this dialect provides attributes that can be attached to tensors
+    of integer or `poly.poly` types, which indicate that they are semantically
+    LWE and RLWE ciphertexts, respectively.
+  }];
+
+  let cppNamespace = "::mlir::heir::lwe";
+  let useDefaultAttributePrinterParser = 1;
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEDIALECT_TD_

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -1,0 +1,25 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "LWEDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/LWE/IR:LWEAttributes.h",
+        "@heir//include/Dialect/LWE/IR:LWEDialect.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/LWE/IR:attributes_inc_gen",
+        "@heir//include/Dialect/LWE/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
+        "@heir//lib/Dialect/Poly/IR:PolyAttributes",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)

--- a/lib/Dialect/LWE/IR/LWEDialect.cpp
+++ b/lib/Dialect/LWE/IR/LWEDialect.cpp
@@ -1,0 +1,54 @@
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated definitions
+#include "include/Dialect/LWE/IR/LWEDialect.cpp.inc"
+#define GET_ATTRDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWEAttributes.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+void LWEDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "include/Dialect/LWE/IR/LWEAttributes.cpp.inc"
+      >();
+}
+
+LogicalResult BitFieldEncodingAttr::verifyEncoding(
+    ArrayRef<int64_t> shape, Type elementType,
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const {
+  if (!elementType.isSignlessInteger()) {
+    return emitError() << "Tensors with a bit_field_encoding must have "
+                       << "signless integer element type, but found "
+                       << elementType;
+  }
+
+  unsigned plaintextBitwidth = elementType.getIntOrFloatBitWidth();
+  unsigned cleartextBitwidth = getCleartextBitwidth();
+  if (plaintextBitwidth < cleartextBitwidth)
+    return emitError() << "The tensor element type's bitwidth "
+                       << plaintextBitwidth
+                       << " is too small to store the cleartext, "
+                       << "which has bit width " << cleartextBitwidth << "";
+
+  auto cleartextStart = getCleartextStart();
+  if (cleartextStart < 0 || cleartextStart >= plaintextBitwidth)
+    return emitError() << "Attribute's cleartext starting bit index ("
+                       << cleartextStart << ") is outside the legal range [0, "
+                       << plaintextBitwidth - 1 << "]";
+
+  // It may be worth adding some sort of warning notification if the attribute
+  // allocates no bits for noise, since this would be effectively useless for
+  // FHE.
+  return success();
+}
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/lwe/BUILD
+++ b/tests/lwe/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/lwe/attributes.mlir
+++ b/tests/lwe/attributes.mlir
@@ -1,0 +1,30 @@
+// RUN: not heir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// This simply tests for syntax.
+
+#encoding1 = #lwe.bit_field_encoding<
+  cleartext_start=14,
+  cleartext_bitwidth=3>
+
+// CHECK-LABEL: test_valid_lwe_attribute
+func.func @test_valid_lwe_attribute() {
+    %c0 = arith.constant 0 : index
+    %two = arith.constant 2 : i16
+    // CHECK: bit_field_encoding
+    %coeffs1 = tensor.from_elements %two, %two : tensor<2xi16, #encoding1>
+  return
+}
+
+// -----
+
+#encoding2 = #lwe.bit_field_encoding<
+  cleartext_start=30,
+  cleartext_bitwidth=3>
+
+// expected-error@below {{cleartext starting bit index (30) is outside the legal range [0, 15]}}
+func.func @test_invalid_lwe_attribute() {
+    %c0 = arith.constant 0 : index
+    %two = arith.constant 2 : i16
+    %coeffs1 = tensor.from_elements %two, %two : tensor<2xi16, #encoding2>
+  return
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,6 +17,7 @@ cc_binary(
         "@heir//lib/Conversion/PolyToStandard",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/EncryptedArith/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Poly/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/Secret/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -3,6 +3,7 @@
 #include "include/Conversion/PolyToStandard/PolyToStandard.h"
 #include "include/Dialect/BGV/IR/BGVDialect.h"
 #include "include/Dialect/EncryptedArith/IR/EncryptedArithDialect.h"
+#include "include/Dialect/LWE/IR/LWEDialect.h"
 #include "include/Dialect/Poly/IR/PolyDialect.h"
 #include "include/Dialect/Secret/IR/SecretDialect.h"
 #include "include/Dialect/Secret/Transforms/Passes.h"
@@ -76,6 +77,7 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registry.insert<mlir::heir::EncryptedArithDialect>();
   registry.insert<mlir::heir::bgv::BGVDialect>();
+  registry.insert<mlir::heir::lwe::LWEDialect>();
   registry.insert<mlir::heir::poly::PolyDialect>();
   registry.insert<mlir::heir::secret::SecretDialect>();
 


### PR DESCRIPTION
Partial progress on https://github.com/google/heir/issues/161

This uses the `VerifiableTensorEncoding` interface to verify the encoding is compatible with the underlying tensor element type.

I also tweaked the lit config slightly to make it easier to check for expected error messages.

Future PRs will add RLWE encoding attributes as per https://github.com/google/heir/issues/161