### PR TITLE
Add more poly ops needed for lowering polymul

### DIFF
--- a/include/Conversion/PolyToStandard/PolyToStandard.td
+++ b/include/Conversion/PolyToStandard/PolyToStandard.td
@@ -3,7 +3,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def PolyToStandard : Pass<"lower-poly"> {
+def PolyToStandard : Pass<"poly-to-standard"> {
   let summary = "Lower `poly` to standard MLIR dialects.";
 
   let description = [{
@@ -14,6 +14,7 @@ def PolyToStandard : Pass<"lower-poly"> {
     "mlir::arith::ArithDialect",
     "mlir::heir::poly::PolyDialect",
     "mlir::tensor::TensorDialect",
+    "mlir::scf::SCFDialect",
   ];
 }
 

--- a/include/Dialect/Poly/IR/PolyOps.td
+++ b/include/Dialect/Poly/IR/PolyOps.td
@@ -51,6 +51,24 @@ def Poly_MulConstantOp : Poly_Op<"mul_constant", [ElementwiseMappable, AllTypesM
   let assemblyFormat = "`(` operands `)` attr-dict `:` type($x) `,` type($constant)" ;
 }
 
+def Poly_DegreeOp: Poly_Op<"degree"> {
+  let summary = "Compute the degree of the polynomial.";
+  let description = [{
+    The degree of a polynomial is the largest `k` for which the coefficient of
+    `x^k` is nonzero.
+  }];
+  let arguments = (ins PolynomialLike:$input);
+  let results = (outs Index:$degree);
+  let assemblyFormat = "operands attr-dict `:` type($input)";
+}
+
+def Poly_MonomialOp: Poly_Op<"monomial"> {
+  let summary = "Create a polynomial that consists of a single monomial.";
+  let arguments = (ins AnyInteger:$coefficient, Index:$degree);
+  let results = (outs Polynomial:$output);
+  let assemblyFormat = "operands attr-dict `:` `(` type($coefficient) `,` type($degree) `)` `->` qualified(type($output))";
+}
+
 def Poly_FromTensorOp : Poly_Op<"from_tensor", [Pure]> {
   let summary = "Creates a polynomial from integer coefficients stored in a tensor.";
   let description = [{

--- a/lib/Conversion/PolyToStandard/BUILD
+++ b/lib/Conversion/PolyToStandard/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
     ],

--- a/tests/poly/lower_add.mlir
+++ b/tests/poly/lower_add.mlir
@@ -1,0 +1,43 @@
+// RUN: heir-opt --poly-to-standard %s | FileCheck %s
+
+#cycl_2048 = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
+#ring_prime = #poly.ring<cmod=4294967291, ideal=#cycl_2048>
+
+func.func @test_lower_add_power_of_two_cmod() -> !poly.poly<#ring> {
+  // 2 + 2x + 2x^2 + ... + 2x^{1023}
+  // CHECK: [[X:%.+]] = arith.constant dense<2> : [[T:tensor<1024xi32>]]
+  %coeffs1 = arith.constant dense<2> : tensor<1024xi32>
+  // CHECK: [[Y:%.+]] = arith.constant dense<3> : [[T]]
+  %coeffs2 = arith.constant dense<3> : tensor<1024xi32>
+  // CHECK-NOT: poly.from_tensor
+  %poly0 = poly.from_tensor %coeffs1 : tensor<1024xi32> -> !poly.poly<#ring>
+  %poly1 = poly.from_tensor %coeffs2 : tensor<1024xi32> -> !poly.poly<#ring>
+  // CHECK-NEXT: [[ADD:%.+]] = arith.addi [[X]], [[Y]]
+  %poly2 = poly.add(%poly0, %poly1) {ring = #ring} : !poly.poly<#ring>
+  // CHECK: return  [[ADD]] : [[T]]
+  return %poly2 : !poly.poly<#ring>
+}
+
+func.func @test_lower_add_prime_cmod() -> !poly.poly<#ring_prime> {
+  // CHECK: [[X:%.+]] = arith.constant dense<2> : [[TCOEFF:tensor<1024xi31>]]
+  %coeffs1 = arith.constant dense<2> : tensor<1024xi31>
+  // CHECK: [[Y:%.+]] = arith.constant dense<3> : [[TCOEFF]]
+  %coeffs2 = arith.constant dense<3> : tensor<1024xi31>
+  // CHECK-NOT: poly.from_tensor
+  // CHECK: [[XEXT:%.+]] = arith.extui [[X]] : [[TCOEFF]] to [[T:tensor<1024xi32>]]
+  // CHECK: [[YEXT:%.+]] = arith.extui [[Y]] : [[TCOEFF]] to [[T:tensor<1024xi32>]]
+  %poly0 = poly.from_tensor %coeffs1 : tensor<1024xi31> -> !poly.poly<#ring_prime>
+  %poly1 = poly.from_tensor %coeffs2 : tensor<1024xi31> -> !poly.poly<#ring_prime>
+
+  // CHECK: [[MOD:%.+]] = arith.constant dense<4294967291> : [[T2:tensor<1024xi33>]]
+  // CHECK: [[XEXT2:%.+]] = arith.extui [[XEXT]] : [[T]] to [[T2]]
+  // CHECK: [[YEXT2:%.+]] = arith.extui [[YEXT]] : [[T]] to [[T2]]
+  // CHECK: [[ADD_RESULT:%.+]] = arith.addi [[XEXT2]], [[YEXT2]]
+  // CHECK: [[REM_RESULT:%.+]] = arith.remui [[ADD_RESULT]], [[MOD]]
+  // CHECK: [[TRUNC_RESULT:%.+]] = arith.trunci [[REM_RESULT]] : [[T2]] to [[T]]
+  %poly2 = poly.add(%poly0, %poly1) {ring = #ring_prime} : !poly.poly<#ring_prime>
+
+  // CHECK: return  [[TRUNC_RESULT]] : [[T]]
+  return %poly2 : !poly.poly<#ring_prime>
+}

--- a/tests/poly/lower_deg.mlir
+++ b/tests/poly/lower_deg.mlir
@@ -1,0 +1,27 @@
+// RUN: heir-opt --poly-to-standard %s > %t
+// RUN: FileCheck %s < %t
+
+#cycl_2048 = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
+
+func.func @lower_poly_degree() {
+  // 2 + 2x + 2x^2 + ... + 2x^{1023}
+  // CHECK: [[X:%.+]] = arith.constant dense<2> : [[T:tensor<1024xi32>]]
+  %coeffs1 = arith.constant dense<2> : tensor<1024xi32>
+  // CHECK-NOT: poly.from_tensor
+  %poly0 = poly.from_tensor %coeffs1 : tensor<1024xi32> -> !poly.poly<#ring>
+  // CHECK-NOT: poly.degree
+  // CHECK: %[[C1023:.+]] = arith.constant 1023 : index
+  // CHECK: scf.while (%[[ARG0:.*]] = %[[C1023]]) : (index) -> index {
+  // CHECK:    tensor.extract
+  // CHECK:    arith.cmpi
+  // CHECK:    scf.condition
+  // CHECK: } do {
+  // CHECK:  ^bb0
+  // CHECK:    arith.subi
+  // CHECK:    scf.yield
+  // CHECK: }
+  %0 = poly.degree %poly0 : !poly.poly<#ring>
+  // CHECK: return
+  return
+}

--- a/tests/poly/lower_monomial.mlir
+++ b/tests/poly/lower_monomial.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --poly-to-standard %s | FileCheck %s
+
+#cycl_2048 = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
+
+func.func @test_monomial() {
+  // CHECK: %[[deg:.*]] = arith.constant 1023
+  %deg = arith.constant 1023 : index
+  // CHECK: %[[five:.*]] = arith.constant 5
+  %five = arith.constant 5 : i32
+  // CHECK: %[[container:.*]] = arith.constant dense<0>
+  // CHECK: tensor.insert %[[five]] into %[[container]][%[[deg]]]
+  %0 = poly.monomial %five, %deg : (i32, index) -> !poly.poly<#ring>
+  return
+}

--- a/tests/poly/lower_poly.mlir
+++ b/tests/poly/lower_poly.mlir
@@ -1,5 +1,4 @@
-// RUN: heir-opt --lower-poly %s > %t
-// RUN: FileCheck %s < %t
+// RUN: heir-opt --poly-to-standard %s | FileCheck %s
 
 #cycl_2048 = #poly.polynomial<1 + x**1024>
 #ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
@@ -12,40 +11,11 @@ module {
     %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
     // CHECK-NOT: poly.from_tensor
     // CHECK: [[COEFFS:%.+]] = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
-    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] : tensor<3xi32> to tensor<3xi64>
-    // CHECK: [[PAD:%.+]] = tensor.pad [[EXT]] low[0] high[1021]
-    // CHECK: tensor<3xi64> to tensor<1024xi64>
+    // CHECK: [[PAD:%.+]] = tensor.pad [[COEFFS]] low[0] high[1021]
+    // CHECK: tensor<3xi32> to tensor<1024xi32>
     %poly = poly.from_tensor %coeffs : tensor<3xi32> -> !poly.poly<#ring>
     // CHECK: return
     return
-  }
-
-  // CHECK-label: test_lower_to_tensor
-  func.func @test_lower_to_tensor() -> tensor<1024xi64> {
-    // CHECK: [[COEFFS:%.+]] = arith.constant
-    %coeffs = arith.constant dense<2> : tensor<1024xi32>
-    // CHECK-NOT: poly.from_tensor
-    %poly = poly.from_tensor %coeffs : tensor<1024xi32> -> !poly.poly<#ring>
-    // CHECK-NOT: poly.to_tensor
-    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] :  tensor<1024xi32> to  tensor<1024xi64>
-    %tensor = poly.to_tensor %poly : !poly.poly<#ring> -> tensor<1024xi64>
-    // CHECK: return [[EXT]]
-    return %tensor : tensor<1024xi64>
-  }
-
-  // CHECK-label: test_lower_to_tensor_small_coeffs
-  func.func @test_lower_to_tensor_small_coeffs() -> tensor<1024xi64> {
-    // CHECK-NOT: poly.from_tensor
-    // CHECK-NOT: poly.to_tensor
-    // CHECK: [[COEFFS:%.+]] = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
-    // CHECK: [[EXT:%.+]] = arith.extui [[COEFFS]] : tensor<3xi32> to tensor<3xi64>
-    // CHECK: [[PAD:%.+]] = tensor.pad [[EXT]] low[0] high[1021]
-    // CHECK: tensor<3xi64> to tensor<1024xi64>
-    %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
-    %poly = poly.from_tensor %coeffs : tensor<3xi32> -> !poly.poly<#ring>
-    %tensor = poly.to_tensor %poly : !poly.poly<#ring> -> tensor<1024xi64>
-    // CHECK: return [[PAD]]
-    return %tensor : tensor<1024xi64>
   }
 
   // CHECK-label: f0
@@ -59,47 +29,6 @@ module {
   func.func @test_lower_fn_and_call(%arg: !poly.poly<#ring>) {
     func.call @f0(%arg) : (!poly.poly<#ring>) -> !poly.poly<#ring>
     return
-  }
-
-  func.func @test_lower_add_power_of_two_cmod() -> !poly.poly<#ring> {
-    // 2 + 2x + 2x^2 + ... + 2x^{1023}
-    // CHECK: [[X:%.+]] = arith.constant dense<2> : [[T:tensor<1024xi32>]]
-    %coeffs1 = arith.constant dense<2> : tensor<1024xi32>
-    // CHECK: [[Y:%.+]] = arith.constant dense<3> : [[T]]
-    %coeffs2 = arith.constant dense<3> : tensor<1024xi32>
-    // CHECK-NOT: poly.from_tensor
-    // CHECK: [[XEXT:%.+]] = arith.extui [[X]] : [[T]] to [[TPOLY:tensor<1024xi64>]]
-    // CHECK: [[YEXT:%.+]] = arith.extui [[Y]] : [[T]] to [[TPOLY:tensor<1024xi64>]]
-    %poly0 = poly.from_tensor %coeffs1 : tensor<1024xi32> -> !poly.poly<#ring>
-    %poly1 = poly.from_tensor %coeffs2 : tensor<1024xi32> -> !poly.poly<#ring>
-    // CHECK:  [[MOD:%.+]] = arith.constant dense<4294967296> : [[TPOLY]]
-    // CHECK-NEXT: [[ADD:%.+]], [[OVERFLOW:%.+]] = arith.addui_extended [[XEXT]], [[YEXT]] : [[TPOLY]], tensor<1024xi1>
-    // CHECK-NEXT: [[REM:%.+]] = arith.remui [[ADD]], [[MOD]] : [[TPOLY]]
-    %poly2 = poly.add(%poly0, %poly1) {ring = #ring} : !poly.poly<#ring>
-    // CHECK: return  [[REM]] : [[TPOLY]]
-    return %poly2 : !poly.poly<#ring>
-  }
-
-  func.func @test_lower_add_prime_cmod() -> !poly.poly<#ring_prime> {
-    // CHECK: [[X:%.+]] = arith.constant dense<2> : [[TCOEFF:tensor<1024xi31>]]
-    %coeffs1 = arith.constant dense<2> : tensor<1024xi31>
-    // CHECK: [[Y:%.+]] = arith.constant dense<3> : [[TCOEFF]]
-    %coeffs2 = arith.constant dense<3> : tensor<1024xi31>
-    // CHECK-NOT: poly.from_tensor
-    // CHECK: [[XEXT:%.+]] = arith.extui [[X]] : [[TCOEFF]] to [[T:tensor<1024xi64>]]
-    // CHECK: [[YEXT:%.+]] = arith.extui [[Y]] : [[TCOEFF]] to [[T:tensor<1024xi64>]]
-    %poly0 = poly.from_tensor %coeffs1 : tensor<1024xi31> -> !poly.poly<#ring_prime>
-    %poly1 = poly.from_tensor %coeffs2 : tensor<1024xi31> -> !poly.poly<#ring_prime>
-    // CHECK:  [[MOD:%.+]] = arith.constant dense<4294967291> : [[T]]
-    // CHECK-NEXT: [[ADD:%.+]], [[OVERFLOW:%.+]] = arith.addui_extended [[XEXT]], [[YEXT]] : [[T]], tensor<1024xi1>
-    // CHECK-NEXT: [[REM:%.+]] = arith.remui [[ADD]], [[MOD]] : [[T]]
-    // CHECK-NEXT: [[NMOD:%.+]] = arith.constant dense<25> : [[T]]
-    // CHECK-NEXT: [[REMPLUS2N:%.+]] = arith.addi [[REM]], [[NMOD]] : [[T]]
-    // CHECK-NEXT: [[RES:%.+]] = arith.select [[OVERFLOW]], [[REM]], [[REMPLUS2N]] : tensor<1024xi1>, [[T]]
-    // CHECK-NEXT: [[RESMOD:%.+]] = arith.remui [[RES]], [[MOD]] : [[T]]
-    %poly2 = poly.add(%poly0, %poly1) {ring = #ring_prime} : !poly.poly<#ring_prime>
-    // CHECK: return  [[RESMOD]] : [[T]]
-    return %poly2 : !poly.poly<#ring_prime>
   }
 
   func.func @test_i32_coeff_with_i32_mod() -> () {

--- a/tests/poly/lower_to_tensor.mlir
+++ b/tests/poly/lower_to_tensor.mlir
@@ -1,0 +1,30 @@
+// RUN: heir-opt --poly-to-standard %s | FileCheck %s
+
+#cycl_2048 = #poly.polynomial<1 + x**1024>
+#ring = #poly.ring<cmod=4294967296, ideal=#cycl_2048>
+
+// CHECK-label: test_lower_to_tensor
+func.func @test_lower_to_tensor() -> tensor<1024xi32> {
+  // CHECK: [[COEFFS:%.+]] = arith.constant
+  %coeffs = arith.constant dense<2> : tensor<1024xi32>
+  // CHECK-NOT: poly.from_tensor
+  %poly = poly.from_tensor %coeffs : tensor<1024xi32> -> !poly.poly<#ring>
+  // CHECK-NOT: poly.to_tensor
+  %tensor = poly.to_tensor %poly : !poly.poly<#ring> -> tensor<1024xi32>
+  // CHECK: return [[COEFFS]]
+  return %tensor : tensor<1024xi32>
+}
+
+// CHECK-label: test_lower_to_tensor_small_coeffs
+func.func @test_lower_to_tensor_small_coeffs() -> tensor<1024xi32> {
+  // CHECK-NOT: poly.from_tensor
+  // CHECK-NOT: poly.to_tensor
+  // CHECK: [[COEFFS:%.+]] = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
+  // CHECK: [[PAD:%.+]] = tensor.pad [[COEFFS]] low[0] high[1021]
+  // CHECK: tensor<3xi32> to tensor<1024xi32>
+  %coeffs = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
+  %poly = poly.from_tensor %coeffs : tensor<3xi32> -> !poly.poly<#ring>
+  %tensor = poly.to_tensor %poly : !poly.poly<#ring> -> tensor<1024xi32>
+  // CHECK: return [[PAD]]
+  return %tensor : tensor<1024xi32>
+}

--- a/tests/poly/poly_ops.mlir
+++ b/tests/poly/poly_ops.mlir
@@ -50,4 +50,16 @@ module {
 
     return
   }
+
+  func.func @test_degree(%p0 : !poly.poly<#ring1>) {
+    %0 = poly.degree %p0 : !poly.poly<#ring1>
+    return
+  }
+
+  func.func @test_monomial() {
+    %deg = arith.constant 1023 : index
+    %five = arith.constant 5 : i16
+    %0 = poly.monomial %five, %deg : (i16, index) -> !poly.poly<#ring1>
+    return
+  }
 }


### PR DESCRIPTION
Adding poly.degree, poly.monomial, which will be useful for lowering poly.mul since I can implement the poly remainder routine using poly ops before the lowering starts.

Also encountered a bug in the bit width of the type conversion, and this led me down a long path that ended with a simpler poly.add lowering, thanks to Asra and Shruthi for pair programming on that.