### PR TITLE
add MergeAdjacentGenerics pattern

### DIFF
--- a/include/Dialect/Secret/IR/SecretOps.td
+++ b/include/Dialect/Secret/IR/SecretOps.td
@@ -164,6 +164,10 @@ def Secret_GenericOp : Secret_Op<"generic", [
     // secret.generic.
     OpOperand *getOpOperandForBlockArgument(Value value);
 
+    // Returns the integer index of a result if the given value is a result of
+    // the generic op.
+    std::optional<int> findResultIndex(Value value);
+
     // Clones a generic op and adds new yielded values. Returns the new op and
     // the value range corresponding to the new result values of the generic.
     // Callers can follow this method with something like the following to

--- a/include/Dialect/Secret/IR/SecretPatterns.h
+++ b/include/Dialect/Secret/IR/SecretPatterns.h
@@ -125,6 +125,16 @@ struct CaptureAmbientScope : public OpRewritePattern<GenericOp> {
                                 PatternRewriter &rewriter) const override;
 };
 
+// Find two adjacent generic ops and merge them into one.
+struct MergeAdjacentGenerics : public OpRewritePattern<GenericOp> {
+  MergeAdjacentGenerics(mlir::MLIRContext *context)
+      : OpRewritePattern<GenericOp>(context, /*benefit=*/1) {}
+
+ public:
+  LogicalResult matchAndRewrite(GenericOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
 }  // namespace secret
 }  // namespace heir
 }  // namespace mlir

--- a/include/Dialect/Secret/Transforms/BUILD
+++ b/include/Dialect/Secret/Transforms/BUILD
@@ -32,5 +32,6 @@ exports_files([
     "CaptureGenericAmbientScope.h",
     "DistributeGeneric.h",
     "ForgetSecrets.h",
+    "MergeAdjacentGenerics.h",
     "Passes.h",
 ])

--- a/include/Dialect/Secret/Transforms/MergeAdjacentGenerics.h
+++ b/include/Dialect/Secret/Transforms/MergeAdjacentGenerics.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_DIALECT_SECRET_TRANSFORMS_MERGEADJACENTGENERICS_H_
+#define INCLUDE_DIALECT_SECRET_TRANSFORMS_MERGEADJACENTGENERICS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+#define GEN_PASS_DECL_SECRETMERGEADJACENTGENERICS
+#include "include/Dialect/Secret/Transforms/Passes.h.inc"
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_DIALECT_SECRET_TRANSFORMS_MERGEADJACENTGENERICS_H_

--- a/include/Dialect/Secret/Transforms/Passes.h
+++ b/include/Dialect/Secret/Transforms/Passes.h
@@ -5,6 +5,7 @@
 #include "include/Dialect/Secret/Transforms/CaptureGenericAmbientScope.h"
 #include "include/Dialect/Secret/Transforms/DistributeGeneric.h"
 #include "include/Dialect/Secret/Transforms/ForgetSecrets.h"
+#include "include/Dialect/Secret/Transforms/MergeAdjacentGenerics.h"
 
 namespace mlir {
 namespace heir {

--- a/include/Dialect/Secret/Transforms/Passes.td
+++ b/include/Dialect/Secret/Transforms/Passes.td
@@ -50,4 +50,14 @@ def SecretCaptureGenericAmbientScope : Pass<"secret-capture-generic-ambient-scop
   let dependentDialects = ["mlir::heir::secret::SecretDialect"];
 }
 
+def SecretMergeAdjacentGenerics : Pass<"secret-merge-adjacent-generics"> {
+  let summary = "Merge two adjacent generics into a single generic";
+  let description = [{
+    This pass merges two immedaitely sequential generics into a single
+    generic. Useful as a sub-operation in some passes, and extracted into
+    its own pass for testing purposes.
+  }];
+  let dependentDialects = ["mlir::heir::secret::SecretDialect"];
+}
+
 #endif  // INCLUDE_DIALECT_SECRET_TRANSFORMS_PASSES_TD_

--- a/lib/Dialect/Secret/IR/SecretOps.cpp
+++ b/lib/Dialect/Secret/IR/SecretOps.cpp
@@ -259,6 +259,13 @@ OpOperand *GenericOp::getOpOperandForBlockArgument(Value value) {
   return &getOperation()->getOpOperand(index);
 }
 
+std::optional<int> GenericOp::findResultIndex(Value value) {
+  int index = std::find(getResults().begin(), getResults().end(), value) -
+              getResults().begin();
+  if (index < getNumResults()) return index;
+  return std::nullopt;
+}
+
 YieldOp GenericOp::getYieldOp() {
   return *getBody()->getOps<YieldOp>().begin();
 }

--- a/lib/Dialect/Secret/IR/SecretPatterns.cpp
+++ b/lib/Dialect/Secret/IR/SecretPatterns.cpp
@@ -14,6 +14,7 @@
 #include "mlir/include/mlir/IR/AffineExpr.h"             // from @llvm-project
 #include "mlir/include/mlir/IR/Block.h"                  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/IRMapping.h"              // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/Region.h"                 // from @llvm-project
 #include "mlir/include/mlir/IR/Types.h"                  // from @llvm-project
@@ -22,6 +23,8 @@
 #include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+
+#define DEBUG_TYPE "secret-patterns"
 
 namespace mlir {
 namespace heir {
@@ -187,6 +190,138 @@ LogicalResult CaptureAmbientScope::matchAndRewrite(
     });
     genericOp.getInputsMutable().append(value);
   });
