### PR TITLE
Abstract importer classes need an explicit virtual destructor

### DIFF
--- a/lib/Transforms/YosysOptimizer/BooleanGateImporter.h
+++ b/lib/Transforms/YosysOptimizer/BooleanGateImporter.h
@@ -21,6 +21,8 @@ class BooleanGateImporter : public RTLILImporter {
  public:
   BooleanGateImporter(MLIRContext *context) : RTLILImporter(context) {}
 
+  ~BooleanGateImporter() override = default;
+
  protected:
   Operation *createOp(Yosys::RTLIL::Cell *cell, SmallVector<Value> &inputs,
                       ImplicitLocOpBuilder &b) const override;

--- a/lib/Transforms/YosysOptimizer/LUTImporter.h
+++ b/lib/Transforms/YosysOptimizer/LUTImporter.h
@@ -20,6 +20,7 @@ namespace heir {
 class LUTImporter : public RTLILImporter {
  public:
   LUTImporter(MLIRContext *context) : RTLILImporter(context) {}
+  ~LUTImporter() override = default;
 
  protected:
   Operation *createOp(Yosys::RTLIL::Cell *cell, SmallVector<Value> &inputs,

--- a/lib/Transforms/YosysOptimizer/RTLILImporter.h
+++ b/lib/Transforms/YosysOptimizer/RTLILImporter.h
@@ -42,6 +42,8 @@ class RTLILImporter {
   func::FuncOp importModule(Yosys::RTLIL::Module *module,
                             const SmallVector<std::string, 10> &cellOrdering);
 
+  virtual ~RTLILImporter() = default;
+
  protected:
   // cellToOp converts an RTLIL cell to an MLIR operation.
   virtual Operation *createOp(Yosys::RTLIL::Cell *cell,


### PR DESCRIPTION
With Apple Clang 15.0.0, the implicitly generated destructors for `BooleanGateImporter`, `RTLILImporter`, and `LUTImporter` cause a run-time error when attempting to run any pipeline that uses them. Explicitly marking them virtual fixes this.