### PR TITLE
add tfhe_rust canonicalization patterns

### DIFF
--- a/include/Dialect/TfheRust/IR/TfheRustDialect.h
+++ b/include/Dialect/TfheRust/IR/TfheRustDialect.h
@@ -6,6 +6,7 @@
 #include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/OpDefinition.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
 
 // Generated headers (block clang-format from messing up order)
 #include "include/Dialect/TfheRust/IR/TfheRustDialect.h.inc"
@@ -17,6 +18,16 @@ namespace tfhe_rust {
 template <typename ConcreteType>
 class PassByReference
     : public TypeTrait::TraitBase<ConcreteType, PassByReference> {};
+
+template <typename SksOp>
+struct HoistConstantLikeOps : public OpRewritePattern<SksOp> {
+  HoistConstantLikeOps(mlir::MLIRContext *context)
+      : OpRewritePattern<SksOp>(context, /*benefit=*/1) {}
+
+ public:
+  LogicalResult matchAndRewrite(SksOp op,
+                                PatternRewriter &rewriter) const override;
+};
 
 }  // namespace tfhe_rust
 }  // namespace heir

--- a/include/Dialect/TfheRust/IR/TfheRustOps.td
+++ b/include/Dialect/TfheRust/IR/TfheRustOps.td
@@ -20,8 +20,8 @@ class TfheRust_Op<string mnemonic, list<Trait> traits = []> :
 def CreateTrivialOp : TfheRust_Op<"create_trivial", [Pure]> {
   let arguments = (ins TfheRust_ServerKey:$serverKey, AnyInteger:$value);
   let results = (outs TfheRust_CiphertextType:$output);
+  let hasCanonicalizer = 1;
 }
-
 
 def BitAndOp : TfheRust_Op<"bitand", [
     Pure,
@@ -92,6 +92,7 @@ def GenerateLookupTableOp : TfheRust_Op<"generate_lookup_table", [Pure]> {
     Builtin_IntegerAttr:$truthTable
   );
   let results = (outs TfheRust_LookupTable:$lookupTable);
+  let hasCanonicalizer = 1;
 }
 
 #endif  // INCLUDE_DIALECT_TFHERUST_IR_TFHERUSTOPS_TD_

--- a/include/Dialect/TfheRust/IR/TfheRustPatterns.h
+++ b/include/Dialect/TfheRust/IR/TfheRustPatterns.h
@@ -1,0 +1,34 @@
+#ifndef INCLUDE_DIALECT_TFHERUST_IR_TFHERUSTPATTERNS_H_
+#define INCLUDE_DIALECT_TFHERUST_IR_TFHERUSTPATTERNS_H_
+
+#include "include/Dialect/TfheRust/IR/TfheRustOps.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace tfhe_rust {
+
+// Moves tfhe_rust ops that only depend on constants and the server key as
+// early as possible in the IR. Works generically across ops that have the
+// tfhe_rust.server_key as the first operand.
+template <typename SksOp>
+struct HoistConstantLikeOps : public OpRewritePattern<SksOp> {
+  HoistConstantLikeOps(mlir::MLIRContext *context)
+      : OpRewritePattern<SksOp>(context, /*benefit=*/1) {}
+
+ public:
+  LogicalResult matchAndRewrite(SksOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+struct HoistGenerateLookupTable : HoistConstantLikeOps<GenerateLookupTableOp> {
+  HoistGenerateLookupTable(mlir::MLIRContext *context)
+      : HoistConstantLikeOps(context, /*benefit=*/1) {}
+};
+struct HoistCreateTrivial : HoistConstantLikeOps<CreateTrivialOp> {};
+
+}  // namespace tfhe_rust
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_DIALECT_TFHERUST_IR_TFHERUSTPATTERNS_H_

--- a/lib/Dialect/TfheRust/IR/BUILD
+++ b/lib/Dialect/TfheRust/IR/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "@heir//include/Dialect/TfheRust/IR:ops_inc_gen",
         "@heir//include/Dialect/TfheRust/IR:types_inc_gen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
     ],

--- a/lib/Dialect/TfheRust/IR/TfheRustDialect.cpp
+++ b/lib/Dialect/TfheRust/IR/TfheRustDialect.cpp
@@ -4,8 +4,11 @@
 #include "include/Dialect/TfheRust/IR/TfheRustOps.h"
 #include "include/Dialect/TfheRust/IR/TfheRustTypes.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dominance.h"              // from @llvm-project
+
 #define GET_TYPEDEF_CLASSES
 #include "include/Dialect/TfheRust/IR/TfheRustTypes.cpp.inc"
 #define GET_OP_CLASSES
