### PR TITLE
fix: fix capturing affine indices in secret generic

### DIFF
--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -42,6 +42,8 @@ cc_library(
         "@heir//include/Dialect/Secret/IR:ops_inc_gen",
         "@heir//include/Dialect/Secret/IR:types_inc_gen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineAnalysis",
+        "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",

--- a/tests/secret/capture_affine_ops.mlir
+++ b/tests/secret/capture_affine_ops.mlir
@@ -1,0 +1,50 @@
+// RUN: heir-opt --secret-capture-generic-ambient-scope %s | FileCheck %s
+
+module attributes {tf_saved_model.semantics} {
+  memref.global "private" constant @__constant_16x1xi8 : memref<16x1xi8> = dense<[[-9], [-54], [57], [71], [104], [115], [98], [99], [64], [-26], [127], [25], [-82], [68], [95], [86]]>
+// CHECK-LABEL: main
+  func.func @main(%arg0: !secret.secret<memref<1x1xi8>> {iree.identifier = "serving_default_dense_input:0", tf_saved_model.index_path = ["dense_input"]}) -> (!secret.secret<memref<1x16xi8>> {iree.identifier = "StatefulPartitionedCall:0", tf_saved_model.index_path = ["dense_2"]}) attributes {tf_saved_model.exported_names = ["serving_default"]} {
+    // CHECK: %[[c0:.*]] = arith.constant
+    %0 = memref.get_global @__constant_16x1xi8 : memref<16x1xi8>
+    // CHECK: %[[mem:.*]] = secret.generic
+    %5 = secret.generic {
+      %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x16xi8>
+      secret.yield %alloc : memref<1x16xi8>
+    } -> !secret.secret<memref<1x16xi8>>
+    // CHECK: affine.for %[[i:.*]] = 0 to 1
+    affine.for %arg1 = 0 to 1 {
+      // CHECK-NEXT: affine.for %[[j:.*]] = 0 to 16
+      affine.for %arg2 = 0 to 16 {
+        // CHECK-NEXT: %[[val:.*]] = affine.load
+        %20 = affine.load %0[%arg2, %arg1] : memref<16x1xi8>
+        // CHECK-NEXT: secret.generic ins(%[[mem]], %[[val]], %[[i]], %[[j]] : !secret.secret<memref<1x16xi8>>, i8, index, index)
+        secret.generic ins(%5 : !secret.secret<memref<1x16xi8>>) {
+        ^bb0(%arg3: memref<1x16xi8>):
+          affine.store %20, %arg3[%arg1, %arg2] : memref<1x16xi8>
+          secret.yield
+        }
+      }
+    }
+    // CHECK: %[[mem1:.*]] = secret.generic
+    %7 = secret.generic {
+      %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x16xi8>
+      secret.yield %alloc : memref<1x16xi8>
+    } -> !secret.secret<memref<1x16xi8>>
+    // CHECK: affine.for %[[j:.*]] = 0 to 16
+    affine.for %arg1 = 0 to 16 {
+      // CHECK-NEXT:  %[[val1:.*]] = secret.generic
+      %20 = secret.generic ins(%5 : !secret.secret<memref<1x16xi8>>) {
+      ^bb0(%arg2: memref<1x16xi8>):
+        %21 = affine.load %arg2[0, %arg1] : memref<1x16xi8>
+        secret.yield %21 : i8
+      } -> !secret.secret<i8>
+        // CHECK: secret.generic ins(%[[mem1]], %[[val1]], %[[j]], %[[c0]] : !secret.secret<memref<1x16xi8>>, !secret.secret<i8>, index, index)
+      secret.generic ins(%7, %20 : !secret.secret<memref<1x16xi8>>, !secret.secret<i8>) {
+      ^bb0(%arg2: memref<1x16xi8>, %arg3: i8):
+        affine.store %arg3, %arg2[0, %arg1] : memref<1x16xi8>
+        secret.yield
+      }
+    }
+    return %7 : !secret.secret<memref<1x16xi8>>
+  }
+}

--- a/tests/secret/generic.mlir
+++ b/tests/secret/generic.mlir
@@ -27,3 +27,21 @@ func.func @test_add_secret_and_plaintext_in_enclosing_scope(%value : i32) {
     } -> (!secret.secret<i32>)
   func.return
 }
+
+// CHECK-LABEL: test_memref_store
+func.func @test_memref_store(%value : i32) -> !secret.secret<memref<1xi32>> {
+  %0 = secret.generic {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1xi32>
+    secret.yield %alloc : memref<1xi32>
+  } -> !secret.secret<memref<1xi32>>
+  // CHECK: secret.generic
+  affine.for %arg1 = 0 to 1 {
+    secret.generic ins(%0, %arg1, %value : !secret.secret<memref<1xi32>>, index, i32) {
+    ^bb0(%arg2: memref<1xi32>, %arg3: index, %arg4: i32):
+      memref.store %arg4, %arg2[%arg3] : memref<1xi32>
+      secret.yield
+    }
+  }
+
+  func.return %0 : !secret.secret<memref<1xi32>>
+}


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/356
Fixes https://github.com/google/heir/issues/355

https://github.com/llvm/llvm-project/blob/315a5cce89d8f15da5c47d85abbc8155b9c0f0b0/mlir/lib/Dialect/Affine/IR/AffineOps.cpp#L298-L304

* `affine.store` and `affine.load` indices must be block arguments of `affine` ops, not of `secret.generic`, so the only way to handle this is to convert them to corresponding memref ops.
* `affine` read and write ops are also able to use inline constants like `affine.load %0[0]` while memref ops cannot. So this also builds the indices needed when constant affine access indices are used