### PR TITLE
Fix bad operand ordering causing collapse-insertion-chains to fail on examples with `arith.subi`

### DIFF
--- a/include/Dialect/TensorExt/Transforms/InsertRotate.td
+++ b/include/Dialect/TensorExt/Transforms/InsertRotate.td
@@ -89,6 +89,8 @@ foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {
 // rotations, and the simplifications will occur by replacing triples
 // of rotations with pairs.
 // TODO(#514): handle OuterOp with two different InnerOps on the LHS and RHS
+// TODO(#579): determine if these patterns are still necessary after the
+// target slot analysis was improved.
 foreach InnerOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {
   foreach OuterOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {
     // Left associated grouping handles (add (add (rotate t1 i1) (rotate t2 i2)) (rotate t3 i3))
@@ -118,7 +120,7 @@ foreach InnerOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp] in {
         (TensorExt_RotateOp:$r1 $t1, (Arith_SubIOp $i1, $i3, DefOverflow)),
         (TensorExt_RotateOp:$r2 $t2, (Arith_SubIOp $i2, $i3, DefOverflow)),
         (InnerOp:$addResult $r1, $r2, $ovf1),
-        (OuterOp:$output $addResult, $t3, $ovf2),
+        (OuterOp:$output $t3, $addResult, $ovf2),
         // Downstream ops are not updated by this pass, so we need to preserve the original
         // rotation and then clean it up in a separate canonicalization pattern.
         (TensorExt_RotateOp $output, $i3),

--- a/tests/heir_simd_vectorizer/linear_polynomial_64.mlir
+++ b/tests/heir_simd_vectorizer/linear_polynomial_64.mlir
@@ -6,6 +6,8 @@
 // CHECK-LABEL: @linear_polynomial
 // CHECK: secret.generic
 // CHECK-NOT: tensor_ext.rotate
+// CHECK-NOT: insert
+// CHECK-NOT: extract
 func.func @linear_polynomial(%a: tensor<64xi16>, %b: tensor<64xi16>, %x: tensor<64xi16>, %y: tensor<64xi16>) -> tensor<64xi16> {
   %0 = affine.for %i = 0 to 64 iter_args(%iter = %y) -> (tensor<64xi16>) {
     %ai = tensor.extract %a[%i] : tensor<64xi16>


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/578

The actual fix is https://github.com/google/heir/pull/580/commits/0cb5e7cfbb219acab25ca8cf4d566c6c432668f1, everything else is improving debugs, tests, comments