### PR TITLE
Secret to BGV to OpenFHE e2e pipeline

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 # HEIR, an MLIR project for homomorphic encryption
 
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
@@ -21,9 +22,22 @@ package_group(
 )
 
 # Disables Yosys deps for CLI tools and tests.
+# use by passing `--//:enable_yosys=0` to `bazel build` or `bazel test`
+string_flag(
+    name = "enable_yosys",
+    build_setting_default = "1",
+)
+
 config_setting(
-    name = "disable_yosys",
-    values = {
-        "define": "HEIR_NO_YOSYS=1",
+    name = "config_enable_yosys",
+    flag_values = {
+        ":enable_yosys": "1",
+    },
+)
+
+config_setting(
+    name = "config_disable_yosys",
+    flag_values = {
+        ":enable_yosys": "0",
     },
 )

--- a/docs/content/en/docs/getting_started.md
+++ b/docs/content/en/docs/getting_started.md
@@ -25,7 +25,7 @@ Some passes in this repository require Yosys as a dependency
 speed up builds, use the following build setting:
 
 ```bash
-bazel build --define=HEIR_NO_YOSYS=1 @heir//tools:heir-opt
+bazel build --//:enable_yosys=0 @heir//tools:heir-opt
 ```
 
 ## Optional: Run the tests
@@ -37,7 +37,7 @@ bazel test @heir//...
 Like above, run the following to skip tests that depend on Yosys:
 
 ```bash
-bazel test --define=HEIR_NO_YOSYS=1 --test_tag_filters=-yosys @heir//...
+bazel test --//:enable_yosys=0 --test_tag_filters=-yosys @heir//...
 ```
 
 ## Run the hello-world example

--- a/include/Dialect/BGV/IR/BGVOps.td
+++ b/include/Dialect/BGV/IR/BGVOps.td
@@ -212,12 +212,11 @@ def BGV_ModulusSwitch : BGV_Op<"modulus_switch"> {
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 
-def BGV_EncryptOp : BGV_Op<"encrypt", [
-  RlweParametersMatch<"secret_key", "RLWESecretKeyType", "output", "RLWECiphertextType">
-]> {
+def BGV_EncryptOp : BGV_Op<"encrypt"> {
   let summary = "Encrypt an encoded plaintext into a BGV ciphertext.";
-  let arguments = (ins RLWEPlaintext:$input, RLWESecretKey:$secret_key);
+  let arguments = (ins RLWEPlaintext:$input, RLWESecretOrPublicKey:$key);
   let results = (outs RLWECiphertext:$output);
+  let hasVerifier = 1;
 }
 
 def BGV_DecryptOp : BGV_Op<"decrypt", [

--- a/include/Dialect/BGV/Transforms/Passes.td
+++ b/include/Dialect/BGV/Transforms/Passes.td
@@ -13,6 +13,10 @@ def AddClientInterface : Pass<"bgv-add-client-interface"> {
   be encoded as a tensor).
   }];
   let dependentDialects = ["mlir::heir::bgv::BGVDialect"];
+  let options = [
+    Option<"usePublicKey", "use-public-key", "bool", /*default=*/"false",
+           "If true, generate a client interface that uses a public key for encryption.">
+  ];
 }
 
 #endif  // INCLUDE_DIALECT_BGV_TRANSFORMS_PASSES_TD_

--- a/include/Dialect/LWE/IR/LWETypes.td
+++ b/include/Dialect/LWE/IR/LWETypes.td
@@ -12,6 +12,7 @@ include "mlir/IR/AttrTypeBase.td"
 class LWE_Type<string name, string typeMnemonic, list<Trait> traits = []>
     : TypeDef<LWE_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
+  let assemblyFormat = "`<` struct(params) `>`";
 }
 
 // LWE Ciphertexts are ranked tensors of integers representing the LWE samples
@@ -34,27 +35,28 @@ def LWECiphertext : LWE_Type<"LWECiphertext", "lwe_ciphertext", [MemRefElementTy
     "::mlir::Attribute":$encoding,
     OptionalParameter<"LWEParamsAttr">:$lwe_params
   );
