### PR TITLE
poly: add pass to convert poly.mul to use ntt ops

### DIFF
--- a/lib/Dialect/Polynomial/Transforms/BUILD
+++ b/lib/Dialect/Polynomial/Transforms/BUILD
@@ -1,0 +1,78 @@
+# Polynomial pass tablegen and headers.
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":NTTRewrites",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "NTTRewrites",
+    srcs = ["NTTRewrites.cpp"],
+    hdrs = [
+        "NTTRewrites.h",
+    ],
+    deps = [
+        ":ntt_rewrites_inc_gen",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=Polynomial",
+            ],
+            "Passes.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "PolynomialPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ntt_rewrites_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-rewriters"],
+            "NTTRewrites.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "NTTRewrites.td",
+    deps = [
+        "@heir//lib/DRR",
+        "@heir//lib/Dialect/Polynomial/IR:ops_inc_gen",
+        "@heir//lib/Dialect/Polynomial/IR:td_files",
+        "@llvm-project//mlir:ArithOpsTdFiles",
+    ],
+)

--- a/lib/Dialect/Polynomial/Transforms/NTTRewrites.cpp
+++ b/lib/Dialect/Polynomial/Transforms/NTTRewrites.cpp
@@ -1,0 +1,31 @@
+#include "lib/Dialect/Polynomial/Transforms/NTTRewrites.h"
+
+#include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
+#include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+#define GEN_PASS_DEF_POLYMULTONTT
+#include "lib/Dialect/Polynomial/Transforms/Passes.h.inc"
+
+namespace rewrites {
+// In an inner namespace to avoid conflicts with canonicalization patterns
+#include "lib/Dialect/Polynomial/Transforms/NTTRewrites.cpp.inc"
+}  // namespace rewrites
+
+struct PolyMulToNTT : impl::PolyMulToNTTBase<PolyMulToNTT> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<rewrites::NTTRewritePolyMul>(patterns.getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Polynomial/Transforms/NTTRewrites.h
+++ b/lib/Dialect/Polynomial/Transforms/NTTRewrites.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_POLYNOMIAL_TRANSFORMS_NTTREWRITES_H_
+#define LIB_DIALECT_POLYNOMIAL_TRANSFORMS_NTTREWRITES_H_
+
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"               // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+#define GEN_PASS_DECL_POLYMULTONTT
+#include "lib/Dialect/Polynomial/Transforms/Passes.h.inc"
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_POLYNOMIAL_TRANSFORMS_NTTREWRITES_H_

--- a/lib/Dialect/Polynomial/Transforms/NTTRewrites.td
+++ b/lib/Dialect/Polynomial/Transforms/NTTRewrites.td
@@ -1,0 +1,65 @@
+#ifndef LIB_DIALECT_POLYNOMIAL_TRANSFORMS_NTTREWRITES_TD_
+#define LIB_DIALECT_POLYNOMIAL_TRANSFORMS_NTTREWRITES_TD_
+
+include "lib/DRR/Utils.td"
+include "lib/Dialect/Polynomial/IR/PolynomialOps.td"
+include "mlir/Dialect/Arith/IR/ArithOps.td"
+include "mlir/IR/PatternBase.td"
+
+def GetRingAttr : NativeCodeCall<
+      "(dyn_cast<PolynomialType>($0.getType())).getRing()">;
+
+def InputTensorType : NativeCodeCall<
+      "RankedTensorType::get({$0.ideal().getDegree()},"
+      " IntegerType::get($_builder.getContext(),"
+      "  ($0.coefficientModulus() - 1).getActiveBits()),"
+      " $0)">;
+
+def IntermediateTensorType : NativeCodeCall<
+      "RankedTensorType::get({$0.ideal().getDegree()},"
+      " IntegerType::get($_builder.getContext(),"
+      "  2 * ($0.coefficientModulus() - 1).getActiveBits()),"
+      " $0)">;
+
+def CreateCModConstant : NativeCodeCall<
+      "$_builder.create<arith::ConstantOp>($0.getLoc(), $2,"
+      " DenseElementsAttr::get($2,"
+      "  $1.coefficientModulus().sextOrTrunc($2.getElementTypeBitWidth())))">;
+
+// Computes (n & (n - 1)) == 0.
+def HasDegreePowerOfTwo : Constraint<
+    CPred<"APInt(64, (dyn_cast<PolynomialType>($0.getType())).getRing()"
+          ".ideal().getDegree()).isPowerOf2()">,
+    "rings are NTT compatible">;
+
+def NTTRewritePolyMul : Pattern<
+  (Polynomial_MulOp:$mulOp $p1, $p2),
+  [
+    // Transform to NTT point-value representation
+    (Polynomial_NTTOp:$p1NTT $p1,
+      (returnType (InputTensorType (GetRingAttr $p1)))),
+    (Polynomial_NTTOp:$p2NTT $p2,
+      (returnType (InputTensorType (GetRingAttr $p2)))),
+
+    // Compute elementwise multiplication modulo cmod
+    (Arith_MulIOp:$mulNTT
+      (Arith_ExtUIOp $p1NTT,
+        (returnType (IntermediateTensorType (GetRingAttr $p1)))),
+      (Arith_ExtUIOp $p2NTT,
+        (returnType (IntermediateTensorType (GetRingAttr $p2)))),
+      DefOverflow),
+    (Arith_TruncIOp:$resNTT
+      (Arith_RemUIOp $mulNTT,
+        (CreateCModConstant $mulNTT,
+          (GetRingAttr $p1), (IntermediateTensorType (GetRingAttr $p2)))),
+      (returnType (InputTensorType (GetRingAttr $p1)))),
+
+    // Compute inverse transform back to coefficient representation
+    (Polynomial_INTTOp:$res $resNTT)
+  ],
+  [
+    (HasDegreePowerOfTwo $p1)
+  ]
+>;
+
+#endif  // LIB_DIALECT_POLYNOMIAL_TRANSFORMS_NTTREWRITES_TD_

--- a/lib/Dialect/Polynomial/Transforms/Passes.h
+++ b/lib/Dialect/Polynomial/Transforms/Passes.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_POLYNOMAIL_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_POLYNOMAIL_TRANSFORMS_PASSES_H_
+
+#include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "lib/Dialect/Polynomial/Transforms/NTTRewrites.h"
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Polynomial/Transforms/Passes.h.inc"
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_POLYNOMAIL_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/Polynomial/Transforms/Passes.td
+++ b/lib/Dialect/Polynomial/Transforms/Passes.td
@@ -1,0 +1,20 @@
+#ifndef LIB_DIALECT_POLYNOMIAL_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_POLYNOMIAL_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def PolyMulToNTT : Pass<"convert-polynomial-mul-to-ntt"> {
+  let summary = "Rewrites polynomial operations to their NTT equivalents";
+  let description = [{
+    Applies a rewrite pattern to convert polynomial multiplication to the
+    equivalent using the number-theoretic transforms (NTT) when possible.
+
+    Polynomial multiplication can be rewritten as polynomial.NTT
+    on each operand, followed by modulo elementwise multiplication of the
+    point-value representation and then the inverse-NTT back to coefficient
+    representation.
+  }];
+  let dependentDialects = ["mlir::heir::polynomial::PolynomialDialect"];
+}
+
+#endif  // LIB_DIALECT_POLYNOMIAL_TRANSFORMS_PASSES_TD_

