### PR TITLE
fix #693 (SmallVector<T> vs SmallVector<T,4>)

### DIFF
--- a/lib/Transforms/YosysOptimizer/BooleanGateImporter.cpp
+++ b/lib/Transforms/YosysOptimizer/BooleanGateImporter.cpp
@@ -40,7 +40,7 @@ mlir::Operation *BooleanGateImporter::createOp(Yosys::RTLIL::Cell *cell,
 SmallVector<Yosys::RTLIL::SigSpec> BooleanGateImporter::getInputs(
     Yosys::RTLIL::Cell *cell) const {
   // Return all non-Y named attributes.
-  SmallVector<Yosys::RTLIL::SigSpec, 4> inputs;
+  SmallVector<Yosys::RTLIL::SigSpec> inputs;
   for (auto &conn : cell->connections()) {
     if (conn.first.contains("Y")) {
       continue;

--- a/lib/Transforms/YosysOptimizer/LUTImporter.cpp
+++ b/lib/Transforms/YosysOptimizer/LUTImporter.cpp
@@ -54,7 +54,7 @@ SmallVector<Yosys::RTLIL::SigSpec> LUTImporter::getInputs(
   }
   // Alphabetical order gives LSB to MSB, but LUT operations order their inputs
   // from MSB to LSB.
-  SmallVector<Yosys::RTLIL::SigSpec, 4> reversed;
+  SmallVector<Yosys::RTLIL::SigSpec> reversed;
   reversed.reserve(inputs.size());
   for (unsigned i = 0; i < inputs.size(); i++) {
     reversed.push_back(inputs[inputs.size() - i - 1]);


### PR DESCRIPTION
Fixes #693:

While some compilers allow returning `SmallVector<T,4>` when the function return type is `SmallVector<T>`, others (including gcc 11.4.0) do not. Not sure which behavior is the correct one, but unless setting the default size is critical for performance here, this should be an easy fix for the issue.