### PR TITLE
Add more secret patterns

### DIFF
--- a/include/Dialect/Secret/IR/SecretOps.h
+++ b/include/Dialect/Secret/IR/SecretOps.h
@@ -16,4 +16,29 @@
 #define GET_OP_CLASSES
 #include "include/Dialect/Secret/IR/SecretOps.h.inc"
 
+namespace mlir {
+namespace heir {
+namespace secret {
+
+// Extracts the given op from inside the generic body and lifting to a new
+// single-op generic after the context generic op. This function assumes as a
+// precondition that the opToExtract's results do not have any uses besides in
+// the yield of the genericOp. The HoistOpAfterGeneric pattern tests for this
+// precondition.
+//
+// Replaces `genericOp` with a new genericOp using `rewriter`, and returns
+// the two newly created generic ops, with the first one being the replacement
+// for the input `genericOp`, and the second one being the extracted genericOp.
+//
+// Handles adding the operands of opToExtract to the yielded values of the
+// generic. The new yields may not be needed, and this can be cleaned up by
+// canonicalize, or a manual application of DedupeYieldedValues and
+// RemoveUnusedYieldedValues.
+std::pair<GenericOp, GenericOp> extractOpAfterGeneric(
+    GenericOp genericOp, Operation *opToExtract, PatternRewriter &rewriter);
+
+}  // namespace secret
+}  // namespace heir
+}  // namespace mlir
+
 #endif  // HEIR_INCLUDE_DIALECT_SECRET_IR_SECRETOPS_H_

--- a/include/Dialect/Secret/IR/SecretOps.td
+++ b/include/Dialect/Secret/IR/SecretOps.td
@@ -171,7 +171,8 @@ def Secret_GenericOp : Secret_Op<"generic", [
     // Clones a generic op and adds new yielded values. Returns the new op and
     // the value range corresponding to the new result values of the generic.
     // Callers can follow this method with something like the following to
-    // replace the current generic op with the result of this method.
+    // replace the current generic op with the result of this method. Always
+    // adds the new yielded values to the end of the list of yielded values.
     //
     // auto [modifiedGeneric, newResults] =
     //     genericOp.addNewYieldedValues(newResults, rewriter);
@@ -203,6 +204,23 @@ def Secret_GenericOp : Secret_Op<"generic", [
       ArrayRef<int> yieldedIndicesToRemove,
       PatternRewriter &rewriter,
       SmallVector<Value> &remainingResults);
+
+    // Modifies a GenericOp in place by taking the given op inside the generic
+    // body and lifting it into a new single-op generic before the context
+    // generic op. Returns the newly created GenericOp.
+    //
+    // For extractOpAfterGeneric, see SecretOps.h (it's a non-member function).
+    GenericOp extractOpBeforeGeneric(
+      Operation *opToExtract, PatternRewriter &rewriter);
+
+    // Inlines the GenericOp in place, dropping any secret types involved.
+    // Extra `operands` argument allows a conversion pattern to pass
+    // adaptor.getOperands().
+    void inlineInPlaceDroppingSecrets(PatternRewriter &rewriter, ValueRange operands);
+
+    void inlineInPlaceDroppingSecrets(PatternRewriter &rewriter) {
+      inlineInPlaceDroppingSecrets(rewriter, getOperands());
+    }
   }];
 
   let hasCanonicalizer = 1;

--- a/tests/secret/canonicalize.mlir
+++ b/tests/secret/canonicalize.mlir
@@ -12,5 +12,23 @@ func.func @remove_unused_yielded_values(%arg0: !secret.secret<i32>) -> !secret.s
       // CHECK: secret.yield %[[value:.*]] : i32
       secret.yield %d, %unused : i32, i32
     } -> (!secret.secret<i32>, !secret.secret<i32>)
-  func.return %Z : !secret.secret<i32>
+  return %Z : !secret.secret<i32>
+}
+
+// CHECK-LABEL: func @remove_pass_through_args
+func.func @remove_pass_through_args(
+// CHECK: %[[arg1:.*]]: !secret.secret<i32>, %[[arg2:.*]]: !secret.secret<i32>
+    %arg1 : !secret.secret<i32>, %arg2 : !secret.secret<i32>) -> (!secret.secret<i32>, !secret.secret<i32>) {
+  // CHECK: %[[out1:.*]] = secret.generic
+  %out1, %out2 = secret.generic
+    ins(%arg1, %arg2 : !secret.secret<i32>, !secret.secret<i32>) {
+    ^bb0(%x: i32, %y: i32) :
+      // CHECK: %[[value:.*]] = arith.addi
+      %z = arith.addi %x, %y : i32
+      // Only yield one value
+      // CHECK: secret.yield %[[value]] : i32
+      secret.yield %z, %y : i32, i32
+    } -> (!secret.secret<i32>, !secret.secret<i32>)
+  // CHECK: return %[[out1]], %[[arg2]]
+  return %out1, %out2 : !secret.secret<i32>, !secret.secret<i32>
 }


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/347

- Patterns:
  - HoistOpBeforeGeneric
  - HoistOpAfterGeneric
  - Improvements to RemoveUnusedGenericArgs
- Powered by new SecretOps functions:
  - GenericOp::extractOpBeforeGeneric
  - extractOpAfterGeneric
  - GenericOp::inlineInPlaceDroppingSecrets
- Refactored DistributeGeneric and ForgetSecrets to use the helpers

This was needed to support extracting stores/loads in `unroll-and-optimize`