### PR TITLE
Properly handle yields when distributing generic through loops

### DIFF
--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -45,6 +45,8 @@ cc_library(
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/306

The hello world test case is handled now, along with memrefs being preserved (conservatively, with no dataflow analysis) in secret generics.