### PR TITLE
simplify openfhe includes and make non-manual

### DIFF
--- a/tests/openfhe/end_to_end/BUILD
+++ b/tests/openfhe/end_to_end/BUILD
@@ -12,7 +12,6 @@ openfhe_end_to_end_test(
     generated_lib_header = "binops_lib.h",
     mlir_src = "binops.mlir",
     tags = [
-        "manual",
         "notap",
     ],
     test_src = "binops_test.cpp",

--- a/tests/openfhe/end_to_end/binops_test.cpp
+++ b/tests/openfhe/end_to_end/binops_test.cpp
@@ -1,16 +1,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "gmock/gmock.h"  // from @googletest
-#include "gtest/gtest.h"  // from @googletest
-#include "src/core/include/lattice/hal/default/lat-backend-default.h"  // from @openfhe
-#include "src/pke/include/constants.h"               // from @openfhe
-#include "src/pke/include/cryptocontext-fwd.h"       // from @openfhe
-#include "src/pke/include/encoding/plaintext-fwd.h"  // from @openfhe
-#include "src/pke/include/gen-cryptocontext.h"       // from @openfhe
-#include "src/pke/include/key/keypair.h"             // from @openfhe
-#include "src/pke/include/scheme/bgvrns/cryptocontext-bgvrns.h"  // from @openfhe
-#include "src/pke/include/scheme/bgvrns/cryptocontextparams-bgvrns.h"  // from @openfhe
+#include "gmock/gmock.h"              // from @googletest
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
 
 // Generated headers (block clang-format from messing up order)
 #include "tests/openfhe/end_to_end/binops_lib.h"


### PR DESCRIPTION
The manual tag made these tests not run in CI, and I found an issue with the OSS version of the include pattern that the internal tooling wanted. I think I'll just use this simpler version and suppress the internal warnings.