### PR TITLE
Use target slot analysis to simplify `insert-rotate`

### DIFF
--- a/include/Dialect/TensorExt/Transforms/InsertRotate.td
+++ b/include/Dialect/TensorExt/Transforms/InsertRotate.td
@@ -7,7 +7,12 @@ include "mlir/Dialect/Arith/IR/ArithOps.td"
 include "mlir/Dialect/Tensor/IR/TensorOps.td"
 include "mlir/IR/PatternBase.td"
 
-// TODO(#512): Support target slot selection when the downstream op is an insert.
+// Get the target_slot attribute from an op, if it exists, or else
+// return a zero index attribute.
+def GetTargetSlotAttr : NativeCodeCall<
+      "$0.getOwner()->hasAttr(\"target_slot\")"
+      " ? llvm::cast<mlir::IntegerAttr>($0.getOwner()->getAttr(\"target_slot\"))"
+      " : $_builder.getIndexAttr(0)">;
 
 // The patterns in this file are intended to align with the automatic-SIMD
 // batching heuristics from the HECO project. See section 4.4 of
@@ -20,23 +25,31 @@ include "mlir/IR/PatternBase.td"
 // canonicalization patterns will remove duplicated rotations.
 foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {
   def InsertRotations_#ArithOp : Pattern<
-    (ArithOp
+    (ArithOp:$arithOp
       (Tensor_ExtractOp $t1, (variadic $i1)),
       (Tensor_ExtractOp $t2, (variadic $i2)),
       $overflow),
     [
-      (TensorExt_RotateOp:$r1 $t1, $i1),
-      (TensorExt_RotateOp:$r2 $t2, $i2),
+      (TensorExt_RotateOp:$r1 $t1,
+          (Arith_SubIOp $i1, (Arith_ConstantOp (GetTargetSlotAttr $arithOp)), DefOverflow)),
+      (TensorExt_RotateOp:$r2 $t2,
+          (Arith_SubIOp $i2, (Arith_ConstantOp (GetTargetSlotAttr $arithOp)), DefOverflow)),
       (ArithOp:$opResult $r1, $r2, $overflow),
       (Tensor_ExtractOp
         $opResult,
-        (MakeSingleResultVariadic (Arith_ConstantOp ConstantAttr<IndexAttr, "0">))),
+        (MakeSingleResultVariadic
+          (Arith_ConstantOp (GetTargetSlotAttr $arithOp)))),
     ]
   >;
 }
 
+
 // Pre-align the first op's operands to the index that the result is
-// used for in a subsequent op.
+// used for in a subsequent op. This is used to simplify the IR
+// primarily when there is no specific slot target selected for an op. In
+// that case, the above pattern will still replace extractions with
+// rotations, and the simplifications will occur by replacing triples
+// of rotations with pairs.
 // TODO(#514): handle OuterOp with two different InnerOps on the LHS and RHS
 foreach InnerOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {
   foreach OuterOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {

--- a/lib/Dialect/TensorExt/Transforms/BUILD
+++ b/lib/Dialect/TensorExt/Transforms/BUILD
@@ -69,6 +69,7 @@ cc_library(
     ],
     deps = [
         "@heir//include/Dialect/TensorExt/Transforms:pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/tests/simd/hamming_distance.mlir
+++ b/tests/simd/hamming_distance.mlir
@@ -1,5 +1,5 @@
 // RUN: heir-opt --secretize=entry-function=hamming --wrap-generic --canonicalize --cse \
-// RUN:   --full-loop-unroll --insert-rotate --cse --canonicalize \
+// RUN:   --full-loop-unroll --cse --canonicalize --insert-rotate --cse --canonicalize \
 // RUN:   %s | FileCheck %s
 
 // CHECK-LABEL: @hamming
@@ -10,9 +10,13 @@
 // CHECK-NEXT: arith.addi
 // CHECK-NEXT: tensor_ext.rotate
 // CHECK-NEXT: arith.addi
+// CHECK-NEXT: tensor_ext.rotate
 // CHECK-NEXT: arith.addi
 // CHECK-NEXT: tensor.extract
 // CHECK-NEXT: secret.yield
+
+// TODO(#521): support rotate-and-reduce when the input is already a series of incremental rotations,
+// as this IR is currently lowered to 4-1 rotate operations to sum after doing (x-y)**2 in SIMD.
 
 func.func @hamming(%arg0: tensor<4xi16> {secret.secret}, %arg1: tensor<4xi16> {secret.secret}) -> i16 {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
Rebased off https://github.com/google/heir/pull/526

This gives us a cleaner implementation of the target slot selection, and has a few benefits:

- Now programs like `hamming_distance` and the `simple_sum` from https://github.com/google/heir/issues/520 materialize their reductions as a sequence of shift-by-1 rotates, which means we can augment `rotate-and-reduce` to support replacing that with a logarithmic number of rotations. In particular, this increased the number of rotations of the hamming_distance test case by one, which is temporary.
- I found a way to incorporate the result of a dataflow analysis into DRR rewrite patterns, which is demonstrated in this PR by first running the dataflow solver, then walking the IR and attaching the output of the analysis as attributes to the relevant ops, and adding a helper NativeCodeCall in DRR to extract the attribute. I found out you can also use this to apply constraints (i.e., apply this pattern only if the op has the relevant attr). This method seems like it would be limited to simple data output by the analysis, not something complex like a struct or piece of a larger data structure.