### PR TITLE
Add support for tensors in -polynomial-to-standard 

### DIFF
--- a/lib/Conversion/PolynomialToStandard/PolynomialToStandard.cpp
+++ b/lib/Conversion/PolynomialToStandard/PolynomialToStandard.cpp
@@ -739,8 +739,8 @@ void PolynomialToStandard::runOnOperation() {
                ConvertConstant, ConvertMulScalar>(typeConverter, context);
   patterns.add<ConvertMul>(typeConverter, patterns.getContext(), getDivmodOp);
   addStructuralConversionPatterns(typeConverter, patterns, target);
+  addTensorOfTensorConversionPatterns(typeConverter, patterns, target);
 
-  // TODO(#143): Handle tensor of polys.
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();
   }

--- a/lib/Conversion/Utils.cpp
+++ b/lib/Conversion/Utils.cpp
@@ -1,8 +1,12 @@
 #include "lib/Conversion/Utils.h"
 
+#include <cstdint>
+
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm - project
 #include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
 
 namespace mlir {
@@ -11,6 +15,237 @@ namespace heir {
 using ::mlir::func::CallOp;
 using ::mlir::func::FuncOp;
 using ::mlir::func::ReturnOp;
+
+struct ConvertAny : public ConversionPattern {
+  ConvertAny(const TypeConverter &typeConverter, MLIRContext *context)
+      : ConversionPattern(typeConverter, RewritePattern::MatchAnyOpTypeTag(),
+                          /*benefit=*/1, context) {
+    setDebugName("ConvertAny");
+    setHasBoundedRewriteRecursion(true);
+  }
+
+  // generate a new op where all operands have been replaced with their
+  // materialized/typeconverted versions
+  LogicalResult matchAndRewrite(
+      Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> newOperandTypes;
+    if (failed(getTypeConverter()->convertTypes(op->getOperandTypes(),
+                                                newOperandTypes)))
+      return failure();
+
+    SmallVector<Type> newResultTypes;
+    if (failed(getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                newResultTypes)))
+      return failure();
+
+    SmallVector<std::unique_ptr<Region>, 1> regions;
+    IRMapping mapping;
+    for (auto &r : op->getRegions()) {
+      Region *newRegion = new Region();
+      rewriter.cloneRegionBefore(r, *newRegion, newRegion->end(), mapping);
+      if (failed(rewriter.convertRegionTypes(newRegion, *this->typeConverter)))
+        return failure();
+      regions.emplace_back(newRegion);
+    }
+
+    Operation *newOp = rewriter.create(OperationState(
+        op->getLoc(), op->getName().getStringRef(), operands, newResultTypes,
+        op->getAttrs(), op->getSuccessors(), regions));
+
+    rewriter.replaceOp(op, newOp);
+    return success();
+  }
+};
+
+struct ConvertExtract : public OpConversionPattern<tensor::ExtractOp> {
+  ConvertExtract(mlir::MLIRContext *context)
+      : OpConversionPattern<tensor::ExtractOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  // Convert a tensor.extract that would type-convert to extracting a tensor to
+  // a tensor.extract_slice operation instead. Specifically, this targets
+  // extracting SourceType from tensor<...xSourceType>  when SourceType would be
+  // type converted to tensor<...>.
+  LogicalResult matchAndRewrite(
+      tensor::ExtractOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // replace tensor.extract %t[%i] from tensor<shape x SourceType>
+    // with an equivalent tensor.slice from tensor<shape x resultshape>
+    auto shape = op.getTensor().getType().getShape();
+    auto resultType = getTypeConverter()
+                          ->convertType(op.getResult().getType())
+                          .cast<RankedTensorType>();
+    auto resultShape = resultType.getShape();
+
+    // expand op's list of indices by appending as many zeros as there are
+    // dimension in resultShape
+    SmallVector<OpFoldResult> offsets;
+    offsets.append(op.getIndices().begin(), op.getIndices().end());
+    for (size_t i = 0; i < resultShape.size(); ++i) {
+      offsets.push_back(rewriter.getIndexAttr(0));
+    }
+
+    // expand resultShape by prepending as many ones as there are dimensions in
+    // shape
+    SmallVector<OpFoldResult> sizes;
+    for (size_t i = 0; i < shape.size(); ++i) {
+      sizes.push_back(rewriter.getIndexAttr(1));
+    }
+    for (long i : resultShape) {
+      sizes.push_back(rewriter.getIndexAttr(i));
+    }
+
+    // strides are all 1, and we need as many as there are dimensions in
+    // both shape and resultShape together
+    SmallVector<OpFoldResult> strides;
+    for (size_t i = 0; i < shape.size() + resultShape.size(); ++i) {
+      strides.push_back(rewriter.getIndexAttr(1));
+    }
+
+    rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
+        op, resultType, adaptor.getTensor(), offsets, sizes, strides);
+
+    return success();
+  }
+};
+
+struct ConvertInsert : public OpConversionPattern<tensor::InsertOp> {
+  ConvertInsert(mlir::MLIRContext *context)
+      : OpConversionPattern<tensor::InsertOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  // Convert a tensor.insert that would type-convert to inserting a tensor to
+  // a tensor.insert_slice operation instead. Specifically, this targets
+  // inserting SourceType into tensor<...xSourceType>  when SourceType would be
+  // type converted to tensor<...>.
+  LogicalResult matchAndRewrite(
+      tensor::InsertOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // replace tensor.insert %s into %t[%i] with tensor<shape x SourceType>
+    // with an equivalent tensor.insert_slice with tensor<shape x resultshape>
+    auto shape = op.getDest().getType().getShape();
+    auto resultType = getTypeConverter()
+                          ->convertType(op.getScalar().getType())
+                          .cast<RankedTensorType>();
+    auto resultShape = resultType.getShape();
+
+    // expand op's list of indices by appending as many zeros as there are
+    // dimension in resultShape
+    SmallVector<OpFoldResult> offsets;
+    offsets.append(op.getIndices().begin(), op.getIndices().end());
+    for (size_t i = 0; i < resultShape.size(); ++i) {
+      offsets.push_back(rewriter.getIndexAttr(0));
+    }
+
+    // expand resultShape by prepending as many ones as there are dimensions in
+    // shape
+    SmallVector<OpFoldResult> sizes;
+    for (size_t i = 0; i < shape.size(); ++i) {
+      sizes.push_back(rewriter.getIndexAttr(1));
+    }
+    for (long i : resultShape) {
+      sizes.push_back(rewriter.getIndexAttr(i));
+    }
+
+    // strides are all 1, and we need as many as there are dimensions in
+    // both shape and resultShape together
+    SmallVector<OpFoldResult> strides;
+    for (size_t i = 0; i < shape.size() + resultShape.size(); ++i) {
+      strides.push_back(rewriter.getIndexAttr(1));
+    }
+
+    rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
+        op, adaptor.getScalar(), adaptor.getDest(), offsets, sizes, strides);
+
+    return success();
+  }
+};
+
+struct ConvertFromElements
+    : public OpConversionPattern<tensor::FromElementsOp> {
+  ConvertFromElements(mlir::MLIRContext *context)
+      : OpConversionPattern<tensor::FromElementsOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  // Converts a tensor.from_elements %s0, %s1, ... : tensor<...xSourceType>
+  // where SourceType would be type-converted to tensor<...> to
+  // a concatenation of the converted operands (with appropriate reshape)
+  LogicalResult matchAndRewrite(
+      tensor::FromElementsOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // Expand each of the (converted) operands:
+    SmallVector<Value> newOperands;
+    for (auto o : adaptor.getElements()) {
+      // extend tensor<...xT> to tensor<1x...xT>
+      if (auto tensorType = o.getType().dyn_cast<RankedTensorType>()) {
+        auto shape = tensorType.getShape();
+        SmallVector<int64_t> newShape(1, 1);
+        newShape.append(shape.begin(), shape.end());
+
+        // Create a dense constant for targetShape
+        auto shapeOp = rewriter.create<arith::ConstantOp>(
+            op.getLoc(),
+            RankedTensorType::get(newShape.size(), rewriter.getIndexType()),
+            rewriter.getIndexTensorAttr(newShape));
+
+        auto reshapeOp = rewriter.create<tensor::ReshapeOp>(
+            op.getLoc(),
+            RankedTensorType::get(newShape, tensorType.getElementType()), o,
+            shapeOp);
+        newOperands.push_back(reshapeOp);
+      } else {
+        newOperands.push_back(o);
+      }
+    }
+    // Create the final tensor.concat operation
+    rewriter.replaceOpWithNewOp<tensor::ConcatOp>(op, 0, newOperands);
+
+    return success();
+  }
+};
+
+void addTensorOfTensorConversionPatterns(TypeConverter &typeConverter,
+                                         RewritePatternSet &patterns,
+                                         ConversionTarget &target) {
+  typeConverter.addConversion([&](TensorType type) -> Type {
+    if (!typeConverter.isLegal(type.getElementType())) {
+      typeConverter.convertType(type.getElementType()).dump();
+      if (auto convertedType =
+              typeConverter.convertType(type.getElementType())) {
+        if (auto castConvertedType =
+                convertedType.dyn_cast<RankedTensorType>()) {
+          //  Create the combined shape
+          auto polyShape = castConvertedType.getShape();
+          auto tensorShape = type.getShape();
+          SmallVector<int64_t, 4> combinedShape(tensorShape.begin(),
+                                                tensorShape.end());
+          combinedShape.append(polyShape.begin(), polyShape.end());
+          auto combinedType = RankedTensorType::get(
+              combinedShape, castConvertedType.getElementType());
+          return combinedType;
+        }
+      }
+    }
+    return type;
+  });
+
+  target.addDynamicallyLegalDialect<tensor::TensorDialect>([&](Operation *op) {
+    return typeConverter.isLegal(op->getOperandTypes()) &&
+           typeConverter.isLegal(op->getResultTypes());
+  });
+
+  target.addDynamicallyLegalDialect<affine::AffineDialect>([&](Operation *op) {
+    return typeConverter.isLegal(op->getOperandTypes()) &&
+           typeConverter.isLegal(op->getResultTypes());
+  });
+
+  patterns.add<ConvertAny, ConvertExtract, ConvertInsert, ConvertFromElements>(
+      typeConverter, patterns.getContext());
+}
 
 void addStructuralConversionPatterns(TypeConverter &typeConverter,
                                      RewritePatternSet &patterns,

--- a/lib/Conversion/Utils.h
+++ b/lib/Conversion/Utils.h
@@ -6,6 +6,12 @@
 namespace mlir {
 namespace heir {
 
+// Adds conversion patterns that deal with tensor<..xsource_type>
+// when source_type will be type converted to tensor<...>, too
+void addTensorOfTensorConversionPatterns(TypeConverter &typeConverter,
+                                         RewritePatternSet &patterns,
+                                         ConversionTarget &target);
+
 // Adds the standard set of conversion patterns for
 // converting types involved in func, cf, etc., which
 // don't depend on the logic of the dialect beyond the

--- a/tests/polynomial/lower_add.mlir
+++ b/tests/polynomial/lower_add.mlir
@@ -4,6 +4,8 @@
 #ring = #polynomial.ring<cmod=4294967296, ideal=#cycl_2048>
 #ring_prime = #polynomial.ring<cmod=4294967291, ideal=#cycl_2048>
 
+
+// CHECK-LABEL: @test_lower_add_power_of_two_cmod
 func.func @test_lower_add_power_of_two_cmod() -> !polynomial.polynomial<#ring> {
   // 2 + 2x + 2x^2 + ... + 2x^{1023}
   // CHECK: [[X:%.+]] = arith.constant dense<2> : [[T:tensor<1024xi32>]]
@@ -19,6 +21,7 @@ func.func @test_lower_add_power_of_two_cmod() -> !polynomial.polynomial<#ring> {
   return %poly2 : !polynomial.polynomial<#ring>
 }
 
+// CHECK-LABEL: @test_lower_add_prime_cmod
 func.func @test_lower_add_prime_cmod() -> !polynomial.polynomial<#ring_prime> {
   // CHECK: [[X:%.+]] = arith.constant dense<2> : [[TCOEFF:tensor<1024xi31>]]
   %coeffs1 = arith.constant dense<2> : tensor<1024xi31>
@@ -40,4 +43,53 @@ func.func @test_lower_add_prime_cmod() -> !polynomial.polynomial<#ring_prime> {
 
   // CHECK: return  [[TRUNC_RESULT]] : [[T]]
   return %poly2 : !polynomial.polynomial<#ring_prime>
+}
+
+// CHECK-LABEL: @test_lower_add_tensor
+func.func @test_lower_add_tensor() -> tensor<2x!polynomial.polynomial<#ring>> {
+  // 2 + 2x + 2x^2 + ... + 2x^{1023}
+  // CHECK-DAG: [[A:%.+]] = arith.constant dense<2> : [[T:tensor<1024xi32>]]
+  %coeffsA = arith.constant dense<2> : tensor<1024xi32>
+  // CHECK-DAG: [[B:%.+]] = arith.constant dense<3> : [[T]]
+  %coeffsB = arith.constant dense<3> : tensor<1024xi32>
+  // CHECK-DAG: [[C:%.+]] = arith.constant dense<4> : [[T]]
+  %coeffsC = arith.constant dense<4> : tensor<1024xi32>
+  // CHECK-DAG: [[D:%.+]] = arith.constant dense<5> : [[T]]
+  %coeffsD = arith.constant dense<5> : tensor<1024xi32>
+  %polyA = polynomial.from_tensor %coeffsA : tensor<1024xi32> -> !polynomial.polynomial<#ring>
+  %polyB = polynomial.from_tensor %coeffsB : tensor<1024xi32> -> !polynomial.polynomial<#ring>
+  %polyC = polynomial.from_tensor %coeffsC : tensor<1024xi32> -> !polynomial.polynomial<#ring>
+  %polyD = polynomial.from_tensor %coeffsD : tensor<1024xi32> -> !polynomial.polynomial<#ring>
+  %tensor1 = tensor.from_elements %polyA, %polyB : tensor<2x!polynomial.polynomial<#ring>>
+  %tensor2 = tensor.from_elements %polyC, %polyD : tensor<2x!polynomial.polynomial<#ring>>
+  // CHECK: [[S1:%.+]] = arith.constant dense<[1, 1024]> : [[TI:tensor<2xindex>]]
+  // CHECK: [[T1:%.+]] = tensor.reshape [[A]]([[S1]]) : ([[T]], [[TI]]) -> [[TEX:tensor<1x1024xi32>]]
+  // CHECK: [[S2:%.+]] = arith.constant dense<[1, 1024]> : [[TI]]
+  // CHECK: [[T2:%.+]] = tensor.reshape [[B]]([[S2]]) : ([[T]], [[TI]]) -> [[TEX]]
+  // CHECK: [[C1:%.+]] = tensor.concat dim(0) [[T1]], [[T2]] : ([[TEX]], [[TEX]]) -> [[TT:tensor<2x1024xi32>]]
+  // CHECK: [[S3:%.+]] = arith.constant dense<[1, 1024]> : [[TI]]
+  // CHECK: [[T3:%.+]] = tensor.reshape [[C]]([[S3]]) : ([[T]], [[TI]]) -> [[TEX]]
+  // CHECK: [[S4:%.+]] = arith.constant dense<[1, 1024]> : [[TI]]
+  // CHECK: [[T4:%.+]] = tensor.reshape [[D]]([[S4]]) : ([[T]], [[TI]]) -> [[TEX]]
+  // CHECK: [[C2:%.+]] = tensor.concat dim(0) [[T3]], [[T4]] : ([[TEX]], [[TEX]]) -> [[TT:tensor<2x1024xi32>]]
+  // CHECK-NOT: polynomial.from_tensor
+  // CHECK-NOT: tensor.from_elements
+  %tensor3 = affine.for %i = 0 to 2 iter_args(%t0 = %tensor1) ->  tensor<2x!polynomial.polynomial<#ring>> {
+      // CHECK: [[FOR:%.]] = affine.for [[I:%.+]] = 0 to 2 iter_args([[T0:%.+]] = [[C1]]) -> ([[TT]]) {
+      %a = tensor.extract %tensor1[%i] :  tensor<2x!polynomial.polynomial<#ring>>
+      %b = tensor.extract %tensor2[%i] :  tensor<2x!polynomial.polynomial<#ring>>
+      // CHECK: [[AA:%.+]] = tensor.extract_slice [[C1]][[[I]], 0] [1, 1024] [1, 1] : [[TT]]
+      // CHECK: [[BB:%.+]] = tensor.extract_slice [[C2]][[[I]], 0] [1, 1024] [1, 1] : [[TT]]
+      // CHECK-NOT: tensor.extract %
+      %s = polynomial.add(%a, %b) : !polynomial.polynomial<#ring>
+      // CHECK: [[SUM:%.+]] = arith.addi [[AA]], [[BB]] : [[T]]
+      // CHECK-NOT: polynomial.add
+      %t = tensor.insert %s into %t0[%i] :  tensor<2x!polynomial.polynomial<#ring>>
+      // CHECK: [[INS:%.+]] = tensor.insert_slice [[SUM]] into [[T0]][[[I]], 0] [1, 1024] [1, 1] : [[T]] into [[TT]]
+      // CHECK-NOT: tensor.insert %
+      affine.yield %t :  tensor<2x!polynomial.polynomial<#ring>>
+      // CHECK: affine.yield [[INS]] : [[TT]]
+    }
+  return %tensor3 :  tensor<2x!polynomial.polynomial<#ring>>
+  // CHECK: return [[FOR]] : [[TT]]
 }