+
+  return success();
+}
+
+LogicalResult MergeAdjacentGenerics::matchAndRewrite(
+    GenericOp genericOp, PatternRewriter &rewriter) const {
+  GenericOp nextGenericOp = dyn_cast<GenericOp>(genericOp->getNextNode());
+  if (!nextGenericOp) {
+    return failure();
+  }
+
+  SmallVector<Type> newResultTypes;
+  newResultTypes.reserve(genericOp->getNumResults() +
+                         nextGenericOp->getNumResults());
+  newResultTypes.append(genericOp->getResultTypes().begin(),
+                        genericOp->getResultTypes().end());
+  newResultTypes.append(nextGenericOp->getResultTypes().begin(),
+                        nextGenericOp->getResultTypes().end());
+
+  llvm::SmallVector<Value, 6> newOperands;
+  newOperands.append(genericOp->getOperands().begin(),
+                     genericOp->getOperands().end());
+  // We need to merge the two operand regions and keep track of the mapping
+  // from the second generic's operands to the new operands. In the case that
+  // the old operand is a result of the first generic, we don't need to include
+  // it because the ops that use that operand will be moved inside the first
+  // generic.
+  DenseMap<Value, int> oldOperandsToNewOperandIndex;
+  for (int i = 0; i < nextGenericOp->getNumOperands(); ++i) {
+    auto currOperand = nextGenericOp->getOperand(i);
+    LLVM_DEBUG(llvm::dbgs() << "Trying to dedupe operand " << i << " in "
+                            << *nextGenericOp << "\n");
+    std::optional<int> resultIndex = genericOp.findResultIndex(currOperand);
+    if (resultIndex.has_value()) {
+      LLVM_DEBUG(llvm::dbgs() << "It's result " << resultIndex.value()
+                              << " of the previous generic.\n");
+      continue;
+    }
+    bool found = false;
+    for (int j = 0; j < newOperands.size(); ++j) {
+      if (currOperand == newOperands[j]) {
+        LLVM_DEBUG(llvm::dbgs() << "Mapping to operand " << j << "\n");
+        oldOperandsToNewOperandIndex[currOperand] = j;
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      newOperands.push_back(currOperand);
+      oldOperandsToNewOperandIndex[currOperand] = newOperands.size() - 1;
+      LLVM_DEBUG(llvm::dbgs() << "Not found, adding to operands at index "
+                              << newOperands.size() - 1 << "\n");
+    }
+  }
+
+  auto newGeneric = rewriter.create<GenericOp>(
+      genericOp.getLoc(), newOperands, newResultTypes,
+      [&](OpBuilder &b, Location loc, ValueRange blockArguments) {
+        IRMapping mp;
+        for (BlockArgument blockArg : genericOp.getBody()->getArguments()) {
+          mp.map(blockArg, blockArguments[blockArg.getArgNumber()]);
+        }
+
+        SmallVector<YieldOp> clonedYieldOps;
+        auto &firstOps = genericOp.getBody()->getOperations();
+        for (auto &op : firstOps) {
+          auto *newOp = b.clone(op, mp);
+          if (auto clonedYield = dyn_cast<YieldOp>(newOp)) {
+            clonedYieldOps.push_back(clonedYield);
+          }
+        }
+
+        // For each block argument of the next generic, see if it's a result
+        // of the first generic, and if so, map it to the yielded value of
+        // the first generic. Otherwise, map it to the corresponding block
+        // argument of the new generic.
+        for (BlockArgument blockArg : nextGenericOp.getBody()->getArguments()) {
+          OpOperand *correspondingOperand =
+              nextGenericOp.getOpOperandForBlockArgument(blockArg);
+          std::optional<int> resultIndex =
+              genericOp.findResultIndex(correspondingOperand->get());
+          if (resultIndex.has_value()) {
+            mp.map(blockArg,
+                   clonedYieldOps[0]->getOperand(resultIndex.value()));
+            continue;
+          }
+
+          LLVM_DEBUG(
+              llvm::dbgs()
+              << "Mapping " << blockArg << " in " << *nextGenericOp
+              << " to new block arg "
+              << oldOperandsToNewOperandIndex[correspondingOperand->get()]
+              << "\n");
+          mp.map(blockArg, blockArguments[oldOperandsToNewOperandIndex.lookup(
+                               correspondingOperand->get())]);
+        }
+
+        auto &secondOps = nextGenericOp.getBody()->getOperations();
+        for (auto &op : secondOps) {
+          auto *newOp = b.clone(op, mp);
+          if (auto clonedYield = dyn_cast<YieldOp>(newOp)) {
+            clonedYieldOps.push_back(clonedYield);
+          }
+        }
+
+        // We have cloned two yields, and now we need to merge them.
+        assert(clonedYieldOps.size() == 2 &&
+               "Expected two yields in cloned generic");
+        SmallVector<Value> newYields;
+        newYields.reserve(newResultTypes.size());
+        for (auto yieldOp : clonedYieldOps) {
+          newYields.append(yieldOp->getOperands().begin(),
+                           yieldOp->getOperands().end());
+          rewriter.eraseOp(yieldOp);
+        }
+        b.create<YieldOp>(loc, newYields);
+      });
+
+  SmallVector<Value> valuesReplacingSecondGeneric;
+  valuesReplacingSecondGeneric.reserve(nextGenericOp->getNumResults());
+  valuesReplacingSecondGeneric.append(
+      newGeneric.getResults().begin() + genericOp->getNumResults(),
+      newGeneric.getResults().end());
+  rewriter.replaceOp(nextGenericOp, valuesReplacingSecondGeneric);
+
+  SmallVector<Value> valuesReplacingFirstGeneric;
+  valuesReplacingFirstGeneric.reserve(genericOp->getNumResults());
+  valuesReplacingFirstGeneric.append(
+      newGeneric.getResults().begin(),
+      newGeneric.getResults().begin() + genericOp->getNumResults());
+  rewriter.replaceOp(genericOp, valuesReplacingFirstGeneric);
 
   return success();
 }

--- a/lib/Dialect/Secret/Transforms/BUILD
+++ b/lib/Dialect/Secret/Transforms/BUILD
@@ -12,6 +12,7 @@ cc_library(
         ":CaptureGenericAmbientScope",
         ":DistributeGeneric",
         ":ForgetSecrets",
+        ":MergeAdjacentGenerics",
         "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//mlir:IR",
@@ -61,6 +62,21 @@ cc_library(
     srcs = ["CaptureGenericAmbientScope.cpp"],
     hdrs = [
         "@heir//include/Dialect/Secret/Transforms:CaptureGenericAmbientScope.h",
+    ],
+    deps = [
+        "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:SecretPatterns",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "MergeAdjacentGenerics",
+    srcs = ["MergeAdjacentGenerics.cpp"],
+    hdrs = [
+        "@heir//include/Dialect/Secret/Transforms:MergeAdjacentGenerics.h",
     ],
     deps = [
         "@heir//include/Dialect/Secret/Transforms:pass_inc_gen",

--- a/lib/Dialect/Secret/Transforms/MergeAdjacentGenerics.cpp
+++ b/lib/Dialect/Secret/Transforms/MergeAdjacentGenerics.cpp
@@ -1,0 +1,32 @@
+#include "include/Dialect/Secret/Transforms/MergeAdjacentGenerics.h"
+
+#include <utility>
+
+#include "include/Dialect/Secret/IR/SecretPatterns.h"
+#include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace secret {
+
+#define GEN_PASS_DEF_SECRETMERGEADJACENTGENERICS
+#include "include/Dialect/Secret/Transforms/Passes.h.inc"
+
+struct MergeAdjacentGenericsPass
+    : impl::SecretMergeAdjacentGenericsBase<MergeAdjacentGenericsPass> {
+  using SecretMergeAdjacentGenericsBase::SecretMergeAdjacentGenericsBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    mlir::RewritePatternSet patterns(context);
+
+    patterns.add<MergeAdjacentGenerics>(context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir

--- a/tests/secret/merge_adjacent_generics.mlir
+++ b/tests/secret/merge_adjacent_generics.mlir
@@ -1,0 +1,71 @@
+// RUN: heir-opt --secret-merge-adjacent-generics --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: test_chained_input_output
+// CHECK-SAME: (%[[value:.*]]: !secret.secret<i32>
+!ty = !secret.secret<i32>
+func.func @test_chained_input_output(%value : !ty) -> !ty {
+  // CHECK: %[[c1:.*]] = arith.constant 1
+  %c1 = arith.constant 1 : i32
+  // CHECK:      secret.generic ins(%[[value]]
+  // CHECK-NEXT: ^bb{{[0-9]}}(%[[clear_value:.*]]: i32):
+  // CHECK-NEXT:   %[[res:.*]] = arith.addi %[[clear_value]], %[[c1]]
+  // CHECK-NEXT:   %[[res2:.*]] = arith.addi %[[res]], %[[c1]]
+  // CHECK-NEXT:   secret.yield %[[res2:.*]]
+  // CHECK-NOT:   secret.generic
+  %0 = secret.generic ins(%value : !ty) {
+    ^bb0(%x: i32) :
+      %res = arith.addi %x, %c1: i32
+      secret.yield %res : i32
+    } -> (!ty)
+  %1 = secret.generic ins(%0 : !ty) {
+    ^bb0(%x: i32) :
+      %res = arith.addi %x, %c1: i32
+      secret.yield %res : i32
+    } -> (!ty)
+  func.return %1 : !ty
+}
+
+// CHECK-LABEL: test_shared_input
+// CHECK-SAME: (%[[v1:.*]]: !secret.secret<i32>, %[[v2:.*]]: !secret.secret<i32>, %[[v3:.*]]: !secret.secret<i32>
+func.func @test_shared_input(%v1: !ty, %v2: !ty, %v3: !ty) -> !ty {
+  // CHECK:      secret.generic ins(%[[v1]], %[[v2]], %[[v3]]
+  // CHECK-NEXT: ^bb{{[0-9]}}(%[[cv1:.*]]: i32, %[[cv2:.*]]: i32, %[[cv3:.*]]: i32
+  // CHECK-NEXT:   %[[r1:.*]] = arith.addi %[[cv1]], %[[cv2]]
+  // CHECK-NEXT:   %[[r2:.*]] = arith.addi %[[cv2]], %[[cv3]]
+  // CHECK-NEXT:   secret.yield %[[r1]], %[[r2]]
+  // CHECK-NOT:  secret.generic
+  %0 = secret.generic ins(%v1, %v2 : !ty, !ty) {
+    ^bb0(%clear1: i32, %clear2: i32) :
+      %res = arith.addi %clear1, %clear2: i32
+      secret.yield %res : i32
+    } -> (!ty)
+  %1 = secret.generic ins(%v2, %v3 : !ty, !ty) {
+    ^bb0(%clear2: i32, %clear3: i32) :
+      %res = arith.addi %clear2, %clear3: i32
+      secret.yield %res : i32
+    } -> (!ty)
+  func.return %1 : !ty
+}
+
+// CHECK-LABEL: test_unshared_input
+// CHECK-SAME: (%[[v1:.*]]: !secret.secret<i32>, %[[v2:.*]]: !secret.secret<i32>, %[[v3:.*]]: !secret.secret<i32>
+func.func @test_unshared_input(%v1: !ty, %v2: !ty, %v3: !ty) -> !ty {
+  %c1 = arith.constant 1 : i32
+  // CHECK:      secret.generic ins(%[[v1]], %[[v2]], %[[v3]]
+  // CHECK-NEXT: ^bb{{[0-9]}}(%[[cv1:.*]]: i32, %[[cv2:.*]]: i32, %[[cv3:.*]]: i32
+  // CHECK-NEXT:   %[[r1:.*]] = arith.addi %[[cv1]], %[[c1]]
+  // CHECK-NEXT:   %[[r2:.*]] = arith.addi %[[cv2]], %[[cv3]]
+  // CHECK-NEXT:   secret.yield %[[r1]], %[[r2]]
+  // CHECK-NOT:  secret.generic
+  %0 = secret.generic ins(%v1 : !ty) {
+    ^bb0(%clear1: i32) :
+      %res = arith.addi %clear1, %c1: i32
+      secret.yield %res : i32
+    } -> (!ty)
+  %1 = secret.generic ins(%v2, %v3 : !ty, !ty) {
+    ^bb0(%clear2: i32, %clear3: i32) :
+      %res = arith.addi %clear2, %clear3: i32
+      secret.yield %res : i32
+    } -> (!ty)
+  func.return %1 : !ty
+}


### PR DESCRIPTION
This pattern merges pairs of adjacent generic ops (with no ops in between them).

Incremental feature extracted from https://github.com/google/heir/pull/347

This could be enhanced later to support merging when extraneous ops (not adding a new dependency) are between two generics.