### PR TITLE
fix: fix bug in wrap-generic to handle memref allocations

### DIFF
--- a/tests/secretize/wrap_generic.mlir
+++ b/tests/secretize/wrap_generic.mlir
@@ -46,3 +46,20 @@ module {
       func.return %1 : i32
     }
 }
+
+
+// -----
+
+module {
+    // CHECK: @secret_memref(%[[ARG0:.*]]: !secret.secret<memref<1xi32>>) -> !secret.secret<memref<1xi32>>
+    func.func @secret_memref(%value: memref<1xi32> {secret.secret}) -> memref<1xi32> {
+      // CHECK: %[[V0:.*]] = secret.generic ins(%[[ARG0]] : !secret.secret<memref<1xi32>>)
+      %const = arith.constant 100 : i32
+      %0 = affine.load %value[0] : memref<1xi32>
+      %1 = arith.addi %const, %0 : i32
+      %2 = memref.alloc() : memref<1xi32>
+      affine.store %1, %2[0] : memref<1xi32>
+      // CHECK: return %[[V0]] : !secret.secret<memref<1xi32>>
+      func.return %2 : memref<1xi32>
+    }
+}


### PR DESCRIPTION
wrap-generic previously assumed that the previous block would be erased because they were unused by the new `func::ReturnOp` that returns the generic result.

however, when memrefs are stored into an allocated memref, these stores are no longer deemed as unused. therefore, the IR keeps these trailing ops in, and `wrap-generic` would segfault.

this PR fixes this by manually erasing the ops that have been cloned into the generic's body