### PR TITLE
use simpler statistic printing method

### DIFF
--- a/include/Transforms/YosysOptimizer/YosysOptimizer.h
+++ b/include/Transforms/YosysOptimizer/YosysOptimizer.h
@@ -8,7 +8,7 @@ namespace heir {
 
 std::unique_ptr<mlir::Pass> createYosysOptimizer(
     const std::string &yosysFilesPath, const std::string &abcPath, bool abcFast,
-    int unrollFactor = 0);
+    int unrollFactor = 0, bool printStats = false);
 
 #define GEN_PASS_DECL
 #include "include/Transforms/YosysOptimizer/YosysOptimizer.h.inc"
@@ -24,13 +24,11 @@ struct YosysOptimizerPipelineOptions
       llvm::cl::desc("Unroll loops by a given factor before optimizing. A "
                      "value of zero (default) prevents unrolling."),
       llvm::cl::init(0)};
-};
 
-struct UnrollAndOptimizePipelineOptions
-    : public PassPipelineOptions<UnrollAndOptimizePipelineOptions> {
-  PassOptions::Option<bool> abcFast{*this, "abc-fast",
-                                    llvm::cl::desc("Run abc in fast mode."),
-                                    llvm::cl::init(false)};
+  PassOptions::Option<bool> printStats{
+      *this, "print-stats",
+      llvm::cl::desc("Prints statistics about the optimized circuit"),
+      llvm::cl::init(false)};
 };
 
 // registerYosysOptimizerPipeline registers a Yosys pipeline pass using
@@ -38,12 +36,6 @@ struct UnrollAndOptimizePipelineOptions
 // the abc binary.
 void registerYosysOptimizerPipeline(const std::string &yosysFilesPath,
                                     const std::string &abcPath);
-
-// Registers a pipeline that interleaves yosys-optimizer and loop unrolling and
-// prints statistics about the optimized circuits. Intended for offline analysis
-// to determine the best loop-unrolling factor.
-void registerUnrollAndOptimizeAnalysisPipeline(
-    const std::string &yosysFilesPath, const std::string &abcPath);
 
 }  // namespace heir
 }  // namespace mlir

--- a/include/Transforms/YosysOptimizer/YosysOptimizer.td
+++ b/include/Transforms/YosysOptimizer/YosysOptimizer.td
@@ -23,33 +23,24 @@ def YosysOptimizer : Pass<"yosys-optimizer"> {
       time at the expense of a possibly larger output circuit.
     - `unroll-factor`: Before optimizing the circuit, unroll loops by a given
       factor. If unset, this pass will not unroll any loops.
+    - `print-stats`: Prints statistics about the optimized circuits.
   }];
-  // TODO(https://github.com/google/heir/issues/257): add option for the pass to select
-  // the unroll factor automatically.
+  // TODO(#257): add option for the pass to select the unroll factor
+  // automatically.
+
+  let statistics = [
+    Statistic<
+      "totalCircuitSize",
+      "total circuit size",
+      "The total circuit size for all optimized circuits, after optimization is done."
+    >,
+  ];
 
   let dependentDialects = [
     "mlir::arith::ArithDialect",
     "mlir::heir::comb::CombDialect",
     "mlir::heir::secret::SecretDialect",
     "mlir::memref::MemRefDialect"
-  ];
-}
-
-def UnrollAndOptimizeAnalysis : Pass<"unroll-and-optimize-analysis"> {
-  let summary = "Iteratively unroll and optimize an IR, printing optimization stats.";
-
-  let description = [{
-    This pass invokes the `--yosys-optimizer` pass while iteratively applying
-    loop-unrolling. Along the way, it prints statistics about the optimized
-    circuits, which can be used to determine an optimal loop-unrolling factor
-    for a given program.
-  }];
-
-  let dependentDialects = [
-    "mlir::arith::ArithDialect",
-    "mlir::heir::comb::CombDialect",
-    "mlir::heir::secret::SecretDialect",
-    "mlir::tensor::TensorDialect"
   ];
 }
 

