### PR TITLE
Add rotate-and-reduce for linear sequences of rotations 

### DIFF
--- a/include/Analysis/RotationAnalysis/BUILD
+++ b/include/Analysis/RotationAnalysis/BUILD
@@ -1,0 +1,9 @@
+# RotationAnalysis analysis pass
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["RotationAnalysis.h"],
+)

--- a/include/Analysis/RotationAnalysis/RotationAnalysis.h
+++ b/include/Analysis/RotationAnalysis/RotationAnalysis.h
@@ -1,0 +1,219 @@
+#ifndef INCLUDE_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_
+#define INCLUDE_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_
+
+#include <unordered_set>
+
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+
+#define DEBUG_TYPE "rotation-analysis"
+
+namespace mlir {
+namespace heir {
+namespace rotation_analysis {
+
+// A wrapper around a mapping from a single tensor SSA value to a set of its
+// access indices.
+class RotationSets {
+ public:
+  enum class Status {
+    // The tensor value has not been set
+    Uninitialized,
+
+    // The rotation set is in a normal state.
+    Normal,
+
+    // The rotation set has a property that makes it invalid for later
+    // optimizations:
+    //
+    //  - It involves operations touch more than one source tensor (not
+    //    including value-semantic outputs)
+    Overdetermined
+
+  };
+
+ public:
+  RotationSets() = default;
+  ~RotationSets() = default;
+
+  // Clear the member data, i.e., set the value back to an uninitialized
+  // state.
+  void clear() {
+    accessedIndices.clear();
+    status = Status::Uninitialized;
+  }
+
+  bool empty() const { return accessedIndices.empty(); }
+
+  bool isOverdetermined() const { return status == Status::Overdetermined; }
+
+  bool isUninitialized() const { return status == Status::Uninitialized; }
+
+  void addRotation(int64_t index) { accessedIndices.insert(index); }
+
+  bool operator==(const RotationSets &rhs) const {
+    return tensor == rhs.tensor && status == rhs.status &&
+           accessedIndices == rhs.accessedIndices;
+  }
+
+  const std::unordered_set<int64_t> &getAccessedIndices() const {
+    return accessedIndices;
+  }
+
+  Value getTensor() const { return tensor; }
+
+  void print(raw_ostream &os) const {
+    os << tensor << ": [";
+    for (auto index : accessedIndices) {
+      os << index << ", ";
+    }
+    os << "]";
+  }
+
+  static RotationSets overdetermined() {
+    RotationSets sets;
+    sets.status = Status::Overdetermined;
+    return sets;
+  }
+
+  static RotationSets from(Value tensor) {
+    RotationSets sets;
+    if (!tensor.getType().isa<RankedTensorType>()) {
+      sets.status = Status::Uninitialized;
+      return sets;
+    }
+
+    sets.status = Status::Normal;
+    sets.tensor = tensor;
+    if (auto blockArg = dyn_cast<BlockArgument>(tensor)) {
+      sets.addRotation(0);
+    }
+    return sets;
+  }
+
+  // Shift the rotation indices by the given amount. This helps in a situation
+  // where an IR repeatedly rotates by 1, to ensure that rotations accumulate
+  // like {1, 2, 3, ...} rather than {1, 1, 1, ...}
+  static RotationSets rotate(const RotationSets &lhs, const int64_t shift) {
+    if (lhs.status == Status::Overdetermined) {
+      return overdetermined();
+    }
+
+    RotationSets shifted;
+    shifted.status = Status::Normal;
+    shifted.tensor = lhs.tensor;
+    int64_t size =
+        llvm::cast<RankedTensorType>(lhs.tensor.getType()).getShape()[0];
+    for (auto index : lhs.accessedIndices) {
+      shifted.addRotation((index + shift) % size);
+    }
+    return shifted;
+  }
+
+  static RotationSets join(const RotationSets &lhs, const RotationSets &rhs) {
+    if (lhs.status == Status::Overdetermined ||
+        rhs.status == Status::Overdetermined) {
+      return overdetermined();
+    }
+
+    if (rhs.status == Status::Uninitialized || rhs.accessedIndices.empty())
+      return lhs;
+    if (lhs.status == Status::Uninitialized || lhs.accessedIndices.empty())
+      return rhs;
+
+    if (lhs.tensor != rhs.tensor) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "Joining rotations of different tensors: " << lhs.tensor
+                     << " and " << rhs.tensor << "\n";
+      });
+      return overdetermined();
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Joining :" << lhs.tensor << " and " << rhs.tensor
+                   << "\n";
+    });
+    RotationSets merged;
+    merged.status = Status::Normal;
+    merged.tensor = lhs.tensor;
+    for (auto index : lhs.accessedIndices) {
+      merged.addRotation(index);
+    }
+    for (auto index : rhs.accessedIndices) {
+      merged.addRotation(index);
+    }
+    return merged;
+  }
+
+  // Assuming two not-overdetermined rotation sets, compute the overlap in
+  // their access indices.
+  static RotationSets overlap(const RotationSets &lhs,
+                              const RotationSets &rhs) {
+    assert(!lhs.isOverdetermined() && !rhs.isOverdetermined() &&
+           "Expected inputs to RotationSets::overlap to be not overdetermined");
+    if (lhs.status == Status::Uninitialized || lhs.empty()) {
+      return lhs;
+    }
+
+    if (rhs.status == Status::Uninitialized || rhs.empty()) {
+      return rhs;
+    }
+
+    RotationSets merged;
+    merged.status = Status::Normal;
+    merged.tensor = lhs.tensor;
+    for (auto index : lhs.accessedIndices) {
+      if (rhs.accessedIndices.count(index)) merged.addRotation(index);
+    }
+    return merged;
+  }
+
+ private:
+  /// The accessed indices of a single SSA value of tensor type.
+  Value tensor;
+
+  // There is likely a data structure that can more efficiently represent a set
+  // of intervals of integers, which properly merges adjacent intervals as
+  // values are added. Java/Guava has RangeSet, and boost has interval_set.
+  std::unordered_set<int64_t> accessedIndices;
+  Status status = Status::Uninitialized;
+};
+
+inline raw_ostream &operator<<(raw_ostream &os, const RotationSets &v) {
+  v.print(os);
+  return os;
+}
+
+class RotationLattice : public dataflow::Lattice<RotationSets> {
+ public:
+  using Lattice::Lattice;
+};
+
+/// An analysis that identifies, for each SSA value, the set of underlying
+/// tensors and rotations of those tensors, provided constant rotation shifts
+/// can be determined.
+class RotationAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<RotationLattice> {
+ public:
+  explicit RotationAnalysis(DataFlowSolver &solver)
+      : SparseForwardDataFlowAnalysis(solver) {}
+  ~RotationAnalysis() override = default;
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  // Given the computed results of the operation, update its operand lattice
+  // values.
+  void visitOperation(Operation *op, ArrayRef<const RotationLattice *> operands,
+                      ArrayRef<RotationLattice *> results) override;
+
+  void setToEntryState(RotationLattice *lattice) override;
+};
+
+}  // namespace rotation_analysis
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_

