### PR TITLE
yosys optimizer: fix bug with chunk connections

### DIFF
--- a/lib/Transforms/YosysOptimizer/YosysOptimizer.cpp
+++ b/lib/Transforms/YosysOptimizer/YosysOptimizer.cpp
@@ -101,6 +101,7 @@ void YosysOptimizer::runOnOperation() {
                                   abcFast ? "-fast" : ""));
 
     // Translate to MLIR and insert into the func
+    LLVM_DEBUG(Yosys::run_pass("dump;"));
     std::stringstream cellOrder;
     Yosys::log_streams.push_back(&cellOrder);
     Yosys::run_pass("torder -stop * P*;");
@@ -112,12 +113,12 @@ void YosysOptimizer::runOnOperation() {
     Yosys::RTLIL::Design *design = Yosys::yosys_get_design();
     func::FuncOp func =
         lutImporter.importModule(design->top_module(), topologicalOrder);
-    op.getBody().takeBody(func.getBody());
 
     LLVM_DEBUG(llvm::dbgs()
                << "Converted & optimized func via yosys. Input func:\n"
                << op << "\n\nOutput func:\n"
                << func << "\n");
+    op.getBody().takeBody(func.getBody());
 
     return WalkResult::advance();
   });

--- a/tests/yosys_optimizer/chunk_connections.mlir
+++ b/tests/yosys_optimizer/chunk_connections.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt -yosys-optimizer %s | FileCheck %s
+
+  // CHECK-LABEL: @for
+  func.func @for_loop(%arg0: i8, %arg1: i8) -> i32 {
+    // CHECK-NOT: arith.extsi
+    // CHECK-NOT: arith.subi
+    // CHECK-NOT: arith.muli
+    // CHECK-NOT: arith.addi
+    %c-128_i16 = arith.constant -128 : i16
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.extsi %arg0 : i8 to i16
+    %1 = arith.subi %0, %c-128_i16 : i16
+    %2 = arith.extsi %1 : i16 to i32
+    %3 = arith.extsi %arg1 : i8 to i32
+    %4 = arith.muli %2, %3 : i32
+    %5 = arith.addi %c0_i32, %4 : i32
+    // CHECK: return
+    return %5 : i32
+  }


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/260

This fixes a bug in the RTLIL importer, where a connection was made between a wire and another chunked wire. The code did not support the RHS chunked wire. A chunked wire is a part of a multi-bit wire. For e.g

```
module \test_multibit_const

  attribute \src "/tmp/file4v9Ejg:3.28-3.33"
  wire width 8 output 2 signed \_out_

  attribute \src "/tmp/file4v9Ejg:2.27-2.31"
  wire width 8 input 1 signed \arg1

  attribute \LUT 2'01
  attribute \module_not_derived 1
  attribute \src "lib/Transforms/YosysOptimizer/yosys/map_lut_to_lut3.v:72.10-81.19"
  cell \lut3 \_0_
    connect \A \arg1 [7]
    connect \B 0
    connect \C 0
    connect \P0 1'1
    connect \P1 1'0
    connect \P2 0
    connect \P3 0
    connect \P4 0
    connect \P5 0
    connect \P6 0
    connect \P7 0
    connect \Y \_out_ [7]
  end

  connect \_out_ [6:0] \arg1 [6:0]
end
```

In the line

```
  connect \_out_ [6:0] \arg1 [6:0]
```

we connect a chunk of `\out` with a chunk of `\arg1`. The code currently only supported chunked LHS by iterating through each bit of the connection. Now, we also do that same code if RHS is chunked.
