### PR TITLE
fix dialect template generation

### DIFF
--- a/templates/Dialect/include/Attributes.h.jinja
+++ b/templates/Dialect/include/Attributes.h.jinja
@@ -1,9 +1,9 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}ATTRIBUTES_H_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}ATTRIBUTES_H_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}ATTRIBUTES_H_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}ATTRIBUTES_H_
 
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Dialect.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Attributes.h.inc"
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}ATTRIBUTES_H_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}ATTRIBUTES_H_

--- a/templates/Dialect/include/Attributes.td.jinja
+++ b/templates/Dialect/include/Attributes.td.jinja
@@ -1,5 +1,5 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}ATTRIBUTES_TD_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}ATTRIBUTES_TD_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}ATTRIBUTES_TD_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}ATTRIBUTES_TD_
 
 include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Dialect.td"
 
@@ -7,4 +7,4 @@ include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/DialectBase.td"
 
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}ATTRIBUTES_TD_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}ATTRIBUTES_TD_

--- a/templates/Dialect/include/Dialect.h.jinja
+++ b/templates/Dialect/include/Dialect.h.jinja
@@ -1,5 +1,5 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}DIALECT_H_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}DIALECT_H_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_H_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_H_
 
 #include "mlir/include/mlir/IR/Builders.h" // from @llvm-project
 #include "mlir/include/mlir/IR/Dialect.h" // from @llvm-project
@@ -7,4 +7,4 @@
 // Generated headers (block clang-format from messing up order)
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Dialect.h.inc"
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}DIALECT_H_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_H_

--- a/templates/Dialect/include/Dialect.td.jinja
+++ b/templates/Dialect/include/Dialect.td.jinja
@@ -1,5 +1,5 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}DIALECT_TD_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}DIALECT_TD_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_TD_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
 
@@ -11,9 +11,6 @@ def {{ dialect_name }}_Dialect : Dialect {
   }];
 
   let cppNamespace = "::mlir::heir::{{ dialect_namespace }}";
-
-  let useDefaultTypePrinterParser = 1;
-  let useDefaultAttributePrinterParser = 1;
 }
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}DIALECT_TD_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_TD_

--- a/templates/Dialect/include/Ops.h.jinja
+++ b/templates/Dialect/include/Ops.h.jinja
@@ -1,5 +1,5 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}OPS_H_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}OPS_H_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}OPS_H_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}OPS_H_
 
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Dialect.h"
 {% if enable_types %}
@@ -10,4 +10,4 @@
 #define GET_OP_CLASSES
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Ops.h.inc"
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}OPS_H_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}OPS_H_

--- a/templates/Dialect/include/Ops.td.jinja
+++ b/templates/Dialect/include/Ops.td.jinja
@@ -1,14 +1,13 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}OPS_TD_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}OPS_TD_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}OPS_TD_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}OPS_TD_
 
 include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Dialect.td"
-{% if enable_types %}
-include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Types.td"
-{% endif %}
+{% if enable_types %}include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Types.td"{% endif %}
+include "mlir/IR/OpBase.td"
 
 class {{ dialect_name }}_Op<string mnemonic, list<Trait> traits = []> :
         Op<{{ dialect_name }}_Dialect, mnemonic, traits> {
   let cppNamespace = "::mlir::heir::{{ dialect_namespace }}";
 }
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}OPS_TD_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}OPS_TD_

--- a/templates/Dialect/include/Types.h.jinja
+++ b/templates/Dialect/include/Types.h.jinja
@@ -1,5 +1,5 @@
-#ifndef HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}TYPES_H_
-#define HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}TYPES_H_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}TYPES_H_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}TYPES_H_
 
 {% if enable_attributes %}
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Attributes.h"
@@ -9,4 +9,4 @@
 #define GET_TYPEDEF_CLASSES
 #include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Types.h.inc"
 
-#endif  // HEIR_INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}TYPES_H_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}TYPES_H_

--- a/templates/Dialect/include/Types.td.jinja
+++ b/templates/Dialect/include/Types.td.jinja
@@ -1,5 +1,5 @@
-#ifndef INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}TYPES_TD_
-#define INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}TYPES_TD_
+#ifndef INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}TYPES_TD_
+#define INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}TYPES_TD_
 
 include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Dialect.td"
 {% if enable_attributes %}
@@ -16,4 +16,4 @@ class {{ dialect_name }}_Type<string name, string typeMnemonic>
 }
 
 
-#endif  // INCLUDE_DIALECT_{{ dialect_name }}_IR_{{ dialect_name }}TYPES_TD_
+#endif  // INCLUDE_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}TYPES_TD_

--- a/templates/Dialect/lib/BUILD.jinja
+++ b/templates/Dialect/lib/BUILD.jinja
@@ -76,6 +76,7 @@ cc_library(
     ],
     hdrs = [
         "@heir//include/Dialect/{{ dialect_name }}/IR:{{ dialect_name }}Dialect.h",
+        "@heir//include/Dialect/{{ dialect_name }}/IR:{{ dialect_name }}Types.h",
         {% if enable_attributes %}
         "@heir//include/Dialect/{{ dialect_name }}/IR:{{ dialect_name }}Attributes.h",
         {% endif %}

--- a/templates/Dialect/lib/Types.cpp.jinja
+++ b/templates/Dialect/lib/Types.cpp.jinja
@@ -1,4 +1,4 @@
-#include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Ops.h"
+#include "include/Dialect/{{ dialect_name }}/IR/{{ dialect_name }}Types.h"
 
 
 namespace mlir {


### PR DESCRIPTION
Minor changes to the dialect template generation tool found during https://github.com/google/heir/pull/549

- make include guards consistent with other templates (remove leading `HEIR_`, capitalize class name)
- Add types header to type build rule
- fix types header include in type cc file