--- a/lib/Analysis/RotationAnalysis/BUILD
+++ b/lib/Analysis/RotationAnalysis/BUILD
@@ -1,0 +1,20 @@
+# RotationAnalysis analysis pass
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RotationAnalysis",
+    srcs = ["RotationAnalysis.cpp"],
+    hdrs = ["@heir//include/Analysis/RotationAnalysis:RotationAnalysis.h"],
+    deps = [
+        "@heir//lib/Dialect:Utils",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)

--- a/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
+++ b/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
@@ -1,0 +1,75 @@
+#include "include/Analysis/RotationAnalysis/RotationAnalysis.h"
+
+#include "include/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotation_analysis {
+
+void RotationAnalysis::visitOperation(
+    Operation *op, ArrayRef<const RotationLattice *> operands,
+    ArrayRef<RotationLattice *> results) {
+  llvm::TypeSwitch<Operation &>(*op)
+      .Case<tensor_ext::RotateOp>([&](auto rotateOp) {
+        LLVM_DEBUG({ llvm::dbgs() << "Visiting: " << *op << "\n"; });
+        auto shiftConstantOp =
+            rotateOp.getShift().template getDefiningOp<arith::ConstantOp>();
+        // If the rotation shift can't be statically determined, we can't
+        // propagate anything through the IR.
+        if (!shiftConstantOp) return;
+
+        int64_t shiftValue =
+            dyn_cast<IntegerAttr>(shiftConstantOp.getValue()).getInt();
+
+        // The target slot propagates from the tensor argument to the result;
+        // the tensor argument is first in the tablegen definition.
+        const RotationLattice *lattice = operands[0];
+        RotationSets latticeRotations = lattice->getValue();
+
+        // If it's a block argument, then there is no initialized lattice value
+        // and we can override it with a "zero rotation"
+        auto blockArg = dyn_cast<BlockArgument>(rotateOp.getTensor());
+        if (blockArg) {
+          latticeRotations = RotationSets::from(blockArg);
+        }
+        RotationSets rotated =
+            RotationSets::rotate(latticeRotations, shiftValue);
+
+        for (RotationLattice *r : results) {
+          ChangeResult result = r->join(rotated);
+          propagateIfChanged(r, result);
+        }
+      })
+      .Default([&](Operation &op) {
+        // By default, an op propagates its result target slots to all its
+        // operands.
+        for (OpOperand &operand : op.getOpOperands()) {
+          auto *latticeOperand = operands[operand.getOperandNumber()];
+
+          for (RotationLattice *r : results) {
+            ChangeResult result = r->join(*latticeOperand);
+            // If the operand is a block arg, this additionally treats this as
+            // a zero rotation. If the underlying tensor differs across
+            // operands, this will also cause a Status::TooManyTensors.
+            // Otherwise, the join is a no-op.
+            result |= r->join(RotationSets::from(operand.get()));
+            propagateIfChanged(r, result);
+          }
+        }
+      });
+}
+
+void RotationAnalysis::setToEntryState(RotationLattice *lattice) {
+  lattice->getValue().clear();
+}
+
+}  // namespace rotation_analysis
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/TensorExt/Transforms/BUILD
+++ b/lib/Dialect/TensorExt/Transforms/BUILD
@@ -69,6 +69,7 @@ cc_library(
     ],
     deps = [
         "@heir//include/Dialect/TensorExt/Transforms:pass_inc_gen",
+        "@heir//lib/Analysis/RotationAnalysis",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@llvm-project//llvm:Support",

--- a/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
+++ b/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
@@ -2,24 +2,26 @@
 
 #include <cstdint>
 
+#include "include/Analysis/RotationAnalysis/RotationAnalysis.h"
 #include "include/Dialect/Secret/IR/SecretOps.h"
 #include "include/Dialect/TensorExt/IR/TensorExtOps.h"
-#include "llvm/include/llvm/ADT/DenseSet.h"              // from @llvm-project
-#include "llvm/include/llvm/ADT/StringRef.h"             // from @llvm-project
-#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
-#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
-#include "mlir/include/mlir/Analysis/SliceAnalysis.h"    // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
-#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
-#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"   // from @llvm-project
-#include "mlir/include/mlir/IR/Iterators.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
-#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
-
-#define DEBUG_TYPE "rotate-and-reduce"
+#include "llvm/include/llvm/ADT/DenseSet.h"    // from @llvm-project
+#include "llvm/include/llvm/ADT/StringRef.h"   // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"   // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/SliceAnalysis.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/Iterators.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"       // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -35,8 +37,121 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
   using RotateAndReduceBase::RotateAndReduceBase;
 
   template <typename ArithOp>
-  void tryReplace(ArithOp op, DenseSet<Operation *> &visited) {
-    LLVM_DEBUG(llvm::dbgs() << "Trying to replace " << *op << "\n");
+  void tryReplaceRotations(ArithOp op, Value tensor,
+                           DenseSet<Operation *> &visited,
+                           DataFlowSolver &solver) {
+    // The dataflow analysis provides some guarantees, but not enough
+    // to prove that we can replace the op with the rotate-and-reduce trick
+    // while still maintaining program correctness.
+    //
+    // We need to do some more complicated checks to ensure that: the op tree
+    // all contains the same op type (all sum or all mul), and that the
+    // accessed rotations are included only once in the reduction.
+    // This cannot be done during the dataflow analysis itself due to the
+    // monotonicity requirements of the framework.
+    LLVM_DEBUG(llvm::dbgs()
+               << "Trying to replace rotations ending in " << *op << "\n");
+    SetVector<Operation *> backwardSlice;
+    BackwardSliceOptions options;
+    // asserts that the parent op has a single region with a single block.
+    options.omitBlockArguments = false;
+
+    DenseSet<Operation *> visitedReductionOps;
+    DenseMap<llvm::StringRef, int> opCounts;
+    opCounts[op->getName().getStringRef()]++;
+
+    getBackwardSlice(op.getOperation(), &backwardSlice, options);
+
+    for (Operation *upstreamOpPtr : backwardSlice) {
+      auto result =
+          llvm::TypeSwitch<Operation *, LogicalResult>(upstreamOpPtr)
+              .Case<arith::ConstantOp, tensor_ext::RotateOp>(
+                  [&](auto upstreamOp) { return success(); })
+              // Ignore generic ops
+              .template Case<secret::GenericOp>(
+                  [&](auto upstreamOp) { return success(); })
+              .template Case<arith::AddIOp, arith::MulIOp>([&](auto
+                                                                   upstreamOp) {
+                opCounts[upstreamOp->getName().getStringRef()]++;
+                // More than one reduction op is mixed in the reduction.
+                if (opCounts.size() > 1) {
+                  LLVM_DEBUG(llvm::dbgs()
+                             << "Not replacing op because reduction "
+                                "contains multiple incompatible ops "
+                             << op->getName() << " and "
+                             << upstreamOp->getName() << "\n");
+                  return failure();
+                }
+
+                // Inspect the lattice values at the join point,
+                // and fail if there is any overlap
+                auto *lhsLattice =
+                    solver.lookupState<rotation_analysis::RotationLattice>(
+                        upstreamOp.getLhs());
+                auto *rhsLattice =
+                    solver.lookupState<rotation_analysis::RotationLattice>(
+                        upstreamOp.getRhs());
+                LLVM_DEBUG(llvm::dbgs()
+                           << "Computing overlap of "
+                           << "lhs: " << lhsLattice->getValue() << "\n"
+                           << "rhs: " << rhsLattice->getValue() << "\n");
+                auto mergedLattice = rotation_analysis::RotationSets::overlap(
+                    lhsLattice->getValue(), rhsLattice->getValue());
+                LLVM_DEBUG(llvm::dbgs()
+                           << "Overlap is: " << mergedLattice << "\n");
+                if (!mergedLattice.empty()) {
+                  LLVM_DEBUG(
+                      llvm::dbgs()
+                      << "Not replacing op because reduction "
+                         "may not be a simple reduction of the input tensor\n"
+                      << "lhs: " << lhsLattice->getValue() << "\n"
+                      << "rhs: " << rhsLattice->getValue() << "\n");
+                  return failure();
+                }
+
+                visitedReductionOps.insert(upstreamOp);
+                return success();
+              })
+              .Default([&](Operation *op) {
+                LLVM_DEBUG(llvm::dbgs() << "Not continuing because type switch "
+                                           "encountered unsupported op "
+                                        << op->getName() << "\n");
+                return failure();
+              });
+
+      if (failed(result)) {
+        return;
+      }
+    }
+
+    // From here we know we will succeed.
+    auto b = ImplicitLocOpBuilder(op->getLoc(), op);
+    Operation *finalOp;
+    auto tensorShape = tensor.getType().cast<RankedTensorType>().getShape();
+    for (int64_t shiftSize = tensorShape[0] / 2; shiftSize > 0;
+         shiftSize /= 2) {
+      auto rotatedTensor = b.create<tensor_ext::RotateOp>(
+          tensor, b.create<arith::ConstantOp>(b.getIndexAttr(shiftSize)));
+      auto addOp = b.create<ArithOp>(tensor, rotatedTensor);
+      finalOp = addOp;
+      tensor = addOp->getResult(0);
+    }
+
+    [[maybe_unused]] auto *parentOp = op->getParentOp();
+    op->replaceAllUsesWith(finalOp);
+    LLVM_DEBUG(llvm::dbgs() << "Post-replacement: " << *parentOp << "\n");
+
+    // Mark all ops in the reduction as visited so we don't try to replace them
+    // twice.
+    for (Operation *visitedOp : visitedReductionOps) {
+      visited.insert(visitedOp);
+    }
+  }
+
+  template <typename ArithOp>
+  void tryReplaceExtractions(ArithOp op, DenseSet<Operation *> &visited) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Trying to replace extractions ending in " << *op << "\n");
     SetVector<Operation *> backwardSlice;
     BackwardSliceOptions options;
     // asserts that the parent op has a single region with a single block.
@@ -187,7 +302,77 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
   }
 
   void runOnOperation() override {
+    DataFlowSolver solver;
+    // These two upstream analyses are required dependencies for any sparse
+    // dataflow analysis, or else the analysis will be a no-op. Cf.
+    // https://github.com/llvm/llvm-project/issues/58922
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::SparseConstantPropagation>();
+    solver.load<rotation_analysis::RotationAnalysis>();
+
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run dataflow analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    LLVM_DEBUG({
+      getOperation()->walk([&](Operation *op) {
+        if (op->getNumResults() == 0) return;
+        auto *targetSlotLattice =
+            solver.lookupState<rotation_analysis::RotationLattice>(
+                op->getResult(0));
+        if (targetSlotLattice->getValue().isOverdetermined()) {
+          llvm::dbgs() << "Rotation lattice for " << *op
+                       << " is overdetermined\n";
+        } else if (targetSlotLattice->getValue().empty()) {
+          llvm::dbgs() << "Rotation lattice for " << *op << " is empty\n";
+        } else {
+          SmallVector<int64_t> sortedRotations(
+              targetSlotLattice->getValue().getAccessedIndices().begin(),
+              targetSlotLattice->getValue().getAccessedIndices().end());
+          llvm::sort(sortedRotations);
+          std::string stringified = llvm::join(
+              llvm::map_range(sortedRotations,
+                              [](int64_t i) { return std::to_string(i); }),
+              ",");
+          llvm::dbgs() << "Rotation lattice for " << *op << ": " << stringified
+                       << "\n";
+        }
+      });
+    });
+
     DenseSet<Operation *> visited;
+
+    getOperation()->walk<WalkOrder::PreOrder, ReverseIterator>(
+        [&](Operation *op) {
+          if (op->getNumResults() == 0) return;
+          auto *targetSlotLattice =
+              solver.lookupState<rotation_analysis::RotationLattice>(
+                  op->getResult(0));
+          if (targetSlotLattice->getValue().isUninitialized() ||
+              targetSlotLattice->getValue().isOverdetermined()) {
+            return;
+          }
+
+          auto tensor = targetSlotLattice->getValue().getTensor();
+          auto accessIndices =
+              targetSlotLattice->getValue().getAccessedIndices();
+          int64_t tensorSize =
+              tensor.getType().cast<RankedTensorType>().getShape()[0];
+          if (accessIndices.size() == tensorSize) {
+            llvm::TypeSwitch<Operation &>(*op)
+                .Case<arith::AddIOp>([&](auto arithOp) {
+                  tryReplaceRotations<arith::AddIOp>(arithOp, tensor, visited,
+                                                     solver);
+                })
+                .Case<arith::MulIOp>([&](auto arithOp) {
+                  tryReplaceRotations<arith::MulIOp>(arithOp, tensor, visited,
+                                                     solver);
+                });
+          }
+        });
+
     // Traverse the IR in reverse order so that we can eagerly compute backward
     // slices for each operation.
     getOperation()->walk<WalkOrder::PreOrder, ReverseIterator>(
@@ -197,10 +382,10 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
           }
           llvm::TypeSwitch<Operation &>(*op)
               .Case<arith::AddIOp>([&](auto arithOp) {
-                tryReplace<arith::AddIOp>(arithOp, visited);
+                tryReplaceExtractions<arith::AddIOp>(arithOp, visited);
               })
               .Case<arith::MulIOp>([&](auto arithOp) {
-                tryReplace<arith::MulIOp>(arithOp, visited);
+                tryReplaceExtractions<arith::MulIOp>(arithOp, visited);
               });
         });
   }

