### PR TITLE
Draft: Initial version of OpenFHE dialect

### DIFF
--- a/include/Dialect/LWE/IR/LWETypes.td
+++ b/include/Dialect/LWE/IR/LWETypes.td
@@ -37,6 +37,16 @@ def LWECiphertext : LWE_Type<"LWECiphertext", "lwe_ciphertext"> {
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
+def RLWECiphertext : LWE_Type<"RLWECiphertext", "rlwe_ciphertext"> {
+  let summary = "A type for RLWE ciphertexts";
+
+  let parameters = (ins
+    "::mlir::Attribute":$encoding,
+    OptionalParameter<"RLWEParamsAttr">:$rlwe_params
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
 
 def LWEPlaintext : LWE_Type<"LWEPlaintext", "lwe_plaintext"> {
   let summary = "A type for LWE plaintexts";
@@ -47,6 +57,16 @@ def LWEPlaintext : LWE_Type<"LWEPlaintext", "lwe_plaintext"> {
     This type keeps track of the plaintext integer encoding for the LWE
     plaintext before it is encrypted.
   }];
+
+  let parameters = (ins
+    "::mlir::Attribute":$encoding
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+def RLWEPlaintext : LWE_Type<"RLWEPlaintext", "rlwe_plaintext"> {
+  let summary = "A type for RLWE plaintexts";
 
   let parameters = (ins
     "::mlir::Attribute":$encoding

--- a/include/Dialect/Openfhe/IR/BUILD
+++ b/include/Dialect/Openfhe/IR/BUILD
@@ -1,0 +1,113 @@
+# OpenFHE, an exit dialect to the OpenFHE API
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "OpenfheDialect.h",
+        "OpenfheOps.h",
+        "OpenfheTypes.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "OpenfheDialect.td",
+        "OpenfheOps.td",
+        "OpenfheTypes.td",
+    ],
+    deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "OpenfheDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "OpenfheDialect.cpp.inc",
+        ),
+        (
+            [
+                "-gen-dialect-doc",
+            ],
+            "OpenfheDialect.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "OpenfheDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-typedef-decls",
+            ],
+            "OpenfheTypes.h.inc",
+        ),
+        (
+            [
+                "-gen-typedef-defs",
+            ],
+            "OpenfheTypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "OpenfheTypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "OpenfheTypes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "OpenfheOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "OpenfheOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "OpenfheOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "OpenfheOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+        "@heir//include/Dialect/LWE/IR:td_files",
+    ],
+)

--- a/include/Dialect/Openfhe/IR/OpenfheDialect.h
+++ b/include/Dialect/Openfhe/IR/OpenfheDialect.h
@@ -1,0 +1,12 @@
+#ifndef INCLUDE_DIALECT_OPENFHE_IR_OPENFHEDIALECT_H_
+#define INCLUDE_DIALECT_OPENFHE_IR_OPENFHEDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "include/Dialect/Openfhe/IR/OpenfheDialect.h.inc"
+
+#endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHEDIALECT_H_

--- a/include/Dialect/Openfhe/IR/OpenfheDialect.td
+++ b/include/Dialect/Openfhe/IR/OpenfheDialect.td
@@ -1,0 +1,21 @@
+#ifndef INCLUDE_DIALECT_OPENFHE_IR_OPENFHEDIALECT_TD_
+#define INCLUDE_DIALECT_OPENFHE_IR_OPENFHEDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+
+def Openfhe_Dialect : Dialect {
+  let name = "openfhe";
+
+  let description = [{
+    The `openfhe` dialect is an exit dialect for generating c++ code against the OpenFHE library API.
+
+    See https://github.com/openfheorg/openfhe-development
+  }];
+
+  let cppNamespace = "::mlir::heir::openfhe";
+
+  let useDefaultTypePrinterParser = 1;
+}
+
+#endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHEDIALECT_TD_

--- a/include/Dialect/Openfhe/IR/OpenfheOps.h
+++ b/include/Dialect/Openfhe/IR/OpenfheOps.h
@@ -1,0 +1,15 @@
+#ifndef INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_H_
+#define INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_H_
+
+#include "include/Dialect/LWE/IR/LWETypes.h"
+#include "include/Dialect/Openfhe/IR/OpenfheDialect.h"
+#include "include/Dialect/Openfhe/IR/OpenfheTypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "include/Dialect/Openfhe/IR/OpenfheOps.h.inc"
+
+#endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_H_

--- a/include/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/include/Dialect/Openfhe/IR/OpenfheOps.td
@@ -1,0 +1,104 @@
+#ifndef INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_TD_
+#define INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_TD_
+
+include "OpenfheDialect.td"
+include "OpenfheTypes.td"
+
+include "include/Dialect/LWE/IR/LWETypes.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class Openfhe_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Openfhe_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    operands attr-dict `:` `(` type(operands) `)` `->` type(results)
+  }];
+  let cppNamespace = "::mlir::heir::openfhe";
+}
+
+def EncryptOp : Openfhe_Op<"encrypt", [Pure]> {
+  let arguments = (ins Openfhe_CryptoContext:$cryptoContext, RLWEPlaintext:$plaintext, Openfhe_PublicKey:$publicKey);
+  let results = (outs RLWECiphertext:$output);
+}
+
+def NegateOp : Openfhe_Op<"negate", [
+    Pure,
+    AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let arguments = (ins Openfhe_CryptoContext:$cryptoContext, RLWECiphertext:$ciphertext);
+  let results = (outs RLWECiphertext:$output);
+}
+
+def AddOp : Openfhe_Op<"add",[
+    Pure,
+    AllTypesMatch<["lhs", "rhs", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$lhs,
+    RLWECiphertext:$rhs
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+def SubOp : Openfhe_Op<"sub",[
+    Pure,
+    AllTypesMatch<["lhs", "rhs", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$lhs,
+    RLWECiphertext:$rhs
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+def MulOp : Openfhe_Op<"mul",[
+    Pure,
+    AllTypesMatch<["lhs", "rhs"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$lhs,
+    RLWECiphertext:$rhs
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+def MulPlainOp : Openfhe_Op<"mulplain",[
+    Pure,
+    AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext,
+    RLWEPlaintext:$plaintext
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+def MulConstOp : Openfhe_Op<"mulconst",[
+    Pure,
+    AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext,
+    I64:$constant
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+def RotOp : Openfhe_Op<"rot",[
+  Pure,
+  AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext,
+    I32:$rot
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+#endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_TD_

--- a/include/Dialect/Openfhe/IR/OpenfheTypes.h
+++ b/include/Dialect/Openfhe/IR/OpenfheTypes.h
@@ -1,0 +1,9 @@
+#ifndef INCLUDE_DIALECT_OPENFHE_IR_OPENFHETYPES_H_
+#define INCLUDE_DIALECT_OPENFHE_IR_OPENFHETYPES_H_
+
+#include "include/Dialect/Openfhe/IR/OpenfheDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/Openfhe/IR/OpenfheTypes.h.inc"
+
+#endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHETYPES_H_

--- a/include/Dialect/Openfhe/IR/OpenfheTypes.td
+++ b/include/Dialect/Openfhe/IR/OpenfheTypes.td
@@ -1,0 +1,25 @@
+#ifndef INCLUDE_DIALECT_OPENFHE_IR_OPENFHETYPES_TD_
+#define INCLUDE_DIALECT_OPENFHE_IR_OPENFHETYPES_TD_
+
+include "OpenfheDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+class Openfhe_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<Openfhe_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def Openfhe_PublicKey : Openfhe_Type<"PublicKey", "public_key"> {
+  let summary = "The public key required to encrypt plaintext in OpenFHE.";
+}
+
+def Openfhe_CryptoContext : Openfhe_Type<"CryptoContext", "crypto_context"> {
+  let summary = "The CryptoContext required to perform homomorphic operations in OpenFHE.";
+}
+
+#endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHETYPES_TD_

--- a/lib/Dialect/Openfhe/IR/BUILD
+++ b/lib/Dialect/Openfhe/IR/BUILD
@@ -1,0 +1,25 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "OpenfheDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Openfhe/IR:OpenfheDialect.h",
+        "@heir//include/Dialect/Openfhe/IR:OpenfheOps.h",
+        "@heir//include/Dialect/Openfhe/IR:OpenfheTypes.h",
+    ],
+    deps = [
+        "@heir//include/Dialect/Openfhe/IR:dialect_inc_gen",
+        "@heir//include/Dialect/Openfhe/IR:ops_inc_gen",
+        "@heir//include/Dialect/Openfhe/IR:types_inc_gen",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)

--- a/lib/Dialect/Openfhe/IR/OpenfheDialect.cpp
+++ b/lib/Dialect/Openfhe/IR/OpenfheDialect.cpp
@@ -1,0 +1,31 @@
+#include "include/Dialect/Openfhe/IR/OpenfheDialect.h"
+
+#include "include/Dialect/Openfhe/IR/OpenfheDialect.cpp.inc"
+#include "include/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "include/Dialect/Openfhe/IR/OpenfheTypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/Openfhe/IR/OpenfheTypes.cpp.inc"
+#define GET_OP_CLASSES
+#include "include/Dialect/Openfhe/IR/OpenfheOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+void OpenfheDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "include/Dialect/Openfhe/IR/OpenfheTypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "include/Dialect/Openfhe/IR/OpenfheOps.cpp.inc"
+      >();
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/lwe/types.mlir
+++ b/tests/lwe/types.mlir
@@ -22,3 +22,11 @@ func.func @test_valid_lwe_ciphertext(%arg0 : !ciphertext) -> !ciphertext {
 func.func @test_valid_lwe_ciphertext_unspecified(%arg0 : !ciphertext_noparams) -> !ciphertext_noparams {
   return %arg0 : !ciphertext_noparams
 }
+
+#rlwe_params = #lwe.rlwe_params<cmod=7917, dimension=10, polyDegree=1024>
+!ciphertext_rlwe = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #rlwe_params>
+
+// CHECK-LABEL: test_valid_rlwe_ciphertext
+func.func @test_valid_rlwe_ciphertext(%arg0 : !ciphertext_rlwe) -> !ciphertext_rlwe {
+  return %arg0 : !ciphertext_rlwe
+}

--- a/tests/openfhe/BUILD
+++ b/tests/openfhe/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/openfhe/ops.mlir
+++ b/tests/openfhe/ops.mlir
@@ -1,0 +1,72 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// This simply tests for syntax.
+#encoding = #lwe.polynomial_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
+#params = #lwe.rlwe_params<cmod=7917, dimension=1, polyDegree=16384>
+!pk = !openfhe.public_key
+!cc = !openfhe.crypto_context
+!pt = !lwe.rlwe_plaintext<encoding = #encoding>
+!ct = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params>
+
+module {
+  // CHECK-LABEL: func @test_encrypt
+  func.func @test_encrypt(%cc: !cc, %pt : !pt, %pk: !pk) {
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_negate
+  func.func @test_negate(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.negate %cc, %ct: (!cc, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_add
+  func.func @test_add(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %c2 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.add %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_sub
+  func.func @test_sub(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %c2 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.sub %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_mul
+  func.func @test_mul(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %c2 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.mul %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_mulplain
+  func.func @test_mulplain(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %0 = arith.constant 5 : i64
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.mulplain %cc, %c1, %pt: (!cc, !ct, !pt) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_mulconst
+  func.func @test_mulconst(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %0 = arith.constant 5 : i64
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.mulconst %cc, %c1, %0: (!cc, !ct, i64) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_rot
+  func.func @test_rot(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %0 = arith.constant 2 : i32
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.rot %cc, %ct, %0: (!cc, !ct, i32) -> !ct
+    return
+  }
+}

--- a/tests/openfhe/types.mlir
+++ b/tests/openfhe/types.mlir
@@ -1,0 +1,11 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// This simply tests for syntax.
+module {
+  // CHECK-LABEL: func @test
+  func.func @test(
+     %arg_cc: !openfhe.crypto_context,
+     %arg_pk: !openfhe.public_key) {
+    return
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -45,6 +45,7 @@ cc_binary(
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/LWE/Transforms",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/PolyExt/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -11,6 +11,7 @@
 #include "include/Dialect/Comb/IR/CombDialect.h"
 #include "include/Dialect/LWE/IR/LWEDialect.h"
 #include "include/Dialect/LWE/Transforms/Passes.h"
+#include "include/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "include/Dialect/PolyExt/IR/PolyExtDialect.h"
 #include "include/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "include/Dialect/Secret/IR/SecretDialect.h"
@@ -164,6 +165,7 @@ int main(int argc, char **argv) {
   registry.insert<polynomial::PolynomialDialect>();
   registry.insert<secret::SecretDialect>();
   registry.insert<tfhe_rust::TfheRustDialect>();
+  registry.insert<openfhe::OpenfheDialect>();
 
   // Add expected MLIR dialects to the registry.
   registry.insert<affine::AffineDialect>();


### PR DESCRIPTION
This PR contains initial draft for OpenFHE exit dialect(#328)

- Added primitive types (RLWEPlaintext, RLWECiphertext, cryptocontext, publickey)
- Added primitive operators (add, sub, negate, mult, rotate)
- Added corresponding simple tests