### PR TITLE
Speed up HoistPlaintextOps

### DIFF
--- a/tests/secret/canonicalize_perf.mlir
+++ b/tests/secret/canonicalize_perf.mlir
@@ -1,0 +1,25 @@
+// RUN: heir-opt --affine-loop-unroll=unroll-factor=1024 --canonicalize %s | FileCheck %s
+
+// A test to ensure that the canonicalize pass is not slow for large secret generic bodies
+// Cf. https://github.com/google/heir/issues/482
+
+// This test should only take ~0.5s to run. Before the bug above, it took ~15s.
+// It will take a bit of extra work to put a strict time limit on the bazel test runner
+// via lit, so I will just leave this note here and if the test starts running slow we will
+// hopefully notice it.
+
+// CHECK-LABEL: func @fast_unrolled_loop
+func.func @fast_unrolled_loop(
+    %arg1 : !secret.secret<memref<1024xi32>>) -> !secret.secret<memref<1024xi32>> {
+  %c5 = arith.constant 5 : i32
+  %out = secret.generic ins(%arg1 : !secret.secret<memref<1024xi32>>) {
+    ^bb0(%pt_arg: memref<1024xi32>):
+      affine.for %i = 0 to 1024 {
+        %x = memref.load %pt_arg[%i] : memref<1024xi32>
+        %y = arith.addi %x, %c5 : i32
+        memref.store %y, %pt_arg[%i] : memref<1024xi32>
+      }
+      secret.yield %pt_arg : memref<1024xi32>
+    } -> !secret.secret<memref<1024xi32>>
+  return %out : !secret.secret<memref<1024xi32>>
+}

--- a/tests/yosys_optimizer/unroll_and_optimize.mlir
+++ b/tests/yosys_optimizer/unroll_and_optimize.mlir
@@ -198,6 +198,8 @@ func.func @cumulative_sums(%arg0: !in_ty) -> (!out_ty) {
 //
 //     Extracted plaintext arith op
 //     CHECK-NEXT: %[[index_minus_one:.*]] = arith.subi %[[index]], %[[c1]]
+//     Same deal, but for second unwrapped loop iteration marked by SECOND_SUB
+//     CHECK-NEXT: arith.subi
 //
 //     Extracted load that can only be extracted because the previous
 //     arith op was extracted.
@@ -208,8 +210,7 @@ func.func @cumulative_sums(%arg0: !in_ty) -> (!out_ty) {
 //       CHECK-NEXT: secret.yield
 //     CHECK-NEXT: }
 //
-//     Same deal, but for second unwrapped loop iteration
-//     CHECK-NEXT: arith.subi
+//     mark: SECOND_SUB
 //     CHECK-NEXT: secret.generic
 //       CHECK-NEXT: bb
 //       CHECK-NEXT: memref.load


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/479

The two main problems:

1. `HoistPlaintextOps` used `std::find_if` to scan the entire generic body, only to extract a single op, leading to a quadratic scan when there were a linear number of ops to hoist. When unrolling an affine.for, each iteration gets an affine.apply op, and they can all be lifted, so it nearly always causes quadratic behavior.
2. In `extractOpBeforeGeneric`, the newly-created single-op generic was cloning all of the operands from the original generic op as its operands, even if it had zero secret operands. When lifting ~1k ops, this became a problem because the output of each single-op generic is added as an operand to the original `generic` it was lifted from, so we got into a situation like:
  - start: original generic has 1 arg
  - lift 1 op with 1 arg; original generic gets +1 arg
  - lift 1 op with 2 args; original generic gets +1 arg
  - lift 1 op with 3 args; original generic gets +1 arg
  - ... (x1000)
After that, we have a quadratic number of unused args, so we apply a quadratic number of EraseUnusedGenericArg patterns. By more finely tracking the subset of operands needed in the new generic, we can reduce this to (# ops to lift * # operands per lifted op), which is minimal. The only tricky bit is that, if the op being extracted is a loop nest, you have to walk the op's subtree to find all the generic arguments it depends on.

The test I added ran in 15s with the bug still in place, and after these fixes it runs in 0.5s.