### PR TITLE
update todo-backlinks version to fix broken URLs

### DIFF
--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -9,7 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
     - name: todo-backlinks
-      uses: j2kun/todo-backlinks@cb650ff669455d273f408df50f57e7b911ee3640 # pin@v0.0.2
+      uses: j2kun/todo-backlinks@c3745671fa215840545336571fc397ac2948d66a # pin@v0.0.3
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        GITHUB_BASE_REF: main


### PR DESCRIPTION
Cr. https://github.com/j2kun/todo-backlinks/commit/a314ca36722ba05696722d6fbc81fc182ab03822, which is the main fix.