### PR TITLE
Add CGGI straight-line vectorizer

### DIFF
--- a/include/Dialect/CGGI/IR/CGGIOps.td
+++ b/include/Dialect/CGGI/IR/CGGIOps.td
@@ -20,11 +20,18 @@ class CGGI_Op<string mnemonic, list<Trait> traits = []> :
 }
 
 // --- Operations for a gate-bootstrapping API of a CGGI library ---
+def LWECiphertextLike : TypeOrContainer<LWECiphertext, "ciphertext-like">;
 
 class CGGI_BinaryGateOp<string mnemonic>
-    : CGGI_Op<mnemonic, [Pure, Commutative, SameOperandsAndResultType]> {
-  let arguments = (ins LWECiphertext:$lhs, LWECiphertext:$rhs);
-  let results = (outs LWECiphertext:$output);
+  : CGGI_Op<mnemonic, [
+    Pure,
+    Commutative,
+    SameOperandsAndResultType,
+    Elementwise,
+    Scalarizable
+]> {
+  let arguments = (ins LWECiphertextLike:$lhs, LWECiphertextLike:$rhs);
+  let results = (outs LWECiphertextLike:$output);
   // Note: error: type of result #0, named 'output', is not buildable and a buildable type cannot be inferred
   // LWECiphertext is not buildable?
   let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
@@ -41,8 +48,14 @@ def CGGI_NotOp : CGGI_Op<"not", [Pure, SameOperandsAndResultType, Involution]> {
   let summary = "Logical NOT of two ciphertexts";
 }
 
-class CGGI_LutOp<string mnemonic> : CGGI_Op<mnemonic, [Pure, Commutative, SameOperandsAndResultType]> {
-  let results = (outs LWECiphertext:$output);
+class CGGI_LutOp<string mnemonic, list<Trait> traits = []>
+  : CGGI_Op<mnemonic, traits # [
+  Pure,
+  Commutative,
+  Elementwise,
+  Scalarizable
+]> {
+  let results = (outs LWECiphertextLike:$output);
   let assemblyFormat = "`(` operands `)` attr-dict `:` qualified(type($output))" ;
 
   let description = [{
@@ -63,14 +76,15 @@ class CGGI_LutOp<string mnemonic> : CGGI_Op<mnemonic, [Pure, Commutative, SameOp
   }];
 }
 
-def CGGI_Lut2Op : CGGI_LutOp<"lut2"> {
+def CGGI_Lut2Op : CGGI_LutOp<"lut2", [AllTypesMatch<["a", "b", "output"]>]> {
   let summary = "A lookup table on two inputs.";
-  let arguments = (ins LWECiphertext:$b, LWECiphertext:$a, Builtin_IntegerAttr:$lookup_table);
+  let arguments = (ins LWECiphertextLike:$b, LWECiphertextLike:$a, Builtin_IntegerAttr:$lookup_table);
 }
 
-def CGGI_Lut3Op : CGGI_LutOp<"lut3"> {
+def CGGI_Lut3Op : CGGI_LutOp<"lut3", [AllTypesMatch<["a", "b", "c", "output"]>]> {
   let summary = "A lookup table on three inputs.";
-  let arguments = (ins LWECiphertext:$c, LWECiphertext:$b, LWECiphertext:$a, Builtin_IntegerAttr:$lookup_table);
+  let arguments = (ins LWECiphertextLike:$c, LWECiphertextLike:$b, LWECiphertextLike:$a, Builtin_IntegerAttr:$lookup_table);
+  let results = (outs LWECiphertextLike:$output);
 }
 
 #endif  // HEIR_INCLUDE_DIALECT_CGGI_IR_CGGIOPS_TD_

--- a/include/Dialect/CGGI/Transforms/BUILD
+++ b/include/Dialect/CGGI/Transforms/BUILD
@@ -33,4 +33,5 @@ gentbl_cc_library(
 exports_files([
     "Passes.h",
     "SetDefaultParameters.h",
+    "StraightLineVectorizer.h",
 ])

--- a/include/Dialect/CGGI/Transforms/Passes.h
+++ b/include/Dialect/CGGI/Transforms/Passes.h
@@ -3,6 +3,7 @@
 
 #include "include/Dialect/CGGI/IR/CGGIDialect.h"
 #include "include/Dialect/CGGI/Transforms/SetDefaultParameters.h"
+#include "include/Dialect/CGGI/Transforms/StraightLineVectorizer.h"
 
 namespace mlir {
 namespace heir {

--- a/include/Dialect/CGGI/Transforms/Passes.td
+++ b/include/Dialect/CGGI/Transforms/Passes.td
@@ -19,4 +19,13 @@ def SetDefaultParameters : Pass<"cggi-set-default-parameters"> {
   let dependentDialects = ["mlir::heir::cggi::CGGIDialect"];
 }
 
+def StraightLineVectorizer : Pass<"cggi-straight-line-vectorizer"> {
+  let summary = "A straight-line vectorizer for CGGI bootstrapping ops.";
+  let description = [{
+  This pass vectorizes CGGI ops. It ignores control flow and only vectorizes
+  straight-line programs within a given region.
+  }];
+  let dependentDialects = ["mlir::heir::cggi::CGGIDialect"];
+}
+
 #endif  // INCLUDE_DIALECT_CGGI_TRANSFORMS_PASSES_TD_

--- a/include/Dialect/CGGI/Transforms/StraightLineVectorizer.h
+++ b/include/Dialect/CGGI/Transforms/StraightLineVectorizer.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_DIALECT_CGGI_TRANSFORMS_STRAIGHTLINEVECTORIZER_H_
+#define INCLUDE_DIALECT_CGGI_TRANSFORMS_STRAIGHTLINEVECTORIZER_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cggi {
+
+#define GEN_PASS_DECL_STRAIGHTLINEVECTORIZER
+#include "include/Dialect/CGGI/Transforms/Passes.h.inc"
+
+}  // namespace cggi
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_DIALECT_CGGI_TRANSFORMS_STRAIGHTLINEVECTORIZER_H_

--- a/include/Graph/BUILD
+++ b/include/Graph/BUILD
@@ -1,0 +1,25 @@
+# General utilities for graphs
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Graph",
+    hdrs = ["Graph.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "GraphTest",
+    srcs = ["GraphTest.cpp"],
+    deps = [
+        ":Graph",
+        "@googletest//:gtest_main",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/include/Graph/Graph.h
+++ b/include/Graph/Graph.h
@@ -1,0 +1,160 @@
+#ifndef INCLUDE_GRAPH_GRAPH_H_
+#define INCLUDE_GRAPH_GRAPH_H_
+
+#include <vector>
+
+#include "llvm/include/llvm/ADT/ArrayRef.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMap.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallSet.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace graph {
+
+// A graph data structure.
+//
+// Parameter `V` is the vertex type, which is expected to be cheap to copy.
+template <typename V>
+class Graph {
+ public:
+  // Adds a vertex to the graph
+  void addVertex(V vertex) { vertices.insert(vertex); }
+
+  // Adds an edge from the given `source` to the given `target`. Returns false
+  // if either the source or target is not a previously inserted vertex, and
+  // returns true otherwise. The graph is unchanged if false is returned.
+  bool addEdge(V source, V target) {
+    if (!vertices.contains(source) || !vertices.contains(target)) {
+      return false;
+    }
+    outEdges[source].insert(target);
+    inEdges[target].insert(source);
+    return true;
+  }
+
+  // Returns true iff the given vertex has previously been added to the graph
+  // using `AddVertex`.
+  bool contains(V vertex) { return vertices.contains(vertex); }
+
+  bool empty() { return vertices.empty(); }
+
+  const llvm::SmallSet<V, 4>& getVertices() { return vertices; }
+
+  // Returns the edges that point out of the given vertex.
+  std::vector<V> edgesOutOf(V vertex) {
+    if (vertices.contains(vertex)) {
+      std::vector<V> result(outEdges[vertex].begin(), outEdges[vertex].end());
+      // Note: The vertices are sorted to ensure determinism in the output.
+      std::sort(result.begin(), result.end());
+      return result;
+    }
+    return {};
+  }
+
+  // Returns the edges that point into the given vertex.
+  std::vector<V> edgesInto(V vertex) {
+    if (vertices.contains(vertex)) {
+      std::vector<V> result(inEdges[vertex].begin(), inEdges[vertex].end());
+      // Note: The vertices are sorted to ensure determinism in the output.
+      std::sort(result.begin(), result.end());
+      return result;
+    }
+    return {};
+  }
+
+  // Returns a topological sort of the nodes in the graph if the graph is
+  // acyclic, otherwise returns failure()
+  FailureOr<std::vector<V>> topologicalSort() {
+    std::vector<V> result;
+
+    // Kahn's algorithm
+    std::vector<V> active;
+    llvm::DenseMap<V, int64_t> edgeCount;
+    for (const V& vertex : vertices) {
+      edgeCount[vertex] = edgesInto(vertex).size();
+      if (edgeCount.at(vertex) == 0) {
+        active.push_back(vertex);
+      }
+    }
+
+    while (!active.empty()) {
+      V source = active.back();
+      active.pop_back();
+      result.push_back(source);
+      for (auto target : edgesOutOf(source)) {
+        edgeCount[target]--;
+        if (edgeCount.at(target) == 0) {
+          active.push_back(target);
+        }
+      }
+    }
+
+    if (result.size() != vertices.size()) {
+      return failure();
+    }
+
+    return result;
+  }
+
+  // Find the level of each node in the graph, where the level
+  // is the length of the longest path from any input node to that node.
+  //
+  // Note: this algorithm doesn't optimize for the most "balanced" levels.
+  // Algorithms that result in better balancing of nodes across levels include
+  // the Coffman-Graham algorithm.
+  //
+  // Possible improvements we could make:
+  //
+  //  - Add a width restriction so that a level has bounded size.
+  //  - Add a compabibility restriction for what operations can be in the same
+  //    level.
+  //
+  FailureOr<std::vector<std::vector<V>>> sortGraphByLevels() {
+    // Topologically sort the adjacency graph, then reverse it.
+    auto result = topologicalSort();
+    if (failed(result)) {
+      return failure();
+    }
+    auto topoOrder = result.value();
+    std::reverse(topoOrder.begin(), topoOrder.end());
+    llvm::DenseMap<V, int> levels;
+
+    // Assign levels to the nodes:
+    // Traverse through the reversed topologically sorted nodes
+    // (working backwards through the graph, starting from the outputs)
+    // and assign the level of each node as 1 + the maximum of all the
+    // destinations of that node and -1, such that the first node processed
+    // (an output node) will have level = 0.
+    int maxLevel = 0;
+    int maxSourceLevel = -1;
+    for (auto vertex : topoOrder) {
+      maxSourceLevel = -1;
+      for (auto edge : edgesOutOf(vertex)) {
+        maxSourceLevel = std::max(maxSourceLevel, levels[edge]);
+      }
+      levels[vertex] = 1 + maxSourceLevel;
+      maxLevel = std::max(levels.at(vertex), maxLevel);
+    }
+
+    // Output will be a vector of vectors of the nodes at each level.
+    // Reverse the levels values, such that input nodes have smaller level
+    // values.
+    std::vector<std::vector<V>> output(maxLevel + 1);
+    for (auto entry : levels) {
+      output[maxLevel - entry.second].push_back(entry.first);
+    }
+    return output;
+  }
+
+ private:
+  llvm::SmallSet<V, 4> vertices;
+  llvm::DenseMap<V, llvm::SmallSet<V, 4>> outEdges;
+  llvm::DenseMap<V, llvm::SmallSet<V, 4>> inEdges;
+};
+
+}  // namespace graph
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_GRAPH_GRAPH_H_

--- a/include/Graph/GraphTest.cpp
+++ b/include/Graph/GraphTest.cpp
@@ -1,0 +1,159 @@
+#include <vector>
+
+#include "gmock/gmock.h"  // from @googletest
+#include "gtest/gtest.h"  // from @googletest
+#include "include/Graph/Graph.h"
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace graph {
+namespace {
+
+using ::testing::UnorderedElementsAre;
+
+TEST(LevelSortTest, SimpleGraphLevelSort) {
+  // Example graph:
+  //       ↗ 2 ↘
+  // 0 → 1 → 3 → 4
+  //   ↘ → → → ↗
+  //
+  // Level divisions:
+  // 0 | 1 | 2 | 3
+  //
+  // Level 0: node 0
+  // Level 1: node 1
+  // Level 2: node 2, 3
+  // Level 3: node 4
+
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addVertex(3);
+  graph.addVertex(4);
+  EXPECT_TRUE(graph.addEdge(0, 1));
+  EXPECT_TRUE(graph.addEdge(1, 2));
+  EXPECT_TRUE(graph.addEdge(1, 3));
+  EXPECT_TRUE(graph.addEdge(1, 4));
+  EXPECT_TRUE(graph.addEdge(2, 4));
+  EXPECT_TRUE(graph.addEdge(3, 4));
+
+  auto levelSorted = graph.sortGraphByLevels();
+  EXPECT_TRUE(succeeded(levelSorted));
+  std::vector<std::vector<int>> levelUnwrapped = levelSorted.value();
+  EXPECT_EQ(levelUnwrapped.size(), 4);
+  EXPECT_THAT(levelUnwrapped[0], UnorderedElementsAre(0));
+  EXPECT_THAT(levelUnwrapped[1], UnorderedElementsAre(1));
+  EXPECT_THAT(levelUnwrapped[2], UnorderedElementsAre(2, 3));
+  EXPECT_THAT(levelUnwrapped[3], UnorderedElementsAre(4));
+}
+
+TEST(LevelSortTest, MultiInputGraphLevelSort) {
+  // Example graph with multiple inputs:
+  // 0 → 5 → 6 → 7 → 8 → 9 → 10
+  //     1 ↗    ↑    ↑   ↑
+  //         2 ↗     ↑   ↑
+  //             3 ↗     ↑
+  //                 4 ↗
+  //
+  // Level divisions:
+  // 0 | 1 | 2 | 3 | 4 | 5 | 6
+  // Level 0: node 0
+  // Level 1: node 1, 5
+  // Level 2: node 2, 6
+  // Level 3: node 3, 7
+  // Level 4: node 4, 8
+  // Level 5: node 9
+  // Level 6: node 10
+
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addVertex(3);
+  graph.addVertex(4);
+  graph.addVertex(5);
+  graph.addVertex(6);
+  graph.addVertex(7);
+  graph.addVertex(8);
+  graph.addVertex(9);
+  graph.addVertex(10);
+  graph.addEdge(0, 5);
+  graph.addEdge(1, 6);
+  graph.addEdge(2, 7);
+  graph.addEdge(3, 8);
+  graph.addEdge(4, 9);
+  graph.addEdge(5, 6);
+  graph.addEdge(6, 7);
+  graph.addEdge(7, 8);
+  graph.addEdge(8, 9);
+  graph.addEdge(9, 10);
+
+  auto levelSorted = graph.sortGraphByLevels();
+  EXPECT_TRUE(succeeded(levelSorted));
+  std::vector<std::vector<int>> levelUnwrapped = levelSorted.value();
+  EXPECT_EQ(levelUnwrapped.size(), 7);
+  EXPECT_THAT(levelUnwrapped[0], UnorderedElementsAre(0));
+  EXPECT_THAT(levelUnwrapped[1], UnorderedElementsAre(5, 1));
+  EXPECT_THAT(levelUnwrapped[2], UnorderedElementsAre(2, 6));
+  EXPECT_THAT(levelUnwrapped[3], UnorderedElementsAre(3, 7));
+  EXPECT_THAT(levelUnwrapped[4], UnorderedElementsAre(4, 8));
+  EXPECT_THAT(levelUnwrapped[5], UnorderedElementsAre(9));
+  EXPECT_THAT(levelUnwrapped[6], UnorderedElementsAre(10));
+}
+
+TEST(LevelSortTest, MultiOutputGraphLevelSort) {
+  // Example graph with multiple outputs:
+  // 0 → 1 → 2 → 3 → 4 → 5
+  //       ↘   ↘   ↘  ↘  6
+  //         ↘   ↘   ↘ → 7
+  //           ↘   ↘ → → 8
+  //             ↘ → → → 9
+  //
+  // Level divisions:
+  // 0 | 1 | 2 | 3 | 4 | 5
+  // Level 0: node 0
+  // Level 1: node 1
+  // Level 2: node 2
+  // Level 3: node 3
+  // Level 4: node 4
+  // Level 5: node 5, 6, 7, 8, 9
+
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addVertex(3);
+  graph.addVertex(4);
+  graph.addVertex(5);
+  graph.addVertex(6);
+  graph.addVertex(7);
+  graph.addVertex(8);
+  graph.addVertex(9);
+  graph.addEdge(0, 1);
+  graph.addEdge(1, 2);
+  graph.addEdge(2, 3);
+  graph.addEdge(3, 4);
+  graph.addEdge(4, 5);
+  graph.addEdge(4, 6);
+  graph.addEdge(1, 9);
+  graph.addEdge(2, 8);
+  graph.addEdge(3, 7);
+
+  auto levelSorted = graph.sortGraphByLevels();
+  EXPECT_TRUE(succeeded(levelSorted));
+  std::vector<std::vector<int>> levelUnwrapped = levelSorted.value();
+  EXPECT_EQ(levelUnwrapped.size(), 6);
+  EXPECT_THAT(levelUnwrapped[0], UnorderedElementsAre(0));
+  EXPECT_THAT(levelUnwrapped[1], UnorderedElementsAre(1));
+  EXPECT_THAT(levelUnwrapped[2], UnorderedElementsAre(2));
+  EXPECT_THAT(levelUnwrapped[3], UnorderedElementsAre(3));
+  EXPECT_THAT(levelUnwrapped[4], UnorderedElementsAre(4));
+  EXPECT_THAT(levelUnwrapped[5], UnorderedElementsAre(5, 6, 7, 8, 9));
+}
+
+}  // namespace
+}  // namespace graph
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/CGGI/Transforms/BUILD
+++ b/lib/Dialect/CGGI/Transforms/BUILD
@@ -10,6 +10,7 @@ cc_library(
     ],
     deps = [
         ":SetDefaultParameters",
+        ":StraightLineVectorizer",
         "@heir//include/Dialect/CGGI/Transforms:pass_inc_gen",
         "@heir//lib/Dialect/CGGI/IR:Dialect",
         "@llvm-project//mlir:IR",
@@ -29,5 +30,25 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
+    ],
+)
+
+cc_library(
+    name = "StraightLineVectorizer",
+    srcs = ["StraightLineVectorizer.cpp"],
+    hdrs = [
+        "@heir//include/Dialect/CGGI/Transforms:StraightLineVectorizer.h",
+    ],
+    deps = [
+        "@heir//include/Dialect/CGGI/Transforms:pass_inc_gen",
+        "@heir//include/Graph",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/lib/Dialect/CGGI/Transforms/StraightLineVectorizer.cpp
+++ b/lib/Dialect/CGGI/Transforms/StraightLineVectorizer.cpp
@@ -1,0 +1,176 @@
+#include "include/Dialect/CGGI/Transforms/StraightLineVectorizer.h"
+
+#include "include/Dialect/CGGI/IR/CGGIAttributes.h"
+#include "include/Dialect/CGGI/IR/CGGIOps.h"
+#include "include/Dialect/LWE/IR/LWEAttributes.h"
+#include "include/Graph/Graph.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Transforms/TopologicalSortUtils.h"  // from @llvm-project
+
+#define DEBUG_TYPE "straight-line-vectorizer"
+
+namespace mlir {
+namespace heir {
+namespace cggi {
+
+#define GEN_PASS_DEF_STRAIGHTLINEVECTORIZER
+#include "include/Dialect/CGGI/Transforms/Passes.h.inc"
+
+/// Returns true if the two operations can be combined into a single vectorized
+/// operation.
+bool areCompatible(Operation *lhs, Operation *rhs) {
+  if (lhs->getName() != rhs->getName() ||
+      lhs->getDialect() != rhs->getDialect() ||
+      lhs->getResultTypes() != rhs->getResultTypes()) {
+    return false;
+  }
+
+  return llvm::TypeSwitch<Operation *, bool>(lhs)
+      // Builtin ops
+      .Case<AndOp, OrOp, XorOp>([&](auto op) { return true; })
+      .Case<Lut2Op>([&](auto op) {
+        return cast<Lut2Op>(rhs).getLookupTable() == op.getLookupTable();
+      })
+      .Case<Lut3Op>([&](auto op) {
+        return cast<Lut3Op>(rhs).getLookupTable() == op.getLookupTable();
+      })
+      .Default([&](Operation *) {
+        lhs->emitOpError("Unsupported check for vectorizable compatibility.");
+        return false;
+      });
+}
+
+bool tryVectorizeBlock(Block *block) {
+  graph::Graph<Operation *> graph;
+  for (auto &op : block->getOperations()) {
+    if (!isa<CGGIDialect>(op.getDialect()) ||
+        !op.hasTrait<OpTrait::Elementwise>()) {
+      continue;
+    }
+
+    // TODO(https://github.com/google/heir/issues/342): Add independence
+    // analysis for transitive dependencies
+    graph.addVertex(&op);
+    for (auto operand : op.getOperands()) {
+      if (auto *producer = operand.getDefiningOp()) {
+        graph.addEdge(producer, &op);
+      }
+    }
+  }
+
+  if (graph.empty()) {
+    return false;
+  }
+
+  auto result = graph.sortGraphByLevels();
+  assert(succeeded(result) &&
+         "Only possible failure is a cycle in the SSA graph!");
+  auto levels = result.value();
+
+  LLVM_DEBUG({
+    llvm::dbgs()
+        << "Found operations to vectorize. In topo-sorted level order:\n";
+    int level_num = 0;
+    for (const auto &level : levels) {
+      llvm::dbgs() << "\nLevel " << level_num++ << ":\n";
+      for (auto op : level) {
+        llvm::dbgs() << " - " << *op << "\n";
+      }
+    }
+  });
+
+  bool madeReplacement = false;
+  for (const auto &level : levels) {
+    DenseMap<Operation *, SmallVector<Operation *, 4>> compatibleOps;
+    for (auto *op : level) {
+      bool foundCompatible = false;
+      for (auto &[key, bucket] : compatibleOps) {
+        if (areCompatible(key, op)) {
+          compatibleOps[key].push_back(op);
+          foundCompatible = true;
+        }
+      }
+      if (!foundCompatible) {
+        compatibleOps[op].push_back(op);
+      }
+    }
+    LLVM_DEBUG(llvm::dbgs()
+               << "Partitioned level of size " << level.size() << " into "
+               << compatibleOps.size() << " groups of compatible ops\n");
+
+    for (auto &[key, bucket] : compatibleOps) {
+      if (bucket.size() < 2) {
+        continue;
+      }
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "Vectorizing ops:\n";
+        for (auto op : bucket) {
+          llvm::dbgs() << " - " << *op << "\n";
+        }
+      });
+
+      OpBuilder builder(bucket.back());
+      // relies on CGGI ops having a single result type
+      Type elementType = key->getResultTypes()[0];
+      RankedTensorType tensorType = RankedTensorType::get(
+          {static_cast<int64_t>(bucket.size())}, elementType);
+
+      SmallVector<Value, 4> vectorizedOperands;
+      for (int operandIndex = 0; operandIndex < key->getNumOperands();
+           ++operandIndex) {
+        SmallVector<Value, 4> operands;
+        operands.reserve(bucket.size());
+        for (auto *op : bucket) {
+          operands.push_back(op->getOperand(operandIndex));
+        }
+        auto fromElementsOp = builder.create<tensor::FromElementsOp>(
+            key->getLoc(), tensorType, operands);
+        vectorizedOperands.push_back(fromElementsOp.getResult());
+      }
+
+      Operation *vectorizedOp = builder.clone(*key);
+      vectorizedOp->setOperands(vectorizedOperands);
+      vectorizedOp->getResult(0).setType(tensorType);
+
+      int bucketIndex = 0;
+      for (auto *op : bucket) {
+        auto extractionIndex = builder.create<arith::ConstantOp>(
+            op->getLoc(), builder.getIndexAttr(bucketIndex));
+        auto extractOp = builder.create<tensor::ExtractOp>(
+            op->getLoc(), elementType, vectorizedOp->getResult(0),
+            extractionIndex.getResult());
+        op->replaceAllUsesWith(ValueRange{extractOp.getResult()});
+        bucketIndex++;
+      }
+
+      for (auto *op : bucket) {
+        op->erase();
+      }
+      madeReplacement = true;
+    }
+  }
+
+  return madeReplacement;
+}
+
+struct StraightLineVectorizer
+    : impl::StraightLineVectorizerBase<StraightLineVectorizer> {
+  using StraightLineVectorizerBase::StraightLineVectorizerBase;
+
+  void runOnOperation() override {
+    getOperation()->walk<WalkOrder::PreOrder>([&](Block *block) {
+      if (tryVectorizeBlock(block)) {
+        sortTopologically(block);
+      }
+    });
+  }
+};
+
+}  // namespace cggi
+}  // namespace heir
+}  // namespace mlir

--- a/tests/cggi/straight_line_vectorizer.mlir
+++ b/tests/cggi/straight_line_vectorizer.mlir
@@ -1,0 +1,95 @@
+// RUN: heir-opt --cggi-straight-line-vectorizer %s | FileCheck %s
+
+#encoding = #lwe.unspecified_bit_field_encoding<cleartext_bitwidth = 3>
+!ct_ty = !lwe.lwe_ciphertext<encoding = #encoding>
+!pt_ty = !lwe.lwe_plaintext<encoding = #encoding>
+
+// CHECK-LABEL: add_one
+// CHECK: cggi.lut3(%[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]]) {lookup_table = 105 : ui8} : tensor<6x!lwe.lwe_ciphertext
+func.func @add_one(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_ty> {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %extracted = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %extracted_0 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+  %extracted_1 = tensor.extract %arg0[%c2] : tensor<8x!ct_ty>
+  %extracted_2 = tensor.extract %arg0[%c3] : tensor<8x!ct_ty>
+  %extracted_3 = tensor.extract %arg0[%c4] : tensor<8x!ct_ty>
+  %extracted_4 = tensor.extract %arg0[%c5] : tensor<8x!ct_ty>
+  %extracted_5 = tensor.extract %arg0[%c6] : tensor<8x!ct_ty>
+  %extracted_6 = tensor.extract %arg0[%c7] : tensor<8x!ct_ty>
+  %0 = lwe.encode %true {encoding = #encoding} : i1 to !pt_ty
+  %1 = lwe.trivial_encrypt %0 : !pt_ty to !ct_ty
+  %2 = lwe.encode %false {encoding = #encoding} : i1 to !pt_ty
+  %3 = lwe.trivial_encrypt %2 : !pt_ty to !ct_ty
+  %4 = cggi.lut3(%extracted, %1, %3) {lookup_table = 8 : ui8} : !ct_ty
+  %5 = cggi.lut3(%4, %extracted_0, %3) {lookup_table = 150 : ui8} : !ct_ty
+  %6 = cggi.lut3(%4, %extracted_0, %3) {lookup_table = 23 : ui8} : !ct_ty
+  %7 = cggi.lut3(%6, %extracted_1, %3) {lookup_table = 43 : ui8} : !ct_ty
+  %8 = cggi.lut3(%7, %extracted_2, %3) {lookup_table = 43 : ui8} : !ct_ty
+  %9 = cggi.lut3(%8, %extracted_3, %3) {lookup_table = 43 : ui8} : !ct_ty
+  %10 = cggi.lut3(%9, %extracted_4, %3) {lookup_table = 43 : ui8} : !ct_ty
+  %11 = cggi.lut3(%10, %extracted_5, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %12 = cggi.lut3(%10, %extracted_5, %3) {lookup_table = 43 : ui8} : !ct_ty
+  %13 = cggi.lut3(%12, %extracted_6, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %14 = cggi.lut3(%extracted, %1, %3) {lookup_table = 6 : ui8} : !ct_ty
+  %15 = cggi.lut3(%6, %extracted_1, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %16 = cggi.lut3(%7, %extracted_2, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %17 = cggi.lut3(%8, %extracted_3, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %18 = cggi.lut3(%9, %extracted_4, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %from_elements = tensor.from_elements %13, %11, %18, %17, %16, %15, %5, %14 : tensor<8x!ct_ty>
+  return %from_elements : tensor<8x!ct_ty>
+}
+
+// CHECK-LABEL: require_post_pass_toposort
+func.func @require_post_pass_toposort(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_ty> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+  %2 = tensor.extract %arg0[%c2] : tensor<8x!ct_ty>
+  %3 = tensor.extract %arg0[%c3] : tensor<8x!ct_ty>
+  %4 = tensor.extract %arg0[%c4] : tensor<8x!ct_ty>
+  %5 = tensor.extract %arg0[%c5] : tensor<8x!ct_ty>
+  %6 = tensor.extract %arg0[%c6] : tensor<8x!ct_ty>
+  %7 = tensor.extract %arg0[%c7] : tensor<8x!ct_ty>
+
+  // Four ops that can be vectorized
+  %r1 = cggi.lut3(%0, %1, %2) {lookup_table = 8 : ui8} : !ct_ty
+  %r2 = cggi.lut3(%3, %4, %5) {lookup_table = 8 : ui8} : !ct_ty
+  %r3 = cggi.lut3(%4, %5, %6) {lookup_table = 8 : ui8} : !ct_ty
+  %r4 = cggi.lut3(%5, %6, %7) {lookup_table = 8 : ui8} : !ct_ty
+
+  // A non-vectorizable op that uses one of the results
+  %x = cggi.not %r4 : !ct_ty
+
+  // Four more ops that can be vectorized
+  %r5 = cggi.lut3(%0, %3, %1) {lookup_table = 8 : ui8} : !ct_ty
+  %r6 = cggi.lut3(%2, %5, %6) {lookup_table = 8 : ui8} : !ct_ty
+  %r7 = cggi.lut3(%7, %1, %6) {lookup_table = 8 : ui8} : !ct_ty
+  %r8 = cggi.lut3(%3, %6, %0) {lookup_table = 8 : ui8} : !ct_ty
+
+  // The resulting lut3 op must precede the cggi.not op, or else we violate SSA
+  // dominance.
+  // CHECK: cggi.lut3(%[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]]) {lookup_table = 8 : ui8} : tensor<8x!lwe.lwe_ciphertext
+  // CHECK: cggi.not
+  // CHECK: cggi.and
+
+  %r9 = cggi.and %x, %1 : !ct_ty
+
+  %from_elements = tensor.from_elements %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r9 : tensor<8x!ct_ty>
+  return %from_elements : tensor<8x!ct_ty>
+}


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/314

This implements the vectorizer with two little deficiencies I'll clean up next:

- The analysis does not consider transitive dependencies between ops that are about to be vectorized: https://github.com/google/heir/issues/342
- It's not producing vectorized ops with a specific tensor width (which should be set by a parameter): https://github.com/google/heir/issues/343