-
-  let assemblyFormat = "`<` struct(params) `>`";
 }
 
 def RLWECiphertext : LWE_Type<"RLWECiphertext", "rlwe_ciphertext"> {
   let summary = "A type for RLWE ciphertexts";
-
   let parameters = (ins
     "::mlir::Attribute":$encoding,
     "RLWEParamsAttr":$rlwe_params,
     "Type":$underlying_type
   );
-
-  let assemblyFormat = "`<` struct(params) `>`";
 }
 
 def RLWESecretKey : LWE_Type<"RLWESecretKey", "rlwe_secret_key"> {
   let summary = "A secret key for RLWE";
   let parameters = (ins "RLWEParamsAttr":$rlwe_params);
-  let assemblyFormat = "`<` struct(params) `>`";
 }
+
+def RLWEPublicKey : LWE_Type<"RLWEPublicKey", "rlwe_public_key"> {
+  let summary = "A public key for RLWE";
+  let parameters = (ins "RLWEParamsAttr":$rlwe_params);
+}
+
+def RLWESecretOrPublicKey : AnyTypeOf<[RLWESecretKey, RLWEPublicKey]>;
 
 def LWEPlaintext : LWE_Type<"LWEPlaintext", "lwe_plaintext"> {
   let summary = "A type for LWE plaintexts";
@@ -69,8 +71,6 @@ def LWEPlaintext : LWE_Type<"LWEPlaintext", "lwe_plaintext"> {
   let parameters = (ins
     "::mlir::Attribute":$encoding
   );
-
-  let assemblyFormat = "`<` struct(params) `>`";
 }
 
 def RLWEPlaintext : LWE_Type<"RLWEPlaintext", "rlwe_plaintext"> {
@@ -81,8 +81,6 @@ def RLWEPlaintext : LWE_Type<"RLWEPlaintext", "rlwe_plaintext"> {
     "::mlir::heir::polynomial::RingAttr":$ring,
     "Type":$underlying_type
   );
-
-  let assemblyFormat = "`<` struct(params) `>`";
 }
 
 #endif  // INCLUDE_DIALECT_LWE_IR_LWETYPES_TD_

--- a/include/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/include/Dialect/Openfhe/IR/OpenfheOps.td
@@ -48,8 +48,21 @@ class Openfhe_BinaryOp<string mnemonic, list<Trait> traits = []>
 }
 
 def EncryptOp : Openfhe_Op<"encrypt", [Pure]> {
-  let arguments = (ins Openfhe_CryptoContext:$cryptoContext, RLWEPlaintext:$plaintext, Openfhe_PublicKey:$publicKey);
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWEPlaintext:$plaintext,
+    Openfhe_PublicKey:$publicKey)
+  ;
   let results = (outs RLWECiphertext:$output);
+}
+
+def DecryptOp : Openfhe_Op<"decrypt", [Pure]> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    RLWECiphertext:$ciphertext,
+    Openfhe_PrivateKey:$privateKey)
+  ;
+  let results = (outs RLWEPlaintext:$plaintext);
 }
 
 def AddOp : Openfhe_BinaryOp<"add"> { let summary = "OpenFHE add operation of two ciphertexts."; }
@@ -112,7 +125,7 @@ def RotOp : Openfhe_Op<"rot",[
   let results = (outs RLWECiphertext:$output);
 }
 
