### PR TITLE
Port roberts_cross from HECO, and use sparse constant analysis to identify static indices

### DIFF
--- a/include/Analysis/TargetSlotAnalysis/TargetSlotAnalysis.h
+++ b/include/Analysis/TargetSlotAnalysis/TargetSlotAnalysis.h
@@ -111,9 +111,16 @@ class TargetSlotLattice : public dataflow::Lattice<TargetSlot> {
 class TargetSlotAnalysis
     : public dataflow::SparseBackwardDataFlowAnalysis<TargetSlotLattice> {
  public:
-  explicit TargetSlotAnalysis(DataFlowSolver &solver,
-                              SymbolTableCollection &symbolTable)
-      : SparseBackwardDataFlowAnalysis(solver, symbolTable) {}
+  explicit TargetSlotAnalysis(
+      DataFlowSolver &solver, SymbolTableCollection &symbolTable,
+      // The dataflow solver is a private member of the base analysis
+      // class, so if we want to access it we have to get it explicitly from
+      // the caller. It's required that this solver is pre-loaded with a
+      // SparseConstantPropagation analysis. I'd like a better way to do
+      // this: maybe pass a callback?
+      const DataFlowSolver *sccpAnalysis)
+      : SparseBackwardDataFlowAnalysis(solver, symbolTable),
+        sccpAnalysis(sccpAnalysis) {}
   ~TargetSlotAnalysis() override = default;
   using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
 
@@ -125,6 +132,9 @@ class TargetSlotAnalysis
   void visitBranchOperand(OpOperand &operand) override {};
   void visitCallOperand(OpOperand &operand) override {};
   void setToExitState(TargetSlotLattice *lattice) override {};
+
+ private:
+  const DataFlowSolver *sccpAnalysis;
 };
 
 }  // namespace target_slot_analysis

