### PR TITLE
ci: bump scorecard-action after breaking change in trust root

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Underlyingly it updates to cosign v2+, https://groups.google.com/g/sigstore-dev/c/_3uylQXHnks

See CI failure at https://github.com/google/heir/actions/runs/8348067472/job/22849144376