### PR TITLE
Add verifiers for secret.generic and yield

### DIFF
--- a/include/Dialect/Secret/IR/SecretOps.td
+++ b/include/Dialect/Secret/IR/SecretOps.td
@@ -71,7 +71,9 @@ def Secret_RevealOp : Secret_Op<"reveal", [Pure]> {
 }
 
 
-def Secret_YieldOp : Secret_Op<"yield", [Pure, ReturnLike, Terminator]>,
+def Secret_YieldOp : Secret_Op<"yield", [
+    Pure, ReturnLike, Terminator, HasParent<"GenericOp">
+]>,
   Arguments<(ins Variadic<AnyType>:$values)> {
   let summary = "Secret yield operation";
   let description = [{
@@ -82,14 +84,7 @@ def Secret_YieldOp : Secret_Op<"yield", [Pure, ReturnLike, Terminator]>,
   }];
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
   let hasCustomAssemblyFormat = 1;
-
-  // TODO(https://github.com/google/heir/issues/108): add a verifier that
-  // ensures the yield op is inside a generic op, that the return type of the
-  // yield op matches the enclosing generic, and any other similar
-  // verifications that linalg.generic has that would be applicable here. Maybe
-  // there are some generic interfaces that produce these verifiers for free,
-  // like SingleBlockImplicitTerminator?
-  // let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 def Secret_GenericOp : Secret_Op<"generic", [
@@ -156,7 +151,7 @@ def Secret_GenericOp : Secret_Op<"generic", [
 
   // TODO(https://github.com/google/heir/issues/108): add a verifier that
   // ensures the arguments to the op match the arguments of the block.
-  // let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 

--- a/tests/secret/verifier.mlir
+++ b/tests/secret/verifier.mlir
@@ -1,0 +1,75 @@
+// RUN: heir-opt --verify-diagnostics --split-input-file %s
+
+func.func @test_cleartext_type_mismatch(%value: i32, %c1: i32) {
+  // expected-error@+1 {{If the operand is not secret, it must be the same type as}}
+  %Z = secret.generic
+    ins(%value, %c1 : i32, i32) {
+    ^bb0(%clear_value: i64, %clear_c1: i64):
+      %0 = arith.addi %clear_value, %clear_c1 : i64
+      secret.yield %0 : i64
+    } -> (!secret.secret<i64>)
+  return
+}
+
+// -----
+
+func.func @test_secret_type_mismatch(%value: !secret.secret<i32>, %c1: i32) {
+  // expected-error@+1 {{Type mismatch between block argument 0 of type 'i64' and generic operand of type '!secret.secret<i32>'}}
+  %Z = secret.generic
+    ins(%value, %c1 : !secret.secret<i32>, i32) {
+    ^bb0(%clear_value: i64, %clear_c1: i32):
+      %0 = arith.trunci %clear_value : i64 to i32
+      %1 = arith.addi %0, %clear_c1 : i32
+      secret.yield %1 : i32
+    } -> (!secret.secret<i32>)
+  return
+}
+
+// -----
+
+func.func @test_refers_to_value_outside_block(%value: !secret.secret<i32>) {
+  %c1 = arith.constant 1 : i32
+  // expected-error@+1 {{uses a value defined outside the block}}
+  %Z = secret.generic
+    ins(%value : !secret.secret<i32>) {
+    ^bb0(%clear_value: i32):
+      %1 = arith.addi %clear_value, %c1 : i32
+      secret.yield %1 : i32
+    } -> (!secret.secret<i32>)
+  return
+}
+
+// -----
+
+func.func @test_refers_to_block_argument_outside_block(%value: !secret.secret<i32>, %c1 : i32) {
+  // expected-error@+1 {{uses a block argument defined outside the block}}
+  %Z = secret.generic
+    ins(%value : !secret.secret<i32>) {
+    ^bb0(%clear_value: i32):
+      %1 = arith.addi %clear_value, %c1 : i32
+      secret.yield %1 : i32
+    } -> (!secret.secret<i32>)
+  return
+}
+
+// -----
+
+func.func @ensure_yield_inside_generic(%value: !secret.secret<i32>) {
+  // expected-error@+1 {{expects parent op 'secret.generic'}}
+  secret.yield %value : !secret.secret<i32>
+  return
+}
+
+// -----
+
+func.func @test_yield_type_agrees_with_generic(%value: !secret.secret<i32>) {
+  %Z = secret.generic
+    ins(%value : !secret.secret<i32>) {
+    ^bb0(%clear_value: i32):
+      %1 = arith.addi %clear_value, %clear_value : i32
+      %2 = arith.extui %1 : i32 to i64
+      // expected-error@+1 {{If a yield op returns types T, S, ..., then the enclosing generic op must have result types secret.secret<T>, secret.secret<S>, ... But this yield op has operand types: 'i64'; while the enclosing generic op has result types: '!secret.secret<i32>'}}
+      secret.yield %2 : i64
+    } -> (!secret.secret<i32>)
+  return
+}


### PR DESCRIPTION
Note one of the verifiers is implemented via a new trait `HasParent<"GenericOp">`