-def AutomorphOp : Openfhe_Op<"automorph",[
+def AutomorphOp : Openfhe_Op<"automorph", [
   Pure,
   AllTypesMatch<["ciphertext", "output"]>
 ]> {
@@ -135,6 +148,5 @@ def KeySwitchOp : Openfhe_Op<"key_switch", [
   );
   let results = (outs RLWECiphertext:$output);
 }
-
 
 #endif  // INCLUDE_DIALECT_OPENFHE_IR_OPENFHEOPS_TD_

--- a/include/Dialect/Openfhe/IR/OpenfheTypes.td
+++ b/include/Dialect/Openfhe/IR/OpenfheTypes.td
@@ -18,6 +18,10 @@ def Openfhe_PublicKey : Openfhe_Type<"PublicKey", "public_key"> {
   let summary = "The public key required to encrypt plaintext in OpenFHE.";
 }
 
+def Openfhe_PrivateKey : Openfhe_Type<"PrivateKey", "private_key"> {
+  let summary = "The private key required to decrypt a ciphertext in OpenFHE.";
+}
+
 def Openfhe_EvalKey : Openfhe_Type<"EvalKey", "eval_key"> {
   let summary = "The evaluation key required to keyswitch/relinearize/rotate/automorphism operation in OpenFHE.";
 }

--- a/include/Target/OpenFhePke/BUILD
+++ b/include/Target/OpenFhePke/BUILD
@@ -16,6 +16,7 @@ cc_library(
     ],
     deps = [
         "@heir//lib/Analysis/SelectVariableNames",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/include/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/include/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -4,6 +4,7 @@
 #include <string_view>
 
 #include "include/Analysis/SelectVariableNames/SelectVariableNames.h"
+#include "include/Dialect/LWE/IR/LWEOps.h"
 #include "include/Dialect/Openfhe/IR/OpenfheOps.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
@@ -44,21 +45,28 @@ class OpenFhePkeEmitter {
   // Functions for printing individual ops
   LogicalResult printOperation(::mlir::ModuleOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  LogicalResult printOperation(::mlir::arith::IndexCastOp op);
   LogicalResult printOperation(::mlir::func::FuncOp op);
   LogicalResult printOperation(::mlir::func::ReturnOp op);
+  LogicalResult printOperation(::mlir::heir::lwe::RLWEEncodeOp op);
+  LogicalResult printOperation(::mlir::heir::lwe::RLWEDecodeOp op);
+  LogicalResult printOperation(
+      ::mlir::heir::lwe::ReinterpretUnderlyingTypeOp op);
   LogicalResult printOperation(AddOp op);
-  LogicalResult printOperation(SubOp op);
+  LogicalResult printOperation(AutomorphOp op);
+  LogicalResult printOperation(DecryptOp op);
+  LogicalResult printOperation(EncryptOp op);
+  LogicalResult printOperation(KeySwitchOp op);
+  LogicalResult printOperation(LevelReduceOp op);
+  LogicalResult printOperation(ModReduceOp op);
+  LogicalResult printOperation(MulConstOp op);
   LogicalResult printOperation(MulOp op);
   LogicalResult printOperation(MulPlainOp op);
-  LogicalResult printOperation(MulConstOp op);
   LogicalResult printOperation(NegateOp op);
-  LogicalResult printOperation(SquareOp op);
   LogicalResult printOperation(RelinOp op);
-  LogicalResult printOperation(ModReduceOp op);
-  LogicalResult printOperation(LevelReduceOp op);
   LogicalResult printOperation(RotOp op);
-  LogicalResult printOperation(AutomorphOp op);
-  LogicalResult printOperation(KeySwitchOp op);
+  LogicalResult printOperation(SquareOp op);
+  LogicalResult printOperation(SubOp op);
 
   // Helpers for above
   LogicalResult printEvalMethod(::mlir::Value result,
@@ -69,7 +77,8 @@ class OpenFhePkeEmitter {
   // Emit an OpenFhe type
   LogicalResult emitType(Type type);
 
-  void emitAssignPrefix(::mlir::Value result);
+  void emitAutoAssignPrefix(::mlir::Value result);
+  LogicalResult emitTypedAssignPrefix(::mlir::Value result);
 };
 
 }  // namespace openfhe

--- a/include/Target/OpenFhePke/OpenFheUtils.h
+++ b/include/Target/OpenFhePke/OpenFheUtils.h
@@ -4,14 +4,20 @@
 #include <string>
 
 #include "mlir/include/mlir/IR/Types.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace openfhe {
 
-/// Convert a type to a string
+/// Convert a type to a string.
 ::mlir::FailureOr<std::string> convertType(::mlir::Type type);
+
+/// Find the CryptoContext SSA value in the input operation's parent func
+/// arguments.
+::mlir::FailureOr<::mlir::Value> getContextualCryptoContext(
+    ::mlir::Operation *op);
 
 }  // namespace openfhe
 }  // namespace heir

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -5,6 +5,7 @@
 #include "include/Dialect/BGV/IR/BGVOps.h"
 #include "include/Dialect/LWE/IR/LWEAttributes.h"
 #include "include/Dialect/LWE/IR/LWETypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Location.h"               // from @llvm-project
@@ -56,6 +57,23 @@ LogicalResult RotateOp::verify() {
   auto out = getOutput().getType();
   if (out.getRlweParams().getDimension() != 2) {
     return emitOpError() << "output.dim == 2 does not hold";
+  }
+  return success();
+}
+
+LogicalResult EncryptOp::verify() {
+  Type keyType = getKey().getType();
+  lwe::RLWEParamsAttr keyParams =
+      llvm::TypeSwitch<Type, lwe::RLWEParamsAttr>(keyType)
+          .Case<lwe::RLWEPublicKeyType, lwe::RLWESecretKeyType>(
+              [](auto key) { return key.getRlweParams(); })
+          .Default([](Type) {
+            llvm_unreachable("impossible by type constraints");
+            return nullptr;
+          });
+
+  if (getOutput().getType().getRlweParams() != keyParams) {
+    return emitOpError() << "input dimensions do not match";
   }
   return success();
 }

--- a/lib/Target/OpenFhePke/BUILD
+++ b/lib/Target/OpenFhePke/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],

--- a/lib/Target/OpenFhePke/OpenFhePkeHeaderEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeHeaderEmitter.cpp
@@ -10,6 +10,7 @@
 #include "llvm/include/llvm/ADT/TypeSwitch.h"           // from @llvm-project
 #include "llvm/include/llvm/Support/FormatVariadic.h"   // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
@@ -35,9 +36,9 @@ void registerToOpenFhePkeHeaderTranslation() {
         return translateToOpenFhePkeHeader(op, output);
       },
       [](DialectRegistry &registry) {
-        registry
-            .insert<func::FuncDialect, openfhe::OpenfheDialect, lwe::LWEDialect,
-                    ::mlir::heir::polynomial::PolynomialDialect>();
+        registry.insert<arith::ArithDialect, func::FuncDialect,
+                        openfhe::OpenfheDialect, lwe::LWEDialect,
+                        ::mlir::heir::polynomial::PolynomialDialect>();
       });
 }
 
