### PR TITLE
ci: check cache to determine runner size

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@
 self-hosted-runner:
   labels:
     - ubuntu-20.04-16core
+    - ubuntu-20.04-4core

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,9 +11,42 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 jobs:
-  build-and-test:
+  check-cache:
     runs-on:
-      labels: ubuntu-20.04-16core
+      labels: ubuntu-20.04-4core
+    outputs:
+      runner: ${{ steps.runner.outputs.runner }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+
+      - name: Cache bazel build artifacts
+        id: cache
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # pin@v3.3.1
+        with:
+          path: |
+            ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+          lookup-only: true
+      - name: Select runner
+        id: runner
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit  == 'true' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${CACHE_HIT}" == "true" ]]; then
+            echo "runner=ubuntu-20.04-4core" >> "$GITHUB_OUTPUT"
+          else
+            echo "runner=ubuntu-20.04-16core" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-test:
+    needs: check-cache
+    runs-on:
+      labels: ${{ needs.check-cache.outputs.runner }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3

--- a/.github/workflows/run_rust_tests.sh
+++ b/.github/workflows/run_rust_tests.sh
@@ -3,4 +3,4 @@
 set -eux
 set -o pipefail
 
-bazel query "filter('.mlir.test$', //tests/tfhe_rust/end_to_end/...)" | xargs bazel test --sandbox_writable_path=$HOME/.cargo "$@"
+bazel query "filter('.mlir.test$', //tests/tfhe_rust/end_to_end/...)" | xargs bazel test -c fastbuild --sandbox_writable_path=$HOME/.cargo "$@"


### PR DESCRIPTION
Uses a smaller runner (4 core) when there's a cache hit, and 16 core when there's no cache hit. maybe i should use 8 cores..

I tested the runner switching on my own fork, but (1) i don't have access to two different runners so all i tested was the use of a variable runner and (2) i couldn't finish the llvm build on the default runners with no cache, so i'm not entirely sure that the 4 core is enough for a cached build

Also adds fastbuild to the rust e2e tests so it doesn't discard the cache for that

TODO: Also enable caching when tests fail (https://github.com/actions/cache/tree/main/save#always-save-cache)