--- a/lib/Dialect/Secret/IR/SecretPatterns.cpp
+++ b/lib/Dialect/Secret/IR/SecretPatterns.cpp
@@ -473,11 +473,6 @@ LogicalResult HoistOpBeforeGeneric::matchAndRewrite(
   Operation *opToHoist = &*it;
   LLVM_DEBUG(llvm::dbgs() << "Hoisting " << *opToHoist << "\n");
   genericOp.extractOpBeforeGeneric(opToHoist, rewriter);
-  LLVM_DEBUG({
-    Operation *parent = genericOp->getParentOp();
-    llvm::dbgs() << "After hoisting op\n";
-    parent->dump();
-  });
   return success();
 }
 
@@ -510,11 +505,6 @@ LogicalResult HoistOpAfterGeneric::matchAndRewrite(
   LLVM_DEBUG(llvm::dbgs() << "Hoisting " << *opToHoist << "\n");
 
   extractOpAfterGeneric(genericOp, opToHoist, rewriter);
-  LLVM_DEBUG({
-    Operation *parent = genericOp->getParentOp();
-    llvm::dbgs() << "After hoisting op\n";
-    parent->dump();
-  });
   return success();
 }
 
@@ -585,11 +575,6 @@ LogicalResult HoistPlaintextOps::matchAndRewrite(
   Operation *opToHoist = &*it;
   LLVM_DEBUG(llvm::dbgs() << "Hoisting " << *opToHoist << "\n");
   genericOp.extractOpBeforeGeneric(opToHoist, rewriter);
-  LLVM_DEBUG({
-    Operation *parent = genericOp->getParentOp();
-    llvm::dbgs() << "After hoisting op\n";
-    parent->dump();
-  });
   return success();
 }
 

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -280,8 +280,6 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   }
   mlir::heir::registerYosysOptimizerPipeline(yosysRunfilesEnvPath, abcEnvPath);
-  mlir::heir::registerUnrollAndOptimizeAnalysisPipeline(yosysRunfilesEnvPath,
-                                                        abcEnvPath);
   tosaToBooleanTfhePipeline(yosysRunfilesEnvPath, abcEnvPath);
 #endif
 


### PR DESCRIPTION
The main change in this PR is adding the `print-stats` option to yosys optimizer. Example:

```
bazel run //tools:heir-opt -- -o >/dev/null \
  --secret-distribute-generic=distribute-through="affine.for" \
  --yosys-optimizer="unroll-factor=4 print-stats=true" \
  $(pwd)/tests/yosys_optimizer/unroll_and_optimize.mlir
```

Output (for the cumulativeSum test in that file):

```
Optimization stats for op:

%22:4 = secret.generic ins(%10, %11, %12, %13, %15, %17, %19, %21 : !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>) {
^bb0(%arg2: i8, %arg3: i8, %arg4: i8, %arg5: i8, %arg6: i8, %arg7: i8, %arg8: i8, %arg9: i8):
  %27 = arith.addi %arg6, %arg2 : i8
  %28 = arith.addi %arg7, %arg3 : i8
  %29 = arith.addi %arg8, %arg4 : i8
  %30 = arith.addi %arg9, %arg5 : i8
  secret.yield %27, %28, %29, %30 : i8, i8, i8, i8
} -> (!secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>, !secret.secret<i8>)

  Starting arith op count: 4
  Ending cell count: 60
  Ratio: 1.500000e+01

Optimization stats for op:

%5 = secret.generic ins(%3, %4 : !secret.secret<i8>, !secret.secret<i8>) {
^bb0(%arg1: i8, %arg2: i8):
  %7 = arith.addi %arg2, %arg1 : i8
  secret.yield %7 : i8
} -> !secret.secret<i8>

  Starting arith op count: 1
  Ending cell count: 15
  Ratio: 1.500000e+01
```

The ratio of ending cell count to start arith op count is a simple measure of the benefit of doing the unrolling (though in this example it is the same ratio no matter how much you unroll).

Next I will add a python helper script that runs this for each possible loop unrolling amount, and tabulate the results. Note that I tried to do this all within MLIR, but there does not seem to be a convenient way to run a different set of passes on the same input IR and compare the results. I was also thinking this could be a good use case for the Python API, when that ever gets done.