### PR TITLE
fix: fix parsing of a secret.generic with no args

### DIFF
--- a/lib/Dialect/Secret/IR/SecretOps.cpp
+++ b/lib/Dialect/Secret/IR/SecretOps.cpp
@@ -98,8 +98,6 @@ static ParseResult parseCommonStructuredOpParts(
       return failure();
   }
   attrsLoc = parser.getCurrentLocation();
-  if (parser.parseOptionalAttrDict(result.attributes)) return failure();
-
   if (succeeded(parser.parseOptionalKeyword("ins"))) {
     if (parser.parseLParen()) return failure();
 
@@ -107,6 +105,8 @@ static ParseResult parseCommonStructuredOpParts(
     if (parser.parseOperandList(inputsOperands) ||
         parser.parseColonTypeList(inputTypes) || parser.parseRParen())
       return failure();
+  } else {
+    inputsOperandsLoc = parser.getCurrentLocation();
   }
 
   if (parser.resolveOperands(inputsOperands, inputTypes, inputsOperandsLoc,

--- a/tests/secret/syntax.mlir
+++ b/tests/secret/syntax.mlir
@@ -8,4 +8,14 @@ module {
   func.func @fooFunc(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
     return %arg0 : !secret.secret<i32>
   }
+
+  // CHECK-LABEL: noInputs
+  func.func @noInputs() -> !secret.secret<memref<1x16xi8>> {
+    // CHECK: secret.generic
+    %Z = secret.generic {
+        %d = memref.alloc() {alignment = 64 : i64} : memref<1x16xi8>
+        secret.yield %d : memref<1x16xi8>
+      } -> (!secret.secret<memref<1x16xi8>>)
+    func.return %Z : !secret.secret<memref<1x16xi8>>
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/350

The attribute dictionary is after the `ins(...)` and labeled with `attrs = {}` already.