### PR TITLE
fix formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
 # clang-format
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v18.1.1"
+    rev: "v18.1.2"
     hooks:
     -   id: clang-format
         args: ["--style=Google"]

--- a/include/Analysis/RotationAnalysis/RotationAnalysis.h
+++ b/include/Analysis/RotationAnalysis/RotationAnalysis.h
@@ -228,7 +228,7 @@ class RotationAnalysis {
   // The constructor requires a DataFlowSolver initialized with a sparse
   // constant propagation analysis, which is used to determine the static
   // values of rotation shifts.
-  RotationAnalysis(const DataFlowSolver &solver) : solver(solver) {};
+  RotationAnalysis(const DataFlowSolver &solver) : solver(solver) {}
   ~RotationAnalysis() = default;
 
   void run(Operation *op);


### PR DESCRIPTION
Google uses clang-format internally at HEAD, incorporating this fix which is not in llvm-18 https://github.com/llvm/llvm-project/issues/79834

Caused CI to break. 