--- a/lib/Dialect/TensorExt/Transforms/InsertRotate.cpp
+++ b/lib/Dialect/TensorExt/Transforms/InsertRotate.cpp
@@ -42,13 +42,33 @@ struct InsertRotate : impl::InsertRotateBase<InsertRotate> {
 
     SymbolTableCollection symbolTable;
     DataFlowSolver solver;
-    // These two upstream analyses are required dependencies for any sparse
-    // dataflow analysis, or else the analysis will be a no-op. Cf.
+
+    // These two upstream analyses are required to be instantiated in any
+    // sparse dataflow analysis, or else the analysis will be a no-op. Cf.
     // https://github.com/llvm/llvm-project/issues/58922
     solver.load<dataflow::DeadCodeAnalysis>();
     solver.load<dataflow::SparseConstantPropagation>();
-    solver.load<target_slot_analysis::TargetSlotAnalysis>(symbolTable);
     if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    // We want to use the result of the sparse constant propagation from the
+    // first dataflow solver as an input to the target slot analysis. For some
+    // reason, actually running `--sccp` before this pass causes the IR to
+    // simplify away some operations that are needed to properly identify
+    // target slots. So the SparseConstantPropagation above is a simulated
+    // folding of arith operations, so as to identify when insertion indices
+    // are statically inferable.
+    //
+    // TODO(#572): find a better way to depend dataflow analyses on each other.
+    DataFlowSolver solver2;
+    solver2.load<dataflow::DeadCodeAnalysis>();
+    solver2.load<dataflow::SparseConstantPropagation>();
+    solver2.load<target_slot_analysis::TargetSlotAnalysis>(symbolTable,
+                                                           &solver);
+    if (failed(solver2.initializeAndRun(getOperation()))) {
       getOperation()->emitOpError() << "Failed to run the analysis.\n";
       signalPassFailure();
       return;
@@ -60,9 +80,9 @@ struct InsertRotate : impl::InsertRotateBase<InsertRotate> {
     getOperation()->walk([&](Operation *op) {
       if (op->getNumResults() == 0) return;
       auto *targetSlotLattice =
-          solver.lookupState<target_slot_analysis::TargetSlotLattice>(
+          solver2.lookupState<target_slot_analysis::TargetSlotLattice>(
               op->getResult(0));
-      if (targetSlotLattice->getValue().isInitialized()) {
+      if (targetSlotLattice && targetSlotLattice->getValue().isInitialized()) {
         op->setAttr(
             "target_slot",
             builder.getIndexAttr(targetSlotLattice->getValue().getValue()));

--- a/tests/heir_simd_vectorizer/box_blur_64x64.mlir
+++ b/tests/heir_simd_vectorizer/box_blur_64x64.mlir
@@ -29,6 +29,7 @@ module  {
   // CHECK-NEXT:     secret.yield %[[v15]]
   // CHECK-NEXT:   } -> !secret.secret<tensor<4096xi16>>
   // CHECK-NEXT:   return %[[v0]]
+
   func.func @box_blur(%arg0: tensor<4096xi16>) -> tensor<4096xi16> {
     %c4096 = arith.constant 4096 : index
     %c64 = arith.constant 64 : index

--- a/tests/heir_simd_vectorizer/roberts_cross_4x4.mlir
+++ b/tests/heir_simd_vectorizer/roberts_cross_4x4.mlir
@@ -1,0 +1,82 @@
+// Ported from https://github.com/MarbleHE/HECO/blob/3e13744233ab0c09030a41ef98b4e061b6fa2eac/evaluation/benchmark/heco_input/robertscross_4x4.mlir
+
+// RUN: heir-opt --secretize=entry-function=roberts_cross --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
+module{
+  // CHECK-LABEL: @roberts_cross
+  // CHECK-SAME: (%[[arg0:.*]]: !secret.secret<tensor<16xi16>>) -> !secret.secret<tensor<16xi16>> {
+  // CHECK-NEXT: %[[c15:.*]] = arith.constant 15 : index
+  // CHECK-NEXT: %[[c11:.*]] = arith.constant 11 : index
+  // CHECK-NEXT: secret.generic ins(%[[arg0]] : !secret.secret<tensor<16xi16>>) {
+  // CHECK-NEXT:  ^bb0(%[[arg1:.*]]: tensor<16xi16>):
+  // CHECK-NEXT:    %[[v1:.*]] = tensor_ext.rotate %[[arg1]], %[[c11]]
+  // CHECK-NEXT:    %[[v2:.*]] = arith.subi %[[v1]], %[[arg1]]
+  // CHECK-NEXT:    %[[v3:.*]] = tensor_ext.rotate %[[arg1]], %[[c15]]
+  // CHECK-NEXT:    %[[v4:.*]] = arith.subi %[[v1]], %[[v3]]
+  // CHECK-NEXT:    %[[v5:.*]] = arith.muli %[[v2]], %[[v2]]
+  // CHECK-NEXT:    %[[v6:.*]] = arith.muli %[[v4]], %[[v4]]
+  // CHECK-NEXT:    %[[v7:.*]] = arith.addi %[[v5]], %[[v6]]
+  func.func @roberts_cross(%img: tensor<16xi16>) -> tensor<16xi16> {
+    %c16 = arith.constant 16 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c-1 =  arith.constant -1 : index
+
+    // Each point p = img[x][y], where x is row and y is column, in the new image will equal:
+    // (img[x-1][y-1] - img[x][y])^2 + (img[x-1][y] - img[x][y-1])^2
+    %r = affine.for %x = 0 to 4 iter_args(%imgx = %img) -> tensor<16xi16> {
+      %1 = affine.for %y = 0 to 4 iter_args(%imgy = %imgx) -> tensor<16xi16> {
+
+        // fetch img[x-1][y-1]
+        %4 = arith.addi %x, %c-1 : index
+        %5 = arith.muli %4, %c4 : index
+        %6 = arith.addi %y, %c-1 : index
+        %7 = arith.addi %5, %6 : index
+        %8 = arith.remui %7, %c16 : index
+        %9 = tensor.extract %img[%8] : tensor<16xi16>
+
+        // fetch img[x][y]
+        %10 = arith.muli %x, %c4 : index
+        %11 = arith.addi %10, %y : index
+        %12 = arith.remui %11, %c16 : index
+        %13 = tensor.extract %img[%12] : tensor<16xi16>
+
+        // subtract those two
+        %14 = arith.subi %9, %13 : i16
+
+        // fetch img[x-1][y]
+        %15 = arith.addi %x, %c-1 : index
+        %16 = arith.muli %15, %c4 : index
+        %17 = arith.addi %y, %c-1 : index
+        %18 = arith.addi %16, %17 : index
+        %19 = arith.remui %18, %c16 : index
+        %20 = tensor.extract %img[%19] : tensor<16xi16>
+
+        // fetch img[x][y-1]
+        %21 = arith.muli %x, %c4 : index
+        %22 = arith.addi %y, %c-1 : index
+        %23 = arith.addi %21, %22 : index
+        %24 = arith.remui %23, %c16 : index
+        %25 = tensor.extract %img[%24] : tensor<16xi16>
+
+        // subtract those two
+        %26 = arith.subi %20, %25 : i16
+
+        // square each difference
+        %27 = arith.muli %14, %14 :  i16
+        %28 = arith.muli %26, %26 :  i16
+
+        // add the squares
+        %29 = arith.addi %27, %28 : i16
+
+        // save to result[x][y]
+        %30 = tensor.insert %29 into %imgy[%12] : tensor<16xi16>
+        affine.yield %30: tensor<16xi16>
+      }
+      affine.yield %1 : tensor<16xi16>
+    }
+    return %r : tensor<16xi16>
+  }
+}


### PR DESCRIPTION
This PR has three parts:

- Porting the roberts_cross example from HECO, and realizing that it doesn't simplify properly because the pipeline can't identify its static insertion indices
- Adding an SCCP pass before insert-rotate to fix the above, and then seeing that it breaks box_blur for a reason I couldn't determine.
- Swapping a SCCP pass for a "simulated folding" sparse constant analysis, which is now used in insert-rotate for identifying constant that materialize as slot targets

Part of https://github.com/google/heir/issues/571