### PR TITLE
disable cggi-straight-line-vectorizer test for now

### DIFF
--- a/tests/cggi/straight_line_vectorizer.mlir
+++ b/tests/cggi/straight_line_vectorizer.mlir
@@ -1,4 +1,5 @@
-// RUN: heir-opt --straight-line-vectorize %s | FileCheck %s
+// TODO(#519): disable FileChecks until nondeterminism issues are resolved
+// RUN: heir-opt --straight-line-vectorize %s
 
 #encoding = #lwe.unspecified_bit_field_encoding<cleartext_bitwidth = 3>
 !ct_ty = !lwe.lwe_ciphertext<encoding = #encoding>


### PR DESCRIPTION
See https://github.com/google/heir/issues/519, and it's causing other unrelated PRs to fail