### PR TITLE
bugfix for addTensorOfTensorConversionPatterns

### DIFF
--- a/lib/Conversion/Utils.cpp
+++ b/lib/Conversion/Utils.cpp
@@ -222,9 +222,8 @@ struct ConvertFromElements
 void addTensorOfTensorConversionPatterns(TypeConverter &typeConverter,
                                          RewritePatternSet &patterns,
                                          ConversionTarget &target) {
-  target.addDynamicallyLegalDialect<tensor::TensorDialect>([&](Operation *op) {
-    return typeConverter.isLegal(op->getOperandTypes());
-  });
+  target.addDynamicallyLegalDialect<tensor::TensorDialect>(
+      [&](Operation *op) { return typeConverter.isLegal(op); });
 
   typeConverter.addConversion([&](TensorType type) -> Type {
     if (!typeConverter.isLegal(type.getElementType())) {
@@ -248,9 +247,8 @@ void addTensorOfTensorConversionPatterns(TypeConverter &typeConverter,
     return type;
   });
 
-  target.addDynamicallyLegalDialect<affine::AffineDialect>([&](Operation *op) {
-    return typeConverter.isLegal(op->getOperandTypes());
-  });
+  target.addDynamicallyLegalDialect<affine::AffineDialect>(
+      [&](Operation *op) { return typeConverter.isLegal(op); });
 
   patterns.add<ConvertAny, ConvertExtract, ConvertInsert, ConvertFromElements>(
       typeConverter, patterns.getContext());


### PR DESCRIPTION
Ops like `affine.yield` wouldn't be marked as illegal even if they contained tensors-of-tensors, as the legality check was previously only on operands. Now it's on the entire op, i.e., both operands and return types. 

PS: separate PR because I hadn't wrapped my head around how the github-google-copybara flow worked so the old one got merged without this fix 🙈 