### PR TITLE
Slightly tweak doc generation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     # disk.
     - name: "Build markdown files from tblgen sources"
       run: |
-        bazel query "filter('_filegroup$', siblings(kind('gentbl_rule', @heir//...)))" | \
+        bazel query "filter('_filegroup', siblings(kind('gentbl_rule', @heir//...)))" | \
           xargs bazel build "$@"
 
     - name: "Copy markdown files to docs/"


### PR DESCRIPTION
The problem was that some markdown files weren't getting generated by the original bazel query, even though the targets were matched.

It seems to affect only those dialects with ops but no types.  Digging in to CGGI as an example, these are the targets defined by the tblgen rule.

```
//include/Dialect/CGGI/IR:dialect_inc_gen_filegroup
//include/Dialect/CGGI/IR:dialect_inc_gen_filegroup___gen_dialect_decls_324940376_genrule
//include/Dialect/CGGI/IR:dialect_inc_gen_filegroup___gen_dialect_defs_-959349281_genrule
//include/Dialect/CGGI/IR:dialect_inc_gen_filegroup___gen_dialect_doc_-1416419769_genrule
//include/Dialect/CGGI/IR:ops_inc_gen_filegroup
//include/Dialect/CGGI/IR:ops_inc_gen_filegroup___gen_op_decls_1294557351_genrule
//include/Dialect/CGGI/IR:ops_inc_gen_filegroup___gen_op_defs_1288686000_genrule
//include/Dialect/CGGI/IR:ops_inc_gen_filegroup___gen_op_doc_-1482449834_genrule
```

The original query was only matching these two

```
//include/Dialect/CGGI/IR:dialect_inc_gen_filegroup
//include/Dialect/CGGI/IR:ops_inc_gen_filegroup
```

I thought that was sufficient to generate the op docs, but apparently it is not. The new query matches them all, and I confirmed the op docs are generated as well.