--- a/tests/simd/simple_sum.mlir
+++ b/tests/simd/simple_sum.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt --secretize=entry-function=simple_sum --wrap-generic --canonicalize --cse \
+// RUN:   --full-loop-unroll --insert-rotate --cse --canonicalize \
+// RUN:   --rotate-and-reduce --canonicalize \
+// RUN:   %s | FileCheck %s
+
+// Sum all entries of a tensor into a single scalar
+// CHECK-LABEL: @simple_sum
+// CHECK: secret.generic
+// CHECK-COUNT-5: tensor_ext.rotate
+// CHECK-NOT: tensor_ext.rotate
+func.func @simple_sum(%arg0: tensor<32xi16> {secret.secret}) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %i = 0 to 32 iter_args(%sum_iter = %c0_si16) -> i16 {
+    %1 = tensor.extract %arg0[%i] : tensor<32xi16>
+    %2 = arith.addi %1, %sum_iter : i16
+    affine.yield %2 : i16
+  }
+  return %0 : i16
+}


### PR DESCRIPTION
Note: rebased off https://github.com/google/heir/pull/530

So this is working but... I can't say I'm particularly happy with it.

Now it recognizes sequences of rotates-and-adds that comprise an aggregation of every value in a vector (exactly once), and replaces them with the logarithmic rotate-and-reduce trick. I wrote down a few non-triggering examples, but I'm not confident it's bug-free by any means.