@@ -90,7 +91,6 @@ LogicalResult OpenFhePkeHeaderEmitter::printOperation(func::FuncOp funcOp) {
   }
 
   os << " " << funcOp.getName() << "(";
-  os.indent();
 
   for (Value arg : funcOp.getArguments()) {
     if (failed(convertType(arg.getType()))) {
@@ -102,9 +102,7 @@ LogicalResult OpenFhePkeHeaderEmitter::printOperation(func::FuncOp funcOp) {
     auto res = convertType(value.getType());
     return res.value() + " " + variableNames->getNameForValue(value);
   });
-  os.unindent();
   os << ");\n";
-  os.indent();
 
   return success();
 }

--- a/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
@@ -7,7 +7,7 @@ namespace mlir {
 namespace heir {
 namespace openfhe {
 
-// The `// from @openfhe` is a bit of a hack to avoid out default copybara
+// The `// from @openfhe` is a bit of a hack to avoid default copybara
 // transforms for HEIR includes.
 
 // clang-format off
@@ -18,6 +18,9 @@ using namespace lbcrypto;
 using CiphertextT = ConstCiphertext<DCRTPoly>;
 using CryptoContextT = CryptoContext<DCRTPoly>;
 using EvalKeyT = EvalKey<DCRTPoly>;
+using PlaintextT = Plaintext;
+using PrivateKeyT = PrivateKey<DCRTPoly>;
+using PublicKeyT = PublicKey<DCRTPoly>;
 )cpp";
 // clang-format on
 

--- a/lib/Target/OpenFhePke/OpenFheUtils.cpp
+++ b/lib/Target/OpenFhePke/OpenFheUtils.cpp
@@ -4,9 +4,10 @@
 
 #include "include/Dialect/LWE/IR/LWETypes.h"
 #include "include/Dialect/Openfhe/IR/OpenfheTypes.h"
-#include "llvm/include/llvm/ADT/TypeSwitch.h"         // from @llvm-project
-#include "mlir/include/mlir/IR/Types.h"               // from @llvm-project
-#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"    // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -23,7 +24,51 @@ FailureOr<std::string> convertType(Type type) {
           [&](auto ty) { return std::string("Plaintext"); })
       .Case<openfhe::EvalKeyType>(
           [&](auto ty) { return std::string("EvalKeyT"); })
+      .Case<openfhe::PrivateKeyType>(
+          [&](auto ty) { return std::string("PrivateKeyT"); })
+      .Case<openfhe::PublicKeyType>(
+          [&](auto ty) { return std::string("PublicKeyT"); })
+      .Case<IndexType>([&](auto ty) { return std::string("size_t"); })
+      .Case<IntegerType>([&](auto ty) {
+        auto width = ty.getWidth();
+        if (width != 8 && width != 16 && width != 32 && width != 64) {
+          return FailureOr<std::string>();
+        }
+        SmallString<8> result;
+        llvm::raw_svector_ostream os(result);
+        os << "int" << width << "_t";
+        return FailureOr<std::string>(std::string(result));
+      })
+      .Case<RankedTensorType>([&](auto ty) {
+        if (ty.getRank() != 1) {
+          return FailureOr<std::string>();
+        }
+
+        auto eltTyResult = convertType(ty.getElementType());
+        if (failed(eltTyResult)) {
+          return FailureOr<std::string>();
+        }
+
+        SmallString<8> result;
+        llvm::raw_svector_ostream os(result);
+        os << "std::vector<" << eltTyResult.value() << ">";
+        return FailureOr<std::string>(std::string(result));
+      })
       .Default([&](Type &) { return failure(); });
+}
+
+FailureOr<Value> getContextualCryptoContext(Operation *op) {
+  Value cryptoContext = op->getParentOfType<func::FuncOp>()
+                            .getBody()
+                            .getBlocks()
+                            .front()
+                            .getArguments()
+                            .front();
+  if (!cryptoContext.getType().isa<openfhe::CryptoContextType>()) {
+    return op->emitOpError()
+           << "Found op in a function without a crypto context argument.";
+  }
+  return cryptoContext;
 }
 
 }  // namespace openfhe

