### PR TITLE
add e2e roberts cross example

### DIFF
--- a/tests/heir_simd_vectorizer/roberts_cross_64x64.mlir
+++ b/tests/heir_simd_vectorizer/roberts_cross_64x64.mlir
@@ -7,16 +7,18 @@ module{
   // CHECK-LABEL: @roberts_cross
   // CHECK-SAME: (%[[arg0:.*]]: !secret.secret<tensor<4096xi16>>) -> !secret.secret<tensor<4096xi16>> {
   // CHECK-NEXT: %[[cMinusOne:.*]] = arith.constant 4095 : index
-  // CHECK-NEXT: %[[cMinusRow:.*]] = arith.constant 4031 : index
+  // CHECK-NEXT: %[[cMinusRow:.*]] = arith.constant 4032 : index
+  // CHECK-NEXT: %[[cMinusRowMinusOne:.*]] = arith.constant 4031 : index
   // CHECK-NEXT: secret.generic ins(%[[arg0]] : !secret.secret<tensor<4096xi16>>) {
   // CHECK-NEXT:  ^bb0(%[[arg1:.*]]: tensor<4096xi16>):
-  // CHECK-NEXT:    %[[v1:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusRow]]
+  // CHECK-NEXT:    %[[v1:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusRowMinusOne]]
   // CHECK-NEXT:    %[[v2:.*]] = arith.subi %[[v1]], %[[arg1]]
-  // CHECK-NEXT:    %[[v3:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusOne]]
-  // CHECK-NEXT:    %[[v4:.*]] = arith.subi %[[v1]], %[[v3]]
-  // CHECK-DAG:     %[[v5:.*]] = arith.muli %[[v2]], %[[v2]]
-  // CHECK-DAG:     %[[v6:.*]] = arith.muli %[[v4]], %[[v4]]
-  // CHECK-NEXT:    %[[v7:.*]] = arith.addi %[[v5]], %[[v6]]
+  // CHECK-NEXT:    %[[v3:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusRow]]
+  // CHECK-NEXT:    %[[v4:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusOne]]
+  // CHECK-NEXT:    %[[v5:.*]] = arith.subi %[[v3]], %[[v4]]
+  // CHECK-DAG:     %[[v6:.*]] = arith.muli %[[v5]], %[[v5]]
+  // CHECK-DAG:     %[[v7:.*]] = arith.muli %[[v2]], %[[v2]]
+  // CHECK-NEXT:    %[[v8:.*]] = arith.addi %[[v7]], %[[v6]]
   func.func @roberts_cross(%img: tensor<4096xi16>) -> tensor<4096xi16> {
     %c4096 = arith.constant 4096 : index
     %c64 = arith.constant 64 : index
@@ -49,8 +51,7 @@ module{
         // fetch img[x-1][y]
         %15 = arith.addi %x, %c-1 : index
         %16 = arith.muli %15, %c64 : index
-        %17 = arith.addi %y, %c-1 : index
-        %18 = arith.addi %16, %17 : index
+        %18 = arith.addi %16, %y : index
         %19 = arith.remui %18, %c4096 : index
         %20 = tensor.extract %img[%19] : tensor<4096xi16>
 

--- a/tests/openfhe/end_to_end/BUILD
+++ b/tests/openfhe/end_to_end/BUILD
@@ -41,3 +41,12 @@ openfhe_end_to_end_test(
     tags = ["notap"],
     test_src = "box_blur_test.cpp",
 )
+
+openfhe_end_to_end_test(
+    name = "roberts_cross_64x64_test",
+    generated_lib_header = "roberts_cross_64x64_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=roberts_cross ciphertext-degree=4096",
+    mlir_src = "roberts_cross_64x64.mlir",
+    tags = ["notap"],
+    test_src = "roberts_cross_test.cpp",
+)

--- a/tests/openfhe/end_to_end/roberts_cross_64x64.mlir
+++ b/tests/openfhe/end_to_end/roberts_cross_64x64.mlir
@@ -1,0 +1,61 @@
+func.func @roberts_cross(%img: tensor<4096xi16>) -> tensor<4096xi16> {
+  %c4096 = arith.constant 4096 : index
+  %c64 = arith.constant 64 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %c-1 =  arith.constant -1 : index
+
+  // Each point p = img[x][y], where x is row and y is column, in the new image will equal:
+  // (img[x-1][y-1] - img[x][y])^2 + (img[x-1][y] - img[x][y-1])^2
+  %r = affine.for %x = 0 to 64 iter_args(%imgx = %img) -> tensor<4096xi16> {
+    %1 = affine.for %y = 0 to 64 iter_args(%imgy = %imgx) -> tensor<4096xi16> {
+
+      // fetch img[x-1][y-1]
+      %4 = arith.addi %x, %c-1 : index
+      %5 = arith.muli %4, %c64 : index
+      %6 = arith.addi %y, %c-1 : index
+      %7 = arith.addi %5, %6 : index
+      %8 = arith.remui %7, %c4096 : index
+      %9 = tensor.extract %img[%8] : tensor<4096xi16>
+
+      // fetch img[x][y]
+      %10 = arith.muli %x, %c64 : index
+      %11 = arith.addi %10, %y : index
+      %12 = arith.remui %11, %c4096 : index
+      %13 = tensor.extract %img[%12] : tensor<4096xi16>
+
+      // subtract those two
+      %14 = arith.subi %9, %13 : i16
+
+      // fetch img[x-1][y]
+      %15 = arith.addi %x, %c-1 : index
+      %16 = arith.muli %15, %c64 : index
+      %18 = arith.addi %16, %y : index
+      %19 = arith.remui %18, %c4096 : index
+      %20 = tensor.extract %img[%19] : tensor<4096xi16>
+
+      // fetch img[x][y-1]
+      %21 = arith.muli %x, %c64 : index
+      %22 = arith.addi %y, %c-1 : index
+      %23 = arith.addi %21, %22 : index
+      %24 = arith.remui %23, %c4096 : index
+      %25 = tensor.extract %img[%24] : tensor<4096xi16>
+
+      // subtract those two
+      %26 = arith.subi %20, %25 : i16
+
+      // square each difference
+      %27 = arith.muli %14, %14 :  i16
+      %28 = arith.muli %26, %26 :  i16
+
+      // add the squares
+      %29 = arith.addi %27, %28 : i16
+
+      // save to result[x][y]
+      %30 = tensor.insert %29 into %imgy[%12] : tensor<4096xi16>
+      affine.yield %30: tensor<4096xi16>
+    }
+    affine.yield %1 : tensor<4096xi16>
+  }
+  return %r : tensor<4096xi16>
+}

--- a/tests/openfhe/end_to_end/roberts_cross_test.cpp
+++ b/tests/openfhe/end_to_end/roberts_cross_test.cpp
@@ -1,0 +1,84 @@
+#include <cstdint>
+#include <vector>
+
+#include "gmock/gmock.h"                               // from @googletest
+#include "gtest/gtest.h"                               // from @googletest
+#include "src/core/include/lattice/hal/lat-backend.h"  // from @openfhe
+#include "src/pke/include/constants.h"                 // from @openfhe
+#include "src/pke/include/cryptocontext-fwd.h"         // from @openfhe
+#include "src/pke/include/gen-cryptocontext.h"         // from @openfhe
+#include "src/pke/include/key/keypair.h"               // from @openfhe
+#include "src/pke/include/openfhe.h"                   // from @openfhe
+#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-params.h"  // from @openfhe
+#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns.h"  // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/openfhe/end_to_end/roberts_cross_64x64_lib.h"
+
+using ::testing::ContainerEq;
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(BinopsTest, TestInput1) {
+  CCParams<CryptoContextBGVRNS> parameters;
+  parameters.SetMultiplicativeDepth(2);
+  // needs to be large enough to accommodate overflow in the plaintext space
+  // pick a 32-bit prime for which (p-1) / 65536 is an integer.
+  parameters.SetPlaintextModulus(4295294977);
+  CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
+  cryptoContext->Enable(PKE);
+  cryptoContext->Enable(KEYSWITCH);
+  cryptoContext->Enable(LEVELEDSHE);
+
+  KeyPair<DCRTPoly> keyPair;
+  keyPair = cryptoContext->KeyGen();
+  cryptoContext->EvalMultKeyGen(keyPair.secretKey);
+  cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {4031, 4032, 4095});
+
+  int32_t n = cryptoContext->GetCryptoParameters()
+                  ->GetElementParams()
+                  ->GetCyclotomicOrder() /
+              2;
+  std::vector<int16_t> input;
+  std::vector<int16_t> expected;
+  input.reserve(n);
+  expected.reserve(4096);
+
+  // TODO(#645): support cyclic repetition in add-client-interface
+  for (int i = 0; i < n; ++i) {
+    input.push_back(i % 4096);
+  }
+
+  for (int row = 0; row < 64; ++row) {
+    for (int col = 0; col < 64; ++col) {
+      // (img[x-1][y-1] - img[x][y])^2 + (img[x-1][y] - img[x][y-1])^2
+      int xY = (row * 64 + col) % 4096;
+      int xYm1 = (row * 64 + col - 1) % 4096;
+      int xm1Y = ((row - 1) * 64 + col) % 4096;
+      int xm1Ym1 = ((row - 1) * 64 + col - 1) % 4096;
+
+      if (xYm1 < 0) xYm1 += 4096;
+      if (xm1Y < 0) xm1Y += 4096;
+      if (xm1Ym1 < 0) xm1Ym1 += 4096;
+
+      int16_t v1 = (input[xm1Ym1] - input[xY]);
+      int16_t v2 = (input[xm1Y] - input[xYm1]);
+      int16_t sum = v1 * v1 + v2 * v2;
+      expected.push_back(sum);
+    }
+  }
+
+  auto inputEncrypted =
+      roberts_cross__encrypt__arg0(cryptoContext, input, keyPair.publicKey);
+  auto outputEncrypted = roberts_cross(cryptoContext, inputEncrypted);
+  auto actual = roberts_cross__decrypt__result0(cryptoContext, outputEncrypted,
+                                                keyPair.secretKey);
+
+  EXPECT_THAT(actual, ContainerEq(expected));
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
Fix bug in the roberts cross input MLIR where the index to input[x-1][y] was incorrectly computed as input[x-1][y-1]