### PR TITLE
add tensor_ext dialect to heir-lsp

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -128,6 +128,7 @@ cc_binary(
         "@heir//lib/Dialect/PolyExt/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Dialect/TfheRust/IR:Dialect",
         "@heir//lib/Dialect/TfheRustBool/IR:Dialect",
         "@heir//lib/Transforms/Secretize",

--- a/tools/heir-lsp.cpp
+++ b/tools/heir-lsp.cpp
@@ -6,6 +6,7 @@
 #include "include/Dialect/PolyExt/IR/PolyExtDialect.h"
 #include "include/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "include/Dialect/Secret/IR/SecretDialect.h"
+#include "include/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "include/Dialect/TfheRust/IR/TfheRustDialect.h"
 #include "include/Dialect/TfheRustBool/IR/TfheRustBoolDialect.h"
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
@@ -35,6 +36,7 @@ int main(int argc, char **argv) {
   registry.insert<tfhe_rust::TfheRustDialect>();
   registry.insert<tfhe_rust_bool::TfheRustBoolDialect>();
   registry.insert<openfhe::OpenfheDialect>();
+  registry.insert<tensor_ext::TensorExtDialect>();
 
   // Add expected MLIR dialects to the registry.
   registerAllDialects(registry);


### PR DESCRIPTION
Minor fix for something I noticed while staring at too much textual `*.mlir`: 
the LSP server executable wasn't aware of the `tensor_ext` operations, this commit fixes that.