### PR TITLE
Canonicalization patterns for NTT/INTT

### DIFF
--- a/include/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/include/Dialect/Polynomial/IR/PolynomialOps.td
@@ -157,6 +157,7 @@ def Polynomial_NTTOp : Polynomial_Op<"ntt", [Pure]> {
   let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` type($output)";
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure]> {
@@ -178,6 +179,7 @@ def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure]> {
   let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` type($output)";
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 #endif  // INCLUDE_DIALECT_POLYNOMIAL_IR_POLYNOMIALOPS_TD_

--- a/include/Dialect/Polynomial/IR/PolynomialPatterns.td
+++ b/include/Dialect/Polynomial/IR/PolynomialPatterns.td
@@ -30,4 +30,26 @@ def SubAsAdd : Pat<
         // FIXME: get this to work
         // (getPolynomialCoefficientIntAttribute $f, -1))))>;
 
+// %0 = _polynomial.ntt %p
+// %1 = _polynomial.intt %0
+// ---> %p
+def INTTAfterNTT : Pat<
+  (Polynomial_INTTOp
+    (Polynomial_NTTOp $poly)
+  ),
+  (replaceWithValue $poly),
+  []
+>;
+
+// %0 = _polynomial.intt %t
+// %1 = _polynomial.ntt %0
+// ---> %t
+def NTTAfterINTT : Pat<
+  (Polynomial_NTTOp
+    (Polynomial_INTTOp $tensor)
+  ),
+  (replaceWithValue $tensor),
+  []
+>;
+
 #endif  // INCLUDE_DIALECT_POLYNOMIAL_IR_POLYNOMIALPATTERNS_TD_

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
@@ -132,6 +132,16 @@ void SubOp::getCanonicalizationPatterns(RewritePatternSet &results,
   populateWithGenerated(results);
 }
 
+void NTTOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                        MLIRContext *context) {
+  populateWithGenerated(results);
+}
+
+void INTTOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
+  populateWithGenerated(results);
+}
+
 }  // namespace polynomial
 }  // namespace heir
 }  // namespace mlir

--- a/tests/polynomial/canonicalize_ntt.mlir
+++ b/tests/polynomial/canonicalize_ntt.mlir
@@ -1,0 +1,36 @@
+// RUN: heir-opt --canonicalize %s | FileCheck %s
+
+#cycl_2048 = #_polynomial.polynomial<1 + x**1024>
+#ring = #_polynomial.ring<cmod=4294967296, ideal=#cycl_2048>
+
+!tensor_ty = tensor<1024xi32, #ring>
+!poly_ty = !_polynomial.polynomial<#ring>
+
+// CHECK: module
+module {
+  // CHECK-LABLE: @test_canonicalize_intt_after_ntt
+  // CHECK: (%[[P:.*]]: [[T:.*]]) -> [[T]]
+  func.func @test_canonicalize_intt_after_ntt(%p0 : !poly_ty) -> !poly_ty {
+    // CHECK-NOT: _polynomial.ntt
+    // CHECK-NOT: _polynomial.intt
+    // CHECK: %[[RESULT:.+]] = _polynomial.add(%[[P]], %[[P]]) : [[T]]
+    %t0 = _polynomial.ntt %p0 : !poly_ty -> !tensor_ty
+    %p1 = _polynomial.intt %t0: !tensor_ty -> !poly_ty
+    %p2 = _polynomial.add(%p1, %p1): !poly_ty
+    // CHECK: return %[[RESULT]] : [[T]]
+    return %p2 : !poly_ty
+  }
+
+  // CHECK-LABLE: @test_canonicalize_ntt_after_intt
+  // CHECK: (%[[X:.*]]: [[T:.*]]) -> [[T]]
+  func.func @test_canonicalize_ntt_after_intt(%t0 : !tensor_ty) -> !tensor_ty {
+    // CHECK-NOT: _polynomial.intt
+    // CHECK-NOT: _polynomial.ntt
+    // CHECK: %[[RESULT:.+]] = arith.addi %[[X]], %[[X]] : [[T]]
+    %p0 = _polynomial.intt %t0 : !tensor_ty -> !poly_ty
+    %t1 = _polynomial.ntt %p0: !poly_ty -> !tensor_ty
+    %t2 = arith.addi %t1, %t1: !tensor_ty
+    // CHECK: return %[[RESULT]] : [[T]]
+    return %t2 : !tensor_ty
+  }
+}


### PR DESCRIPTION
This is a canonicalization pass that transforms `ntt(intt(x))` and `ntt(intt(x))` into `x`.