--- a/lib/Target/Utils.cpp
+++ b/lib/Target/Utils.cpp
@@ -21,9 +21,11 @@ std::string commaSeparatedValues(
   if (values.empty()) {
     return std::string();
   }
-  return std::accumulate(
-      std::next(values.begin()), values.end(), valueToString(values[0]),
-      [&](std::string a, Value b) { return a + ", " + valueToString(b); });
+  return std::accumulate(std::next(values.begin()), values.end(),
+                         valueToString(values[0]),
+                         [&](const std::string& a, Value b) {
+                           return a + ", " + valueToString(b);
+                         });
 }
 
 FailureOr<std::string> commaSeparatedTypes(
@@ -47,10 +49,11 @@ std::string bracketEnclosedValues(
   if (values.empty()) {
     return std::string();
   }
-  return std::accumulate(
-      std::next(values.begin()), values.end(),
-      "[" + valueToString(values[0]) + "]",
-      [&](std::string a, Value b) { return a + "[" + valueToString(b) + "]"; });
+  return std::accumulate(std::next(values.begin()), values.end(),
+                         "[" + valueToString(values[0]) + "]",
+                         [&](const std::string& a, Value b) {
+                           return a + "[" + valueToString(b) + "]";
+                         });
 }
 
 std::string flattenIndexExpression(

--- a/tests/bgv/add_client_interface_public_key.mlir
+++ b/tests/bgv/add_client_interface_public_key.mlir
@@ -1,0 +1,49 @@
+// RUN: heir-opt --bgv-add-client-interface=use-public-key=true %s | FileCheck %s
+
+// These two types differ only on their underlying_type. The IR stays as the !in_ty
+// for the entire computation until the final extract op.
+#encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
+#params = #lwe.rlwe_params<ring = <cmod=463187969, ideal=#_polynomial.polynomial<1 + x**32>>>
+!in_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = tensor<32xi16>>
+!out_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = i16>
+
+func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  %c31 = arith.constant 31 : index
+  %0 = bgv.rotate %arg0, %c16 : !in_ty, index
+  %1 = bgv.add %arg0, %0 : !in_ty
+  %2 = bgv.rotate %1, %c8 : !in_ty, index
+  %3 = bgv.add %1, %2 : !in_ty
+  %4 = bgv.rotate %3, %c4 : !in_ty, index
+  %5 = bgv.add %3, %4 : !in_ty
+  %6 = bgv.rotate %5, %c2 : !in_ty, index
+  %7 = bgv.add %5, %6 : !in_ty
+  %8 = bgv.rotate %7, %c1 : !in_ty, index
+  %9 = bgv.add %7, %8 : !in_ty
+  %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
+  return %10 : !out_ty
+}
+
+// CHECK-LABEL: @simple_sum
+// CHECK-SAME: (%[[original_input:[^:]*]]: [[in_ty:[^)]*]])
+// CHECK-SAME: -> [[out_ty:[^{]*]] {
+
+// CHECK: @simple_sum__encrypt
+// CHECK-SAME: (%[[arg0:[^:]*]]: tensor<32xi16>,
+// CHECK-SAME:     %[[sk:.*]]: !lwe.rlwe_public_key
+// CHECK-SAME:     -> [[in_ty]] {
+// CHECK-NEXT:   %[[encoded:.*]] = lwe.rlwe_encode %[[arg0]]
+// CHECK-NEXT:   %[[encrypted:.*]] = bgv.encrypt %[[encoded]], %[[sk]]
+// CHECK-NEXT:   return %[[encrypted]]
+
+// CHECK: @simple_sum__decrypt
+// CHECK-SAME: (%[[arg1:[^:]*]]: [[out_ty]]
+// CHECK-SAME:     %[[sk2:.*]]: !lwe.rlwe_secret_key
+// CHECK-SAME:     -> i16 {
+// CHECK-NEXT:   %[[decrypted:.*]] = bgv.decrypt %[[arg1]], %[[sk2]]
+// CHECK-NEXT:   %[[decoded:.*]] = lwe.rlwe_decode %[[decrypted]]
+// CHECK-NEXT:   return %[[decoded]]

--- a/tests/mlir_to_openfhe_bgv/BUILD
+++ b/tests/mlir_to_openfhe_bgv/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/mlir_to_openfhe_bgv/simple_sum.mlir
+++ b/tests/mlir_to_openfhe_bgv/simple_sum.mlir
@@ -1,0 +1,14 @@
+// RUN: heir-opt --mlir-to-openfhe-bgv='entry-function=simple_sum ciphertext-degree=32' %s | FileCheck %s
+
+// CHECK-LABEL: @simple_sum
+// CHECK: openfhe
+func.func @simple_sum(%arg0: tensor<32xi16>) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %i = 0 to 32 iter_args(%sum_iter = %c0_si16) -> i16 {
+    %1 = tensor.extract %arg0[%i] : tensor<32xi16>
+    %2 = arith.addi %1, %sum_iter : i16
+    affine.yield %2 : i16
+  }
+  return %0 : i16
+}

