### PR TITLE
Demo elementwise lowering of tensor<poly> to loops

### DIFF
--- a/include/Dialect/Polynomial/IR/BUILD
+++ b/include/Dialect/Polynomial/IR/BUILD
@@ -30,6 +30,7 @@ td_library(
     # include from the heir-root to enable fully-qualified include-paths
     includes = ["../../../.."],
     deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
@@ -87,15 +88,24 @@ gentbl_cc_library(
     name = "types_inc_gen",
     tbl_outs = [
         (
-            ["-gen-typedef-decls"],
+            [
+                "-gen-typedef-decls",
+                "-typedefs-dialect=polynomial",
+            ],
             "PolynomialTypes.h.inc",
         ),
         (
-            ["-gen-typedef-defs"],
+            [
+                "-gen-typedef-defs",
+                "-typedefs-dialect=polynomial",
+            ],
             "PolynomialTypes.cpp.inc",
         ),
         (
-            ["-gen-typedef-doc"],
+            [
+                "-gen-typedef-doc",
+                "-typedefs-dialect=polynomial",
+            ],
             "PolynomialTypes.md",
         ),
     ],

--- a/include/Dialect/Polynomial/IR/PolynomialTypes.td
+++ b/include/Dialect/Polynomial/IR/PolynomialTypes.td
@@ -4,16 +4,17 @@
 include "include/Dialect/Polynomial/IR/PolynomialDialect.td"
 include "include/Dialect/Polynomial/IR/PolynomialAttributes.td"
 
-include "mlir/IR/DialectBase.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypes.td"
+include "mlir/IR/DialectBase.td"
 
 // A base class for all types in this dialect
-class Polynomial_Type<string name, string typeMnemonic>
-    : TypeDef<Polynomial_Dialect, name> {
+class Polynomial_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<Polynomial_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
 }
 
-def Polynomial : Polynomial_Type<"Polynomial", "polynomial"> {
+def Polynomial : Polynomial_Type<"Polynomial", "polynomial", [MemRefElementTypeInterface]> {
   let summary = "An element of a polynomial quotient ring";
 
   let description = [{

--- a/tests/polynomial/elementwise.mlir
+++ b/tests/polynomial/elementwise.mlir
@@ -1,0 +1,10 @@
+// RUN: heir-opt --convert-elementwise-to-linalg --one-shot-bufferize --convert-linalg-to-affine-loops
+
+!poly = !polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>
+
+// CHECK-LABEL:  @test_bin_ops
+// CHECK: affine.for
+func.func @test_bin_ops(%arg0: tensor<2x!poly>, %arg1: tensor<2x!poly>) ->  tensor<2x!poly> {
+  %0 = polynomial.add(%arg0, %arg1) : tensor<2x!poly>
+  return %0 :  tensor<2x!poly>
+}


### PR DESCRIPTION
Adds the `MemRefElementTypeInterface` to the polynomial type, and demonstrates the lowering to affine loops

```
bazel run //tools:heir-opt -- --convert-elementwise-to-linalg --one-shot-bufferize --convert-linalg-to-affine-loops $PWD/tests/polynomial/elementwise.mlir
```

The strange part is that lowering linalg to loops requires de-tensorizing the inputs to linalg.generic, which inserts `bufferization.to_memref` and `bufferization.to_tensor` as materializations. To completely eliminate those requires converting everything to memrefs, see https://github.com/google/heir/blob/main/tools/heir-opt.cpp#L85-L99

I tried running `--polynomial-to-standard` after this, but ran into another issue 


```
/home/j2kun/fhe/heir/tests/polynomial/elementwise.mlir:8:8: 
error: failed to legalize unresolved materialization from 
'!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>' 
to 'tensor<1024xi25>' that remained live after conversion
  %0 = polynomial.add(%arg0, %arg1) : tensor<2x!poly>
       ^
/home/j2kun/fhe/heir/tests/polynomial/elementwise.mlir:8:8: 
note: see current operation: %7 = "builtin.unrealized_conversion_cast"(%6) :
 (!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>) -> tensor<1024xi25>
/home/j2kun/fhe/heir/tests/polynomial/elementwise.mlir:8:8: 
note: see existing live user here: %8 = arith.extsi %6 : tensor<1024xi25> to tensor<1024xi26>
```