--- a/tests/polynomial/ntt_rewrites.mlir
+++ b/tests/polynomial/ntt_rewrites.mlir
@@ -1,0 +1,33 @@
+// RUN: heir-opt --convert-polynomial-mul-to-ntt %s | FileCheck %s
+
+#ideal = #_polynomial.polynomial<1 + x**4>
+#ring = #_polynomial.ring<cmod=17, ideal=#ideal, root=2>
+!poly_ty = !_polynomial.polynomial<#ring>
+
+// CHECK: func.func @rewrite_poly_mul(%[[poly0:.*]]: [[POLY_TY:.*]], %[[poly1:.*]]: [[POLY_TY]]) -> [[POLY_TY]] {
+// CHECK:      %[[CMOD:.*]] = arith.constant dense<17> : [[INTERMEDIATE_TENSOR_TYPE:.*]]
+// CHECK:      %[[NTT_POLY0:.*]] = _polynomial.ntt %[[poly0]] : [[POLY_TY]] -> [[INPUT_TENSOR_TYPE:.*]]
+// CHECK:      %[[NTT_POLY1:.*]] = _polynomial.ntt %[[poly1]] : [[POLY_TY]] -> [[INPUT_TENSOR_TYPE]]
+// CHECK:      %[[NTT_EXT0:.*]] = arith.extui %[[NTT_POLY0]] : [[INPUT_TENSOR_TYPE]] to [[INTERMEDIATE_TENSOR_TYPE]]
+// CHECK:      %[[NTT_EXT1:.*]] = arith.extui %[[NTT_POLY1]] : [[INPUT_TENSOR_TYPE]] to [[INTERMEDIATE_TENSOR_TYPE]]
+// CHECK:      %[[NTT_MUL:.*]] = arith.muli %[[NTT_EXT0]], %[[NTT_EXT1]] : [[INTERMEDIATE_TENSOR_TYPE]]
+// CHECK:      %[[NTT_MOD:.*]] = arith.remui %[[NTT_MUL]], %[[CMOD]] : [[INTERMEDIATE_TENSOR_TYPE]]
+// CHECK:      %[[NTT_RES:.*]] = arith.trunci %[[NTT_MOD]] : [[INTERMEDIATE_TENSOR_TYPE]] to [[INPUT_TENSOR_TYPE]]
+// CHECK:      %[[RES:.*]] = _polynomial.intt %[[NTT_RES]] : [[INPUT_TENSOR_TYPE]] -> {{.*}}
+// CHECK:      return %[[RES]] : [[POLY_TY]]
+func.func @rewrite_poly_mul(%poly0: !poly_ty, %poly1: !poly_ty) -> !poly_ty {
+  %poly = _polynomial.mul(%poly0, %poly1) : !poly_ty
+  return %poly : !poly_ty
+}
+
+#bad_ideal = #_polynomial.polynomial<1 + x**6>
+#bad_ring = #_polynomial.ring<cmod=17, ideal=#bad_ideal>
+!bad_poly_ty = !_polynomial.polynomial<#bad_ring>
+
+// CHECK: func.func @rewrite_bad_poly_mul
+// CHECK:      %[[POLYMUL:.*]] = _polynomial.mul
+// CHECK:      return %[[POLYMUL]]
+func.func @rewrite_bad_poly_mul(%poly0: !bad_poly_ty, %poly1: !bad_poly_ty) -> !bad_poly_ty {
+  %poly = _polynomial.mul(%poly0, %poly1) : !bad_poly_ty
+  return %poly : !bad_poly_ty
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -53,6 +53,8 @@ cc_binary(
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/PolyExt/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@heir//lib/Dialect/Polynomial/Transforms",
+        "@heir//lib/Dialect/Polynomial/Transforms:NTTRewrites",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/Secret/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -22,6 +22,8 @@
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "lib/Dialect/PolyExt/IR/PolyExtDialect.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "lib/Dialect/Polynomial/Transforms/NTTRewrites.h"
+#include "lib/Dialect/Polynomial/Transforms/Passes.h"
 #include "lib/Dialect/RNS/IR/RNSDialect.h"
 #include "lib/Dialect/Secret/IR/SecretDialect.h"
 #include "lib/Dialect/Secret/Transforms/BufferizableOpInterfaceImpl.h"
@@ -497,6 +499,7 @@ int main(int argc, char **argv) {
   bgv::registerBGVPasses();
   cggi::registerCGGIPasses();
   lwe::registerLWEPasses();
+  ::mlir::heir::polynomial::registerPolynomialPasses();
   secret::registerSecretPasses();
   tensor_ext::registerTensorExtPasses();
   registerElementwiseToAffinePasses();


### PR DESCRIPTION
  - We can reduce complexity of polynomial multiplication by using the number-theoretic transform

  - Here we add a pass that will convert all poly.mul operations into a poly.ntt of both operands -> modulus multiplication of the coefficients -> poly.intt back into the polynomial type

Resolves #541