--- a/tests/openfhe/end_to_end/BUILD
+++ b/tests/openfhe/end_to_end/BUILD
@@ -16,3 +16,14 @@ openfhe_end_to_end_test(
     ],
     test_src = "binops_test.cpp",
 )
+
+openfhe_end_to_end_test(
+    name = "simple_sum_test",
+    generated_lib_header = "simple_sum_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=simple_sum ciphertext-degree=32",
+    mlir_src = "simple_sum.mlir",
+    tags = [
+        "notap",
+    ],
+    test_src = "simple_sum_test.cpp",
+)

--- a/tests/openfhe/end_to_end/simple_sum.mlir
+++ b/tests/openfhe/end_to_end/simple_sum.mlir
@@ -1,0 +1,17 @@
+// This is effectively the pipeline run for this test, but it is run by bazel
+// and not lit, so the official definition of what command is run can be found
+// in the BUILD file for this directory, and the openfhe_end_to_end_test macro
+// in test.bzl
+//
+// heir-opt --mlir-to-openfhe-bgv='entry-function=simple_sum ciphertext-degree=32' %s | bazel-bin/tools/heir-translate --emit-openfhe-pke
+
+func.func @simple_sum(%arg0: tensor<32xi16>) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %i = 0 to 32 iter_args(%sum_iter = %c0_si16) -> i16 {
+    %1 = tensor.extract %arg0[%i] : tensor<32xi16>
+    %2 = arith.addi %1, %sum_iter : i16
+    affine.yield %2 : i16
+  }
+  return %0 : i16
+}

