### PR TITLE
Add CNAME to docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+heir.dev


### PR DESCRIPTION
This is required because

1. GitHub adds CNAME to the `gh-pages` branch when setting up a custom domain via a commit.
2. The webite deploy action force-pushes to `gh-pages`, overriding this commit.

See https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors

With this commit the CNAME file will be copied over with all the other website files.