To the extent that this PR uses a dataflow analysis, I'm somewhat happy. It's an improvement over how I handled the version of this trick that worked on tensor.extract. However, the dataflow analysis has some limitations that left me frustrated. Specifically, I wanted to have the dataflow analysis accumulate the tensor accesses _with multiplicity_ and across multiple tensors. The original  
member variable inside RotationLattice was something like `DenseMap<Value, std::unordered_multiset<int64_t>>`. The join method then updated all accessed tensors and added the index access counts rather than just taking a union as it does in this PR.

However, doing this hit assertions in the dataflow framework because the `Lattice` class asserts that repeated applications of `join` are idempotent (they call it monotonic) but in my case that would accumulate. I worked around it by constructing the analysis to work with set unions, and then added an extra step in the actual pass to do more specific detailed checks for validity.  I hoped that with the extra index multiplicity information, we might be able to do more sophisticated transformations, like reordering some of the ops instead of just giving up. E.g., one thing that wouldn't work here is if the IR computes twice the sum of the tensor elements. I wonder if not using the `Lattice` framework and going one step lower to `AbstractSparseForwardDataFlowAnalysis` might fix that, or just making a totally custom analysis unrelated to the dataflow engine, but I ran out of steam this week. I also suspect we could rely on some more academic ideas like e-graphs to identify more optimal transformations.

Fixes https://github.com/google/heir/issues/520

Fixes https://github.com/google/heir/issues/511