### PR TITLE
Rewrite rotation analysis to support dot product port from HECO

### DIFF
--- a/include/Analysis/RotationAnalysis/RotationAnalysis.h
+++ b/include/Analysis/RotationAnalysis/RotationAnalysis.h
@@ -1,14 +1,15 @@
 #ifndef INCLUDE_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_
 #define INCLUDE_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_
 
-#include <unordered_set>
+#include <set>
 
-#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
-#include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Diagnostics.h"            // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/OperationSupport.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
 
 #define DEBUG_TYPE "rotation-analysis"
 
@@ -16,200 +17,249 @@ namespace mlir {
 namespace heir {
 namespace rotation_analysis {
 
-// A wrapper around a mapping from a single tensor SSA value to a set of its
-// access indices.
-class RotationSets {
+// A PartialReduction represents a subset of an arithmetic op tree that reduces
+// values within a tensor to a scalar (present in index zero of the result
+// tensor).
+//
+// It is "partial" in the sense that it may not reduce across all elements of a
+// tensor, and it is used in the analysis to accumulate reduced tensor indices
+// across the IR.
+//
+// It also stores a reference to the SSA value that identifes the "end" of the
+// computation (i.e., the SSA value that contains the result of the reduction).
+class PartialReduction {
  public:
-  enum class Status {
-    // The tensor value has not been set
-    Uninitialized,
-
-    // The rotation set is in a normal state.
-    Normal,
-
-    // The rotation set has a property that makes it invalid for later
-    // optimizations:
-    //
-    //  - It involves operations touch more than one source tensor (not
-    //    including value-semantic outputs)
-    Overdetermined
-
-  };
-
- public:
-  RotationSets() = default;
-  ~RotationSets() = default;
-
-  // Clear the member data, i.e., set the value back to an uninitialized
-  // state.
-  void clear() {
-    accessedIndices.clear();
-    status = Status::Uninitialized;
-  }
-
   bool empty() const { return accessedIndices.empty(); }
-
-  bool isOverdetermined() const { return status == Status::Overdetermined; }
-
-  bool isUninitialized() const { return status == Status::Uninitialized; }
 
   void addRotation(int64_t index) { accessedIndices.insert(index); }
 
-  bool operator==(const RotationSets &rhs) const {
-    return tensor == rhs.tensor && status == rhs.status &&
-           accessedIndices == rhs.accessedIndices;
+  // Returns true if the accessed indices constitute all indices of the reduced
+  // tensor.
+  bool isComplete() const {
+    auto tensorType = tensor.getType().dyn_cast<RankedTensorType>();
+    assert(tensorType &&
+           "Internal state of RotationAnalysis is broken; tensor must have a "
+           "ranked tensor type");
+
+    // std::set is ordered, so min/max is first/last element of the set
+    int64_t minIndex = *accessedIndices.begin();
+    int64_t maxIndex = *accessedIndices.rbegin();
+    return minIndex == 0 && maxIndex == tensorType.getShape()[0] - 1 &&
+           accessedIndices.size() == tensorType.getShape()[0];
   }
 
-  const std::unordered_set<int64_t> &getAccessedIndices() const {
+  const std::set<int64_t> &getAccessedIndices() const {
     return accessedIndices;
   }
 
   Value getTensor() const { return tensor; }
 
+  Value getRoot() const { return root; }
+
   void print(raw_ostream &os) const {
-    os << tensor << ": [";
+    os << "{ opName: " << (opName.has_value() ? opName->getStringRef() : "None")
+       << "; " << " tensor: " << tensor << "; " << "rotations: [";
     for (auto index : accessedIndices) {
       os << index << ", ";
     }
-    os << "]";
+    os << "]; root: " << root << "; }";
   }
 
-  static RotationSets overdetermined() {
-    RotationSets sets;
-    sets.status = Status::Overdetermined;
-    return sets;
-  }
+  // Construct a "leaf" of a reduction, i.e., a PartialReduction that represents
+  // no operations applied to a starting tensor SSA value.
+  static PartialReduction initializeFromValue(Value tensor) {
+    PartialReduction reduction;
+    reduction.tensor = tensor;
+    reduction.root = tensor;
+    reduction.opName = std::nullopt;
+    // In the FHE world, the only extractible element (without a rotation) of a
+    // packed ciphertext is the constant term, i.e., the first element of the
+    // tensor. So a tensor by itself is always considered a reduction by that
+    // first element.
+    reduction.addRotation(0);
 
-  static RotationSets from(Value tensor) {
-    RotationSets sets;
-    if (!tensor.getType().isa<RankedTensorType>()) {
-      sets.status = Status::Uninitialized;
-      return sets;
-    }
-
-    sets.status = Status::Normal;
-    sets.tensor = tensor;
-    if (auto blockArg = dyn_cast<BlockArgument>(tensor)) {
-      sets.addRotation(0);
-    }
-    return sets;
+    LLVM_DEBUG(llvm::dbgs()
+               << "Initializing at " << tensor << " with rotations [0]\n");
+    return reduction;
   }
 
   // Shift the rotation indices by the given amount. This helps in a situation
   // where an IR repeatedly rotates by 1, to ensure that rotations accumulate
   // like {1, 2, 3, ...} rather than {1, 1, 1, ...}
-  static RotationSets rotate(const RotationSets &lhs, const int64_t shift) {
-    if (lhs.status == Status::Overdetermined) {
-      return overdetermined();
-    }
-
-    RotationSets shifted;
-    shifted.status = Status::Normal;
+  static PartialReduction rotate(const PartialReduction &lhs,
+                                 const int64_t shift, Value result) {
+    LLVM_DEBUG({
+      llvm::dbgs() << "Rotating\n\t";
+      lhs.print(llvm::dbgs());
+      llvm::dbgs() << " by " << shift;
+    });
+    PartialReduction shifted;
     shifted.tensor = lhs.tensor;
+    shifted.opName = lhs.opName;
+    shifted.root = result;
     int64_t size =
         llvm::cast<RankedTensorType>(lhs.tensor.getType()).getShape()[0];
+    assert(!lhs.accessedIndices.empty() &&
+           "Internal state of RotationAnalysis is broken; empty rotation sets "
+           "should be impossible");
     for (auto index : lhs.accessedIndices) {
       shifted.addRotation((index + shift) % size);
     }
+    LLVM_DEBUG({
+      llvm::dbgs() << " to\n\t";
+      shifted.print(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    });
     return shifted;
   }
 
-  static RotationSets join(const RotationSets &lhs, const RotationSets &rhs) {
-    if (lhs.status == Status::Overdetermined ||
-        rhs.status == Status::Overdetermined) {
-      return overdetermined();
-    }
-
-    if (rhs.status == Status::Uninitialized || rhs.accessedIndices.empty())
-      return lhs;
-    if (lhs.status == Status::Uninitialized || lhs.accessedIndices.empty())
-      return rhs;
-
+  // Determine if two PartialRotations are legal to join at an op whose
+  // OperationName is given.
+  static bool canJoin(const PartialReduction &lhs, const PartialReduction &rhs,
+                      OperationName opName) {
     if (lhs.tensor != rhs.tensor) {
-      LLVM_DEBUG({
-        llvm::dbgs() << "Joining rotations of different tensors: " << lhs.tensor
-                     << " and " << rhs.tensor << "\n";
-      });
-      return overdetermined();
+      return false;
     }
 
-    LLVM_DEBUG({
-      llvm::dbgs() << "Joining :" << lhs.tensor << " and " << rhs.tensor
-                   << "\n";
-    });
-    RotationSets merged;
-    merged.status = Status::Normal;
+    // If neither of the lhs and rhs ops are set, then any op is legal.
+    if (lhs.opName.has_value() || rhs.opName.has_value()) {
+      // Otherwise, if both ops are set, then they must agree with each other
+      // and the new op.
+      if (lhs.opName.has_value() && rhs.opName.has_value() &&
+          (*lhs.opName != *rhs.opName || *lhs.opName != opName)) {
+        return false;
+      }
+
+      // Otherwise, at least one of lhs and rhs must have a set op name, and it
+      // must agree with the new op.
+      auto materializedOpName =
+          lhs.opName.has_value() ? *lhs.opName : *rhs.opName;
+      if (materializedOpName != opName) {
+        return false;
+      }
+    }
+
+    // If the two partial reductions have access indices in common, then they
+    // cannot be joined because some indices would be contributing multiple
+    // times to the overall reduction. Maybe we could improve this in the
+    // future so that we could handle a kind of reduction that sums the same
+    // index twice, but likely it is better to account for that in a different
+    // fashion.
+    auto smaller =
+        lhs.accessedIndices.size() < rhs.accessedIndices.size() ? lhs : rhs;
+    auto larger =
+        lhs.accessedIndices.size() >= rhs.accessedIndices.size() ? lhs : rhs;
+    return std::all_of(smaller.accessedIndices.begin(),
+                       smaller.accessedIndices.end(), [&](int64_t index) {
+                         return larger.accessedIndices.count(index) == 0;
+                       });
+  }
+
+  // Join two partial reductions. This assumes the lhs and rhs have already
+  // been checked to have compatible tensors and opNames via canJoin.
+  static PartialReduction join(const PartialReduction &lhs,
+                               const PartialReduction &rhs, Value newRoot,
+                               OperationName opName) {
+    assert(!lhs.accessedIndices.empty() &&
+           "Internal state of RotationAnalysis is broken; empty rotation sets "
+           "should be impossible");
+    assert(!rhs.accessedIndices.empty() &&
+           "Internal state of RotationAnalysis is broken; empty rotation sets "
+           "should be impossible");
+
+    PartialReduction merged;
     merged.tensor = lhs.tensor;
+    merged.root = newRoot;
+    merged.opName = opName;
     for (auto index : lhs.accessedIndices) {
       merged.addRotation(index);
     }
     for (auto index : rhs.accessedIndices) {
       merged.addRotation(index);
     }
-    return merged;
-  }
-
-  // Assuming two not-overdetermined rotation sets, compute the overlap in
-  // their access indices.
-  static RotationSets overlap(const RotationSets &lhs,
-                              const RotationSets &rhs) {
-    assert(!lhs.isOverdetermined() && !rhs.isOverdetermined() &&
-           "Expected inputs to RotationSets::overlap to be not overdetermined");
-    if (lhs.status == Status::Uninitialized || lhs.empty()) {
-      return lhs;
-    }
-
-    if (rhs.status == Status::Uninitialized || rhs.empty()) {
-      return rhs;
-    }
-
-    RotationSets merged;
-    merged.status = Status::Normal;
-    merged.tensor = lhs.tensor;
-    for (auto index : lhs.accessedIndices) {
-      if (rhs.accessedIndices.count(index)) merged.addRotation(index);
-    }
+    LLVM_DEBUG({
+      llvm::dbgs() << "Joining\n\t";
+      lhs.print(llvm::dbgs());
+      llvm::dbgs() << " and\n\t";
+      rhs.print(llvm::dbgs());
+      llvm::dbgs() << " to get\n\t";
+      merged.print(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    });
     return merged;
   }
 
  private:
-  /// The accessed indices of a single SSA value of tensor type.
+  // The SSA value being reduced
   Value tensor;
 
+  // The root of the reduction tree constructed so far, e.g., the result of the
+  // last op in a linear chain of reduction operations. During
+  // rotate-and-reduce, this represents the final SSA value that is replaced by
+  // an optimized set of rotations.
+  Value root;
+
+  // The operation performed in the reduction.
+  //
+  // Set to std::nullopt if no binary operation is applied (i.e., the reduction
+  // is a raw tensor at the leaf of a reduction tree).
+  std::optional<OperationName> opName;
+
+  // The set of indices of `tensor` accumulated by the reduction so far.
+  //
   // There is likely a data structure that can more efficiently represent a set
   // of intervals of integers, which properly merges adjacent intervals as
   // values are added. Java/Guava has RangeSet, and boost has interval_set.
-  std::unordered_set<int64_t> accessedIndices;
-  Status status = Status::Uninitialized;
+  // For now we use std::set which is implemented as a binary tree and ordered
+  // by the index values.
+  std::set<int64_t> accessedIndices;
 };
 
-inline raw_ostream &operator<<(raw_ostream &os, const RotationSets &v) {
+inline raw_ostream &operator<<(raw_ostream &os, const PartialReduction &v) {
   v.print(os);
   return os;
 }
 
-class RotationLattice : public dataflow::Lattice<RotationSets> {
+/// An analysis that identifies, for each tensor-typed SSA value, the set of
+/// partial reductions of associative, commutative binary arithmetic operations
+/// that reduce it to a scalar via tensor_ext.rotate ops.
+class RotationAnalysis {
  public:
-  using Lattice::Lattice;
-};
+  // The constructor requires a DataFlowSolver initialized with a sparse
+  // constant propagation analysis, which is used to determine the static
+  // values of rotation shifts.
+  RotationAnalysis(const DataFlowSolver &solver) : solver(solver) {};
+  ~RotationAnalysis() = default;
 
-/// An analysis that identifies, for each SSA value, the set of underlying
-/// tensors and rotations of those tensors, provided constant rotation shifts
-/// can be determined.
-class RotationAnalysis
-    : public dataflow::SparseForwardDataFlowAnalysis<RotationLattice> {
- public:
-  explicit RotationAnalysis(DataFlowSolver &solver)
-      : SparseForwardDataFlowAnalysis(solver) {}
-  ~RotationAnalysis() override = default;
-  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  void run(Operation *op);
 
-  // Given the computed results of the operation, update its operand lattice
-  // values.
-  void visitOperation(Operation *op, ArrayRef<const RotationLattice *> operands,
-                      ArrayRef<RotationLattice *> results) override;
+  /// Add partial reduction
+  void addPartialReduction(PartialReduction reduction) {
+    rootToPartialReductions[reduction.getRoot()].emplace_back(reduction);
+  }
 
-  void setToEntryState(RotationLattice *lattice) override;
+  /// Add a tensor value as the start of a new reduction to the internal
+  /// reduction mappings.
+  void initializeFromValueIfTensor(Value value) {
+    if (RankedTensorType tensorType =
+            value.getType().dyn_cast<RankedTensorType>()) {
+      addPartialReduction(PartialReduction::initializeFromValue(value));
+    }
+  }
+
+  const std::vector<PartialReduction> &getRootedReductionsAt(
+      Value value) const {
+    return rootToPartialReductions.at(value);
+  }
+
+ private:
+  // The constant propagation analysis used to determine the static values of
+  // rotation shifts.
+  const DataFlowSolver &solver;
+
+  // A mapping from a root of a PartialReduction to its PartitalReduction. Note
+  // each tensor SSA value can be the root of many partial reductions.
+  llvm::DenseMap<Value, std::vector<PartialReduction>> rootToPartialReductions;
 };
 
 }  // namespace rotation_analysis

--- a/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
+++ b/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
@@ -1,73 +1,113 @@
 #include "include/Analysis/RotationAnalysis/RotationAnalysis.h"
 
 #include "include/Dialect/TensorExt/IR/TensorExtOps.h"
-#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
-#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
-#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"   // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace rotation_analysis {
 
-void RotationAnalysis::visitOperation(
-    Operation *op, ArrayRef<const RotationLattice *> operands,
-    ArrayRef<RotationLattice *> results) {
-  llvm::TypeSwitch<Operation &>(*op)
-      .Case<tensor_ext::RotateOp>([&](auto rotateOp) {
-        LLVM_DEBUG({ llvm::dbgs() << "Visiting: " << *op << "\n"; });
-        auto shiftConstantOp =
-            rotateOp.getShift().template getDefiningOp<arith::ConstantOp>();
-        // If the rotation shift can't be statically determined, we can't
-        // propagate anything through the IR.
-        if (!shiftConstantOp) return;
+void RotationAnalysis::run(Operation *op) {
+  op->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    // If the op has no tensor results and no regions, then there's nothing to
+    // do. The operation may consume a tensor but cannot further reduce it.
+    if (op->getNumRegions() == 0 &&
+        llvm::none_of(op->getResultTypes(),
+                      [](Type type) { return type.isa<RankedTensorType>(); })) {
+      return WalkResult::advance();
+    }
 
-        int64_t shiftValue =
-            dyn_cast<IntegerAttr>(shiftConstantOp.getValue()).getInt();
+    // Each tensor result can be the start of a new reduction.
+    for (Value result : op->getResults()) {
+      initializeFromValueIfTensor(result);
+    }
 
-        // The target slot propagates from the tensor argument to the result;
-        // the tensor argument is first in the tablegen definition.
-        const RotationLattice *lattice = operands[0];
-        RotationSets latticeRotations = lattice->getValue();
-
-        // If it's a block argument, then there is no initialized lattice value
-        // and we can override it with a "zero rotation"
-        auto blockArg = dyn_cast<BlockArgument>(rotateOp.getTensor());
-        if (blockArg) {
-          latticeRotations = RotationSets::from(blockArg);
+    // Block args within regions can be the start of a new reduction.
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        for (Value arg : block.getArguments()) {
+          initializeFromValueIfTensor(arg);
         }
-        RotationSets rotated =
-            RotationSets::rotate(latticeRotations, shiftValue);
+      }
+    }
 
-        for (RotationLattice *r : results) {
-          ChangeResult result = r->join(rotated);
-          propagateIfChanged(r, result);
-        }
-      })
-      .Default([&](Operation &op) {
-        // By default, an op propagates its result target slots to all its
-        // operands.
-        for (OpOperand &operand : op.getOpOperands()) {
-          auto *latticeOperand = operands[operand.getOperandNumber()];
+    // Each op now gets special treatment.
+    //
+    // - Rotate ops shift the accessIndices of their tensor operand's
+    //   reductions if the shift is known to be constant.
+    // - Binary ops join partial reductions of operands and set the opName.
+    // - Everything else is ignored.
+    llvm::TypeSwitch<Operation &>(*op)
+        .Case<tensor_ext::RotateOp>([&](auto rotateOp) {
+          LLVM_DEBUG({ llvm::dbgs() << "Visiting: " << *op << "\n"; });
+          const dataflow::Lattice<dataflow::ConstantValue> *shiftLattice =
+              solver.lookupState<dataflow::Lattice<dataflow::ConstantValue>>(
+                  rotateOp.getShift());
 
-          for (RotationLattice *r : results) {
-            ChangeResult result = r->join(*latticeOperand);
-            // If the operand is a block arg, this additionally treats this as
-            // a zero rotation. If the underlying tensor differs across
-            // operands, this will also cause a Status::TooManyTensors.
-            // Otherwise, the join is a no-op.
-            result |= r->join(RotationSets::from(operand.get()));
-            propagateIfChanged(r, result);
+          if (shiftLattice) {
+            LLVM_DEBUG(llvm::dbgs() << "At " << rotateOp
+                                    << " SCCP analysis gives lattice of "
+                                    << *shiftLattice << "\n");
           }
-        }
-      });
-}
 
-void RotationAnalysis::setToEntryState(RotationLattice *lattice) {
-  lattice->getValue().clear();
+          // If the rotation shift can't be statically determined, we can't
+          // propagate anything through the IR.
+          if (!shiftLattice || shiftLattice->getValue().isUninitialized() ||
+              !shiftLattice->getValue().getConstantValue()) {
+            LLVM_DEBUG(
+                llvm::dbgs()
+                << "At " << rotateOp
+                << " can't statically determine constant insertion index\n");
+            return;
+          }
+          auto shiftValue = shiftLattice->getValue()
+                                .getConstantValue()
+                                .dyn_cast<IntegerAttr>()
+                                .getInt();
+
+          // For each partial reduction the tensor operand is a root of,
+          // rotate the accessed indices appropriately.
+          Value tensor = rotateOp.getTensor();
+          Value result = rotateOp.getResult();
+          for (const auto &reduction : rootToPartialReductions[tensor]) {
+            addPartialReduction(
+                PartialReduction::rotate(reduction, shiftValue, result));
+          }
+        })
+        .Case<arith::AddIOp, arith::MulIOp>([&](auto arithOp) {
+          LLVM_DEBUG({ llvm::dbgs() << "Visiting: " << arithOp << "\n"; });
+          Value lhs = arithOp.getLhs();
+          Value rhs = arithOp.getRhs();
+          Value newRoot = arithOp.getResult();
+          OperationName opName = arithOp.getOperation()->getName();
+
+          // This is inefficient, but what can we do better here? I suspect a
+          // better approach may be to identify cases in which only one of these
+          // reductions needs to be kept because it's "the best" according to
+          // some metric (e.g., it monotonically increases the number of indices
+          // and all else stays the same). But for now even on the
+          // box_blur_64x64 example this is far from the bottleneck.
+          for (const auto &lhsReduction : rootToPartialReductions[lhs]) {
+            for (const auto &rhsReduction : rootToPartialReductions[rhs]) {
+              if (PartialReduction::canJoin(lhsReduction, rhsReduction,
+                                            opName)) {
+                addPartialReduction(PartialReduction::join(
+                    lhsReduction, rhsReduction, newRoot, opName));
+              }
+            }
+          }
+        });
+
+    return WalkResult::advance();
+  });
 }
 
 }  // namespace rotation_analysis

--- a/lib/Analysis/SelectVariableNames/SelectVariableNames.cpp
+++ b/lib/Analysis/SelectVariableNames/SelectVariableNames.cpp
@@ -1,7 +1,5 @@
 #include "include/Analysis/SelectVariableNames/SelectVariableNames.h"
 
-#include <string>
-
 #include "llvm/include/llvm/ADT/DenseMap.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"      // from @llvm-project

--- a/tests/heir_simd_vectorizer/dot_product_8.mlir
+++ b/tests/heir_simd_vectorizer/dot_product_8.mlir
@@ -1,0 +1,18 @@
+// RUN: heir-opt --secretize=entry-function=dot_product --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
+// CHECK-LABEL: func @dot_product
+// CHECK-COUNT-3: tensor_ext.rotate
+// CHECK-NOT: tensor_ext.rotate
+func.func @dot_product(%arg0: tensor<8xi16>, %arg1: tensor<8xi16>) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %arg2 = 0 to 8 iter_args(%iter = %c0_si16) -> (i16) {
+    %1 = tensor.extract %arg0[%arg2] : tensor<8xi16>
+    %2 = tensor.extract %arg1[%arg2] : tensor<8xi16>
+    %3 = arith.muli %1, %2 : i16
+    %4 = arith.addi %iter, %3 : i16
+    affine.yield %4 : i16
+  }
+  return %0 : i16
+}

--- a/tests/heir_simd_vectorizer/hamming_distance.mlir
+++ b/tests/heir_simd_vectorizer/hamming_distance.mlir
@@ -9,14 +9,8 @@
 // CHECK-NEXT: arith.addi
 // CHECK-NEXT: tensor_ext.rotate
 // CHECK-NEXT: arith.addi
-// CHECK-NEXT: tensor_ext.rotate
-// CHECK-NEXT: arith.addi
 // CHECK-NEXT: tensor.extract
 // CHECK-NEXT: secret.yield
-
-// TODO(#521): Fix rotate-and-reduce to work on this IR.
-// The problem is that the lattice identifies the rotate-version of this IR as
-// being overdetermined.
 
 func.func @hamming(%arg0: tensor<4xi16>, %arg1: tensor<4xi16>) -> i16 {
   %c0 = arith.constant 0 : index

--- a/tests/heir_simd_vectorizer/linear_polynomial_64.mlir
+++ b/tests/heir_simd_vectorizer/linear_polynomial_64.mlir
@@ -1,0 +1,22 @@
+// Ported from: https://github.com/MarbleHE/HECO/blob/3e13744233ab0c09030a41ef98b4e061b6fa2eac/evaluation/comparison/heco_input/linearpolynomial_64.mlir
+
+// RUN: heir-opt --secretize=entry-function=linear_polynomial --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
+// CHECK-LABEL: @linear_polynomial
+// CHECK: secret.generic
+// CHECK-NOT: tensor_ext.rotate
+func.func @linear_polynomial(%a: tensor<64xi16>, %b: tensor<64xi16>, %x: tensor<64xi16>, %y: tensor<64xi16>) -> tensor<64xi16> {
+  %0 = affine.for %i = 0 to 64 iter_args(%iter = %y) -> (tensor<64xi16>) {
+    %ai = tensor.extract %a[%i] : tensor<64xi16>
+    %bi = tensor.extract %b[%i] : tensor<64xi16>
+    %xi = tensor.extract %x[%i] : tensor<64xi16>
+    %yi = tensor.extract %y[%i] : tensor<64xi16>
+    %axi = arith.muli %ai, %xi : i16
+    %t1 = arith.subi %yi, %axi : i16
+    %t2 = arith.subi %t1, %bi : i16
+    %out = tensor.insert %t2 into %iter[%i] : tensor<64xi16>
+    affine.yield %out : tensor<64xi16>
+  }
+  return %0 : tensor<64xi16>
+}

--- a/tests/heir_simd_vectorizer/quadratic_polynomial.mlir
+++ b/tests/heir_simd_vectorizer/quadratic_polynomial.mlir
@@ -1,0 +1,25 @@
+// Ported from: https://github.com/MarbleHE/HECO/blob/3e13744233ab0c09030a41ef98b4e061b6fa2eac/evaluation/comparison/heco_input/quadraticpolynomial_64.mlir
+
+// RUN: heir-opt --secretize=entry-function=quadratic_polynomial --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
+// CHECK-LABEL: @quadratic_polynomial
+// CHECK: secret.generic
+// CHECK-NOT: tensor_ext.rotate
+func.func @quadratic_polynomial(%a: tensor<64xi16>, %b: tensor<64xi16>, %c: tensor<64xi16>, %x: tensor<64xi16>, %y: tensor<64xi16>) -> tensor<64xi16> {
+  %0 = affine.for %i = 0 to 64 iter_args(%iter = %y) -> (tensor<64xi16>) {
+    %ai = tensor.extract %a[%i] : tensor<64xi16>
+    %bi = tensor.extract %b[%i] : tensor<64xi16>
+    %ci = tensor.extract %c[%i] : tensor<64xi16>
+    %xi = tensor.extract %x[%i] : tensor<64xi16>
+    %yi = tensor.extract %y[%i] : tensor<64xi16>
+    %axi = arith.muli %ai, %xi : i16
+    %t1 = arith.addi %axi, %bi : i16
+    %t2 = arith.muli %xi, %t1 : i16
+    %t3 = arith.addi %t2, %ci : i16
+    %t4 = arith.subi %yi, %t3 : i16
+    %out = tensor.insert %t4 into %iter[%i] : tensor<64xi16>
+    affine.yield %out : tensor<64xi16>
+  }
+  return %0 : tensor<64xi16>
+}

--- a/tests/secret_to_bgv/hamming_distance_1024.mlir
+++ b/tests/secret_to_bgv/hamming_distance_1024.mlir
@@ -7,9 +7,7 @@
 // CHECK: bgv.sub
 // CHECK-NEXT: bgv.mul
 // CHECK-NEXT: bgv.relinearize
-
-// TODO(#521): After rotate-and-reduce works, only check for 10 bg.rotate
-// CHECK-COUNT-1023: bgv.rotate
+// CHECK-COUNT-10: bgv.rotate
 // CHECK: bgv.extract
 // CHECK-NEXT: return
 


### PR DESCRIPTION
Ports:

- dot_product
- linear_polynomial
- quadratic_polynomial

Part of https://github.com/google/heir/issues/571

The main thing this PR does it rewrite the rotation analysis used in `rotate-and-reduce`. It originally did not support any reduction that started from two separate tensors (e.g., the `dot_product` example ported in this PR) because the lattice framework considered that overdetermined. After thinking about this, I realized that what I really wanted to do was "reset" the lattice after I found an overdetermined state, re-initializing it at the result of the operation that made it overdetermined. E.g.,

```
%0 = arith.muli %arg1, %arg2  <-- overdetermined b/c two different source tensors
%1 = tensor_ext.rotate %0, %c1  <-- valid start of a reduction with base tensor %0
%2 = arith.addi %0, %1
...
```

The lattice framework doesn't support this because "resetting" is not a monotonic operation which is required of a semijoin lattice. I suspect that subclassing a higher level of the dataflow framework may have worked, but I felt it was just simpler to write a "generic" analysis with no constraints.

The new analysis does a single walk over the IR, and cumulatively builds up a `PartialReduction` struct corresponding to the set of indices visited, along with extra information about the operation being processed, the source tensor being reduced, and the "root" tensor which is the SSA value that may ultimately be replaced by a log-number of rotations in the pass, and is used as the extension point for the accumulation.

The logic should be much clearer now, and the pass itself no longer requires any extra hacks to ensure consistency. If this looks good to everyone else, I think it would make sense to mirror this flow for the `tryReplaceExtractions` part of `rotate-and-reduce`.