### PR TITLE
remove BuiltinAttributes.td from Polynomial

### DIFF
--- a/include/Dialect/LWE/IR/BUILD
+++ b/include/Dialect/LWE/IR/BUILD
@@ -27,6 +27,7 @@ td_library(
     # include from the heir-root to enable fully-qualified include-paths
     includes = ["../../../.."],
     deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",

--- a/include/Dialect/PolyExt/IR/BUILD
+++ b/include/Dialect/PolyExt/IR/BUILD
@@ -22,6 +22,7 @@ td_library(
     ],
     deps = [
         "@heir//include/Dialect/Polynomial/IR:td_files",
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",

--- a/include/Dialect/Polynomial/IR/BUILD
+++ b/include/Dialect/Polynomial/IR/BUILD
@@ -30,7 +30,6 @@ td_library(
     # include from the heir-root to enable fully-qualified include-paths
     includes = ["../../../.."],
     deps = [
-        "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
@@ -64,17 +63,11 @@ gentbl_cc_library(
     name = "attributes_inc_gen",
     tbl_outs = [
         (
-            [
-                "-gen-attrdef-decls",
-                "-attrdefs-dialect=polynomial",
-            ],
+            ["-gen-attrdef-decls"],
             "PolynomialAttributes.h.inc",
         ),
         (
-            [
-                "-gen-attrdef-defs",
-                "-attrdefs-dialect=polynomial",
-            ],
+            ["-gen-attrdef-defs"],
             "PolynomialAttributes.cpp.inc",
         ),
         (

--- a/include/Dialect/Polynomial/IR/PolynomialAttributes.td
+++ b/include/Dialect/Polynomial/IR/PolynomialAttributes.td
@@ -4,7 +4,6 @@
 include "include/Dialect/Polynomial/IR/PolynomialDialect.td"
 
 include "mlir/IR/AttrTypeBase.td"
-include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/DialectBase.td"
 
 class Polynomial_Attr<string name, string attrMnemonic, list<Trait> traits = []>

--- a/include/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/include/Dialect/Polynomial/IR/PolynomialOps.td
@@ -4,7 +4,6 @@
 include "include/Dialect/Polynomial/IR/PolynomialAttributes.td"
 include "include/Dialect/Polynomial/IR/PolynomialDialect.td"
 include "include/Dialect/Polynomial/IR/PolynomialTypes.td"
-include "mlir/IR/BuiltinAttributes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 


### PR DESCRIPTION
This should ensure that the polynomial dialect isn't getting builtin attributes re-defined on it.