### PR DESCRIPTION
Fixes #143 (see discussion there) by adding support for dealing with `tensor<..x!polynomial.polynomial<..>>` types in the `-polynomial-to-standard` pass.

This PR assumes the `ElementwiseMappable` `polynomial` operations have somehow been "unrolled" (c.f. #504) and focuses on lowering the resulting IR, which no longer contains `polynomial` operations over tensors, but contains various other operations with `tensor<..x!polynomial.polynomial<..>>` types. This is necessary because MLIR does not alllow tensor-of-tensor (which the pass would produce) and (afaik) does not offer any built-in systems to handle lowering of `ElementwiseMappable` operations in a more generic fashion.


* Declares `tensor` dialect dynamically legal 
(using `typeConverter.isLegal`, ops are illegal if their operands require type conversion)
* Adds a `ConvertAny` conversion pattern that matches any operation and simply replaces the operation by a copy of itself with the types converted.
* Adds `ConvertExtract` and `ConvertInsert` patterns that match `tensor.extract` and `tensor.insert` operations and rewrites them to `tensor.extract_slice` and `tensor.insert_slice` operations, respectively.
* Extends the `TypeConverter` with a conversion that converts tensors of polynomial types to multi-dimensional tensors.
* In order to support affine loops, this also declares the `affine` dialect dynamically legal (same rule as for `tensor`).

For example, the pass converts this example as follows:
```llvm
#map = affine_map<(d0) -> (d0)>
func.func @test_bin_ops(%arg0: tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>, %arg1: tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>) -> tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>> {
  %0 = affine.for %i = 0 to 2 iter_args(%a = %arg0) -> tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>> {
    %in = tensor.extract %arg0[%i] :  tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>
    %in_0 = tensor.extract %arg1[%i] :  tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>
    %1 = polynomial.add(%in, %in_0) : !polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>
    %t = tensor.insert %1 into %a[%i] :  tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>
    affine.yield %t :  tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>
  }
  return %0 : tensor<2x!polynomial.polynomial<<cmod=33538049, ideal=#polynomial.polynomial<1 + x**1024>>>>
}
```
```llvm 
func.func @test_bin_ops(%arg0: tensor<2x1024xi25>, %arg1: tensor<2x1024xi25>) -> tensor<2x1024xi25> {
  %0 = affine.for %arg2 = 0 to 2 iter_args(%arg3 = %arg0) -> (tensor<2x1024xi25>) {
    %extracted_slice = tensor.extract_slice %arg0[%arg2, 0] [1, 1024] [1, 1] : tensor<2x1024xi25> to tensor<1024xi25>
    %extracted_slice_0 = tensor.extract_slice %arg1[%arg2, 0] [1, 1024] [1, 1] : tensor<2x1024xi25> to tensor<1024xi25>
    %cst = arith.constant dense<33538049> : tensor<1024xi26>
    %1 = arith.extsi %extracted_slice : tensor<1024xi25> to tensor<1024xi26>
    %2 = arith.extsi %extracted_slice_0 : tensor<1024xi25> to tensor<1024xi26>
    %3 = arith.addi %1, %2 : tensor<1024xi26>
    %4 = arith.remsi %3, %cst : tensor<1024xi26>
    %5 = arith.trunci %4 : tensor<1024xi26> to tensor<1024xi25>
    %inserted_slice = tensor.insert_slice %5 into %arg3[%arg2, 0] [1, 1024] [1, 1] : tensor<1024xi25> into tensor<2x1024xi25>
    affine.yield %inserted_slice : tensor<2x1024xi25>
  }
  return %0 : tensor<2x1024xi25>
}
``` 

This is still WIP, there's a few things left to clean-up/improve:
* This is mostly a generic set of utilities for lowering `ElementwiseMappable` Ops so it should probably move to `Utils.cpp` where `addStructuralConversionPatterns` already is. 
* The `addConversion` to go from tensor-of-poly to multi-dim-poly currently uses the `convertPolynomialType` function, but it could probably be made generic by calling the typeconverter itself to convert the tensor's element in a  black-box fashion.
* The `ConvertAny` pattern needs to be marked as `setHasBoundedRewriteRecursion(true)` because otherwise it will not apply to operations it generates (e.g., the "new" operations created when cloning a region, such as when called on `affine.for`). This seems to be fine (operations are "legalized" in the eyes of the type converter after being visited once) but and the more specific patterns seem to have higher priority, but there could be a case where an operation is marked explicitly illegal but no other pattern matches it, in which case this pattern would probably be applied infinitely. 
* Still need to add tests that actually exercise this logic

Most importantly, I'd still need to extend this concept to `memref`, since that's what actually gets generated by the pipeline in #504, but there's a bit of annoying issue in that we'd somehow have to go from a `memref<2x1024xi25>` to `tensor<1024xi25>` because that's what the `arith` operations that we insert in place of the `polynomial` operations expect.