@@ -24,6 +27,57 @@ void TfheRustDialect::initialize() {
 #define GET_OP_LIST
 #include "include/Dialect/TfheRust/IR/TfheRustOps.cpp.inc"
       >();
+}
+
+// Move an operation as early as possible, so long as it only depends on the
+// server key. This pattern has the downside of adding an annotation to the
+// moved op, but this is necsesary to avoid infinite loops in the pattern
+// matcher. A later pass could remove the attributes, but they are harmless
+// and not emitted in the final codegen.
+template <typename SksOp>
+LogicalResult HoistConstantLikeOps<SksOp>::matchAndRewrite(
+    SksOp op, PatternRewriter &rewriter) const {
+  if (op->hasAttr("hoisted")) {
+    return failure();
+  }
+  DominanceInfo dom(op);
+  Operation *lastOperandDefiner = nullptr;
+  Block *lastBlock = nullptr;
+  for (Value operand : op->getOperands()) {
+    if (auto *defOp = operand.getDefiningOp()) {
+      if (lastOperandDefiner == nullptr ||
+          dom.dominates(lastOperandDefiner, defOp)) {
+        lastOperandDefiner = defOp;
+      }
+    } else if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
+      Block *block = blockArg.getOwner();
+      if (lastBlock == nullptr || dom.dominates(lastBlock, block)) {
+        lastBlock = block;
+      }
+    }
+  }
+
+  // The last argument's defining thing is a block
+  if (lastOperandDefiner == nullptr ||
+      dom.dominates(lastOperandDefiner, lastBlock->getParentOp())) {
+    rewriter.moveOpBefore(op, &lastBlock->getOperations().front());
+    op->setAttr("hoisted", rewriter.getBoolAttr(true));
+    return success();
+  }
+
+  rewriter.moveOpAfter(op, lastOperandDefiner);
+  op->setAttr("hoisted", rewriter.getBoolAttr(true));
+  return success();
+}
+
+void GenerateLookupTableOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.add<HoistConstantLikeOps<GenerateLookupTableOp>>(context);
+}
+
+void CreateTrivialOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                  MLIRContext *context) {
+  results.add<HoistConstantLikeOps<CreateTrivialOp>>(context);
 }
 
 }  // namespace tfhe_rust

--- a/tests/tfhe_rust/canonicalize.mlir
+++ b/tests/tfhe_rust/canonicalize.mlir
@@ -1,0 +1,65 @@
+// RUN: heir-opt --canonicalize %s | FileCheck %s
+
+!sks = !tfhe_rust.server_key
+
+module {
+  // CHECK-LABEL: func @test_move_create_trivial
+  func.func @test_move_create_trivial(%sks : !sks, %lut: !tfhe_rust.lookup_table) -> !tfhe_rust.eui3 {
+    // CHECK: arith.constant
+    // CHECK-NEXT: arith.constant
+    // CHECK-NEXT: tfhe_rust.create_trivial
+    // CHECK-NEXT: tfhe_rust.create_trivial
+    %0 = arith.constant 1 : i3
+    %1 = arith.constant 2 : i3
+    %e2 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
+    %shiftAmount = arith.constant 1 : i8
+    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2, %shiftAmount : (!sks, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %e1 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
+    %eCombined =  tfhe_rust.add %sks, %e1, %e2Shifted : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %out = tfhe_rust.apply_lookup_table %sks, %eCombined, %lut : (!sks, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
+    return %out : !tfhe_rust.eui3
+  }
+
+  // CHECK-LABEL: func @test_move_out_of_loop
+  func.func @test_move_out_of_loop(%sks : !sks, %lut: !tfhe_rust.lookup_table) -> memref<10x!tfhe_rust.eui3> {
+    // CHECK: arith.constant
+    // CHECK-NEXT: arith.constant
+    // CHECK-NEXT: tfhe_rust.create_trivial
+    // CHECK-NEXT: tfhe_rust.create_trivial
+    // CHECK-NEXT: memref.alloc
+    // CHECK-NEXT: affine.for
+    %0 = arith.constant 1 : i3
+    %1 = arith.constant 2 : i3
+    %memref = memref.alloca() : memref<10x!tfhe_rust.eui3>
+
+    affine.for %i = 0 to 10 {
+      %e2 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
+      %shiftAmount = arith.constant 1 : i8
+      %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2, %shiftAmount : (!sks, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+      %e1 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
+      %eCombined =  tfhe_rust.add %sks, %e1, %e2Shifted : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+      %out = tfhe_rust.apply_lookup_table %sks, %eCombined, %lut : (!sks, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
+      memref.store %out, %memref[%i] : memref<10x!tfhe_rust.eui3>
+      affine.yield
+    }
+    return %memref : memref<10x!tfhe_rust.eui3>
+  }
+
+  // CHECK-LABEL: func @test_move_to_front_of_block
+  func.func @test_move_to_front_of_block(%sks : !sks, %value : i3) -> (!tfhe_rust.eui3, i3, i3) {
+    // CHECK-NEXT: arith.constant
+    // CHECK-NEXT: arith.constant
+    // CHECK-NEXT: arith.constant
+    // CHECK-NEXT: tfhe_rust.create_trivial
+    // CHECK-NEXT: tfhe_rust.create_trivial
+    // CHECK-NEXT: arith.addi
+    %c3 = arith.constant 3 : i3
+    %c2 = arith.constant 2 : i3
+    %c1 = arith.constant 1 : i3
+    %sum = arith.addi %c3, %value : i3
+    %enc_val_2 = tfhe_rust.create_trivial %sks, %c1 : (!sks, i3) -> !tfhe_rust.eui3
+    %enc_val = tfhe_rust.create_trivial %sks, %value : (!sks, i3) -> !tfhe_rust.eui3
+    %combined = tfhe_rust.add %sks, %enc_val, %enc_val_2 : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    return %combined, %c2, %sum : !tfhe_rust.eui3, i3, i3
+  }
+}


### PR DESCRIPTION
Add canonicalization patterns that hoist `tfhe_rs.create_trivial` and `tfhe_rs.generate_lookup_table` as early as possible, to simplify parallelization analysis by @asraa 