### PR TITLE
Add an end-to-end BGV/OpenFHE test for dot product

### DIFF
--- a/lib/Dialect/BGV/Transforms/AddClientInterface.cpp
+++ b/lib/Dialect/BGV/Transforms/AddClientInterface.cpp
@@ -26,90 +26,50 @@ namespace bgv {
 #define GEN_PASS_DEF_ADDCLIENTINTERFACE
 #include "lib/Dialect/BGV/Transforms/Passes.h.inc"
 
-/// Adds the client interface for a single func. This should only be used on the
-/// "entry" func for the IR being compiled, but there may be multiple.
-LogicalResult convertFunc(func::FuncOp op, bool usePublicKey) {
-  auto module = op->getParentOfType<ModuleOp>();
-  auto argTypes = op.getArgumentTypes();
-  auto returnTypes = op.getResultTypes();
-
-  ImplicitLocOpBuilder builder =
-      ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
-
-  std::string encFuncName("");
-  llvm::raw_string_ostream encNameOs(encFuncName);
-  encNameOs << op.getSymName() << "__encrypt";
-
-  std::string decFuncName("");
-  llvm::raw_string_ostream decNameOs(decFuncName);
-  decNameOs << op.getSymName() << "__decrypt";
-
-  // The enryption function converts each plaintext operand to its encrypted
-  // form. We also have to add a secret key arg, and we put it at the end to
-  // maintain zippability of the non-secret-key args.
-  SmallVector<Type> encFuncArgTypes;
-  SmallVector<Type> encFuncResultTypes;
+FailureOr<lwe::RLWEParamsAttr> getRlweParmsFromFuncOp(func::FuncOp op) {
   lwe::RLWEParamsAttr rlweParams = nullptr;
+  auto argTypes = op.getArgumentTypes();
   for (auto argTy : argTypes) {
     if (auto argCtTy = dyn_cast<lwe::RLWECiphertextType>(argTy)) {
-      encFuncArgTypes.push_back(argCtTy.getUnderlyingType());
-      encFuncResultTypes.push_back(argCtTy);
       if (rlweParams && rlweParams != argCtTy.getRlweParams()) {
-        op.emitError() << "Func op has multiple distinct RLWE params"
-                       << " but only 1 is currently supported per func.";
-        return failure();
+        return op.emitError() << "Func op has multiple distinct RLWE params"
+                              << " but only 1 is currently supported per func.";
       }
       rlweParams = argCtTy.getRlweParams();
-      continue;
     }
-
-    // For plaintext arguments, the function is a no-op
-    encFuncArgTypes.push_back(argTy);
-    encFuncResultTypes.push_back(argTy);
   }
-
   if (!rlweParams) {
-    op.emitError("Func op has no RLWE ciphertext inputs");
-    return failure();
+    return op.emitError() << "Func op has no RLWE ciphertext arguments.";
   }
+  return rlweParams;
+}
 
+/// Generates an encryption func for one or more types.
+LogicalResult generateEncryptionFunc(
+    func::FuncOp op, const std::string &encFuncName, TypeRange encFuncArgTypes,
+    TypeRange encFuncResultTypes, bool usePublicKey,
+    lwe::RLWEParamsAttr rlweParams, ImplicitLocOpBuilder &builder) {
+  // The enryption function converts each plaintext operand to its encrypted
+  // form. We also have to add a public/secret key arg, and we put it at the
+  // end to maintain zippability of the non-key args.
   Type encryptionKeyType =
       usePublicKey
           ? (Type)lwe::RLWEPublicKeyType::get(op.getContext(), rlweParams)
           : (Type)lwe::RLWESecretKeyType::get(op.getContext(), rlweParams);
-  Type decryptionKeyType =
-      lwe::RLWESecretKeyType::get(op.getContext(), rlweParams);
-  encFuncArgTypes.push_back(encryptionKeyType);
+  SmallVector<Type> funcArgTypes(encFuncArgTypes.begin(),
+                                 encFuncArgTypes.end());
+  funcArgTypes.push_back(encryptionKeyType);
 
-  // The decryption function is the opposite.
-  SmallVector<Type> decFuncArgTypes;
-  SmallVector<Type> decFuncResultTypes;
-  for (auto returnTy : returnTypes) {
-    if (auto returnCtTy = dyn_cast<lwe::RLWECiphertextType>(returnTy)) {
-      decFuncArgTypes.push_back(returnCtTy);
-      decFuncResultTypes.push_back(returnCtTy.getUnderlyingType());
-      continue;
-    }
-
-    // For plaintext results, the function is a no-op
-    decFuncArgTypes.push_back(returnTy);
-    decFuncResultTypes.push_back(returnTy);
-  }
-  decFuncArgTypes.push_back(decryptionKeyType);
-
-  // Build the encryption function first
-  FunctionType encFuncType = FunctionType::get(
-      builder.getContext(), encFuncArgTypes, encFuncResultTypes);
+  FunctionType encFuncType =
+      FunctionType::get(builder.getContext(), funcArgTypes, encFuncResultTypes);
   auto encFuncOp = builder.create<func::FuncOp>(encFuncName, encFuncType);
   Block *entryBlock = encFuncOp.addEntryBlock();
   builder.setInsertionPointToEnd(entryBlock);
   Value secretKey = encFuncOp.getArgument(encFuncOp.getNumArguments() - 1);
 
   SmallVector<Value> encValuesToReturn;
-  // Use result types because arg types has the secret key at the end, but
-  // result types does not
   // TODO(#615): encode/decode should convert scalar types to tensors.
-  for (size_t i = 0; i < encFuncResultTypes.size(); ++i) {
+  for (size_t i = 0; i < encFuncArgTypes.size(); ++i) {
     auto argTy = encFuncArgTypes[i];
     auto resultTy = encFuncResultTypes[i];
 
@@ -132,16 +92,28 @@ LogicalResult convertFunc(func::FuncOp op, bool usePublicKey) {
   }
 
   builder.create<func::ReturnOp>(encValuesToReturn);
+  return success();
+}
+
+/// Generates a decryption func for one or more types.
+LogicalResult generateDecryptionFunc(func::FuncOp op,
+                                     const std::string &decFuncName,
+                                     TypeRange decFuncArgTypes,
+                                     TypeRange decFuncResultTypes,
+                                     lwe::RLWEParamsAttr rlweParams,
+                                     ImplicitLocOpBuilder &builder) {
+  Type decryptionKeyType =
+      lwe::RLWESecretKeyType::get(op.getContext(), rlweParams);
+  SmallVector<Type> funcArgTypes(decFuncArgTypes.begin(),
+                                 decFuncArgTypes.end());
+  funcArgTypes.push_back(decryptionKeyType);
 
   // Then the decryption function
-  FunctionType decFuncType = FunctionType::get(
-      builder.getContext(), decFuncArgTypes, decFuncResultTypes);
-  // Insertion point is inside the encryption func, have to move it
-  // back out to the module
-  builder.setInsertionPointToEnd(module.getBody());
+  FunctionType decFuncType =
+      FunctionType::get(builder.getContext(), funcArgTypes, decFuncResultTypes);
   auto decFuncOp = builder.create<func::FuncOp>(decFuncName, decFuncType);
   builder.setInsertionPointToEnd(decFuncOp.addEntryBlock());
-  secretKey = decFuncOp.getArgument(decFuncOp.getNumArguments() - 1);
+  Value secretKey = decFuncOp.getArgument(decFuncOp.getNumArguments() - 1);
 
   SmallVector<Value> decValuesToReturn;
   // Use result types because arg types has the secret key at the end, but
@@ -172,6 +144,114 @@ LogicalResult convertFunc(func::FuncOp op, bool usePublicKey) {
   }
 
   builder.create<func::ReturnOp>(decValuesToReturn);
+  return success();
+}
+
+/// Adds the client interface for a single func. This should only be used on the
+/// "entry" func for the IR being compiled, but there may be multiple.
+LogicalResult convertFunc(func::FuncOp op, bool usePublicKey,
+                          bool oneValuePerHelperFn) {
+  auto module = op->getParentOfType<ModuleOp>();
+  auto rlweParamsResult = getRlweParmsFromFuncOp(op);
+  if (failed(rlweParamsResult)) {
+    return failure();
+  }
+  lwe::RLWEParamsAttr rlweParams = rlweParamsResult.value();
+  ImplicitLocOpBuilder builder =
+      ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
+
+  if (!oneValuePerHelperFn) {
+    std::string encFuncName("");
+    llvm::raw_string_ostream encNameOs(encFuncName);
+    encNameOs << op.getSymName() << "__encrypt";
+
+    std::string decFuncName("");
+    llvm::raw_string_ostream decNameOs(decFuncName);
+    decNameOs << op.getSymName() << "__decrypt";
+
+    SmallVector<Type> encFuncArgTypes;
+    SmallVector<Type> encFuncResultTypes;
+    auto argTypes = op.getArgumentTypes();
+
+    for (auto argTy : argTypes) {
+      if (auto argCtTy = dyn_cast<lwe::RLWECiphertextType>(argTy)) {
+        encFuncArgTypes.push_back(argCtTy.getUnderlyingType());
+        encFuncResultTypes.push_back(argCtTy);
+        continue;
+      }
+
+      // For plaintext arguments, the function is a no-op
+      encFuncArgTypes.push_back(argTy);
+      encFuncResultTypes.push_back(argTy);
+    }
+
+    if (failed(generateEncryptionFunc(op, encFuncName, encFuncArgTypes,
+                                      encFuncResultTypes, usePublicKey,
+                                      rlweParams, builder))) {
+      return failure();
+    }
+
+    // insertion point is inside encryption func, move back out
+    builder.setInsertionPointToEnd(module.getBody());
+
+    auto returnTypes = op.getResultTypes();
+    SmallVector<Type> decFuncArgTypes;
+    SmallVector<Type> decFuncResultTypes;
+    for (auto returnTy : returnTypes) {
+      if (auto returnCtTy = dyn_cast<lwe::RLWECiphertextType>(returnTy)) {
+        decFuncArgTypes.push_back(returnCtTy);
+        decFuncResultTypes.push_back(returnCtTy.getUnderlyingType());
+        continue;
+      }
+
+      // For plaintext results, the function is a no-op
+      decFuncArgTypes.push_back(returnTy);
+      decFuncResultTypes.push_back(returnTy);
+    }
+
+    if (failed(generateDecryptionFunc(op, decFuncName, decFuncArgTypes,
+                                      decFuncResultTypes, rlweParams,
+                                      builder))) {
+      return failure();
+    }
+    return success();
+  }
+
+  // Otherwise, we need one encryption function per argument and one decryption
+  // function per return value. This is mainly to avoid complicated C++ codegen
+  // when encrypting multiple inputs which requires out-params.
+  for (auto val : op.getArguments()) {
+    auto argTy = val.getType();
+    if (auto argCtTy = dyn_cast<lwe::RLWECiphertextType>(argTy)) {
+      std::string encFuncName("");
+      llvm::raw_string_ostream encNameOs(encFuncName);
+      encNameOs << op.getSymName() << "__encrypt__arg" << val.getArgNumber();
+      if (failed(generateEncryptionFunc(
+              op, encFuncName, {argCtTy.getUnderlyingType()}, {argCtTy},
+              usePublicKey, rlweParams, builder))) {
+        return failure();
+      }
+      // insertion point is inside func, move back out
+      builder.setInsertionPointToEnd(module.getBody());
+    }
+  }
+
+  ArrayRef<Type> returnTypes = op.getFunctionType().getResults();
+  for (size_t i = 0; i < returnTypes.size(); ++i) {
+    auto returnTy = returnTypes[i];
+    if (auto returnCtTy = dyn_cast<lwe::RLWECiphertextType>(returnTy)) {
+      std::string decFuncName("");
+      llvm::raw_string_ostream encNameOs(decFuncName);
+      encNameOs << op.getSymName() << "__decrypt__result" << i;
+      if (failed(generateDecryptionFunc(op, decFuncName, {returnCtTy},
+                                        {returnCtTy.getUnderlyingType()},
+                                        rlweParams, builder))) {
+        return failure();
+      }
+      // insertion point is inside func, move back out
+      builder.setInsertionPointToEnd(module.getBody());
+    }
+  }
 
   return success();
 }
@@ -182,7 +262,7 @@ struct AddClientInterface : impl::AddClientInterfaceBase<AddClientInterface> {
   void runOnOperation() override {
     auto result =
         getOperation()->walk<WalkOrder::PreOrder>([&](func::FuncOp op) {
-          if (failed(convertFunc(op, usePublicKey))) {
+          if (failed(convertFunc(op, usePublicKey, oneValuePerHelperFn))) {
             op->emitError("Failed to add client interface for func");
             return WalkResult::interrupt();
           }

--- a/lib/Dialect/BGV/Transforms/Passes.td
+++ b/lib/Dialect/BGV/Transforms/Passes.td
@@ -11,11 +11,71 @@ def AddClientInterface : Pass<"bgv-add-client-interface"> {
   while the compiled function may lose some of this information by the lowerings
   to ciphertext types (e.g., a scalar ciphertext, when lowered through BGV, must
   be encoded as a tensor).
+
+  Example:
+
+  For an input function with signature
+
+  ```mlir
+  #encoding = ...
+  #params = ...
+  !in_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = tensor<32xi16>>
+  !out_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = i16>
+  func.func @my_func(%arg0: !in_ty) -> !out_ty {
+    ...
+  }
+  ```
+
+  The pass will generate two new functions with signatures
+
+  ```mlir
+  func.func @my_func__encrypt(
+    %arg0: tensor<32xi16>,
+    %sk: !lwe.rlwe_secret_key<...>
+  ) -> !in_ty
+
+  func.func @my_func__decrypt(
+    %arg0: !out_ty,
+    %sk: !lwe.rlwe_secret_key<...>
+  ) -> i16
+  ```
+
+  The `my_func__encrypt` function has the same order of operands as `my_func`,
+  and uses their `underylying_type` as the corresponding input type.
+  The last operand is the encryption key.
+  The same holds for `my_func__decrypt`, but the inputs are the return types
+  of `my_func` and the results are the underlying types of the return types of `my_func`.
+
+  If `use-public-key` is set to true, the encrypt function uses
+  `lwe.rlwe_public_key` for encryption.
+
+  If `one-value-per-helper-fn` is set to true, the encryption helpers are split
+  into separate functions, one for each SSA value being converted. For example,
+  using the same `!in_ty` and `!out_ty` as above, this function signature
+
+  ```mlir
+  func.func @my_func(%arg0: !in_ty, %arg1: !in_ty) -> (!out_ty, !out_ty)
+  ```
+
+  generates the following four helpers.
+
+  ```mlir
+  func.func @my_func__encrypt__arg0(%arg0: tensor<32xi16>, %sk: !lwe.rlwe_secret_key<...>) -> !in_ty
+  func.func @my_func__encrypt__arg1(%arg1: tensor<32xi16>, %sk: !lwe.rlwe_secret_key<...>) -> !in_ty
+  func.func @my_func__decrypt__result0(%arg0: !out_ty, %sk: !lwe.rlwe_secret_key<...>) -> i16
+  func.func @my_func__decrypt__result1(%arg1: !out_ty, %sk: !lwe.rlwe_secret_key<...>) -> i16
+  }
+  ```
+
+  The suffix `__argN` indicates the SSA value being encrypted is the N-th argument of `my_func`,
+  and similarly for `__resultN`.
   }];
   let dependentDialects = ["mlir::heir::bgv::BGVDialect"];
   let options = [
     Option<"usePublicKey", "use-public-key", "bool", /*default=*/"false",
-           "If true, generate a client interface that uses a public key for encryption.">
+           "If true, generate a client interface that uses a public key for encryption.">,
+    Option<"oneValuePerHelperFn", "one-value-per-helper-fn", "bool", /*default=*/"false",
+           "If true, split encryption helpers into separate functions for each SSA value.">
   ];
 }
 

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -74,9 +74,9 @@ LogicalResult OpenFhePkeEmitter::translate(Operation &op) {
                 lwe::ReinterpretUnderlyingTypeOp>(
               [&](auto op) { return printOperation(op); })
           // OpenFHE ops
-          .Case<AddOp, SubOp, MulOp, MulPlainOp, SquareOp, NegateOp, MulConstOp,
-                RelinOp, ModReduceOp, LevelReduceOp, RotOp, AutomorphOp,
-                KeySwitchOp, EncryptOp, DecryptOp>(
+          .Case<AddOp, SubOp, MulNoRelinOp, MulOp, MulPlainOp, SquareOp,
+                NegateOp, MulConstOp, RelinOp, ModReduceOp, LevelReduceOp,
+                RotOp, AutomorphOp, KeySwitchOp, EncryptOp, DecryptOp>(
               [&](auto op) { return printOperation(op); })
           .Default([&](Operation &) {
             return op.emitOpError("unable to find printer for op");
@@ -192,6 +192,11 @@ LogicalResult OpenFhePkeEmitter::printOperation(AddOp op) {
 LogicalResult OpenFhePkeEmitter::printOperation(SubOp op) {
   return printEvalMethod(op.getResult(), op.getCryptoContext(),
                          {op.getLhs(), op.getRhs()}, "EvalSub");
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(MulNoRelinOp op) {
+  return printEvalMethod(op.getResult(), op.getCryptoContext(),
+                         {op.getLhs(), op.getRhs()}, "EvalMultNoRelin");
 }
 
 LogicalResult OpenFhePkeEmitter::printOperation(MulOp op) {

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -60,6 +60,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(LevelReduceOp op);
   LogicalResult printOperation(ModReduceOp op);
   LogicalResult printOperation(MulConstOp op);
+  LogicalResult printOperation(MulNoRelinOp op);
   LogicalResult printOperation(MulOp op);
   LogicalResult printOperation(MulPlainOp op);
   LogicalResult printOperation(NegateOp op);

--- a/tests/bgv/add_client_interface_split.mlir
+++ b/tests/bgv/add_client_interface_split.mlir
@@ -1,0 +1,29 @@
+// RUN: heir-opt '--bgv-add-client-interface=use-public-key=true one-value-per-helper-fn=true' %s | FileCheck %s
+
+#encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
+#params = #lwe.rlwe_params<ring = <cmod=463187969, ideal=#_polynomial.polynomial<1 + x**8>>>
+!in_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = tensor<8xi16>>
+!out_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = i16>
+!mul_ty = !lwe.rlwe_ciphertext<encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>, rlwe_params = <dimension = 3, ring = <cmod=463187969, ideal=#_polynomial.polynomial<1 + x**8>>>, underlying_type = tensor<8xi16>>
+
+func.func @dot_product(%arg0: !in_ty, %arg1: !in_ty) -> (!out_ty, !out_ty) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  %c7 = arith.constant 7 : index
+  %0 = bgv.mul %arg0, %arg1 : (!in_ty, !in_ty) -> !mul_ty
+  %1 = bgv.relinearize %0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !mul_ty -> !in_ty
+  %2 = bgv.rotate %1, %c4 : !in_ty, index
+  %3 = bgv.add %1, %2 : !in_ty
+  %4 = bgv.rotate %3, %c2 : !in_ty, index
+  %5 = bgv.add %3, %4 : !in_ty
+  %6 = bgv.rotate %5, %c1 : !in_ty, index
+  %7 = bgv.add %5, %6 : !in_ty
+  %8 = bgv.extract %7, %c7 : (!in_ty, index) -> !out_ty
+  return %8, %8 : !out_ty, !out_ty
+}
+
+// CHECK: func.func @dot_product__encrypt__arg0
+// CHECK: func.func @dot_product__encrypt__arg1
+// CHECK: func.func @dot_product__decrypt__result0
+// CHECK: func.func @dot_product__decrypt__result1

--- a/tests/openfhe/end_to_end/BUILD
+++ b/tests/openfhe/end_to_end/BUILD
@@ -11,9 +11,7 @@ openfhe_end_to_end_test(
     name = "binops_test",
     generated_lib_header = "binops_lib.h",
     mlir_src = "binops.mlir",
-    tags = [
-        "notap",
-    ],
+    tags = ["notap"],
     test_src = "binops_test.cpp",
 )
 
@@ -22,8 +20,15 @@ openfhe_end_to_end_test(
     generated_lib_header = "simple_sum_lib.h",
     heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=simple_sum ciphertext-degree=32",
     mlir_src = "simple_sum.mlir",
-    tags = [
-        "notap",
-    ],
+    tags = ["notap"],
     test_src = "simple_sum_test.cpp",
+)
+
+openfhe_end_to_end_test(
+    name = "dot_product_8_test",
+    generated_lib_header = "dot_product_8_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=dot_product ciphertext-degree=8",
+    mlir_src = "dot_product_8.mlir",
+    tags = ["notap"],
+    test_src = "dot_product_8_test.cpp",
 )

--- a/tests/openfhe/end_to_end/dot_product_8.mlir
+++ b/tests/openfhe/end_to_end/dot_product_8.mlir
@@ -1,0 +1,12 @@
+func.func @dot_product(%arg0: tensor<8xi16>, %arg1: tensor<8xi16>) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %arg2 = 0 to 8 iter_args(%iter = %c0_si16) -> (i16) {
+    %1 = tensor.extract %arg0[%arg2] : tensor<8xi16>
+    %2 = tensor.extract %arg1[%arg2] : tensor<8xi16>
+    %3 = arith.muli %1, %2 : i16
+    %4 = arith.addi %iter, %3 : i16
+    affine.yield %4 : i16
+  }
+  return %0 : i16
+}

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -450,6 +450,7 @@ void mlirToOpenFheBgvPipelineBuilder(
   auto addClientInterfaceOptions = bgv::AddClientInterfaceOptions{};
   // OpenFHE's pke API, which this pipeline generates, is always public-key
   addClientInterfaceOptions.usePublicKey = true;
+  addClientInterfaceOptions.oneValuePerHelperFn = true;
   pm.addPass(bgv::createAddClientInterface(addClientInterfaceOptions));
 
   // Lower to openfhe


### PR DESCRIPTION
To add an e2e test for dot product, this PR modifies `bgv-add-client-interface` to create separate encryption/decryption functions for each input/output value of the compiled function. Otherwise the codegen would have to be modified to have multiple return values via outparams, which I think is more fuss than it's worth.