### PR TITLE
extract distribute-generic patterns for canonicalization

### DIFF
--- a/include/Dialect/Secret/IR/BUILD
+++ b/include/Dialect/Secret/IR/BUILD
@@ -11,6 +11,7 @@ exports_files(
     [
         "SecretDialect.h",
         "SecretOps.h",
+        "SecretPatterns.h",
         "SecretTypes.h",
     ],
 )

--- a/include/Dialect/Secret/IR/SecretOps.td
+++ b/include/Dialect/Secret/IR/SecretOps.td
@@ -158,7 +158,7 @@ def Secret_GenericOp : Secret_Op<"generic", [
     using BodyBuilderFn = function_ref<void(OpBuilder &, Location, ValueRange)>;
   }];
 
-  // let hasCanonicalizer = 1;
+  let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
 
   // TODO(https://github.com/google/heir/issues/108): add a folder that removes

--- a/include/Dialect/Secret/IR/SecretPatterns.h
+++ b/include/Dialect/Secret/IR/SecretPatterns.h
@@ -1,0 +1,82 @@
+#ifndef INCLUDE_DIALECT_SECRET_IR_SECRETPATTERNS_H_
+#define INCLUDE_DIALECT_SECRET_IR_SECRETPATTERNS_H_
+
+#include "include/Dialect/Secret/IR/SecretOps.h"
+#include "include/Dialect/Secret/IR/SecretTypes.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+// Inline the inner block of a secret.generic that has no secret operands.
+//
+// E.g.,
+//
+//    %res = secret.generic ins(%value : i32) {
+//     ^bb0(%clear_value: i32):
+//       %c7 = arith.constant 7 : i32
+//       %0 = arith.muli %clear_value, %c7 : i32
+//       secret.yield %0 : i32
+//    } -> (!secret.secret<i32>)
+//
+// is transformed to
+//
+//    %0 = arith.constant 0 : i32
+//    %res = arith.muli %value, %0 : i32
+//
+struct CollapseSecretlessGeneric : public OpRewritePattern<GenericOp> {
+  CollapseSecretlessGeneric(mlir::MLIRContext *context)
+      : OpRewritePattern<GenericOp>(context, /*benefit=*/3) {}
+
+ public:
+  LogicalResult matchAndRewrite(GenericOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+// Remove unused args of a secret.generic op
+//
+// E.g.,
+//
+//    %res = secret.generic
+//       ins(%value_sec, %unused_sec : !secret.secret<i32>, !secret.secret<i32>)
+//       {
+//     ^bb0(%used: i32, %unused: i32):
+//       %0 = arith.muli %used, %used : i32
+//       secret.yield %0 : i32
+//    } -> (!secret.secret<i32>)
+//
+// is transformed to
+//
+//    %res = secret.generic
+//       ins(%value_sec : !secret.secret<i32>) {
+//     ^bb0(%used: i32):
+//       %0 = arith.muli %used, %used : i32
+//       secret.yield %0 : i32
+//    } -> (!secret.secret<i32>)
+//
+struct RemoveUnusedGenericArgs : public OpRewritePattern<GenericOp> {
+  RemoveUnusedGenericArgs(mlir::MLIRContext *context)
+      : OpRewritePattern<GenericOp>(context, /*benefit=*/2) {}
+
+ public:
+  LogicalResult matchAndRewrite(GenericOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+// Remove non-secret args of a secret.generic op, since they can be referenced
+// directly in the enclosing scope.
+struct RemoveNonSecretGenericArgs : public OpRewritePattern<GenericOp> {
+  RemoveNonSecretGenericArgs(mlir::MLIRContext *context)
+      : OpRewritePattern<GenericOp>(context, /*benefit=*/2) {}
+
+ public:
+  LogicalResult matchAndRewrite(GenericOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_DIALECT_SECRET_IR_SECRETPATTERNS_H_

--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -15,6 +15,7 @@ cc_library(
     ],
     deps = [
         ":SecretOps",
+        ":SecretPatterns",
         "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
         "@heir//include/Dialect/Secret/IR:ops_inc_gen",
         "@heir//include/Dialect/Secret/IR:types_inc_gen",
@@ -22,6 +23,29 @@ cc_library(
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)
+
+cc_library(
+    name = "SecretPatterns",
+    srcs = [
+        "SecretPatterns.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Secret/IR:SecretDialect.h",
+        "@heir//include/Dialect/Secret/IR:SecretOps.h",
+        "@heir//include/Dialect/Secret/IR:SecretPatterns.h",
+        "@heir//include/Dialect/Secret/IR:SecretTypes.h",
+    ],
+    deps = [
+        "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Secret/IR:ops_inc_gen",
+        "@heir//include/Dialect/Secret/IR:types_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ControlFlowInterfaces",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:Support",
     ],
 )
 
@@ -36,6 +60,7 @@ cc_library(
         "@heir//include/Dialect/Secret/IR:SecretTypes.h",
     ],
     deps = [
+        ":SecretPatterns",
         "@heir//include/Dialect/Secret/IR:dialect_inc_gen",
         "@heir//include/Dialect/Secret/IR:ops_inc_gen",
         "@heir//include/Dialect/Secret/IR:types_inc_gen",

--- a/lib/Dialect/Secret/IR/SecretOps.cpp
+++ b/lib/Dialect/Secret/IR/SecretOps.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 
+#include "include/Dialect/Secret/IR/SecretPatterns.h"
 #include "include/Dialect/Secret/IR/SecretTypes.h"
 #include "llvm/include/llvm/Support/Casting.h"        // from @llvm-project
 #include "mlir/include/mlir/IR/Attributes.h"          // from @llvm-project
@@ -231,6 +232,12 @@ OpFoldResult CastOp::fold(CastOp::FoldAdaptor adaptor) {
     return OpFoldResult();
 
   return inputOp.getInput();
+}
+
+void GenericOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.add<CollapseSecretlessGeneric, RemoveUnusedGenericArgs,
+              RemoveNonSecretGenericArgs>(context);
 }
 
 }  // namespace secret

--- a/lib/Dialect/Secret/IR/SecretPatterns.cpp
+++ b/lib/Dialect/Secret/IR/SecretPatterns.cpp
@@ -1,0 +1,68 @@
+#include "include/Dialect/Secret/IR/SecretPatterns.h"
+
+#include "include/Dialect/Secret/IR/SecretOps.h"
+#include "include/Dialect/Secret/IR/SecretTypes.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+LogicalResult CollapseSecretlessGeneric::matchAndRewrite(
+    GenericOp op, PatternRewriter &rewriter) const {
+  for (Type ty : op.getOperandTypes()) {
+    if (dyn_cast<SecretType>(ty)) {
+      return failure();
+    }
+  }
+
+  YieldOp yieldOp = dyn_cast<YieldOp>(op.getBody()->getOperations().back());
+  rewriter.inlineBlockBefore(op.getBody(), op.getOperation(), op.getInputs());
+  rewriter.replaceOp(op, yieldOp.getValues());
+  rewriter.eraseOp(yieldOp);
+  return success();
+};
+
+LogicalResult RemoveUnusedGenericArgs::matchAndRewrite(
+    GenericOp op, PatternRewriter &rewriter) const {
+  bool hasUnusedOps = false;
+  Block *body = op.getBody();
+  for (int i = 0; i < body->getArguments().size(); ++i) {
+    BlockArgument arg = body->getArguments()[i];
+    if (arg.use_empty()) {
+      hasUnusedOps = true;
+      rewriter.updateRootInPlace(op, [&]() {
+        body->eraseArgument(i);
+        op.getOperation()->eraseOperand(i);
+      });
+      // Ensure the next iteration uses the right arg number
+      --i;
+    }
+  }
+
+  return hasUnusedOps ? success() : failure();
+}
+
+LogicalResult RemoveNonSecretGenericArgs::matchAndRewrite(
+    GenericOp op, PatternRewriter &rewriter) const {
+  bool deletedAny = false;
+  for (OpOperand &operand : op->getOpOperands()) {
+    if (!isa<SecretType>(operand.get().getType())) {
+      deletedAny = true;
+      Block *body = op.getBody();
+      BlockArgument correspondingArg =
+          body->getArgument(operand.getOperandNumber());
+
+      rewriter.replaceAllUsesWith(correspondingArg, operand.get());
+      rewriter.updateRootInPlace(op, [&]() {
+        body->eraseArgument(operand.getOperandNumber());
+        op.getOperation()->eraseOperand(operand.getOperandNumber());
+      });
+    }
+  }
+
+  return deletedAny ? success() : failure();
+}
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Secret/Transforms/BUILD
+++ b/lib/Dialect/Secret/Transforms/BUILD
@@ -44,6 +44,7 @@ cc_library(
     deps = [
         "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",
         "@heir//lib/Dialect/Secret/IR:SecretOps",
+        "@heir//lib/Dialect/Secret/IR:SecretPatterns",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LoopLikeInterface",


### PR DESCRIPTION
`--canonicalize` will now do the following canonicalizations on secret.generic:

- Fold generic entirely when there are no secret data types being operated on.
- Remove operands that are not secret, since they can be referenced directly from the enclosing scope now.
- Remove operands that are secret, but not used in the body of the generic.