### PR TITLE
Remove unneeded includes directive

### DIFF
--- a/include/Dialect/BGV/IR/BUILD
+++ b/include/Dialect/BGV/IR/BUILD
@@ -25,7 +25,6 @@ td_library(
         "BGVOps.td",
         "BGVTypes.td",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",

--- a/include/Dialect/EncryptedArith/IR/BUILD
+++ b/include/Dialect/EncryptedArith/IR/BUILD
@@ -20,7 +20,6 @@ td_library(
         "EncryptedArithDialect.td",
         "EncryptedArithTypes.td",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
     ],

--- a/include/Dialect/LWE/IR/BUILD
+++ b/include/Dialect/LWE/IR/BUILD
@@ -20,7 +20,6 @@ td_library(
         "LWEAttributes.td",
         "LWEDialect.td",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",

--- a/include/Dialect/Poly/IR/BUILD
+++ b/include/Dialect/Poly/IR/BUILD
@@ -26,7 +26,6 @@ td_library(
         "PolyOps.td",
         "PolyTypes.td",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",

--- a/include/Dialect/Secret/IR/BUILD
+++ b/include/Dialect/Secret/IR/BUILD
@@ -22,7 +22,6 @@ td_library(
         "SecretOps.td",
         "SecretTypes.td",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",

--- a/lib/Conversion/MemrefToArith/BUILD
+++ b/lib/Conversion/MemrefToArith/BUILD
@@ -9,7 +9,6 @@ cc_library(
     name = "Utils",
     srcs = ["Utils.cpp"],
     hdrs = ["@heir//include/Conversion/MemrefToArith:Utils.h"],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:AffineDialect",
@@ -20,7 +19,6 @@ cc_library(
 cc_test(
     name = "UtilsTest",
     srcs = ["UtilsTest.cpp"],
-    includes = ["@heir//include"],
     deps = [
         ":Utils",
         "@googletest//:gtest_main",
@@ -34,7 +32,6 @@ cc_library(
     name = "MemrefGlobalReplace",
     srcs = ["MemrefGlobalReplace.cpp"],
     hdrs = ["@heir//include/Conversion/MemrefToArith:MemrefToArith.h"],
-    includes = ["@heir//include"],
     deps = [
         ":Utils",
         "@llvm-project//mlir:AffineAnalysis",
@@ -51,7 +48,6 @@ cc_library(
     name = "ExpandCopy",
     srcs = ["ExpandCopy.cpp"],
     hdrs = ["@heir//include/Conversion/MemrefToArith:MemrefToArith.h"],
-    includes = ["@heir//include"],
     deps = [
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:AffineDialect",
@@ -67,7 +63,6 @@ cc_library(
     name = "ExtractLoopBody",
     srcs = ["ExtractLoopBody.cpp"],
     hdrs = ["@heir//include/Conversion/MemrefToArith:MemrefToArith.h"],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Conversion/MemrefToArith:pass_inc_gen",
         "@llvm-project//llvm:Support",
@@ -86,7 +81,6 @@ cc_library(
     name = "UnrollAndForward",
     srcs = ["UnrollAndForward.cpp"],
     hdrs = ["@heir//include/Conversion/MemrefToArith:MemrefToArith.h"],
-    includes = ["@heir//include"],
     deps = [
         ":Utils",
         "@llvm-project//llvm:Support",

--- a/lib/Conversion/PolyToStandard/BUILD
+++ b/lib/Conversion/PolyToStandard/BUILD
@@ -9,7 +9,6 @@ cc_library(
     hdrs = [
         "@heir//include/Conversion/PolyToStandard:PolyToStandard.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Conversion/PolyToStandard:pass_inc_gen",
         "@heir//lib/Conversion:Utils",

--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -17,7 +17,6 @@ cc_library(
         "@heir//include/Dialect/BGV/IR:BGVTraits.h",
         "@heir//include/Dialect/BGV/IR:BGVTypes.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Dialect/BGV/IR:attributes_inc_gen",
         "@heir//include/Dialect/BGV/IR:dialect_inc_gen",

--- a/lib/Dialect/EncryptedArith/IR/BUILD
+++ b/lib/Dialect/EncryptedArith/IR/BUILD
@@ -14,7 +14,6 @@ cc_library(
         "@heir//include/Dialect/EncryptedArith/IR:EncryptedArithDialect.h",
         "@heir//include/Dialect/EncryptedArith/IR:EncryptedArithTypes.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Dialect/EncryptedArith/IR:dialect_inc_gen",
         "@heir//include/Dialect/EncryptedArith/IR:types_inc_gen",

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -12,7 +12,6 @@ cc_library(
         "@heir//include/Dialect/LWE/IR:LWEAttributes.h",
         "@heir//include/Dialect/LWE/IR:LWEDialect.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Dialect/LWE/IR:attributes_inc_gen",
         "@heir//include/Dialect/LWE/IR:dialect_inc_gen",

--- a/lib/Dialect/Poly/IR/BUILD
+++ b/lib/Dialect/Poly/IR/BUILD
@@ -16,7 +16,6 @@ cc_library(
         "@heir//include/Dialect/Poly/IR:PolyOps.h",
         "@heir//include/Dialect/Poly/IR:PolyTypes.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         ":PolyAttributes",
         ":PolyOps",
@@ -61,7 +60,6 @@ cc_library(
         "@heir//include/Dialect/Poly/IR:PolyOps.h",
         "@heir//include/Dialect/Poly/IR:PolyTypes.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         ":PolyAttributes",
         "@heir//include/Dialect/Poly/IR:dialect_inc_gen",

--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -11,7 +11,6 @@ cc_library(
     hdrs = [
         "@heir//include/Dialect/Secret/IR:SecretDialect.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         ":SecretOps",
         "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
@@ -32,7 +31,6 @@ cc_library(
         "@heir//include/Dialect/Secret/IR:SecretOps.h",
         "@heir//include/Dialect/Secret/IR:SecretTypes.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
         "@heir//include/Dialect/Secret/IR:ops_inc_gen",

--- a/lib/Dialect/Secret/Transforms/BUILD
+++ b/lib/Dialect/Secret/Transforms/BUILD
@@ -22,7 +22,6 @@ cc_library(
     hdrs = [
         "@heir//include/Dialect/Secret/Transforms:ForgetSecrets.h",
     ],
-    includes = ["@heir//include"],
     deps = [
         "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",
         "@heir//lib/Dialect/Secret/IR:Dialect",


### PR DESCRIPTION
I'm not sure what they were doing, but they are malformed anyway (the includes are passed to clang as is without resolution in the bazel namespace).