### PR TITLE
Add RLWE encoding attributes

### DIFF
--- a/docs/layouts/shortcodes/markdown.html
+++ b/docs/layouts/shortcodes/markdown.html
@@ -1,0 +1,1 @@
+{{ .Inner | markdownify }}

--- a/include/Dialect/LWE/IR/LWEAttributes.td
+++ b/include/Dialect/LWE/IR/LWEAttributes.td
@@ -19,7 +19,19 @@ class LWE_EncodingAttr<string attrName, string attrMnemonic, list<Trait> traits 
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
-def LWE_BitFieldEncoding: LWE_EncodingAttr<"BitFieldEncoding", "bit_field_encoding"> {
+class LWE_EncodingAttrWithScalingFactor<string attrName, string attrMnemonic, list<Trait> traits = []>
+    : LWE_EncodingAttr<attrName, attrMnemonic, traits> {
+  // These parameters represent the base-2 logarithm of the scaling factor to
+  // scale cleartexts in preparation for noise growth of FHE schemes. This
+  // representation restricts the scaling factors to being powers of two.
+  let parameters = (ins
+    "unsigned":$cleartext_start,
+    "unsigned":$cleartext_bitwidth
+  );
+}
+
+def LWE_BitFieldEncoding
+  : LWE_EncodingAttrWithScalingFactor<"BitFieldEncoding", "bit_field_encoding"> {
   let summary = "An attribute describing encoded LWE plaintexts using bit fields.";
   let description = [{
     A bit field encoding of an integer describes which contiguous region
@@ -55,10 +67,167 @@ def LWE_BitFieldEncoding: LWE_EncodingAttr<"BitFieldEncoding", "bit_field_encodi
     %lwe_ciphertext = arith.constant <[1,2,3,4]> : tensor<4xi32, #lwe_encoding>
     ```
   }];
-
-  let parameters = (ins
-    "unsigned":$cleartext_start,
-    "unsigned":$cleartext_bitwidth
-  );
 }
+
+def RLWE_PolyCoefficientEncoding
+  : LWE_EncodingAttrWithScalingFactor<"PolyCoefficientEncoding", "poly_coefficient_encoding"> {
+  let summary = "An attribute describing encoded RLWE plaintexts via coefficients.";
+  let description = [{
+    A coefficient encoding of a list of integers asserts that the coefficients
+    of the polynomials contain the cleartexts, with the same semantics as
+    `bit_field_encoding` for per-coefficient encodings.
+
+    The presence of this attribute as the `encoding` attribute of a tensor of
+    `poly.poly` indicates that the tensor is an RLWE ciphertext for some RLWE
+    scheme that supports the coefficient encoding.
+
+    Example:
+
+    ```
+    #generator = #poly.polynomial<1 + x**1024>
+    #ring = #poly.ring<cmod=65536, ideal=#generator>
+    #coeff_encoding = #lwe.poly_coefficient_encoding<cleartext_start=15, cleartext_bitwidth=4>
+
+    %poly1 = poly.from_tensor %coeffs1 : tensor<10xi16> -> !poly.poly<#ring>
+    %poly2 = poly.from_tensor %coeffs2 : tensor<10xi16> -> !poly.poly<#ring>
+    %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring>, #coeff_encoding>
+    ```
+  }];
+}
+
+def RLWE_PolyEvaluationEncoding
+  : LWE_EncodingAttrWithScalingFactor<"PolyEvaluationEncoding", "poly_evaluation_encoding"> {
+  let summary = "An attribute describing encoded RLWE plaintexts via evaluations at fixed points.";
+  let description = [{
+    A "evaluation encoding" of a list of integers $(v_1, \dots, v_n)$ asserts
+    that $f(\x_1) = v_1, \dots, f(x_n) = v_n$ for some implicit, but fixed and
+    distinct choice of inputs $x_i$. The encoded values are also scaled by a
+    scale factor, having the same semantics as `bit_field_encoding`, but
+    applied entry-wise (to either the coefficient or evaluation representation).
+
+    This attribute can be used in multiple ways:
+
+    - On a `poly.poly`, it asserts that the polynomial has been transformed
+      from an evaluation tensor.
+    - On a tensor of `poly.poly`, it asserts that the tensor is an RLWE
+      ciphertext for some RLWE scheme that supports the evaluation encoding.
+
+    A typical workflow for the BFV/BGV schemes using this encoding would be
+    to apply a INTT operation to the input list of cleartexts to convert from
+    evaluation form to coefficient form, then encrypt the resulting polynomial
+    in coefficient form, then apply NTT back to the evaluation form for faster
+    multiplication of ciphertexts.
+
+    The points chosen are fixed to be the powers of a primitive root of unity
+    of the coefficient ring of the plaintext space, which allows one to use
+    NTT/INTT to tansform quickly between the coefficient and evaluation forms.
+
+    Example:
+
+    ```
+    #generator = #poly.polynomial<1 + x**1024>
+    // note that the cmod should be chosen so as to ensure a primitive root of
+    // unity exists in the multiplicative group (Z / cmod Z)^*
+    #ring = #poly.ring<cmod=65536, ideal=#generator>
+    #lwe_encoding = #lwe.poly_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
+
+    %evals = arith.constant <[1, 2, 4, 5]> : tensor<4xi16>
+    // TODO(https://github.com/google/heir/issues/182): fix docs
+    // Note no `intt` operation exists in poly yet.
+    %poly1 = poly.intt %evals : tensor<4xi16> -> !poly.poly<#ring, #eval_encoding>
+    %poly2 = poly.intt %evals : tensor<4xi16> -> !poly.poly<#ring, #eval_encoding>
+    %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring, #eval_encoding>>
+    ```
+  }];
+}
+
+// TODO(https://github.com/google/heir/issues/183): does it make sense to use
+// the bit-field parameters here? It may not work sensibly because the rounding
+// happens after scaling-post-INTT, so rounding doesn't happen via bit shifting,
+// and this scheme might need a scaling factor that is not a power of two.
+def RLWE_InverseCanonicalEmbeddingEncoding
+  : LWE_EncodingAttrWithScalingFactor<"InverseCanonicalEmbeddingEncoding", "inverse_canonical_embedding_encoding"> {
+  let summary = "An attribute describing encoded RLWE plaintexts via the rounded inverse canonical embedding.";
+  let description = [{
+    Let $n$ be the degree of the polynomials in the plaintext space. An
+    "inverse canonical embedding encoding" of a list of real or complex values
+    $v_1, \dots, v_{n/2}$ is (almost) the inverse of the following decoding
+    map.
+
+    Define a map $\tau_N$ that maps a polynomial $p \in \mathbb{Z}[x] / (x^N +
+    1) \to \mathbb{C}^{N/2}$ by evaluating it at the following $N/2$ points,
+    where $\omega = e^{2 \pi i / 2N}$ is the primitive $2N$th root of unity:
+
+    \[
+      \omega, \omega^3, \omega^5, \dots, \omega^{N-1}
+    \]
+
+    Then the complete decoding operation is $\textup{Decode}(p) =
+    (1/\Delta)\tau_N(p)$, where $\Delta$ is a scaling parameter and $\tau_N$ is
+    the truncated canonical embedding above. The encoding operation is the
+    inverse of the decoding operation, with some caveats explained below.
+
+    The map $\tau_N$ is derived from the so-called _canonical embedding_
+    $\tau$, though in the standard canonical embedding, we evaluate at all odd
+    powers of the root of unity, $\omega, \omega^3, \dots, \omega^{2N-1}$. For
+    polynomials in the slightly larger space $\mathbb{R}[x] / (x^N + 1)$, the
+    image of the canonical embedding is the subspace $H \subset \mathbb{C}^N$
+    defined by tuples $(z_1, \dots, z_N)$ such that $\overline{z_i} =
+    \overline{z_{N-i+1}}$. Note that this property holds because polynomial
+    evaluation commutes with complex conjugates, and the second half of the
+    roots of unity evaluate are complex conjugates of the first half. The
+    converse, that any such tuple with complex conjugate symmetry has an
+    inverse under $\tau$ with all real coefficients, makes $\tau$ is a
+    bijection onto $H$. $\tau$ and its inverse are explicitly computable as
+    discrete Fourier Transforms.
+
+    Because of the symmetry in canonical embedding for real polynomials, inputs
+    to this encoding can be represented as a list of $N/2$ complex points, with
+    the extra symmetric structure left implicit. $\tau_N$ and its inverse can
+    also be explicitly computed without need to expand the vectors to length
+    $N$.
+
+    The rounding step is required to invert the decoding because, while
+    cleartexts must be (implicitly) in the subspace $H$, they need not be the
+    output of $\tau_N$ for an _integer_ polynomial. The rounding step ensures
+    we can use integer polynomial plaintexts for the FHE operations. There are
+    multiple rounding mechanisms, and this attribute does not specify which is
+    used, because in theory two ciphertexts that have used different roundings
+    are still compatible, though they may have different noise growth patterns.
+
+    The scaling parameter $\Delta$ is specified by the `cleartext_start` and
+    `cleartext_bitwidth` parameters, which are applied coefficient-wise using
+    the same semantics as the `bit_field_encoding`.
+
+    This attribute can be used in multiple ways:
+
+    - On a `poly.poly`, it asserts that the polynomial has been transformed
+      from a coefficient list using the canonical embedding.
+    - On a tensor of `poly.poly`, it asserts that the tensor is an RLWE
+      ciphertext for some RLWE scheme that supports the approximate embedding
+      encoding.
+
+    A typical flow for the CKKS scheme using this encoding would be to apply an
+    inverse FFT operation to invert the canonical embedding to be a polynomial
+    with real coefficients, then encrypt scale the resulting polynomial's
+    coefficients according to the scaling parameters, then round to get integer
+    coefficients.
+
+    Example:
+
+    ```
+    #generator = #poly.polynomial<1 + x**1024>
+    #ring = #poly.ring<cmod=65536, ideal=#generator>
+    #lwe_encoding = #lwe.poly_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
+
+    %evals = arith.constant <[1, 2, 4, 5]> : tensor<4xi16>
+    // TODO(https://github.com/google/heir/issues/182): fix docs
+    // Note no `intt` operation exists in poly yet.
+    %poly1 = poly.intt %evals : tensor<4xi16> -> !poly.poly<#ring, #eval_encoding>
+    %poly2 = poly.intt %evals : tensor<4xi16> -> !poly.poly<#ring, #eval_encoding>
+    %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring, #eval_encoding>>
+    ```
+  }];
+}
+
 #endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_

--- a/include/Dialect/Poly/IR/PolyTypes.td
+++ b/include/Dialect/Poly/IR/PolyTypes.td
@@ -20,8 +20,25 @@ def Polynomial : Poly_Type<"Poly", "poly"> {
     A type for polynomials in a polynomial quotient ring.
   }];
 
-  let parameters = (ins Ring_Attr:$ring);
-  let assemblyFormat = "`<` $ring `>`";
+  let parameters = (ins
+    Ring_Attr:$ring,
+    OptionalParameter<"Attribute">:$encoding
+  );
+
+  // TODO(https://github.com/google/heir/issues/181): Skip the default
+  // builder since the custom builder enables the default value for the
+  // encoding parameter, And I couldn't get DefaultValueParameter to
+  // auto-generate a builder with the appropriate default value.
+  let skipDefaultBuilders = 1;
+  let builders = [
+    TypeBuilder<(ins
+      "RingAttr":$ring, CArg<"Attribute", "{}">:$encoding
+    ), [{
+      return $_get($_ctxt, ring, encoding);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` $ring (`,` $encoding^ )? `>`";
 }
 
 def PolynomialLike: TypeOrContainer<Polynomial, "polynomial-like">;

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -15,8 +15,7 @@ cc_library(
     deps = [
         "@heir//include/Dialect/LWE/IR:attributes_inc_gen",
         "@heir//include/Dialect/LWE/IR:dialect_inc_gen",
-        "@heir//include/Dialect/Poly/IR:attributes_inc_gen",
-        "@heir//lib/Dialect/Poly/IR:PolyAttributes",
+        "@heir//lib/Dialect/Poly/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",

--- a/tests/lwe/attributes.mlir
+++ b/tests/lwe/attributes.mlir
@@ -28,3 +28,85 @@ func.func @test_invalid_lwe_attribute() {
     %coeffs1 = tensor.from_elements %two, %two : tensor<2xi16, #encoding2>
   return
 }
+
+// -----
+
+#generator = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=65536, ideal=#generator>
+#coeff_encoding = #lwe.poly_coefficient_encoding<cleartext_start=15, cleartext_bitwidth=4>
+// CHECK-LABEL: test_valid_coefficient_encoding_attr
+// CHECK: poly_coefficient_encoding
+func.func @test_valid_coefficient_encoding_attr(%coeffs1 : tensor<10xi16>, %coeffs2 : tensor<10xi16>) {
+  %poly1 = poly.from_tensor %coeffs1 : tensor<10xi16> -> !poly.poly<#ring>
+  %poly2 = poly.from_tensor %coeffs2 : tensor<10xi16> -> !poly.poly<#ring>
+  %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring>, #coeff_encoding>
+  return
+}
+
+// -----
+
+#coeff_encoding1 = #lwe.poly_coefficient_encoding<cleartext_start=15, cleartext_bitwidth=4>
+// expected-error@below {{must have `poly.poly` element type}}
+func.func @test_invalid_coefficient_encoding_type(%a : i16, %b: i16) {
+  %rlwe_ciphertext = tensor.from_elements %a, %b : tensor<2xi16, #coeff_encoding1>
+  return
+}
+
+// -----
+
+#generator2 = #poly.polynomial<1 + x**1024>
+#ring2 = #poly.ring<cmod=65536, ideal=#generator2>
+#coeff_encoding2 = #lwe.poly_coefficient_encoding<cleartext_start=30, cleartext_bitwidth=3>
+// expected-error@below {{cleartext starting bit index (30) is outside the legal range [0, 15]}}
+func.func @test_invalid_coefficient_encoding_width(%coeffs1 : tensor<10xi16>, %coeffs2 : tensor<10xi16>) {
+  %poly1 = poly.from_tensor %coeffs1 : tensor<10xi16> -> !poly.poly<#ring2>
+  %poly2 = poly.from_tensor %coeffs2 : tensor<10xi16> -> !poly.poly<#ring2>
+  %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring2>, #coeff_encoding2>
+  return
+}
+
+// -----
+
+#generator3 = #poly.polynomial<1 + x**1024>
+#ring3 = #poly.ring<cmod=65536, ideal=#generator3>
+// CHECK-LABEL: test_valid_evaluation_encoding
+// CHECK: poly_evaluation_encoding
+#eval_enc = #lwe.poly_evaluation_encoding<cleartext_start=14, cleartext_bitwidth=3>
+func.func @test_valid_evaluation_encoding(%coeffs1 : tensor<10xi16>, %coeffs2 : tensor<10xi16>) {
+  %poly1 = poly.from_tensor %coeffs1 : tensor<10xi16> -> !poly.poly<#ring3, #eval_enc>
+  %poly2 = poly.from_tensor %coeffs2 : tensor<10xi16> -> !poly.poly<#ring3, #eval_enc>
+  %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring3, #eval_enc>, #eval_enc>
+  return
+}
+
+// -----
+
+#eval_enc2 = #lwe.poly_evaluation_encoding<cleartext_start=14, cleartext_bitwidth=3>
+// expected-error@below {{must have `poly.poly` element type}}
+func.func @test_invalid_evaluation_encoding_type() {
+  %a = arith.constant dense<[2, 2, 5]> : tensor<3xi32, #eval_enc2>
+  return
+}
+
+// -----
+
+#generator4 = #poly.polynomial<1 + x**1024>
+#ring4 = #poly.ring<cmod=65536, ideal=#generator4>
+// CHECK-LABEL: test_valid_inverse_canonical_embedding_encoding
+// CHECK: inverse_canonical_embedding_encoding
+#inverse_canonical_enc = #lwe.inverse_canonical_embedding_encoding<cleartext_start=14, cleartext_bitwidth=4>
+func.func @test_valid_inverse_canonical_embedding_encoding(%coeffs1 : tensor<10xi16>, %coeffs2 : tensor<10xi16>) {
+  %poly1 = poly.from_tensor %coeffs1 : tensor<10xi16> -> !poly.poly<#ring4, #inverse_canonical_enc>
+  %poly2 = poly.from_tensor %coeffs2 : tensor<10xi16> -> !poly.poly<#ring4, #inverse_canonical_enc>
+  %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring4, #inverse_canonical_enc>, #inverse_canonical_enc>
+  return
+}
+
+// -----
+
+#inverse_canonical_enc2 = #lwe.inverse_canonical_embedding_encoding<cleartext_start=14, cleartext_bitwidth=4>
+// expected-error@below {{must have `poly.poly` element type}}
+func.func @test_invalid_inverse_canonical_embedding_encoding() {
+  %a = arith.constant dense<[2, 2, 5]> : tensor<3xi32, #inverse_canonical_enc2>
+  return
+}


### PR DESCRIPTION
Adds three more encodings:

 - PolyCoefficientEncoding, for CGGI's bootstrapping rotation polynomial encoding
 - PolyEvaluationEnvoding, for standard BGV/BFV encodings
 - PolyRoundedEmbeddingEncoding, for CKKS's standard encoding