### PR TITLE
Dynamically find LUT size in comb-to-cggi

### DIFF
--- a/tests/comb_to_cggi/bool_ops.mlir
+++ b/tests/comb_to_cggi/bool_ops.mlir
@@ -3,12 +3,12 @@
 // CHECK-NOT: secret
 // CHECK: @boolean_gates([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.*>]]) -> [[LWET]]
 func.func @boolean_gates(%arg0: !secret.secret<i1>) -> !secret.secret<i1> {
-  // CHECK: [[VAL1:%.+]] = cggi.and [[ARG]], [[ARG]]
-  // CHECK: [[VAL2:%.+]] = cggi.or [[VAL1]], [[ARG]]
-  // CHECK: [[VAL3:%.+]] = cggi.nand [[VAL2]], [[VAL1]]
-  // CHECK: [[VAL4:%.+]] = cggi.xor [[VAL3]], [[VAL2]]
-  // CHECK: [[VAL5:%.+]] = cggi.xnor [[VAL4]], [[VAL3]]
-  // CHECK: [[VAL6:%.+]] = cggi.nor [[VAL5]], [[VAL4]]
+  // CHECK: [[VAL1:%.+]] = cggi.and [[ARG]], [[ARG]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
+  // CHECK: [[VAL2:%.+]] = cggi.or [[VAL1]], [[ARG]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
+  // CHECK: [[VAL3:%.+]] = cggi.nand [[VAL2]], [[VAL1]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
+  // CHECK: [[VAL4:%.+]] = cggi.xor [[VAL3]], [[VAL2]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
+  // CHECK: [[VAL5:%.+]] = cggi.xnor [[VAL4]], [[VAL3]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
+  // CHECK: [[VAL6:%.+]] = cggi.nor [[VAL5]], [[VAL4]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
   %0 = secret.generic
       ins(%arg0:  !secret.secret<i1>) {
       ^bb0(%ARG0: i1) :
@@ -32,7 +32,7 @@ func.func @boolean_gates(%arg0: !secret.secret<i1>) -> !secret.secret<i1> {
 func.func @boolean_gates_partial_secret(%arg0: !secret.secret<i1>, %arg1 : i1) -> !secret.secret<i1> {
   // CHECK: [[ENC:%.+]] = lwe.encode [[ARG1]]
   // CHECK: [[LWE:%.+]] = lwe.trivial_encrypt [[ENC]]
-  // CHECK: [[VAL1:%.+]] = cggi.and [[ARG0]], [[LWE]]
+  // CHECK: [[VAL1:%.+]] = cggi.and [[ARG0]], [[LWE]] : [[LWET:!lwe.lwe_ciphertext<.* = 1>]]
   %0 = secret.generic
       ins(%arg0, %arg1: !secret.secret<i1>, i1) {
       ^bb0(%ARG0: i1, %ARG1: i1) :

--- a/tests/comb_to_cggi/truth_table.mlir
+++ b/tests/comb_to_cggi/truth_table.mlir
@@ -1,7 +1,7 @@
 // RUN: heir-opt --secret-distribute-generic --split-input-file --comb-to-cggi --cse %s | FileCheck %s
 
 // CHECK-NOT: secret
-// CHECK: @truth_table_all_secret([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.*>]]) -> [[LWET]]
+// CHECK: @truth_table_all_secret([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]) -> [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]
 func.func @truth_table_all_secret(%arg0: !secret.secret<i1>) -> !secret.secret<i1> {
   // CHECK: [[VAL:%.+]] = cggi.lut3([[ARG]], [[ARG]], [[ARG]])
   %0 = secret.generic
@@ -10,14 +10,14 @@ func.func @truth_table_all_secret(%arg0: !secret.secret<i1>) -> !secret.secret<i
           %1 = comb.truth_table %ARG0, %ARG0, %ARG0 -> 6 : ui8
           secret.yield %1 : i1
       } -> (!secret.secret<i1>)
-  // CHECK: return [[VAL]] : [[LWET]]
+  // CHECK: return [[VAL]] : [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]
   func.return %0 : !secret.secret<i1>
 }
 
 // -----
 
 // CHECK-NOT: secret
-// CHECK: @truth_table_partial_secret([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.*>]]) -> [[LWET]]
+// CHECK: @truth_table_partial_secret([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]) -> [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]
 func.func @truth_table_partial_secret(%arg0: !secret.secret<i1>) -> !secret.secret<i1> {
   // CHECK: [[FALSE:%.+]] = arith.constant false
   %false = arith.constant false


### PR DESCRIPTION
A starter for dynammically finding the LUT size in the comb-to-cggi conversion
For now, once its detect a TruthTableOp, it goes to the default of 3

(Partial) Solve for ToDo #250 