### PR TITLE
End-to-end test for generated tfhe-rs code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ hugo_stats.json
 
 # for python dependencies
 venv
+
+# for rust codegen tests
+Cargo.lock

--- a/tests/tfhe_rust/end_to_end/BUILD
+++ b/tests/tfhe_rust/end_to_end/BUILD
@@ -1,0 +1,23 @@
+# See README.md for setup required to run these tests
+
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = [
+        "Cargo.toml",
+        "src/main.rs",
+        "@heir//tests:test_utilities",
+    ],
+    default_tags = [
+        "manual",
+        "notap",
+    ],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/tfhe_rust/end_to_end/Cargo.toml
+++ b/tests/tfhe_rust/end_to_end/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "heir-tfhe-rust-integration-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.1.8", features = ["derive"] }
+rayon = "1.6.1"
+serde = { version = "1.0.152", features = ["derive"] }
+tfhe = { version = "0.2.3", features = ["boolean", "shortint", "x86_64-unix"] }
+
+[[bin]]
+name = "main"
+path = "src/main.rs"

--- a/tests/tfhe_rust/end_to_end/README.md
+++ b/tests/tfhe_rust/end_to_end/README.md
@@ -1,0 +1,22 @@
+# End to end Rust codegen tests
+
+These tests exercise Rust codegen for the
+[tfhe-rs](https://github.com/zama-ai/tfhe-rs) backend library, including
+compiling the generated Rust source and running the resulting binary.
+
+To avoid introducing these large dependencies into the entire project, these
+tests are manual, and require the system they're running on to have
+[Cargo](https://doc.rust-lang.org/cargo/index.html) installed. During the test,
+cargo will fetch and build the required dependencies, and `Cargo.toml` in this
+directory effectively pins the version of `tfhe` supported.
+
+Use the following command to run the tests in this directory, where the default
+Cargo home `$HOME/.cargo` may need to be replaced by your custom `$CARGO_HOME`,
+if you overrode the default option when installing Cargo.
+
+```bash
+bazel test //tests/tfhe_rust/end_to_end:all --sandbox_writable_path=$HOME/.cargo
+```
+
+The `manual` tag is added to the targets in this directory to ensure that they
+are not run when someone runs a glob test like `bazel test //...`.

--- a/tests/tfhe_rust/end_to_end/src/main.rs
+++ b/tests/tfhe_rust/end_to_end/src/main.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use tfhe::shortint::parameters::get_parameters_from_message_and_carry;
+
+mod fn_under_test;
+
+// TODO(https://github.com/google/heir/issues/235): improve generality
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(id = "message_bits", long)]
+    message_bits: usize,
+
+    #[arg(id = "carry_bits", long, default_value = "2")]
+    carry_bits: usize,
+
+    /// arguments to forward to function under test
+    #[arg(id = "input_1", index = 1)]
+    input1: u8,
+
+    #[arg(id = "input_2", index = 2)]
+    input2: u8,
+}
+
+fn main() {
+    let flags = Args::parse();
+    let parameters = get_parameters_from_message_and_carry((1 << flags.message_bits) - 1, flags.carry_bits);
+    let (client_key, server_key) = tfhe::shortint::gen_keys(parameters);
+
+    let ct_1 = client_key.encrypt(flags.input1.into());
+    let ct_2 = client_key.encrypt(flags.input2.into());
+
+    let result = fn_under_test::fn_under_test(&server_key, &ct_1, &ct_2);
+    let output = client_key.decrypt(&result);
+    println!("{:?}", output);
+}

--- a/tests/tfhe_rust/end_to_end/test_add.mlir
+++ b/tests/tfhe_rust/end_to_end/test_add.mlir
@@ -1,0 +1,14 @@
+// This test ensures the testing harness is working properly with minimal codegen.
+
+// RUN: heir-translate %s --emit-tfhe-rust > %S/src/fn_under_test.rs
+// RUN: cargo run --release --manifest-path %S/Cargo.toml --bin main -- 2 3 --message_bits=3 | FileCheck %s
+
+!sks = !tfhe_rust.server_key
+!lut = !tfhe_rust.lookup_table
+!eui3 = !tfhe_rust.eui3
+
+// CHECK: 5
+func.func @fn_under_test(%sks : !sks, %a: !eui3, %b: !eui3) -> !eui3 {
+  %res = tfhe_rust.add %sks, %a, %b: (!sks, !eui3, !eui3) -> !eui3
+  return %res : !eui3
+}


### PR DESCRIPTION
This PR adds the necessary components for running end-to-end tests of generated tfhe-rs code in HEIR.

The actual test itself is marked `manual`, so it will not be run by CI, which is intended because of the extra dependency on cargo, `tfhe` crate, and all its dependencies. Future work on the tfhe-rs codegen should come with the expectation of running these tests manually on a machine that has cargo installed.

Will follow up this PR with more e2e tests, along with more codegen support.