### PR TITLE
Temporary fix for GITHUB_BASE_REF

### DIFF
--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -12,4 +12,4 @@ jobs:
       uses: j2kun/todo-backlinks@cb650ff669455d273f408df50f57e7b911ee3640 # pin@v0.0.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        GITHUB_BASE_REF: ${{ github.base_ref }}
+        GITHUB_BASE_REF: main


### PR DESCRIPTION
The links in the generated comments are broken because apparently the `github.base_ref` is empty when running on main. @asraa I misread that variable from https://docs.github.com/en/actions/learn-github-actions/contexts#github-context, and it looks like there's no variable that says what the default branch is, so I just hard-coded it for now. I will probably update the action to use a proper "input" instead of an environment variable, and call it something clearer than "BASE_REF". But this should fix the links in the short term, and the action will edit the comments in place to fix it.