### PR TITLE
ci: bump clang-format version in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
 # clang-format
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v17.0.6"
+    rev: "v18.1.1"
     hooks:
     -   id: clang-format
         args: ["--style=Google"]


### PR DESCRIPTION
See failure in https://github.com/google/heir/actions/runs/8345552561/job/22840722906