### PR TITLE
Draft: Generate a helper function that configures OpenFHE crypto context

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -47,13 +47,43 @@ class Openfhe_BinaryOp<string mnemonic, list<Trait> traits = []>
   let results = (outs RLWECiphertext:$output);
 }
 
+def GenParamsOp : Openfhe_Op<"gen_params"> {
+  let arguments = (ins
+    I64Attr:$mulDepth,
+    I64Attr:$plainMod
+  );
+  let results = (outs Openfhe_CCParams:$params);
+}
+
+def GenContextOp : Openfhe_Op<"gen_context"> {
+  let arguments = (ins
+    Openfhe_CCParams:$params
+  );
+  let results = (outs Openfhe_CryptoContext:$context);
+}
+
+def GenMulKeyOp : Openfhe_Op<"gen_mulkey"> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    Openfhe_PrivateKey:$privateKey
+  );
+}
+
+def GenRotKeyOp : Openfhe_Op<"gen_rotkey"> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    Openfhe_PrivateKey:$privateKey,
+    DenseI64ArrayAttr:$indices
+  );
+}
+
 def EncryptOp : Openfhe_Op<"encrypt", [Pure]> {
   let arguments = (ins
     Openfhe_CryptoContext:$cryptoContext,
     RLWEPlaintext:$plaintext,
     Openfhe_PublicKey:$publicKey)
   ;
-  let results = (outs RLWECiphertext:$output);
+  let results = (outs RLWECiphertext:$ciphertext);
 }
 
 def DecryptOp : Openfhe_Op<"decrypt", [Pure]> {

--- a/lib/Dialect/Openfhe/IR/OpenfheTypes.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheTypes.td
@@ -26,6 +26,10 @@ def Openfhe_EvalKey : Openfhe_Type<"EvalKey", "eval_key"> {
   let summary = "The evaluation key required to keyswitch/relinearize/rotate/automorphism operation in OpenFHE.";
 }
 
+def Openfhe_CCParams : Openfhe_Type<"CCParams", "cc_params"> {
+  let summary = "The CCParams required to create CryptoContext.";
+}
+
 def Openfhe_CryptoContext : Openfhe_Type<"CryptoContext", "crypto_context"> {
   let summary = "The CryptoContext required to perform homomorphic operations in OpenFHE.";
 }

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -1,0 +1,58 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":ConfigureCryptoContext",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+    ],
+)
+
+cc_library(
+    name = "ConfigureCryptoContext",
+    srcs = ["ConfigureCryptoContext.cpp"],
+    hdrs = [
+        "ConfigureCryptoContext.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=Openfhe",
+            ],
+            "Passes.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "OpenfhePasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -1,0 +1,160 @@
+#include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
+
+#include <cstddef>
+#include <set>
+#include <string>
+
+#include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheTypes.h"
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DEF_CONFIGURECRYPTOCONTEXT
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+// Helper function to check if the function has MulOp or MulNoRelinOp
+bool hasMulOp(func::FuncOp op) {
+  bool result = false;
+  op.walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (isa<openfhe::MulOp>(op) || isa<openfhe::MulNoRelinOp>(op) ||
+        isa<openfhe::MulPlainOp>(op)) {
+      result = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return result;
+}
+
+// Helper function to find all the rotation indices in the function
+SmallVector<int64_t> findAllRotIndices(func::FuncOp op) {
+  std::set<int64_t> distinctRotIndices;
+  op.walk([&](openfhe::RotOp rotOp) {
+    auto indexAttr =
+        dyn_cast<arith::ConstantOp>(rotOp.getIndex().getDefiningOp())
+            .getValue();
+    int64_t rotIndex = dyn_cast<IntegerAttr>(indexAttr).getInt();
+    distinctRotIndices.insert(rotIndex);
+    return WalkResult::advance();
+  });
+  SmallVector<int64_t> rotIndicesResult(distinctRotIndices.begin(),
+                                        distinctRotIndices.end());
+  return rotIndicesResult;
+}
+
+// function that generates the crypto context with proper parameters
+LogicalResult generateGenFunc(func::FuncOp op, const std::string &genFuncName,
+                              ImplicitLocOpBuilder &builder) {
+  Type openfheContextType =
+      openfhe::CryptoContextType::get(builder.getContext());
+  SmallVector<Type> funcArgTypes;
+  SmallVector<Type> funcResultTypes;
+  funcResultTypes.push_back(openfheContextType);
+
+  FunctionType genFuncType =
+      FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
+  auto genFuncOp = builder.create<func::FuncOp>(genFuncName, genFuncType);
+  builder.setInsertionPointToEnd(genFuncOp.addEntryBlock());
+
+  // TODO(#661) : Calculate the appropriate values by analyzing the function
+  int64_t mulDepth = 2;
+  int64_t plainMod = 4295294977;
+  Type openfheParamsType = openfhe::CCParamsType::get(builder.getContext());
+  Value ccParams = builder.create<openfhe::GenParamsOp>(openfheParamsType,
+                                                        mulDepth, plainMod);
+  Value cryptoContext =
+      builder.create<openfhe::GenContextOp>(openfheContextType, ccParams);
+
+  builder.create<func::ReturnOp>(cryptoContext);
+  return success();
+}
+
+// function that configures the crypto context with proper keygeneration
+LogicalResult generateConfigFunc(func::FuncOp op,
+                                 const std::string &configFuncName,
+                                 bool hasMulOp, SmallVector<int64_t> rotIndices,
+                                 ImplicitLocOpBuilder &builder) {
+  Type openfheContextType =
+      openfhe::CryptoContextType::get(builder.getContext());
+  Type privateKeyType = openfhe::PrivateKeyType::get(builder.getContext());
+
+  SmallVector<Type> funcArgTypes;
+  funcArgTypes.push_back(openfheContextType);
+  funcArgTypes.push_back(privateKeyType);
+
+  SmallVector<Type> funcResultTypes;
+  funcResultTypes.push_back(openfheContextType);
+
+  FunctionType configFuncType =
+      FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
+  auto configFuncOp =
+      builder.create<func::FuncOp>(configFuncName, configFuncType);
+  builder.setInsertionPointToEnd(configFuncOp.addEntryBlock());
+
+  Value cryptoContext = configFuncOp.getArgument(0);
+  Value privateKey = configFuncOp.getArgument(1);
+
+  if (hasMulOp) {
+    builder.create<openfhe::GenMulKeyOp>(cryptoContext, privateKey);
+  }
+  if (!rotIndices.empty()) {
+    builder.create<openfhe::GenRotKeyOp>(cryptoContext, privateKey, rotIndices);
+  }
+
+  builder.create<func::ReturnOp>(cryptoContext);
+  return success();
+}
+
+LogicalResult convertFunc(func::FuncOp op) {
+  auto module = op->getParentOfType<ModuleOp>();
+  std::string genFuncName("");
+  llvm::raw_string_ostream genNameOs(genFuncName);
+  genNameOs << op.getSymName() << "__generate_crypto_context";
+
+  std::string configFuncName("");
+  llvm::raw_string_ostream configNameOs(configFuncName);
+  configNameOs << op.getSymName() << "__configure_crypto_context";
+
+  ImplicitLocOpBuilder builder =
+      ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
+
+  if (failed(generateGenFunc(op, genFuncName, builder))) {
+    return failure();
+  }
+
+  builder.setInsertionPointToEnd(module.getBody());
+
+  bool hasMulOpResult = hasMulOp(op);
+  SmallVector<int64_t> rotIndices = findAllRotIndices(op);
+  if (failed(generateConfigFunc(op, configFuncName, hasMulOpResult, rotIndices,
+                                builder))) {
+    return failure();
+  }
+  return success();
+}
+
+struct ConfigureCryptoContext
+    : impl::ConfigureCryptoContextBase<ConfigureCryptoContext> {
+  using ConfigureCryptoContextBase::ConfigureCryptoContextBase;
+
+  void runOnOperation() override {
+    auto result =
+        getOperation()->walk<WalkOrder::PreOrder>([&](func::FuncOp op) {
+          auto funcName = op.getSymName();
+          if ((funcName == entryFunction) && failed(convertFunc(op))) {
+            op->emitError("Failed to configure the crypto context for func");
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
+    if (result.wasInterrupted()) signalPassFailure();
+  }
+};
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_OPENFHE_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+#define LIB_DIALECT_OPENFHE_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DECL_CONFIGURECRYPTOCONTEXT
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_

--- a/lib/Dialect/Openfhe/Transforms/Passes.h
+++ b/lib/Dialect/Openfhe/Transforms/Passes.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_H_
+
+#include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
+#include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/Openfhe/Transforms/Passes.td
+++ b/lib/Dialect/Openfhe/Transforms/Passes.td
@@ -1,0 +1,27 @@
+#ifndef LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ConfigureCryptoContext : Pass<"openfhe-configure-crypto-context"> {
+  let summary = "Configure the crypto context in OpenFHE";
+  let description = [{
+     This pass generates helper functions to generate and configure the OpenFHE crypto context for the given function. Generating the crypto context sets the appropriate encryption parameters, while the configuration generates the necessary evaluation keys (relinearization and rotation keys).
+
+     For example, for an MLIR function `@my_func`, the generated helpers have the following signatures
+     ```mlir
+    func.func  @my_func__generate_crypto_context() -> !openfhe.crypto_context
+
+    func.func  @my_func__configure_crypto_context(!openfhe.crypto_context, !openfhe.private_key) -> !openfhe.crypto_context
+     ```
+  }];
+  let dependentDialects = ["mlir::heir::openfhe::OpenfheDialect"];
+  let options = [
+    Option<"entryFunction", "entry-function", "std::string",
+           /*default=*/"", "Default entry function "
+           "name of entry function.">
+
+  ];
+}
+
+#endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_TD_

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -56,6 +56,10 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(AutomorphOp op);
   LogicalResult printOperation(DecryptOp op);
   LogicalResult printOperation(EncryptOp op);
+  LogicalResult printOperation(GenParamsOp op);
+  LogicalResult printOperation(GenContextOp op);
+  LogicalResult printOperation(GenMulKeyOp op);
+  LogicalResult printOperation(GenRotKeyOp op);
   LogicalResult printOperation(KeySwitchOp op);
   LogicalResult printOperation(LevelReduceOp op);
   LogicalResult printOperation(ModReduceOp op);

--- a/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
@@ -16,6 +16,7 @@ constexpr std::string_view kModulePrelude = R"cpp(
 
 using namespace lbcrypto;
 using CiphertextT = ConstCiphertext<DCRTPoly>;
+using CCParamsT = CCParams<CryptoContextBGVRNS>;
 using CryptoContextT = CryptoContext<DCRTPoly>;
 using EvalKeyT = EvalKey<DCRTPoly>;
 using PlaintextT = Plaintext;

--- a/lib/Target/OpenFhePke/OpenFheUtils.cpp
+++ b/lib/Target/OpenFhePke/OpenFheUtils.cpp
@@ -23,6 +23,7 @@ FailureOr<std::string> convertType(Type type) {
       // For now, these types are defined in the prelude as aliases.
       .Case<CryptoContextType>(
           [&](auto ty) { return std::string("CryptoContextT"); })
+      .Case<CCParamsType>([&](auto ty) { return std::string("CCParamsT"); })
       .Case<lwe::RLWECiphertextType>(
           [&](auto ty) { return std::string("CiphertextT"); })
       .Case<lwe::RLWEPlaintextType>(

--- a/tests/openfhe/configure_crypto_context.mlir
+++ b/tests/openfhe/configure_crypto_context.mlir
@@ -1,0 +1,38 @@
+// RUN: heir-opt --openfhe-configure-crypto-context=entry-function=simple_sum %s | FileCheck %s
+
+#encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
+#ideal = #_polynomial.polynomial<1 + x**32>
+#params = #lwe.rlwe_params<ring = <cmod=463187969, ideal=#ideal>>
+!in_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = tensor<32xi16>>
+!out_ty = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #params, underlying_type = i16>
+!ctxt_ty = !openfhe.crypto_context
+!plain_ty = !lwe.rlwe_plaintext<encoding = #encoding, ring = <cmod=463187969, ideal=#_polynomial.polynomial<1 + x**32>>, underlying_type = tensor<32xi16>>
+
+func.func @simple_sum(%arg0: !ctxt_ty, %arg1: !in_ty) -> !out_ty {
+  %c31_i64 = arith.constant 31 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c2_i64 = arith.constant 2 : i64
+  %c4_i64 = arith.constant 4 : i64
+  %c8_i64 = arith.constant 8 : i64
+  %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]> : tensor<32xi16>
+  %c16_i64 = arith.constant 16 : i64
+  %0 = openfhe.rot %arg0, %arg1, %c16_i64 : (!ctxt_ty, !in_ty, i64) -> !in_ty
+  %1 = openfhe.add %arg0, %arg1, %0 : (!ctxt_ty, !in_ty, !in_ty) -> !in_ty
+  %2 = openfhe.rot %arg0, %1, %c8_i64 : (!ctxt_ty, !in_ty, i64) -> !in_ty
+  %3 = openfhe.add %arg0, %1, %2 : (!ctxt_ty, !in_ty, !in_ty) -> !in_ty
+  %4 = openfhe.rot %arg0, %3, %c4_i64 : (!ctxt_ty, !in_ty, i64) -> !in_ty
+  %5 = openfhe.add %arg0, %3, %4 : (!ctxt_ty, !in_ty, !in_ty) -> !in_ty
+  %6 = openfhe.rot %arg0, %5, %c2_i64 : (!ctxt_ty, !in_ty, i64) -> !in_ty
+  %7 = openfhe.add %arg0, %5, %6 : (!ctxt_ty, !in_ty, !in_ty) -> !in_ty
+  %8 = openfhe.rot %arg0, %7, %c1_i64 : (!ctxt_ty, !in_ty, i64) -> !in_ty
+  %9 = openfhe.add %arg0, %7, %8 : (!ctxt_ty, !in_ty, !in_ty) -> !in_ty
+  %10 = lwe.rlwe_encode %cst {encoding = #encoding, ring = #_polynomial.ring<cmod=463187969, ideal=#ideal>} : tensor<32xi16> -> !plain_ty
+  %11 = openfhe.mul_plain %arg0, %9, %10 : (!ctxt_ty, !in_ty, !plain_ty) -> !in_ty
+  %12 = openfhe.rot %arg0, %11, %c31_i64 : (!ctxt_ty, !in_ty, i64) -> !in_ty
+  %13 = lwe.reinterpret_underlying_type %12 : !in_ty to !out_ty
+  return %13 : !out_ty
+}
+
+// CHECK-LABEL: @simple_sum
+// CHECK: @simple_sum__generate_crypto_context
+// CHECK: @simple_sum__configure_crypto_context

--- a/tests/openfhe/end_to_end/box_blur_test.cpp
+++ b/tests/openfhe/end_to_end/box_blur_test.cpp
@@ -21,21 +21,15 @@ namespace mlir {
 namespace heir {
 namespace openfhe {
 
-TEST(BinopsTest, TestInput1) {
-  CCParams<CryptoContextBGVRNS> parameters;
-  parameters.SetMultiplicativeDepth(2);
+TEST(BoxBlurTest, TestInput1) {
   // needs to be large enough to accommodate overflow in the plaintext space
   // 786433 is the smallest prime p above 2**17 for which (p-1) / 65536 is an
   // integer.
-  parameters.SetPlaintextModulus(786433);
-  CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
-  cryptoContext->Enable(PKE);
-  cryptoContext->Enable(KEYSWITCH);
-  cryptoContext->Enable(LEVELEDSHE);
-
-  KeyPair<DCRTPoly> keyPair;
-  keyPair = cryptoContext->KeyGen();
-  cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {65, 3968, 127, 4032, 63});
+  auto cryptoContext = box_blur__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext = box_blur__configure_crypto_context(cryptoContext, secretKey);
 
   int32_t n = cryptoContext->GetCryptoParameters()
                   ->GetElementParams()

--- a/tests/openfhe/end_to_end/dot_product_8_test.cpp
+++ b/tests/openfhe/end_to_end/dot_product_8_test.cpp
@@ -21,18 +21,12 @@ namespace openfhe {
 TEST(DotProduct8Test, RunTest) {
   // TODO(#661): Generate a helper function to set up CryptoContext based on
   // what is used in the generated code.
-  CCParams<CryptoContextBGVRNS> parameters;
-  parameters.SetMultiplicativeDepth(2);
-  parameters.SetPlaintextModulus(65537);
-  CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
-  cryptoContext->Enable(PKE);
-  cryptoContext->Enable(KEYSWITCH);
-  cryptoContext->Enable(LEVELEDSHE);
-
-  KeyPair<DCRTPoly> keyPair;
-  keyPair = cryptoContext->KeyGen();
-  cryptoContext->EvalMultKeyGen(keyPair.secretKey);
-  cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {1, 2, 4, 7});
+  auto cryptoContext = dot_product__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      dot_product__configure_crypto_context(cryptoContext, secretKey);
 
   int32_t n = cryptoContext->GetCryptoParameters()
                   ->GetElementParams()
@@ -54,13 +48,13 @@ TEST(DotProduct8Test, RunTest) {
   }
 
   auto arg0Encrypted =
-      dot_product__encrypt__arg0(cryptoContext, arg0, keyPair.publicKey);
+      dot_product__encrypt__arg0(cryptoContext, arg0, publicKey);
   auto arg1Encrypted =
-      dot_product__encrypt__arg1(cryptoContext, arg1, keyPair.publicKey);
+      dot_product__encrypt__arg1(cryptoContext, arg1, publicKey);
   auto outputEncrypted =
       dot_product(cryptoContext, arg0Encrypted, arg1Encrypted);
-  auto actual = dot_product__decrypt__result0(cryptoContext, outputEncrypted,
-                                              keyPair.secretKey);
+  auto actual =
+      dot_product__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
 
   EXPECT_EQ(expected, actual);
 }

--- a/tests/openfhe/end_to_end/roberts_cross_test.cpp
+++ b/tests/openfhe/end_to_end/roberts_cross_test.cpp
@@ -21,21 +21,13 @@ namespace mlir {
 namespace heir {
 namespace openfhe {
 
-TEST(BinopsTest, TestInput1) {
-  CCParams<CryptoContextBGVRNS> parameters;
-  parameters.SetMultiplicativeDepth(2);
-  // needs to be large enough to accommodate overflow in the plaintext space
-  // pick a 32-bit prime for which (p-1) / 65536 is an integer.
-  parameters.SetPlaintextModulus(4295294977);
-  CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
-  cryptoContext->Enable(PKE);
-  cryptoContext->Enable(KEYSWITCH);
-  cryptoContext->Enable(LEVELEDSHE);
-
-  KeyPair<DCRTPoly> keyPair;
-  keyPair = cryptoContext->KeyGen();
-  cryptoContext->EvalMultKeyGen(keyPair.secretKey);
-  cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {4031, 4032, 4095});
+TEST(RobertsCrossTest, TestInput1) {
+  auto cryptoContext = roberts_cross__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      roberts_cross__configure_crypto_context(cryptoContext, secretKey);
 
   int32_t n = cryptoContext->GetCryptoParameters()
                   ->GetElementParams()

--- a/tests/openfhe/end_to_end/simple_sum_test.cpp
+++ b/tests/openfhe/end_to_end/simple_sum_test.cpp
@@ -19,17 +19,12 @@ namespace heir {
 namespace openfhe {
 
 TEST(BinopsTest, TestInput1) {
-  CCParams<CryptoContextBGVRNS> parameters;
-  parameters.SetMultiplicativeDepth(2);
-  parameters.SetPlaintextModulus(65537);
-  CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
-  cryptoContext->Enable(PKE);
-  cryptoContext->Enable(KEYSWITCH);
-  cryptoContext->Enable(LEVELEDSHE);
-
-  KeyPair<DCRTPoly> keyPair;
-  keyPair = cryptoContext->KeyGen();
-  cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {1, 2, 4, 8, 16, 31});
+  auto cryptoContext = simple_sum__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      simple_sum__configure_crypto_context(cryptoContext, secretKey);
 
   int32_t n = cryptoContext->GetCryptoParameters()
                   ->GetElementParams()

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -53,6 +53,8 @@ cc_binary(
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/LWE/Transforms",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@heir//lib/Dialect/Openfhe/Transforms",
+        "@heir//lib/Dialect/Openfhe/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/PolyExt/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/Transforms",
         "@heir//lib/Dialect/Polynomial/Transforms:NTTRewrites",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -22,6 +22,8 @@
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/Passes.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
+#include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
+#include "lib/Dialect/Openfhe/Transforms/Passes.h"
 #include "lib/Dialect/PolyExt/IR/PolyExtDialect.h"
 #include "lib/Dialect/Polynomial/Transforms/NTTRewrites.h"
 #include "lib/Dialect/Polynomial/Transforms/Passes.h"
@@ -460,6 +462,11 @@ void mlirToOpenFheBgvPipelineBuilder(
 
   // Lower to openfhe
   pm.addPass(bgv::createBGVToOpenfhe());
+  pm.addPass(createCanonicalizerPass());
+  auto configureCryptoContextOptions = openfhe::ConfigureCryptoContextOptions{};
+  configureCryptoContextOptions.entryFunction = options.entryFunction;
+  pm.addPass(
+      openfhe::createConfigureCryptoContext(configureCryptoContextOptions));
 }
 
 int main(int argc, char **argv) {
@@ -501,6 +508,7 @@ int main(int argc, char **argv) {
   ::mlir::heir::polynomial::registerPolynomialPasses();
   secret::registerSecretPasses();
   tensor_ext::registerTensorExtPasses();
+  openfhe::registerOpenfhePasses();
   registerElementwiseToAffinePasses();
   registerSecretizePasses();
   registerFullLoopUnrollPasses();


### PR DESCRIPTION
Made a pass in the OpenFHE dialect to generate a helper function that configures OpenFHE crypto context. (#661)

edit:
I think the configurations can be split into two phases:
1. Setting appropriate encryption parameters (`CCParams`) when generating the crypto context.
2. Calling the appropriate each `KeyGen` APIs on the generated crypto context.

Therefore, I have decided to create two helper functions for each phase: generate_crypto_context and configure_crypto_context.

Current Status:

- [x] Make `ConfigureCryptoContext` pass in the OpenFHE dialect
- [x] Generate the helper functions
- [x] Add ops and types corresponding to `CCParams` and `CryptoContext` API in OpenFHE
- [x] Add OpenFhePke printers
- [x] Express each `KeyGen`s (~~`KeyGen`~~, `EvalKeyGen`, `EvalRotateKeyGen`) in OpenFHE dialect
- [ ] Find appropriate encryption parameters(`mulDepth`, `plainMod`) by analyzing the given function
- [x] Configurate each keygen (`EvalMultKeyGen`, vector of indices for `EvalRotateKeyGen`) by analyzing the given function
- [ ] Add more tests