--- a/tests/openfhe/end_to_end/simple_sum_test.cpp
+++ b/tests/openfhe/end_to_end/simple_sum_test.cpp
@@ -1,0 +1,62 @@
+#include <cstdint>
+#include <vector>
+
+#include "gmock/gmock.h"              // from @googletest
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/openfhe/end_to_end/simple_sum_lib.h"
+
+using namespace lbcrypto;
+using ::testing::ElementsAre;
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(BinopsTest, TestInput1) {
+  CCParams<CryptoContextBGVRNS> parameters;
+  parameters.SetMultiplicativeDepth(2);
+  parameters.SetPlaintextModulus(65537);
+  CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
+  cryptoContext->Enable(PKE);
+  cryptoContext->Enable(KEYSWITCH);
+  cryptoContext->Enable(LEVELEDSHE);
+
+  KeyPair<DCRTPoly> keyPair;
+  keyPair = cryptoContext->KeyGen();
+  cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {1, 2, 4, 8, 16, 31});
+
+  int32_t n = cryptoContext->GetCryptoParameters()
+                  ->GetElementParams()
+                  ->GetCyclotomicOrder() /
+              2;
+  std::vector<int16_t> input;
+  // TODO(#645): support cyclic repetition in add-client-interface
+  // I want to do this, but MakePackedPlaintext does not repeat the values.
+  // It zero pads, and rotating the zero-padded values will not achieve the
+  // rotate-and-reduce trick required for simple_sum
+  //
+  // = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+  //    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+  //    23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
+  input.reserve(n);
+
+  for (int i = 0; i < n; ++i) {
+    input.push_back((i % 32) + 1);
+  }
+  int64_t expected = 16 * 33;
+
+  auto inputEncrypted =
+      simple_sum__encrypt(cryptoContext, input, keyPair.publicKey);
+  auto outputEncrypted = simple_sum(cryptoContext, inputEncrypted);
+  auto actual =
+      simple_sum__decrypt(cryptoContext, outputEncrypted, keyPair.secretKey);
+
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,24 +12,23 @@ cc_binary(
     name = "heir-opt",
     srcs = ["heir-opt.cpp"],
     data = select({
-        "@heir//:disable_yosys": [],
-        "//conditions:default": [
+        "@heir//:config_enable_yosys": [
             "@edu_berkeley_abc//:abc",
             "@heir//lib/Transforms/YosysOptimizer/yosys:share_files",
         ],
-    }),
-    defines = select({
-        "@heir//:disable_yosys": ["HEIR_NO_YOSYS=1"],
         "//conditions:default": [],
     }),
-    # Using the location directive to find share files results in multiple expanded paths.
-    env = select({
-        "@heir//:disable_yosys": {
-        },
-        "//conditions:default": {
-            "HEIR_ABC_BINARY": "$(location @edu_berkeley_abc//:abc)",
-            "HEIR_YOSYS_SCRIPTS_DIR": WORKSPACE_PATH + "lib/Transforms/YosysOptimizer/yosys",
-        },
+    # The strings in these defines are passed through various pre-processors,
+    # including the materializing of quoted strings as done in bash, so to
+    # ensure that the #define'd variables stay quoted strings in the generated
+    # C++, we need to enclose them in `\\\"` (an escaped backslash followed by
+    # an escaped quote).
+    defines = select({
+        "@heir//:config_enable_yosys": [
+            "HEIR_ABC_BINARY=\\\"$(location @edu_berkeley_abc//:abc)\\\"",
+            "HEIR_YOSYS_SCRIPTS_DIR=\\\"" + WORKSPACE_PATH + "lib/Transforms/YosysOptimizer/yosys\\\"",
+        ],
+        "//conditions:default": ["HEIR_NO_YOSYS=1"],
     }),
     includes = ["include"],
     deps = [
@@ -106,10 +105,10 @@ cc_binary(
         "@llvm-project//mlir:TosaToTensor",
         "@llvm-project//mlir:Transforms",
     ] + select({
-        "@heir//:disable_yosys": [],
-        "//conditions:default": [
+        "@heir//:config_enable_yosys": [
             "@heir//lib/Transforms/YosysOptimizer",
         ],
+        "//conditions:default": [],
     }),
 )
 

--- a/tools/heir-opt.bzl
+++ b/tools/heir-opt.bzl
@@ -1,0 +1,54 @@
+"""A rule for running heir-opt."""
+
+def executable_attr(label):
+    """A helper for declaring executable dependencies."""
+    return attr.label(
+        default = Label(label),
+        executable = True,
+        cfg = "exec",
+    )
+
+_HEIR_OPT = "@heir//tools:heir-opt"
+
+def _heir_opt_impl(ctx):
+    generated_file = ctx.outputs.generated_filename
+    args = ctx.actions.args()
+    args.add(ctx.attr.pass_flag)
+    args.add_all(["-o", generated_file.path])
+    args.add(ctx.file.src)
+    ctx.actions.run(
+        inputs = ctx.attr.src.files,
+        outputs = [generated_file],
+        arguments = [args],
+        executable = ctx.executable._heir_opt_binary,
+    )
+    return [
+        DefaultInfo(files = depset([generated_file, ctx.file.src])),
+    ]
+
+heir_opt = rule(
+    doc = """
+      This rule takes MLIR input and runs heir-opt on it to produce
+      a single output file after applying the given MLIR passes.
+      """,
+    implementation = _heir_opt_impl,
+    attrs = {
+        "src": attr.label(
+            doc = "A single MLIR source file to opt.",
+            allow_single_file = [".mlir"],
+        ),
+        "pass_flag": attr.string(
+            doc = """
+            The pass flags passed to heir-opt, e.g., --canonicalize
+            """,
+        ),
+        "generated_filename": attr.output(
+            doc = """
+            The name used for the output file, including the extension (e.g.,
+            <filename>.mlir).
+            """,
+            mandatory = True,
+        ),
+        "_heir_opt_binary": executable_attr(_HEIR_OPT),
+    },
+)


### PR DESCRIPTION
This PR runs an end-to-end example (`simple_sum`) through the `heir-simd-vectorizer` pipeline, with the new `bgv-add-client-interface`, down to OpenFHE codegen, and runs the generated code in a test.

Deficiencies (still need to file TODOs):

- OpenFHE's `MakePackedPlaintext` will zero-pad to the ring degree `N`, and this breaks the rotate-and-reduce trick, so instead I have to manually repeat the coefficients cyclically until it fills the whole ciphertext. I'd like to add this to the encode helper, and it suggests a bunch more work to do if we have an input cleartext tensor that is not divisible by the OpenFHE's ring degree (rotate-and-reduce tricks won't work in that case, or will have to be tweaked to account for the true underlying ring degree).
- Support non-tensor input types to the encode codegen
- move `int64_t` casting to a higher-level lowering (say, from BGV to OpenFHE)


The output code generated for simple_sum

```cpp

#include "src/pke/include/openfhe.h" // from @openfhe

using namespace lbcrypto;
using CiphertextT = ConstCiphertext<DCRTPoly>;
using CryptoContextT = CryptoContext<DCRTPoly>;
using EvalKeyT = EvalKey<DCRTPoly>;
using PlaintextT = Plaintext;
using PrivateKeyT = PrivateKey<DCRTPoly>;
using PublicKeyT = PublicKey<DCRTPoly>;

CiphertextT simple_sum(CryptoContextT v0, CiphertextT v1) {
  size_t v2 = 1;
  size_t v3 = 2;
  size_t v4 = 4;
  size_t v5 = 8;
  size_t v6 = 16;
  size_t v7 = 31;
  int64_t v8 = static_cast<int64_t>(v6);
  const auto& v9 = v0->EvalRotate(v1, v8);
  const auto& v10 = v0->EvalAdd(v1, v9);
  int64_t v11 = static_cast<int64_t>(v5);
  const auto& v12 = v0->EvalRotate(v10, v11);
  const auto& v13 = v0->EvalAdd(v10, v12);
  int64_t v14 = static_cast<int64_t>(v4);
  const auto& v15 = v0->EvalRotate(v13, v14);
  const auto& v16 = v0->EvalAdd(v13, v15);
  int64_t v17 = static_cast<int64_t>(v3);
  const auto& v18 = v0->EvalRotate(v16, v17);
  const auto& v19 = v0->EvalAdd(v16, v18);
  int64_t v20 = static_cast<int64_t>(v2);
  const auto& v21 = v0->EvalRotate(v19, v20);
  const auto& v22 = v0->EvalAdd(v19, v21);
  std::vector<int16_t> v23 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
  std::vector<int64_t> v23_cast(std::begin(v23), std::end(v23));
  const auto& v24 = v0->MakePackedPlaintext(v23_cast);
  const auto& v25 = v0->EvalMult(v22, v24);
  int64_t v26 = static_cast<int64_t>(v7);
  const auto& v27 = v0->EvalRotate(v25, v26);
  const auto& v28 = v27;
  return v28;
}

CiphertextT simple_sum__encrypt(CryptoContextT v29, std::vector<int16_t> v30, PublicKeyT v31) {
  std::vector<int64_t> v30_cast(std::begin(v30), std::end(v30));
  const auto& v32 = v29->MakePackedPlaintext(v30_cast);
  const auto& v33 = v29->Encrypt(v31, v32);
  return v33;
}

int16_t simple_sum__decrypt(CryptoContextT v34, CiphertextT v35, PrivateKeyT v36) {
  PlaintextT v37;
  v34->Decrypt(v36, v35, &v37);
  int16_t v38 = v37->GetPackedValue()[0];
  return v38;
}
```