### PR TITLE
Add RNS dialect and type

### DIFF
--- a/include/Dialect/Polynomial/IR/BUILD
+++ b/include/Dialect/Polynomial/IR/BUILD
@@ -30,6 +30,7 @@ td_library(
     # include from the heir-root to enable fully-qualified include-paths
     includes = ["../../../.."],
     deps = [
+        "@heir//include/Dialect/RNS/IR:td_files",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",

--- a/include/Dialect/Polynomial/IR/PolynomialTypes.h
+++ b/include/Dialect/Polynomial/IR/PolynomialTypes.h
@@ -3,6 +3,7 @@
 
 #include "include/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "include/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "include/Dialect/RNS/IR/RNSTypeInterfaces.h"
 
 #define GET_TYPEDEF_CLASSES
 #include "include/Dialect/Polynomial/IR/PolynomialTypes.h.inc"

--- a/include/Dialect/Polynomial/IR/PolynomialTypes.td
+++ b/include/Dialect/Polynomial/IR/PolynomialTypes.td
@@ -3,6 +3,7 @@
 
 include "include/Dialect/Polynomial/IR/PolynomialDialect.td"
 include "include/Dialect/Polynomial/IR/PolynomialAttributes.td"
+include "include/Dialect/RNS/IR/RNSTypeInterfaces.td"
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinTypes.td"
@@ -14,7 +15,8 @@ class Polynomial_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def Polynomial : Polynomial_Type<"Polynomial", "polynomial"> {
+def Polynomial : Polynomial_Type<"Polynomial", "polynomial",
+    [DeclareTypeInterfaceMethods<RNSBasisTypeInterface>]> {
   let summary = "An element of a polynomial quotient ring";
 
   let description = [{

--- a/include/Dialect/RNS/IR/BUILD
+++ b/include/Dialect/RNS/IR/BUILD
@@ -121,6 +121,10 @@ gentbl_cc_library(
             ["--gen-type-interface-defs"],
             "RNSTypeInterfaces.cpp.inc",
         ),
+        (
+            ["-gen-type-interface-docs"],
+            "RNSTypeInterfaces.md",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "RNSTypeInterfaces.td",

--- a/include/Dialect/RNS/IR/BUILD
+++ b/include/Dialect/RNS/IR/BUILD
@@ -1,0 +1,109 @@
+# RNS tablegen and headers
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "RNSDialect.h",
+        "RNSTypes.h",
+        "RNSOps.h",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "RNSDialect.td",
+        "RNSOps.td",
+        "RNSTypes.td",
+    ],
+    # include from the heir-root to enable fully-qualified include-paths
+    includes = ["../../../.."],
+    deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "RNSDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "RNSDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "RNSDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-typedef-decls",
+            ],
+            "RNSTypes.h.inc",
+        ),
+        (
+            [
+                "-gen-typedef-defs",
+            ],
+            "RNSTypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "RNSTypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "RNSTypes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        "@heir//include/Dialect/Polynomial/IR:td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "RNSOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "RNSOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "RNSOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "RNSOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+        "@heir//include/Dialect/Polynomial/IR:td_files",
+    ],
+)

--- a/include/Dialect/RNS/IR/BUILD
+++ b/include/Dialect/RNS/IR/BUILD
@@ -10,8 +10,9 @@ package(
 exports_files(
     [
         "RNSDialect.h",
-        "RNSTypes.h",
         "RNSOps.h",
+        "RNSTypeInterfaces.h",
+        "RNSTypes.h",
     ],
 )
 
@@ -20,6 +21,7 @@ td_library(
     srcs = [
         "RNSDialect.td",
         "RNSOps.td",
+        "RNSTypeInterfaces.td",
         "RNSTypes.td",
     ],
     # include from the heir-root to enable fully-qualified include-paths
@@ -105,5 +107,24 @@ gentbl_cc_library(
         ":td_files",
         ":types_inc_gen",
         "@heir//include/Dialect/Polynomial/IR:td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "type_interfaces_inc_gen",
+    tbl_outs = [
+        (
+            ["--gen-type-interface-decls"],
+            "RNSTypeInterfaces.h.inc",
+        ),
+        (
+            ["--gen-type-interface-defs"],
+            "RNSTypeInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "RNSTypeInterfaces.td",
+    deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
     ],
 )

--- a/include/Dialect/RNS/IR/RNSDialect.h
+++ b/include/Dialect/RNS/IR/RNSDialect.h
@@ -1,0 +1,10 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSDIALECT_H_
+#define INCLUDE_DIALECT_RNS_IR_RNSDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"   // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "include/Dialect/RNS/IR/RNSDialect.h.inc"
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSDIALECT_H_

--- a/include/Dialect/RNS/IR/RNSDialect.td
+++ b/include/Dialect/RNS/IR/RNSDialect.td
@@ -6,11 +6,22 @@ include "mlir/IR/DialectBase.td"
 def RNS_Dialect : Dialect {
   let name = "rns";
   let description = [{
-    // FIXME: add documentation
-    The `rns` dialect is ...
+    The `rns` dialect represents types and ops related to residue number
+    system (RNS) representations of ring-like types, such as integers or
+    polynomials decomposed from high-bit width to lower-bit-width prime
+    moduli. Sometimes RNS is referred to as CRT, for "Chinese Remainder
+    Theorem."
+
+    This dialect is intended to be as generic as possible in terms of its
+    interaction with standard MLIR. However, because of upstream MLIR
+    constraints, we do not have the ability to override, say, `arith.addi`
+    to operate on an `rns` type. So such situations require dedicated ops,
+    canonicalization patterns, etc.
   }];
 
   let cppNamespace = "::mlir::heir::rns";
+
+  let useDefaultTypePrinterParser = 1;
 }
 
 #endif  // INCLUDE_DIALECT_RNS_IR_RNSDIALECT_TD_

--- a/include/Dialect/RNS/IR/RNSDialect.td
+++ b/include/Dialect/RNS/IR/RNSDialect.td
@@ -1,0 +1,16 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSDIALECT_TD_
+#define INCLUDE_DIALECT_RNS_IR_RNSDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def RNS_Dialect : Dialect {
+  let name = "rns";
+  let description = [{
+    // FIXME: add documentation
+    The `rns` dialect is ...
+  }];
+
+  let cppNamespace = "::mlir::heir::rns";
+}
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSDIALECT_TD_

--- a/include/Dialect/RNS/IR/RNSOps.h
+++ b/include/Dialect/RNS/IR/RNSOps.h
@@ -1,0 +1,11 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSOPS_H_
+#define INCLUDE_DIALECT_RNS_IR_RNSOPS_H_
+
+#include "include/Dialect/RNS/IR/RNSDialect.h"
+#include "include/Dialect/RNS/IR/RNSTypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "include/Dialect/RNS/IR/RNSOps.h.inc"
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSOPS_H_

--- a/include/Dialect/RNS/IR/RNSOps.td
+++ b/include/Dialect/RNS/IR/RNSOps.td
@@ -1,0 +1,13 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSOPS_TD_
+#define INCLUDE_DIALECT_RNS_IR_RNSOPS_TD_
+
+include "include/Dialect/RNS/IR/RNSDialect.td"
+include "include/Dialect/RNS/IR/RNSTypes.td"
+include "mlir/IR/OpBase.td"
+
+class RNS_Op<string mnemonic, list<Trait> traits = []> :
+        Op<RNS_Dialect, mnemonic, traits> {
+  let cppNamespace = "::mlir::heir::rns";
+}
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSOPS_TD_

--- a/include/Dialect/RNS/IR/RNSTypeInterfaces.h
+++ b/include/Dialect/RNS/IR/RNSTypeInterfaces.h
@@ -1,0 +1,10 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSTYPEINTERFACES_H_
+#define INCLUDE_DIALECT_RNS_IR_RNSTYPEINTERFACES_H_
+
+#include "include/Dialect/RNS/IR/RNSDialect.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/RNS/IR/RNSTypeInterfaces.h.inc"
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSTYPEINTERFACES_H_

--- a/include/Dialect/RNS/IR/RNSTypeInterfaces.td
+++ b/include/Dialect/RNS/IR/RNSTypeInterfaces.td
@@ -1,0 +1,33 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSTYPEINTERFACES_TD_
+#define INCLUDE_DIALECT_RNS_IR_RNSTYPEINTERFACES_TD_
+
+include "mlir/IR/BuiltinTypeInterfaces.td"
+
+def RNSBasisTypeInterface : TypeInterface<"RNSBasisTypeInterface"> {
+  let cppNamespace = "::mlir::heir::rns";
+  let description = [{
+    This interface is required for a type to be used as a parameter
+    to an `rns` type.
+  }];
+  let methods = [
+    InterfaceMethod<
+    /*description=*/[{
+      Returns true if this type is compatible with another type in the
+      same RNS basis. In particular, the set of types used for a single
+      RNS basis are never equal as types, but instead have some common
+      attribute that must be checked here. For example, an RNS type where
+      the basis types are polynomials would return true if the two types
+      are both polynomial types, even if they have different coefficient
+      moduli.
+
+      `isCompatibleWith` must be both commutative and associative, in the sense
+      that `type1.isCompatibleWith(type2)` if and only if
+      `type2.isCompatibleWith(type1)`, and further
+      `type2.isCompatibleWith(type3)` if and only if
+      `type1.isCompatibleWith(type3)`.
+    }],
+    "bool", "isCompatibleWith", (ins "::mlir::Type":$otherRnsBasisType)>
+  ];
+}
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSTYPEINTERFACES_TD_

--- a/include/Dialect/RNS/IR/RNSTypes.h
+++ b/include/Dialect/RNS/IR/RNSTypes.h
@@ -1,0 +1,9 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSTYPES_H_
+#define INCLUDE_DIALECT_RNS_IR_RNSTYPES_H_
+
+#include "include/Dialect/RNS/IR/RNSDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/RNS/IR/RNSTypes.h.inc"
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSTYPES_H_

--- a/include/Dialect/RNS/IR/RNSTypes.h
+++ b/include/Dialect/RNS/IR/RNSTypes.h
@@ -2,6 +2,7 @@
 #define INCLUDE_DIALECT_RNS_IR_RNSTYPES_H_
 
 #include "include/Dialect/RNS/IR/RNSDialect.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
 
 #define GET_TYPEDEF_CLASSES
 #include "include/Dialect/RNS/IR/RNSTypes.h.inc"

--- a/include/Dialect/RNS/IR/RNSTypes.td
+++ b/include/Dialect/RNS/IR/RNSTypes.td
@@ -2,16 +2,24 @@
 #define INCLUDE_DIALECT_RNS_IR_RNSTYPES_TD_
 
 include "include/Dialect/RNS/IR/RNSDialect.td"
-
-
+include "include/Dialect/RNS/IR/RNSTypeInterfaces.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/AttrTypeBase.td"
 
 // A base class for all types in this dialect
-class RNS_Type<string name, string typeMnemonic>
-    : TypeDef<RNS_Dialect, name> {
+class RNS_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<RNS_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
 }
 
+def RNS : RNS_Type<"RNS", "rns"> {
+  let summary = "A residue number system representation";
+  let description = [{
+  }];
+
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$basisTypes);
+  let assemblyFormat = "`<` $basisTypes `>`";
+  let genVerifyDecl = 1;
+}
 
 #endif  // INCLUDE_DIALECT_RNS_IR_RNSTYPES_TD_

--- a/include/Dialect/RNS/IR/RNSTypes.td
+++ b/include/Dialect/RNS/IR/RNSTypes.td
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_DIALECT_RNS_IR_RNSTYPES_TD_
+#define INCLUDE_DIALECT_RNS_IR_RNSTYPES_TD_
+
+include "include/Dialect/RNS/IR/RNSDialect.td"
+
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+// A base class for all types in this dialect
+class RNS_Type<string name, string typeMnemonic>
+    : TypeDef<RNS_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+
+#endif  // INCLUDE_DIALECT_RNS_IR_RNSTYPES_TD_

--- a/lib/Dialect/Polynomial/IR/BUILD
+++ b/lib/Dialect/Polynomial/IR/BUILD
@@ -20,6 +20,7 @@ cc_library(
         ":Polynomial",
         ":PolynomialAttributes",
         ":PolynomialOps",
+        ":PolynomialTypes",
         "@heir//include/Dialect/Polynomial/IR:attributes_inc_gen",
         "@heir//include/Dialect/Polynomial/IR:canonicalize_inc_gen",
         "@heir//include/Dialect/Polynomial/IR:dialect_inc_gen",
@@ -60,6 +61,7 @@ cc_library(
         "@heir//include/Dialect/Polynomial/IR:PolynomialDialect.h",
         "@heir//include/Dialect/Polynomial/IR:PolynomialOps.h",
         "@heir//include/Dialect/Polynomial/IR:PolynomialTypes.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypeInterfaces.h",
     ],
     deps = [
         ":PolynomialAttributes",
@@ -67,11 +69,29 @@ cc_library(
         "@heir//include/Dialect/Polynomial/IR:dialect_inc_gen",
         "@heir//include/Dialect/Polynomial/IR:ops_inc_gen",
         "@heir//include/Dialect/Polynomial/IR:types_inc_gen",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "PolynomialTypes",
+    srcs = [
+        "PolynomialTypes.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/Polynomial/IR:PolynomialTypes.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypeInterfaces.h",
+    ],
+    deps = [
+        ":PolynomialAttributes",
+        "@heir//include/Dialect/Polynomial/IR:types_inc_gen",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@llvm-project//mlir:IR",
     ],
 )
 

--- a/lib/Dialect/Polynomial/IR/PolynomialTypes.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialTypes.cpp
@@ -1,0 +1,22 @@
+#include "include/Dialect/Polynomial/IR/PolynomialTypes.h"
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+bool PolynomialType::isCompatibleWith(::mlir::Type otherRnsBasisType) const {
+  auto other = otherRnsBasisType.dyn_cast<PolynomialType>();
+  if (!other) {
+    return false;
+  }
+
+  // The coefficient moduli may be different, but the polynomial moduli must
+  // agree. This is the typical RNS situation where the point is to avoid using
+  // big-integer coefficient moduli by converting them to a smaller set of
+  // prime moduli.
+  return getRing().getIdeal() == other.getRing().getIdeal();
+}
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -13,6 +13,7 @@ cc_library(
     hdrs = [
         "@heir//include/Dialect/RNS/IR:RNSDialect.h",
         "@heir//include/Dialect/RNS/IR:RNSOps.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypeInterfaces.h",
         "@heir//include/Dialect/RNS/IR:RNSTypes.h",
     ],
     deps = [
@@ -20,6 +21,7 @@ cc_library(
         ":RNSTypes",
         "@heir//include/Dialect/RNS/IR:dialect_inc_gen",
         "@heir//include/Dialect/RNS/IR:ops_inc_gen",
+        "@heir//include/Dialect/RNS/IR:type_interfaces_inc_gen",
         "@heir//include/Dialect/RNS/IR:types_inc_gen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
@@ -33,11 +35,13 @@ cc_library(
     ],
     hdrs = [
         "@heir//include/Dialect/RNS/IR:RNSDialect.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypeInterfaces.h",
         "@heir//include/Dialect/RNS/IR:RNSTypes.h",
     ],
     deps = [
         "@heir//include/Dialect/RNS/IR:dialect_inc_gen",
         "@heir//include/Dialect/RNS/IR:ops_inc_gen",
+        "@heir//include/Dialect/RNS/IR:type_interfaces_inc_gen",
         "@heir//include/Dialect/RNS/IR:types_inc_gen",
         "@llvm-project//mlir:IR",
     ],

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -1,0 +1,63 @@
+# RNS dialect implementation
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "RNSDialect.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/RNS/IR:RNSDialect.h",
+        "@heir//include/Dialect/RNS/IR:RNSOps.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypes.h",
+    ],
+    deps = [
+        ":RNSOps",
+        ":RNSTypes",
+        "@heir//include/Dialect/RNS/IR:dialect_inc_gen",
+        "@heir//include/Dialect/RNS/IR:ops_inc_gen",
+        "@heir//include/Dialect/RNS/IR:types_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "RNSTypes",
+    srcs = [
+        "RNSTypes.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/RNS/IR:RNSDialect.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypes.h",
+    ],
+    deps = [
+        "@heir//include/Dialect/RNS/IR:dialect_inc_gen",
+        "@heir//include/Dialect/RNS/IR:ops_inc_gen",
+        "@heir//include/Dialect/RNS/IR:types_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "RNSOps",
+    srcs = [
+        "RNSOps.cpp",
+    ],
+    hdrs = [
+        "@heir//include/Dialect/RNS/IR:RNSDialect.h",
+        "@heir//include/Dialect/RNS/IR:RNSOps.h",
+        "@heir//include/Dialect/RNS/IR:RNSTypes.h",
+    ],
+    deps = [
+        ":RNSTypes",
+        "@heir//include/Dialect/RNS/IR:dialect_inc_gen",
+        "@heir//include/Dialect/RNS/IR:ops_inc_gen",
+        "@heir//include/Dialect/RNS/IR:types_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)

--- a/lib/Dialect/RNS/IR/RNSDialect.cpp
+++ b/lib/Dialect/RNS/IR/RNSDialect.cpp
@@ -1,0 +1,37 @@
+#include "include/Dialect/RNS/IR/RNSDialect.h"
+
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// NOLINTNEXTLINE(misc-include-cleaner): Required to define RNSOps
+
+#include "include/Dialect/RNS/IR/RNSOps.h"
+#include "include/Dialect/RNS/IR/RNSTypes.h"
+
+// Generated definitions
+#include "include/Dialect/RNS/IR/RNSDialect.cpp.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "include/Dialect/RNS/IR/RNSTypes.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "include/Dialect/RNS/IR/RNSOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace rns {
+
+void RNSDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "include/Dialect/RNS/IR/RNSTypes.cpp.inc"
+      >();
+
+  addOperations<
+#define GET_OP_LIST
+#include "include/Dialect/RNS/IR/RNSOps.cpp.inc"
+      >();
+}
+
+}  // namespace rns
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/IR/RNSDialect.cpp
+++ b/lib/Dialect/RNS/IR/RNSDialect.cpp
@@ -3,18 +3,17 @@
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 
 // NOLINTNEXTLINE(misc-include-cleaner): Required to define RNSOps
-
 #include "include/Dialect/RNS/IR/RNSOps.h"
+#include "include/Dialect/RNS/IR/RNSTypeInterfaces.h"
 #include "include/Dialect/RNS/IR/RNSTypes.h"
 
 // Generated definitions
 #include "include/Dialect/RNS/IR/RNSDialect.cpp.inc"
-
 #define GET_TYPEDEF_CLASSES
 #include "include/Dialect/RNS/IR/RNSTypes.cpp.inc"
-
 #define GET_OP_CLASSES
 #include "include/Dialect/RNS/IR/RNSOps.cpp.inc"
+#include "include/Dialect/RNS/IR/RNSTypeInterfaces.cpp.inc"
 
 namespace mlir {
 namespace heir {

--- a/lib/Dialect/RNS/IR/RNSOps.cpp
+++ b/lib/Dialect/RNS/IR/RNSOps.cpp
@@ -1,0 +1,7 @@
+#include "include/Dialect/RNS/IR/RNSOps.h"
+
+namespace mlir {
+namespace heir {
+namespace rns {}  // namespace rns
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/IR/RNSTypes.cpp
+++ b/lib/Dialect/RNS/IR/RNSTypes.cpp
@@ -1,0 +1,7 @@
+#include "include/Dialect/RNS/IR/RNSTypes.h"
+
+namespace mlir {
+namespace heir {
+namespace rns {}  // namespace rns
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/IR/RNSTypes.cpp
+++ b/lib/Dialect/RNS/IR/RNSTypes.cpp
@@ -1,7 +1,30 @@
 #include "include/Dialect/RNS/IR/RNSTypes.h"
 
+#include "include/Dialect/RNS/IR/RNSTypeInterfaces.h"
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
 namespace mlir {
 namespace heir {
-namespace rns {}  // namespace rns
+namespace rns {
+
+LogicalResult RNSType::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    llvm::ArrayRef<mlir::Type> basisTypes) {
+  bool compatible = true;
+  RNSBasisTypeInterface first =
+      llvm::dyn_cast<RNSBasisTypeInterface>(basisTypes[0]);
+  if (!first) return failure();
+
+  for (auto other : basisTypes) {
+    compatible &= first.isCompatibleWith(other);
+  }
+
+  if (!compatible) {
+    return emitError() << "RNS type has incompatible basis types";
+  }
+  return success();
+}
+
+}  // namespace rns
 }  // namespace heir
 }  // namespace mlir

--- a/tests/rns/BUILD
+++ b/tests/rns/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/rns/syntax.mlir
+++ b/tests/rns/syntax.mlir
@@ -1,0 +1,24 @@
+// RUN: heir-opt --verify-diagnostics %s
+
+#ideal = #polynomial.polynomial<1 + x**1024>
+#ideal_2 = #polynomial.polynomial<1 + x**2048>
+
+// Below we use random 32-bit primes
+#ring_1 = #polynomial.ring<cmod=3721063133, ideal=#ideal>
+#ring_2 = #polynomial.ring<cmod=2737228591, ideal=#ideal>
+#ring_3 = #polynomial.ring<cmod=3180146689, ideal=#ideal>
+#ring_bad = #polynomial.ring<cmod=3180146689, ideal=#ideal_2>
+
+!poly_ty_1 = !polynomial.polynomial<#ring_1>
+!poly_ty_2 = !polynomial.polynomial<#ring_2>
+!poly_ty_3 = !polynomial.polynomial<#ring_3>
+
+!ty = !rns.rns<!poly_ty_1, !poly_ty_2, !poly_ty_3>
+
+func.func @test_syntax(%arg0: !ty) -> !ty {
+  return %arg0 : !ty
+}
+
+!poly_ty_bad = !polynomial.polynomial<#ring_bad>
+// expected-error@+1 {{RNS type has incompatible basis types}}
+!ty_bad = !rns.rns<!poly_ty_1, !poly_ty_2, !poly_ty_bad>

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -51,6 +51,7 @@ cc_binary(
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/PolyExt/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/Secret/Transforms",
         "@heir//lib/Dialect/Secret/Transforms:DistributeGeneric",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -18,6 +18,7 @@
 #include "include/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "include/Dialect/PolyExt/IR/PolyExtDialect.h"
 #include "include/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "include/Dialect/RNS/IR/RNSDialect.h"
 #include "include/Dialect/Secret/IR/SecretDialect.h"
 #include "include/Dialect/Secret/Transforms/DistributeGeneric.h"
 #include "include/Dialect/Secret/Transforms/Passes.h"
@@ -262,16 +263,17 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
   registry.insert<bgv::BGVDialect>();
+  registry.insert<cggi::CGGIDialect>();
   registry.insert<comb::CombDialect>();
   registry.insert<lwe::LWEDialect>();
-  registry.insert<cggi::CGGIDialect>();
+  registry.insert<openfhe::OpenfheDialect>();
   registry.insert<poly_ext::PolyExtDialect>();
   registry.insert<polynomial::PolynomialDialect>();
+  registry.insert<rns::RNSDialect>();
   registry.insert<secret::SecretDialect>();
+  registry.insert<tensor_ext::TensorExtDialect>();
   registry.insert<tfhe_rust::TfheRustDialect>();
   registry.insert<tfhe_rust_bool::TfheRustBoolDialect>();
-  registry.insert<openfhe::OpenfheDialect>();
-  registry.insert<tensor_ext::TensorExtDialect>();
 
   // Add expected MLIR dialects to the registry.
   registry.insert<affine::AffineDialect>();


### PR DESCRIPTION
This PR adds:

- an RNS dialect (boilerplate and plumbing)
- a new type `rns<ty1, ..., tyN>`, representing the domain of an RNS decomposition
- a new type interface `RNSBasisTypeInterface` which allows types to determine if they are compatible with other basis types used in the same instance of an `rns` type.

One interesting thing I learned while doing this is that it _is_ possible to attach an out-of-tree type interface to an upstream type, using the `attachInterface` method of the type at the out-of-tree dialect initialization time. We can use this to retroactively attach `RNSBasisTypeInterface` to integer types if that ends up being the best option.

Another interesting thing I learned is that the TypeInterface requires no registration on its own, it is only implicitly registered once a type ends up using it.

A simple example, pulled from `syntax.mlir` test

```
#ideal = #polynomial.polynomial<1 + x**1024>

// random 32-bit primes
#ring_1 = #polynomial.ring<cmod=3721063133, ideal=#ideal>
#ring_2 = #polynomial.ring<cmod=2737228591, ideal=#ideal>
#ring_3 = #polynomial.ring<cmod=3180146689, ideal=#ideal>

!poly_ty_1 = !polynomial.polynomial<#ring_1>
!poly_ty_2 = !polynomial.polynomial<#ring_2>
!poly_ty_3 = !polynomial.polynomial<#ring_3>

!ty = !rns.rns<!poly_ty_1, !poly_ty_2, !poly_ty_3>

func.func @test_syntax(%arg0: !ty) -> !ty {
  return %arg0 : !ty
}
```

In follow-up PRs, I intend to introduce an op for [applying an RNS decomposition](https://github.com/google/heir/issues/558) (agnostic of how that is done), and update polynomial ops to [operate on RNS types](https://github.com/google/heir/issues/559).