### PR TITLE
Improve build_and_test

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# To tell rhysd/actionlint that we have a custom runner
+self-hosted-runner:
+  labels:
+    - ubuntu-20.04-16core

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,9 +7,13 @@ on:
   pull_request:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-20.04-16core
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
@@ -25,8 +29,8 @@ jobs:
 
       - name: "Run `bazel build`"
         run: |
-          bazel build //...
+          bazel build -c fastbuild //...
 
       - name: "Run `bazel test`"
         run: |
-          bazel test //...
+          bazel test -c fastbuild //...


### PR DESCRIPTION
- Add concurrency mode to cancel if a new run overrides an old one
- Use a faster runner
- Use `-c fastbuild` on bazel invocations