### PR TITLE
CGGI Dialect and LWE ciphertexts

### DIFF
--- a/include/Dialect/CGGI/IR/BUILD
+++ b/include/Dialect/CGGI/IR/BUILD
@@ -1,0 +1,76 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "CGGIDialect.h",
+        "CGGIOps.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "CGGIDialect.td",
+        "CGGIOps.td",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-dialect-decls"],
+            "CGGIDialect.h.inc",
+        ),
+        (
+            ["-gen-dialect-defs"],
+            "CGGIDialect.cpp.inc",
+        ),
+        (
+            ["-gen-dialect-doc"],
+            "CGGIDialect.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "CGGIDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "CGGIOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "CGGIOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "CGGIOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "CGGIOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        "@heir//include/Dialect/LWE/IR:td_files",
+        "@heir//include/Dialect/Polynomial/IR:td_files",
+    ],
+)

--- a/include/Dialect/CGGI/IR/CGGIDialect.h
+++ b/include/Dialect/CGGI/IR/CGGIDialect.h
@@ -1,0 +1,12 @@
+#ifndef HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIDIALECT_H_
+#define HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "include/Dialect/CGGI/IR/CGGIDialect.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIDIALECT_H_

--- a/include/Dialect/CGGI/IR/CGGIDialect.td
+++ b/include/Dialect/CGGI/IR/CGGIDialect.td
@@ -1,0 +1,14 @@
+#ifndef HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIDIALECT_TD_
+#define HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/CommonTypeConstraints.td"
+
+def CGGI_Dialect : Dialect {
+  let name = "cggi";
+  let summary = "A dialect for types and operations in the CGGI cryptosystem";
+  let cppNamespace = "::mlir::heir::cggi";
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIDIALECT_TD_

--- a/include/Dialect/CGGI/IR/CGGIOps.h
+++ b/include/Dialect/CGGI/IR/CGGIOps.h
@@ -1,0 +1,15 @@
+#ifndef HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_H_
+#define HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_H_
+
+#include "include/Dialect/CGGI/IR/CGGIDialect.h"
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "include/Dialect/LWE/IR/LWETypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "include/Dialect/CGGI/IR/CGGIOps.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_H_

--- a/include/Dialect/CGGI/IR/CGGIOps.td
+++ b/include/Dialect/CGGI/IR/CGGIOps.td
@@ -1,0 +1,75 @@
+#ifndef HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_TD_
+#define HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_TD_
+
+include "CGGIDialect.td"
+
+include "include/Dialect/Polynomial/IR/PolynomialAttributes.td"
+include "include/Dialect/LWE/IR/LWETypes.td"
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class CGGI_Op<string mnemonic, list<Trait> traits = []> :
+        Op<CGGI_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    `(` operands `)` attr-dict `:`  `(` qualified(type(operands)) `)` `->` qualified(type(results))
+  }];
+  let cppNamespace = "::mlir::heir::cggi";
+}
+
+// --- Operations for a gate-bootstrapping API of a CGGI library ---
+
+class CGGI_BinaryGateOp<string mnemonic>
+    : CGGI_Op<mnemonic, [Pure, Commutative, SameOperandsAndResultType]> {
+  let arguments = (ins LWECiphertext:$lhs, LWECiphertext:$rhs);
+  let results = (outs LWECiphertext:$output);
+  // Note: error: type of result #0, named 'output', is not buildable and a buildable type cannot be inferred
+  // LWECiphertext is not buildable?
+  let assemblyFormat = "operands attr-dict `->` type($output)" ;
+}
+
+def CGGI_AndOp : CGGI_BinaryGateOp<"and"> { let summary = "Logical AND of two ciphertexts."; }
+def CGGI_OrOp  : CGGI_BinaryGateOp<"or">  { let summary = "Logical OR of two ciphertexts."; }
+def CGGI_XorOp : CGGI_BinaryGateOp<"xor"> { let summary = "Logical XOR of two ciphertexts."; }
+
+class CGGI_NotOp : CGGI_Op<"not", [Pure, SameOperandsAndResultType, Involution]> {
+  let arguments = (ins LWECiphertext:$input);
+  let results = (outs LWECiphertext:$output);
+  let assemblyFormat = "operands attr-dict" ;
+  let summary = "Logical NOT of two ciphertexts";
+}
+
+class CGGI_LutOp<string mnemonic> : CGGI_Op<mnemonic, [Pure, Commutative, SameOperandsAndResultType]> {
+  let results = (outs LWECiphertext:$output);
+  let assemblyFormat = "`(` operands `)` attr-dict `:` type($output)" ;
+
+  let description = [{
+    An op representing a lookup table applied to some number `n` of ciphertexts
+    encrypting boolean input bits.
+
+    Over cleartext bits `a, b, c`, using `n = 3` for example, the operation
+    computed by this function can be interpreted as
+
+    ```
+      truth_table >> {c, b, a}
+    ```
+
+    where `{c, b, a}` is the unsigned 3-bit integer with bits `c, b, a` from most
+    significant bit to least-significant bit. The input are combined into a
+    single ciphertext input to the lookup table using products with plaintexts
+    and sums.
+  }];
+}
+
+def CGGI_Lut2Op : CGGI_LutOp<"lut2"> {
+  let summary = "A lookup table on two inputs.";
+  let arguments = (ins LWECiphertext:$b, LWECiphertext:$a, IndexAttr:$lookup_table);
+}
+
+def CGGI_Lut3Op : CGGI_LutOp<"lut3"> {
+  let summary = "A lookup table on three inputs.";
+  let arguments = (ins LWECiphertext:$c, LWECiphertext:$b, LWECiphertext:$a, IndexAttr:$lookup_table);
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_TD_

--- a/include/Dialect/LWE/IR/BUILD
+++ b/include/Dialect/LWE/IR/BUILD
@@ -11,6 +11,8 @@ exports_files(
     [
         "LWEDialect.h",
         "LWEAttributes.h",
+        "LWETypes.h",
+        "LWEOps.h",
     ],
 )
 
@@ -19,6 +21,8 @@ td_library(
     srcs = [
         "LWEAttributes.td",
         "LWEDialect.td",
+        "LWEOps.td",
+        "LWETypes.td",
     ],
     deps = [
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
@@ -75,5 +79,61 @@ gentbl_cc_library(
     deps = [
         ":dialect_inc_gen",
         ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-typedef-decls",
+            ],
+            "LWETypes.h.inc",
+        ),
+        (
+            [
+                "-gen-typedef-defs",
+            ],
+            "LWETypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "LWETypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWETypes.td",
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        ":td_files",
+        "@heir//include/Dialect/Polynomial/IR:td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "LWEOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "LWEOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "LWEOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LWEOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+        "@heir//include/Dialect/Polynomial/IR:td_files",
     ],
 )

--- a/include/Dialect/LWE/IR/LWEAttributes.h
+++ b/include/Dialect/LWE/IR/LWEAttributes.h
@@ -2,7 +2,8 @@
 #define HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_H_
 
 #include "include/Dialect/LWE/IR/LWEDialect.h"
-#include "mlir/include/mlir/IR/TensorEncoding.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/TensorEncoding.h"         // from @llvm-project
 
 #define GET_ATTRDEF_CLASSES
 #include "include/Dialect/LWE/IR/LWEAttributes.h.inc"

--- a/include/Dialect/LWE/IR/LWEAttributes.td
+++ b/include/Dialect/LWE/IR/LWEAttributes.td
@@ -1,7 +1,7 @@
 #ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_
 #define HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_
 
-include "LWEDialect.td"
+include "include/Dialect/LWE/IR/LWEDialect.td"
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/DialectBase.td"
@@ -228,6 +228,21 @@ def RLWE_InverseCanonicalEmbeddingEncoding
     %rlwe_ciphertext = tensor.from_elements %poly1, %poly2 : tensor<2x!poly.poly<#ring, #eval_encoding>>
     ```
   }];
+}
+
+def LWE_LWEParams : AttrDef<LWE_Dialect, "LWEParams"> {
+  let mnemonic = "lwe_params";
+
+  let parameters = (ins "int64_t": $cwidth, "APInt": $cmod, "unsigned":$dimension);
+
+  let builders = [
+    AttrBuilder<(ins "APInt": $cmod, "unsigned":$dimension), [{
+      return $_get($_ctxt, cmod.getBitWidth(), cmod, dimension);
+    }]>
+  ];
+
+  let skipDefaultBuilders = 1;
+  let hasCustomAssemblyFormat = 1;
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEATTRIBUTES_TD_

--- a/include/Dialect/LWE/IR/LWEDialect.td
+++ b/include/Dialect/LWE/IR/LWEDialect.td
@@ -25,6 +25,8 @@ def LWE_Dialect : Dialect {
   }];
 
   let cppNamespace = "::mlir::heir::lwe";
+
+  let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 }
 

--- a/include/Dialect/LWE/IR/LWEOps.h
+++ b/include/Dialect/LWE/IR/LWEOps.h
@@ -1,0 +1,12 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_H_
+
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+#include "include/Dialect/LWE/IR/LWETypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "include/Dialect/LWE/IR/LWEOps.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_H_

--- a/include/Dialect/LWE/IR/LWEOps.td
+++ b/include/Dialect/LWE/IR/LWEOps.td
@@ -1,0 +1,50 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_TD_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_TD_
+
+include "LWEDialect.td"
+include "LWETypes.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class LWE_Op<string mnemonic, list<Trait> traits = []> :
+        Op<LWE_Dialect, mnemonic, traits> {
+  let cppNamespace = "::mlir::heir::lwe";
+}
+
+def LWE_EncodeOp : LWE_Op<"encode", [Pure]> {
+  let summary = "Encode an integer to yield an LWE plaintext";
+  let description = [{
+    Encode an integer to yield an LWE plaintext.
+
+    This op uses a an encoding attribute to encode the bits of the integer into
+    an LWE plaintext value that can then be encrypted.
+
+    Examples:
+
+    ```
+    %Y = lwe.encode %value {encoding = #enc}: i1 to !lwe.lwe_plaintext<encoding = #enc, ring = #ring>
+    ```
+  }];
+
+  let arguments = (ins SignlessIntegerLike:$plaintext);
+  let results = (outs LWEPlaintext:$output);
+  let assemblyFormat = "$plaintext attr-dict `:` type($plaintext) `to` type($output)";
+}
+
+def LWE_TrivialEncryptOp: LWE_Op<"trivial_encrypt", [Pure]> {
+  let summary = "Create a trivial encryption of a plaintext.";
+
+  let arguments = (ins
+    LWEPlaintext:$input,
+    LWE_LWEParams:$params
+  );
+
+  let results = (outs LWECiphertext:$output);
+
+  let assemblyFormat = [{
+    operands attr-dict `:`  qualified(type(operands)) `to` qualified(type(results))
+  }];
+}
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWEOPS_TD_

--- a/include/Dialect/LWE/IR/LWETypes.h
+++ b/include/Dialect/LWE/IR/LWETypes.h
@@ -1,0 +1,10 @@
+#ifndef HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_H_
+#define HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_H_
+
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/LWE/IR/LWETypes.h.inc"
+
+#endif  // HEIR_INCLUDE_DIALECT_LWE_IR_LWETYPES_H_

--- a/include/Dialect/LWE/IR/LWETypes.td
+++ b/include/Dialect/LWE/IR/LWETypes.td
@@ -1,0 +1,56 @@
+#ifndef INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_
+#define INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_
+
+include "include/Dialect/LWE/IR/LWEDialect.td"
+include "include/Dialect/LWE/IR/LWEAttributes.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+// A base class for all types in this dialect
+class LWE_Type<string name, string typeMnemonic>
+    : TypeDef<LWE_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+// LWE Ciphertexts are ranked tensors of integers representing the LWE samples
+// and the bias.
+def LWECiphertext : LWE_Type<"LWECiphertext", "lwe_ciphertext"> {
+  let summary = "A type for LWE ciphertexts";
+
+  let description = [{
+    A type for LWE ciphertexts.
+
+    This type keeps track of the plaintext integer encoding for the LWE
+    Ciphertext to ensure proper decoding after decryption. It also keeps track
+    of the ring where the LWE ciphertext is defined, which provides information
+    on the ciphertext shape and the ring operations used in LWE operations.
+  }];
+
+  let parameters = (ins
+    LWE_BitFieldEncoding:$encoding,
+    LWE_LWEParams:$lwe_params
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+
+def LWEPlaintext : LWE_Type<"LWEPlaintext", "lwe_plaintext"> {
+  let summary = "A type for LWE plaintexts";
+
+  let description = [{
+    A type for LWE plaintexts.
+
+    This type keeps track of the plaintext integer encoding for the LWE
+    plaintext before it is encrypted.
+  }];
+
+  let parameters = (ins
+    LWE_BitFieldEncoding:$encoding
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+#endif  // INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_

--- a/lib/Dialect/CGGI/IR/BUILD
+++ b/lib/Dialect/CGGI/IR/BUILD
@@ -1,0 +1,26 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "CGGIDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/CGGI/IR:CGGIDialect.h",
+        "@heir//include/Dialect/CGGI/IR:CGGIOps.h",
+    ],
+    includes = ["@heir//include"],
+    deps = [
+        "@heir//include/Dialect/CGGI/IR:dialect_inc_gen",
+        "@heir//include/Dialect/CGGI/IR:ops_inc_gen",
+        "@heir//include/Dialect/Polynomial/IR:attributes_inc_gen",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/Polynomial/IR:PolynomialAttributes",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)

--- a/lib/Dialect/CGGI/IR/CGGIDialect.cpp
+++ b/lib/Dialect/CGGI/IR/CGGIDialect.cpp
@@ -1,0 +1,35 @@
+#include "include/Dialect/CGGI/IR/CGGIDialect.h"
+
+#include "include/Dialect/CGGI/IR/CGGIOps.h"
+#include "include/Dialect/LWE/IR/LWEDialect.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated definitions
+#include "include/Dialect/CGGI/IR/CGGIDialect.cpp.inc"
+#define GET_OP_CLASSES
+#include "include/Dialect/CGGI/IR/CGGIOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace cggi {
+
+//===----------------------------------------------------------------------===//
+// CGGI dialect.
+//===----------------------------------------------------------------------===//
+
+// Dialect construction: there is one instance per context and it registers its
+// operations, types, and interfaces here.
+void CGGIDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "include/Dialect/CGGI/IR/CGGIOps.cpp.inc"
+      >();
+
+  getContext()->getOrLoadDialect("lwe");
+}
+
+}  // namespace cggi
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -11,10 +11,14 @@ cc_library(
     hdrs = [
         "@heir//include/Dialect/LWE/IR:LWEAttributes.h",
         "@heir//include/Dialect/LWE/IR:LWEDialect.h",
+        "@heir//include/Dialect/LWE/IR:LWEOps.h",
+        "@heir//include/Dialect/LWE/IR:LWETypes.h",
     ],
     deps = [
         "@heir//include/Dialect/LWE/IR:attributes_inc_gen",
         "@heir//include/Dialect/LWE/IR:dialect_inc_gen",
+        "@heir//include/Dialect/LWE/IR:ops_inc_gen",
+        "@heir//include/Dialect/LWE/IR:types_inc_gen",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",

--- a/tests/cggi/BUILD
+++ b/tests/cggi/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/cggi/syntax.mlir
+++ b/tests/cggi/syntax.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s
+
+// This simply tests for syntax.
+#encoding = #lwe.bit_field_encoding<cleartext_start=30, cleartext_bitwidth=3>
+#poly = #polynomial.polynomial<1 + x**1024>
+#params = #lwe.lwe_params<cmod=7917, dimension=4>
+!plaintext = !lwe.lwe_plaintext<encoding = #encoding>
+!ciphertext = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+module {
+  func.func @test_syntax(%arg0 : !ciphertext) -> !ciphertext {
+    %0 = arith.constant 0 : i1
+    %1 = arith.constant 1 : i1
+    %2 = lwe.encode %0 { encoding = #encoding }: i1 to !plaintext
+    %3 = lwe.encode %1 { encoding = #encoding }: i1 to !plaintext
+    %4 = lwe.trivial_encrypt %2 { params = #params } : !plaintext to !ciphertext
+    %5 = lwe.trivial_encrypt %3 { params = #params } : !plaintext to !ciphertext
+    %6 = cggi.lut3 (%arg0, %4, %5) {lookup_table = 127 : index} : !ciphertext
+    return %4 : !ciphertext
+  }
+}

--- a/tests/lwe/types.mlir
+++ b/tests/lwe/types.mlir
@@ -1,0 +1,14 @@
+// RUN: heir-opt %s 2>&1 | FileCheck %s
+
+// This simply tests for syntax.
+
+#encoding = #lwe.bit_field_encoding<
+  cleartext_start=14,
+  cleartext_bitwidth=3>
+#params = #lwe.lwe_params<cmod=7917, dimension=10>
+!ciphertext = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+// CHECK-LABEL: test_valid_lwe_ciphertext
+func.func @test_valid_lwe_ciphertext(%arg0 : !ciphertext) -> !ciphertext {
+  return %arg0 : !ciphertext
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -38,6 +38,7 @@ cc_binary(
         "@heir//lib/Conversion/MemrefToArith:MemrefToArithRegistration",
         "@heir//lib/Conversion/PolynomialToStandard",
         "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/PolyExt/IR:Dialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -4,6 +4,7 @@
 #include "include/Conversion/MemrefToArith/MemrefToArith.h"
 #include "include/Conversion/PolynomialToStandard/PolynomialToStandard.h"
 #include "include/Dialect/BGV/IR/BGVDialect.h"
+#include "include/Dialect/CGGI/IR/CGGIDialect.h"
 #include "include/Dialect/Comb/IR/CombDialect.h"
 #include "include/Dialect/LWE/IR/LWEDialect.h"
 #include "include/Dialect/PolyExt/IR/PolyExtDialect.h"
@@ -152,6 +153,7 @@ int main(int argc, char **argv) {
   registry.insert<bgv::BGVDialect>();
   registry.insert<comb::CombDialect>();
   registry.insert<lwe::LWEDialect>();
+  registry.insert<cggi::CGGIDialect>();
   registry.insert<poly_ext::PolyExtDialect>();
   registry.insert<polynomial::PolynomialDialect>();
   registry.insert<secret::SecretDialect>();


### PR DESCRIPTION
* Moves LWECiphertext type to the LWE dialect
* Adds an LWEPlaintext type and encode operation to the LWE dialect
* Adds a CGGI trivial encryption into a ring to get an LWECiphertext type (it's possible this could also go to LWE?)

This gives sufficient functionality to implement a LUT based lowering from comb dialect.