### PR TITLE
Add more OpenFHE dialect type and ops

### DIFF
--- a/include/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/include/Dialect/Openfhe/IR/OpenfheOps.td
@@ -18,58 +18,52 @@ class Openfhe_Op<string mnemonic, list<Trait> traits = []> :
   let cppNamespace = "::mlir::heir::openfhe";
 }
 
+class Openfhe_UnaryOp<string mnemonic, list<Trait> traits = []>
+  :  Openfhe_Op<mnemonic, traits # [
+    Pure,
+    AllTypesMatch<["ciphertext", "output"]>,
+]>{
+ let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+class Openfhe_BinaryOp<string mnemonic, list<Trait> traits = []>
+  :  Openfhe_Op<mnemonic, traits # [
+    Pure,
+    AllTypesMatch<["lhs", "rhs", "output"]>,
+]>{
+ let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$lhs,
+    RLWECiphertext:$rhs
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
 def EncryptOp : Openfhe_Op<"encrypt", [Pure]> {
   let arguments = (ins Openfhe_CryptoContext:$cryptoContext, RLWEPlaintext:$plaintext, Openfhe_PublicKey:$publicKey);
   let results = (outs RLWECiphertext:$output);
 }
 
-def NegateOp : Openfhe_Op<"negate", [
+def AddOp : Openfhe_BinaryOp<"add"> { let summary = "OpenFHE add operation of two ciphertexts."; }
+def SubOp : Openfhe_BinaryOp<"sub"> { let summary = "OpenFHE sub operation of two ciphertexts."; }
+
+def MulOp : Openfhe_BinaryOp<"mul"> { let summary = "OpenFHE mul operation of two ciphertexts with relinearization."; }
+def MulNoRelinOp : Openfhe_BinaryOp<"mul_no_relin"> {
+  let summary = "OpenFHE mul operation of two ciphertexts without relinearization.";
+}
+def MulAndRelinOp : Openfhe_BinaryOp<"mul_and_relin"> {
+  let summary = "OpenFHE mul operation of two ciphertexts followed by relinearization to the lowest level.";
+}
+
+def MulPlainOp : Openfhe_Op<"mul_plain",[
     Pure,
     AllTypesMatch<["ciphertext", "output"]>
 ]> {
-  let arguments = (ins Openfhe_CryptoContext:$cryptoContext, RLWECiphertext:$ciphertext);
-  let results = (outs RLWECiphertext:$output);
-}
-
-def AddOp : Openfhe_Op<"add",[
-    Pure,
-    AllTypesMatch<["lhs", "rhs", "output"]>
-]> {
-  let arguments = (ins
-    Openfhe_CryptoContext:$cryptoContext,
-    RLWECiphertext:$lhs,
-    RLWECiphertext:$rhs
-  );
-  let results = (outs RLWECiphertext:$output);
-}
-
-def SubOp : Openfhe_Op<"sub",[
-    Pure,
-    AllTypesMatch<["lhs", "rhs", "output"]>
-]> {
-  let arguments = (ins
-    Openfhe_CryptoContext:$cryptoContext,
-    RLWECiphertext:$lhs,
-    RLWECiphertext:$rhs
-  );
-  let results = (outs RLWECiphertext:$output);
-}
-
-def MulOp : Openfhe_Op<"mul",[
-    Pure,
-    AllTypesMatch<["lhs", "rhs"]>
-]> {
-  let arguments = (ins
-    Openfhe_CryptoContext:$cryptoContext,
-    RLWECiphertext:$lhs,
-    RLWECiphertext:$rhs
-  );
-  let results = (outs RLWECiphertext:$output);
-}
-def MulPlainOp : Openfhe_Op<"mulplain",[
-    Pure,
-    AllTypesMatch<["ciphertext", "output"]>
-]> {
+  let summary = "OpenFHE mul operation of a ciphertext and a plaintext.";
   let arguments = (ins
     Openfhe_CryptoContext:$cryptoContext,
     RLWECiphertext:$ciphertext,
@@ -78,10 +72,11 @@ def MulPlainOp : Openfhe_Op<"mulplain",[
   let results = (outs RLWECiphertext:$output);
 }
 
-def MulConstOp : Openfhe_Op<"mulconst",[
+def MulConstOp : Openfhe_Op<"mul_const",[
     Pure,
     AllTypesMatch<["ciphertext", "output"]>
 ]> {
+  let summary = "OpenFHE mul operation of a ciphertext and a constant.";
   let arguments = (ins
     Openfhe_CryptoContext:$cryptoContext,
     RLWECiphertext:$ciphertext,
@@ -90,6 +85,13 @@ def MulConstOp : Openfhe_Op<"mulconst",[
   let results = (outs RLWECiphertext:$output);
 }
 
+def NegateOp : Openfhe_UnaryOp<"negate"> { let summary = "OpenFHE negate operation of a ciphertext."; }
+def SquareOp : Openfhe_UnaryOp<"square"> { let summary = "OpenFHE square operation of a ciphertext."; }
+def RelinOp : Openfhe_UnaryOp<"relin"> { let summary = "OpenFHE relinearize operation of a ciphertext."; }
+
+def ModReduceOp : Openfhe_UnaryOp<"mod_reduce"> { let summary = "OpenFHE mod_reduce operation of a ciphertext. (used only for BGV/CKKS)"; }
+def LevelReduceOp : Openfhe_UnaryOp<"level_reduce"> { let summary = "OpenFHE level_reduce operation of a ciphertext."; }
+
 def RotOp : Openfhe_Op<"rot",[
   Pure,
   AllTypesMatch<["ciphertext", "output"]>
@@ -97,8 +99,46 @@ def RotOp : Openfhe_Op<"rot",[
   let arguments = (ins
     Openfhe_CryptoContext:$cryptoContext,
     RLWECiphertext:$ciphertext,
-    I32:$rot
+    I64:$index
   );
   let results = (outs RLWECiphertext:$output);
 }
+
+def AutomorphOp : Openfhe_Op<"automorph",[
+  Pure,
+  AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext,
+    Openfhe_EvalKey:$evalKey,
+    I32:$index
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+def FindAutomorphIdxOp : Openfhe_Op<"find_automorph_idx",[
+  Pure,
+  AllTypesMatch<["idx", "automorph_idx"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    I32:$idx
+  );
+  let results = (outs I32:$automorph_idx);
+}
+
+def KeySwitchOp : Openfhe_Op<"keyswitch", [
+   Pure,
+   AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext,
+    Openfhe_EvalKey:$evalKey
+  );
+  let results = (outs RLWECiphertext:$output);
+}
+
+
 #endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_TD_

--- a/include/Dialect/Openfhe/IR/OpenfheTypes.td
+++ b/include/Dialect/Openfhe/IR/OpenfheTypes.td
@@ -18,6 +18,10 @@ def Openfhe_PublicKey : Openfhe_Type<"PublicKey", "public_key"> {
   let summary = "The public key required to encrypt plaintext in OpenFHE.";
 }
 
+def Openfhe_EvalKey : Openfhe_Type<"EvalKey", "eval_key"> {
+  let summary = "The evaluation key required to keyswitch/relinearize/rotate/automorphism operation in OpenFHE.";
+}
+
 def Openfhe_CryptoContext : Openfhe_Type<"CryptoContext", "crypto_context"> {
   let summary = "The CryptoContext required to perform homomorphic operations in OpenFHE.";
 }

--- a/tests/openfhe/ops.mlir
+++ b/tests/openfhe/ops.mlir
@@ -4,6 +4,7 @@
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
 #params = #lwe.rlwe_params<cmod=7917, dimension=1, polyDegree=16384>
 !pk = !openfhe.public_key
+!ek = !openfhe.eval_key
 !cc = !openfhe.crypto_context
 !pt = !lwe.rlwe_plaintext<encoding = #encoding>
 !ct = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params>
@@ -46,27 +47,93 @@ module {
     return
   }
 
-  // CHECK-LABEL: func @test_mulplain
-  func.func @test_mulplain(%cc : !cc, %pt : !pt, %pk: !pk) {
+  // CHECK-LABEL: func @test_mul_plain
+  func.func @test_mul_plain(%cc : !cc, %pt : !pt, %pk: !pk) {
     %0 = arith.constant 5 : i64
     %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
-    %out = openfhe.mulplain %cc, %c1, %pt: (!cc, !ct, !pt) -> !ct
+    %out = openfhe.mul_plain %cc, %c1, %pt: (!cc, !ct, !pt) -> !ct
     return
   }
 
-  // CHECK-LABEL: func @test_mulconst
-  func.func @test_mulconst(%cc : !cc, %pt : !pt, %pk: !pk) {
+  // CHECK-LABEL: func @test_mul_const
+  func.func @test_mul_const(%cc : !cc, %pt : !pt, %pk: !pk) {
     %0 = arith.constant 5 : i64
     %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
-    %out = openfhe.mulconst %cc, %c1, %0: (!cc, !ct, i64) -> !ct
+    %out = openfhe.mul_const %cc, %c1, %0: (!cc, !ct, i64) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_mul_and_relin
+  func.func @test_mul_and_relin(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %c2 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.mul_and_relin %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_mul_no_relin
+  func.func @test_mul_no_relin(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %c2 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.mul_no_relin %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_square
+  func.func @test_square(%cc : !cc, %pt : !pt, %pk: !pk) {
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.square %cc, %ct: (!cc, !ct) -> !ct
     return
   }
 
   // CHECK-LABEL: func @test_rot
   func.func @test_rot(%cc : !cc, %pt : !pt, %pk: !pk) {
-    %0 = arith.constant 2 : i32
+    %0 = arith.constant 2 : i64
     %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
-    %out = openfhe.rot %cc, %ct, %0: (!cc, !ct, i32) -> !ct
+    %out = openfhe.rot %cc, %ct, %0: (!cc, !ct, i64) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_automorph
+  func.func @test_automorph(%cc : !cc, %pt : !pt, %ek: !ek, %pk: !pk) {
+    %0 = arith.constant 3 : i32
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.automorph %cc, %ct, %ek, %0: (!cc, !ct, !ek, i32) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_find_automorph_idx
+  func.func @test_find_automorph_idx(%cc : !cc) {
+    %0 = arith.constant 1 : i32
+    %out = openfhe.find_automorph_idx %cc, %0: (!cc, i32) -> i32
+    return
+  }
+
+  // CHECK-LABEL: func @test_keyswitch
+  func.func @test_keyswitch(%cc : !cc, %pt : !pt, %pk: !pk, %ek : !ek) {
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.keyswitch %cc, %ct, %ek: (!cc, !ct, !ek) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_relin
+  func.func @test_relin(%cc : !cc, %pt : !pt, %pk1 : !pk) {
+    %ct = openfhe.encrypt %cc, %pt, %pk1 : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.relin %cc, %ct: (!cc, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_mod_reduce
+  func.func @test_mod_reduce(%cc : !cc, %pt : !pt, %pk2 : !pk) {
+    %ct = openfhe.encrypt %cc, %pt, %pk2 : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.mod_reduce %cc, %ct: (!cc, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_level_reduce
+  func.func @test_level_reduce(%cc : !cc, %pt : !pt, %pk3 : !pk) {
+    %ct = openfhe.encrypt %cc, %pt, %pk3 : (!cc, !pt, !pk) -> !ct
+    %out = openfhe.level_reduce %cc, %ct: (!cc, !ct) -> !ct
     return
   }
 }

--- a/tests/openfhe/types.mlir
+++ b/tests/openfhe/types.mlir
@@ -5,7 +5,8 @@ module {
   // CHECK-LABEL: func @test
   func.func @test(
      %arg_cc: !openfhe.crypto_context,
-     %arg_pk: !openfhe.public_key) {
+     %arg_pk: !openfhe.public_key,
+     %arg_ek: !openfhe.eval_key) {
     return
   }
 }


### PR DESCRIPTION
Add more ops in OpenFHE dialect (#328)

## Ops
#### KeySwitch
This operation explicitly needs a corresponding Evalkey for key switching operation.
#### EvalMultNoRelin / EvalMultAndRelin / EvalMult
After taking a closer look at the OpenFHE implementation, it seems that these three functions do the following:
```
EvalMult (c1, c2) : Mult(c1, c2) + Relinearize(s^2 -> s) // size(c1) = size(c2) = size(output) = 2
EvalMultNoRelin (c1, c2) : Mult(c1,c2) // size(c1) and size(c2) can vary.
EvalMultAndRelin (c1, c2) : Mult(c1, c2) + Relinearize(s^i-> s)  where i = 2, 3, ... //  size(c1) and size(c2) can vary, size(output) = 2
```
#### Square / Relinearlize
These operations (and EvalMult, EvalMultAndRelin) are implicitly use EvalKey.

#### ModReduce
a.k.a Rescale in CKKS (question : When is ModReduce used in BGV?)

#### LevelReduce
a.k.a Modulus switch

#### EvalAutomorphism / FindAutomorphismIndex/FindAutomorphismIndices
I'm not sure, but these operation is generalization of rotation.

EvalAutomorphism takes an index `i` and a map `EvalKeyMap` (mapping i to EvalKey), but internally only `EvalKeyMap(i)` (of type: `EvalKey`) is used. Therefore, I designed `openfhe.automorph` to require only a single `EvalKey`.