### PR TITLE
Add lwe.add, lwe.mul_scalar, and cggi.lut_lincomb

### DIFF
--- a/lib/Dialect/CGGI/IR/CGGIOps.td
+++ b/lib/Dialect/CGGI/IR/CGGIOps.td
@@ -21,7 +21,6 @@ class CGGI_Op<string mnemonic, list<Trait> traits = []> :
 }
 
 // --- Operations for a gate-bootstrapping API of a CGGI library ---
-def LWECiphertextLike : TypeOrContainer<LWECiphertext, "ciphertext-like">;
 
 class CGGI_BinaryGateOp<string mnemonic>
   : CGGI_Op<mnemonic, [
@@ -65,10 +64,9 @@ class CGGI_LutOp<string mnemonic, list<Trait> traits = []>
   ElementwiseMappable,
   Scalarizable,
   DeclareOpInterfaceMethods<LUTOpInterface>
-
 ]> {
   let results = (outs LWECiphertextLike:$output);
-  let assemblyFormat = "`(` operands `)` attr-dict `:` qualified(type($output))" ;
+  let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
 
   let description = [{
     An op representing a lookup table applied to some number `n` of ciphertexts
@@ -97,6 +95,52 @@ def CGGI_Lut3Op : CGGI_LutOp<"lut3", [AllTypesMatch<["a", "b", "c", "output"]>]>
   let summary = "A lookup table on three inputs.";
   let arguments = (ins LWECiphertextLike:$c, LWECiphertextLike:$b, LWECiphertextLike:$a, Builtin_IntegerAttr:$lookup_table);
   let results = (outs LWECiphertextLike:$output);
+}
+
+def CGGI_LutLinCombOp : CGGI_Op<"lut_lincomb", [
+  Pure,
+  Commutative,
+  ElementwiseMappable,
+  Scalarizable,
+  SameOperandsAndResultType,
+  DeclareOpInterfaceMethods<LUTOpInterface>
+]> {
+  let summary = "A variadic-input lookup table with inputs prepared via linear combination.";
+  let description = [{
+    An op representing a lookup table applied to an arbitrary number of
+    input ciphertexts, which are combined according to a static linear
+    combination attached to the op.
+
+    The user must ensure the chosen linear combination does not bleed error
+    bits into the message space according to the underlying ciphertext's
+    encoding attributes. E.g., a bit_field_encoding with 3 cleartext bits
+    cannot be multiplied by 16.
+
+    Example:
+
+    ```mlir
+    #encoding = #lwe.bit_field_encoding<cleartext_start=30, cleartext_bitwidth=3>
+    #params = #lwe.lwe_params<cmod=7917, dimension=4>
+    !ciphertext = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+    %4 = cggi.lut_lincomb %c0, %c1, %c2, %c3 {coefficients = array<i32: 1, 2, 3, 2>, lookup_table = 68 : index} : !ciphertext
+    ```
+
+    Represents applying the lut
+
+    ```
+      68 >> (1 * c0 + 2 * c1 + 3 * c2 + 2 * c3)
+    ```
+  }];
+
+  let arguments = (ins
+    Variadic<LWECiphertext>:$inputs,
+    DenseI32ArrayAttr:$coefficients,
+    Builtin_IntegerAttr:$lookup_table
+  );
+  let results = (outs LWECiphertext:$output);
+  let assemblyFormat = "operands attr-dict `:` type($output)" ;
+  let hasVerifier = 1;
 }
 
 #endif  // HEIR_LIB_DIALECT_CGGI_IR_CGGIOPS_TD_

--- a/lib/Dialect/LWE/IR/LWEOps.h
+++ b/lib/Dialect/LWE/IR/LWEOps.h
@@ -4,6 +4,7 @@
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 
 #define GET_OP_CLASSES
 #include "lib/Dialect/LWE/IR/LWEOps.h.inc"

--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -93,6 +93,21 @@ def LWE_TrivialEncryptOp: LWE_Op<"trivial_encrypt", [
   let hasVerifier = 1;
 }
 
+def LWE_AddOp : LWE_Op<"add", [
+    Pure, Commutative, SameOperandsAndResultType]> {
+  let summary = "Add two LWE ciphertexts";
+  let arguments = (ins LWECiphertextLike:$lhs, LWECiphertextLike:$rhs);
+  let results = (outs LWECiphertextLike:$output);
+  let assemblyFormat = "operands attr-dict `:` type($output)";
+}
+
+def LWE_MulScalarOp : LWE_Op<"mul_scalar", [
+    Pure, Commutative, AllTypesMatch<["ciphertext", "output"]>]> {
+  let summary = "Multiply an LWE ciphertext by a scalar";
+  let arguments = (ins LWECiphertextLike:$ciphertext, AnyInteger:$scalar);
+  let results = (outs LWECiphertextLike:$output);
+}
+
 def LWE_RLWEEncodeOp : LWE_Op<"rlwe_encode", [Pure, HasEncoding<"output", "encoding", "RLWEPlaintextType">]> {
   let summary = "Encode an integer to yield an RLWE plaintext";
   let description = [{

--- a/lib/Dialect/LWE/IR/LWETypes.td
+++ b/lib/Dialect/LWE/IR/LWETypes.td
@@ -30,12 +30,12 @@ def LWECiphertext : LWE_Type<"LWECiphertext", "lwe_ciphertext", [MemRefElementTy
   }];
 
   let parameters = (ins
-  // FIXME: Encoding attrs belong on ops and types, should the encoding
-  //   attributes be a different class?
     "::mlir::Attribute":$encoding,
     OptionalParameter<"LWEParamsAttr">:$lwe_params
   );
 }
+
+def LWECiphertextLike : TypeOrContainer<LWECiphertext, "ciphertext-like">;
 
 def RLWECiphertext : LWE_Type<"RLWECiphertext", "rlwe_ciphertext"> {
   let summary = "A type for RLWE ciphertexts";

--- a/tests/cggi/set_default_parameters.mlir
+++ b/tests/cggi/set_default_parameters.mlir
@@ -19,6 +19,6 @@ func.func @test_adds_attribute(%arg0 : !ciphertext) -> !ciphertext {
   // CHECK: cggi.lut3
   // Testing that the pass adds the right kind of attribute to the op
   // CHECK: cggi_params = #cggi.cggi_params
-  %6 = cggi.lut3 (%arg0, %4, %5) {lookup_table = 127 : index} : !ciphertext
+  %6 = cggi.lut3 %arg0, %4, %5 {lookup_table = 127 : index} : !ciphertext
   return %4 : !ciphertext
 }

--- a/tests/cggi/straight_line_vectorizer.mlir
+++ b/tests/cggi/straight_line_vectorizer.mlir
@@ -7,7 +7,7 @@
 
 // CHECK-LABEL: add_one
 // CHECK-COUNT-9: cggi.lut3
-// CHECK: cggi.lut3(%[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]]) {lookup_table = 105 : ui8} : tensor<6x!lwe.lwe_ciphertext
+// CHECK: cggi.lut3 %[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]] {lookup_table = 105 : ui8} : tensor<6x!lwe.lwe_ciphertext
 func.func @add_one(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_ty> {
   %true = arith.constant true
   %false = arith.constant false
@@ -31,21 +31,21 @@ func.func @add_one(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_ty> {
   %1 = lwe.trivial_encrypt %0 : !pt_ty to !ct_ty
   %2 = lwe.encode %false {encoding = #encoding} : i1 to !pt_ty
   %3 = lwe.trivial_encrypt %2 : !pt_ty to !ct_ty
-  %4 = cggi.lut3(%extracted, %1, %3) {lookup_table = 8 : ui8} : !ct_ty
-  %5 = cggi.lut3(%4, %extracted_0, %3) {lookup_table = 150 : ui8} : !ct_ty
-  %6 = cggi.lut3(%4, %extracted_0, %3) {lookup_table = 23 : ui8} : !ct_ty
-  %7 = cggi.lut3(%6, %extracted_1, %3) {lookup_table = 43 : ui8} : !ct_ty
-  %8 = cggi.lut3(%7, %extracted_2, %3) {lookup_table = 43 : ui8} : !ct_ty
-  %9 = cggi.lut3(%8, %extracted_3, %3) {lookup_table = 43 : ui8} : !ct_ty
-  %10 = cggi.lut3(%9, %extracted_4, %3) {lookup_table = 43 : ui8} : !ct_ty
-  %11 = cggi.lut3(%10, %extracted_5, %3) {lookup_table = 105 : ui8} : !ct_ty
-  %12 = cggi.lut3(%10, %extracted_5, %3) {lookup_table = 43 : ui8} : !ct_ty
-  %13 = cggi.lut3(%12, %extracted_6, %3) {lookup_table = 105 : ui8} : !ct_ty
-  %14 = cggi.lut3(%extracted, %1, %3) {lookup_table = 6 : ui8} : !ct_ty
-  %15 = cggi.lut3(%6, %extracted_1, %3) {lookup_table = 105 : ui8} : !ct_ty
-  %16 = cggi.lut3(%7, %extracted_2, %3) {lookup_table = 105 : ui8} : !ct_ty
-  %17 = cggi.lut3(%8, %extracted_3, %3) {lookup_table = 105 : ui8} : !ct_ty
-  %18 = cggi.lut3(%9, %extracted_4, %3) {lookup_table = 105 : ui8} : !ct_ty
+  %4 = cggi.lut3 %extracted, %1, %3 {lookup_table = 8 : ui8} : !ct_ty
+  %5 = cggi.lut3 %4, %extracted_0, %3 {lookup_table = 150 : ui8} : !ct_ty
+  %6 = cggi.lut3 %4, %extracted_0, %3 {lookup_table = 23 : ui8} : !ct_ty
+  %7 = cggi.lut3 %6, %extracted_1, %3 {lookup_table = 43 : ui8} : !ct_ty
+  %8 = cggi.lut3 %7, %extracted_2, %3 {lookup_table = 43 : ui8} : !ct_ty
+  %9 = cggi.lut3 %8, %extracted_3, %3 {lookup_table = 43 : ui8} : !ct_ty
+  %10 = cggi.lut3 %9, %extracted_4, %3 {lookup_table = 43 : ui8} : !ct_ty
+  %11 = cggi.lut3 %10, %extracted_5, %3 {lookup_table = 105 : ui8} : !ct_ty
+  %12 = cggi.lut3 %10, %extracted_5, %3 {lookup_table = 43 : ui8} : !ct_ty
+  %13 = cggi.lut3 %12, %extracted_6, %3 {lookup_table = 105 : ui8} : !ct_ty
+  %14 = cggi.lut3 %extracted, %1, %3 {lookup_table = 6 : ui8} : !ct_ty
+  %15 = cggi.lut3 %6, %extracted_1, %3 {lookup_table = 105 : ui8} : !ct_ty
+  %16 = cggi.lut3 %7, %extracted_2, %3 {lookup_table = 105 : ui8} : !ct_ty
+  %17 = cggi.lut3 %8, %extracted_3, %3 {lookup_table = 105 : ui8} : !ct_ty
+  %18 = cggi.lut3 %9, %extracted_4, %3 {lookup_table = 105 : ui8} : !ct_ty
   %from_elements = tensor.from_elements %13, %11, %18, %17, %16, %15, %5, %14 : tensor<8x!ct_ty>
   return %from_elements : tensor<8x!ct_ty>
 }
@@ -70,24 +70,24 @@ func.func @require_post_pass_toposort(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_t
   %7 = tensor.extract %arg0[%c7] : tensor<8x!ct_ty>
 
   // Four ops that can be vectorized
-  %r1 = cggi.lut3(%0, %1, %2) {lookup_table = 8 : ui8} : !ct_ty
-  %r2 = cggi.lut3(%3, %4, %5) {lookup_table = 8 : ui8} : !ct_ty
-  %r3 = cggi.lut3(%4, %5, %6) {lookup_table = 8 : ui8} : !ct_ty
-  %r4 = cggi.lut3(%5, %6, %7) {lookup_table = 8 : ui8} : !ct_ty
+  %r1 = cggi.lut3 %0, %1, %2 {lookup_table = 8 : ui8} : !ct_ty
+  %r2 = cggi.lut3 %3, %4, %5 {lookup_table = 8 : ui8} : !ct_ty
+  %r3 = cggi.lut3 %4, %5, %6 {lookup_table = 8 : ui8} : !ct_ty
+  %r4 = cggi.lut3 %5, %6, %7 {lookup_table = 8 : ui8} : !ct_ty
 
   // A non-vectorizable op that uses one of the results
   %x = cggi.not %r4 : !ct_ty
 
   // Four more ops that can be vectorized
-  %r5 = cggi.lut3(%0, %3, %1) {lookup_table = 8 : ui8} : !ct_ty
-  %r6 = cggi.lut3(%2, %5, %6) {lookup_table = 8 : ui8} : !ct_ty
-  %r7 = cggi.lut3(%7, %1, %6) {lookup_table = 8 : ui8} : !ct_ty
-  %r8 = cggi.lut3(%3, %6, %0) {lookup_table = 8 : ui8} : !ct_ty
+  %r5 = cggi.lut3 %0, %3, %1 {lookup_table = 8 : ui8} : !ct_ty
+  %r6 = cggi.lut3 %2, %5, %6 {lookup_table = 8 : ui8} : !ct_ty
+  %r7 = cggi.lut3 %7, %1, %6 {lookup_table = 8 : ui8} : !ct_ty
+  %r8 = cggi.lut3 %3, %6, %0 {lookup_table = 8 : ui8} : !ct_ty
 
   // The not op has to occur after the lut3s, since it depends on one of the
   // results.
 
-  // CHECK: cggi.lut3(%[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]]) {lookup_table = 8 : ui8} : tensor<8x!lwe.lwe_ciphertext
+  // CHECK: cggi.lut3 %[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]] {lookup_table = 8 : ui8} : tensor<8x!lwe.lwe_ciphertext
   // CHECK: cggi.not
 
   %from_elements = tensor.from_elements %r1, %r2, %r3, %r4, %r5, %r6, %r7, %x : tensor<8x!ct_ty>
@@ -114,10 +114,10 @@ func.func @transitive_dep_splits_level(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_
   %7 = tensor.extract %arg0[%c7] : tensor<8x!ct_ty>
 
   // Four ops that can be vectorized
-  %r1 = cggi.lut3(%0, %1, %2) {lookup_table = 8 : ui8} : !ct_ty
-  %r2 = cggi.lut3(%3, %4, %5) {lookup_table = 8 : ui8} : !ct_ty
-  %r3 = cggi.lut3(%4, %5, %6) {lookup_table = 8 : ui8} : !ct_ty
-  %r4 = cggi.lut3(%5, %6, %7) {lookup_table = 8 : ui8} : !ct_ty
+  %r1 = cggi.lut3 %0, %1, %2 {lookup_table = 8 : ui8} : !ct_ty
+  %r2 = cggi.lut3 %3, %4, %5 {lookup_table = 8 : ui8} : !ct_ty
+  %r3 = cggi.lut3 %4, %5, %6 {lookup_table = 8 : ui8} : !ct_ty
+  %r4 = cggi.lut3 %5, %6, %7 {lookup_table = 8 : ui8} : !ct_ty
 
   // A non-vectorizable op that uses one of the results
   %n1 = cggi.not %r1 : !ct_ty
@@ -126,15 +126,15 @@ func.func @transitive_dep_splits_level(%arg0: tensor<8x!ct_ty>) -> tensor<8x!ct_
   %n4 = cggi.not %r4 : !ct_ty
 
   // Four more ops that can be vectorized
-  %r5 = cggi.lut3(%0, %n1, %1) {lookup_table = 8 : ui8} : !ct_ty
-  %r6 = cggi.lut3(%2, %n2, %6) {lookup_table = 8 : ui8} : !ct_ty
-  %r7 = cggi.lut3(%7, %n3, %6) {lookup_table = 8 : ui8} : !ct_ty
-  %r8 = cggi.lut3(%3, %n4, %0) {lookup_table = 8 : ui8} : !ct_ty
+  %r5 = cggi.lut3 %0, %n1, %1 {lookup_table = 8 : ui8} : !ct_ty
+  %r6 = cggi.lut3 %2, %n2, %6 {lookup_table = 8 : ui8} : !ct_ty
+  %r7 = cggi.lut3 %7, %n3, %6 {lookup_table = 8 : ui8} : !ct_ty
+  %r8 = cggi.lut3 %3, %n4, %0 {lookup_table = 8 : ui8} : !ct_ty
 
   // The slice analysis ensures these are split into two levels of 4 ops each.
-  // CHECK: cggi.lut3(%[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]]) {lookup_table = 8 : ui8} : tensor<4x!lwe.lwe_ciphertext
+  // CHECK: cggi.lut3 %[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]] {lookup_table = 8 : ui8} : tensor<4x!lwe.lwe_ciphertext
   // CHECK-COUNT-4: cggi.not
-  // CHECK: cggi.lut3(%[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]]) {lookup_table = 8 : ui8} : tensor<4x!lwe.lwe_ciphertext
+  // CHECK: cggi.lut3 %[[arg1:.*]], %[[arg2:.*]], %[[arg3:.*]] {lookup_table = 8 : ui8} : tensor<4x!lwe.lwe_ciphertext
 
   %from_elements = tensor.from_elements %r1, %r2, %r3, %r4, %r5, %r6, %r7, %r8 : tensor<8x!ct_ty>
   return %from_elements : tensor<8x!ct_ty>

--- a/tests/cggi/syntax.mlir
+++ b/tests/cggi/syntax.mlir
@@ -15,7 +15,11 @@ module {
     %3 = lwe.encode %1 { encoding = #encoding }: i1 to !plaintext
     %4 = lwe.trivial_encrypt %2 { params = #params } : !plaintext to !ciphertext
     %5 = lwe.trivial_encrypt %3 { params = #params } : !plaintext to !ciphertext
-    %6 = cggi.lut3 (%arg0, %4, %5) {lookup_table = 127 : index} : !ciphertext
+    %6 = cggi.lut3 %arg0, %4, %5 {lookup_table = 127 : index} : !ciphertext
+    %c3 = arith.constant 3 : i3
+    %7 = lwe.mul_scalar %4, %c3 : (!ciphertext, i3) -> !ciphertext
+    %8 = lwe.add %7, %5 : !ciphertext
+    %9 = cggi.lut_lincomb %4, %5, %6, %7 {coefficients = array<i32: 1, 1, 1, 2>, lookup_table = 68 : index} : !ciphertext
     return %4 : !ciphertext
   }
 }

--- a/tests/cggi/verifier.mlir
+++ b/tests/cggi/verifier.mlir
@@ -1,0 +1,40 @@
+// RUN: heir-opt --split-input-file --verify-diagnostics %s
+
+#encoding = #lwe.bit_field_encoding<cleartext_start=30, cleartext_bitwidth=3>
+#params = #lwe.lwe_params<cmod=7917, dimension=4>
+!ciphertext = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+func.func @test_bad_coeff_len(%a: !ciphertext, %b: !ciphertext) -> () {
+  // expected-error@+1 {{number of coefficients must match number of inputs}}
+  %0 = cggi.lut_lincomb %a, %b {coefficients = array<i32: 1, 1, 1>, lookup_table = 68 : index} : !ciphertext
+  return
+}
+
+
+// -----
+
+#encoding = #lwe.bit_field_encoding<cleartext_start=30, cleartext_bitwidth=3>
+#params = #lwe.lwe_params<cmod=7917, dimension=4>
+!ciphertext = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+func.func @test_overflowing_coeff(%a: !ciphertext, %b: !ciphertext) -> () {
+  // expected-error@below {{coefficient pushes error bits into message space}}
+  // expected-note@below {{coefficient is 95}}
+  // expected-note@below {{largest allowable coefficient is 7}}
+  %0 = cggi.lut_lincomb %a, %b {coefficients = array<i32: 1, 95>, lookup_table = 68 : index} : !ciphertext
+  return
+}
+
+// -----
+
+#encoding = #lwe.bit_field_encoding<cleartext_start=30, cleartext_bitwidth=3>
+#params = #lwe.lwe_params<cmod=7917, dimension=4>
+!ciphertext = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+func.func @test_too_large_lut(%a: !ciphertext, %b: !ciphertext) -> () {
+  // expected-error@below {{LUT is larger than available cleartext bit width}}
+  // expected-note@below {{LUT has 18 active bits}}
+  // expected-note@below {{max LUT size is 8 bits}}
+  %0 = cggi.lut_lincomb %a, %b {coefficients = array<i32: 1, 1>, lookup_table = 172836 : index} : !ciphertext
+  return
+}

--- a/tests/cggi_to_tfhe_rust/add_one.mlir
+++ b/tests/cggi_to_tfhe_rust/add_one.mlir
@@ -40,65 +40,65 @@ module {
     %3 = lwe.trivial_encrypt %2 : !pt_ty to !ct_ty
     %4 = lwe.encode %false {encoding = #encoding} : i1 to !pt_ty
     %5 = lwe.trivial_encrypt %4 : !pt_ty to !ct_ty
-    %6 = cggi.lut3(%0, %3, %5) {lookup_table = 8 : ui8} : !ct_ty
+    %6 = cggi.lut3 %0, %3, %5 {lookup_table = 8 : ui8} : !ct_ty
     %7 = memref.load %arg0[%c1] : memref<8x!ct_ty>
     %8 = memref.load %alloc[%c1] : memref<8xi1>
     %9 = lwe.encode %8 {encoding = #encoding} : i1 to !pt_ty
     %10 = lwe.trivial_encrypt %9 : !pt_ty to !ct_ty
-    %11 = cggi.lut3(%6, %7, %10) {lookup_table = 150 : ui8} : !ct_ty
+    %11 = cggi.lut3 %6, %7, %10 {lookup_table = 150 : ui8} : !ct_ty
     %12 = lwe.encode %8 {encoding = #encoding} : i1 to !pt_ty
     %13 = lwe.trivial_encrypt %12 : !pt_ty to !ct_ty
-    %14 = cggi.lut3(%6, %7, %13) {lookup_table = 23 : ui8} : !ct_ty
+    %14 = cggi.lut3 %6, %7, %13 {lookup_table = 23 : ui8} : !ct_ty
     %15 = memref.load %arg0[%c2] : memref<8x!ct_ty>
     %16 = memref.load %alloc[%c2] : memref<8xi1>
     %17 = lwe.encode %16 {encoding = #encoding} : i1 to !pt_ty
     %18 = lwe.trivial_encrypt %17 : !pt_ty to !ct_ty
-    %19 = cggi.lut3(%14, %15, %18) {lookup_table = 43 : ui8} : !ct_ty
+    %19 = cggi.lut3 %14, %15, %18 {lookup_table = 43 : ui8} : !ct_ty
     %20 = memref.load %arg0[%c3] : memref<8x!ct_ty>
     %21 = memref.load %alloc[%c3] : memref<8xi1>
     %22 = lwe.encode %21 {encoding = #encoding} : i1 to !pt_ty
     %23 = lwe.trivial_encrypt %22 : !pt_ty to !ct_ty
-    %24 = cggi.lut3(%19, %20, %23) {lookup_table = 43 : ui8} : !ct_ty
+    %24 = cggi.lut3 %19, %20, %23 {lookup_table = 43 : ui8} : !ct_ty
     %25 = memref.load %arg0[%c4] : memref<8x!ct_ty>
     %26 = memref.load %alloc[%c4] : memref<8xi1>
     %27 = lwe.encode %26 {encoding = #encoding} : i1 to !pt_ty
     %28 = lwe.trivial_encrypt %27 : !pt_ty to !ct_ty
-    %29 = cggi.lut3(%24, %25, %28) {lookup_table = 43 : ui8} : !ct_ty
+    %29 = cggi.lut3 %24, %25, %28 {lookup_table = 43 : ui8} : !ct_ty
     %30 = memref.load %arg0[%c5] : memref<8x!ct_ty>
     %31 = memref.load %alloc[%c5] : memref<8xi1>
     %32 = lwe.encode %31 {encoding = #encoding} : i1 to !pt_ty
     %33 = lwe.trivial_encrypt %32 : !pt_ty to !ct_ty
-    %34 = cggi.lut3(%29, %30, %33) {lookup_table = 43 : ui8} : !ct_ty
+    %34 = cggi.lut3 %29, %30, %33 {lookup_table = 43 : ui8} : !ct_ty
     %35 = memref.load %arg0[%c6] : memref<8x!ct_ty>
     %36 = memref.load %alloc[%c6] : memref<8xi1>
     %37 = lwe.encode %36 {encoding = #encoding} : i1 to !pt_ty
     %38 = lwe.trivial_encrypt %37 : !pt_ty to !ct_ty
-    %39 = cggi.lut3(%34, %35, %38) {lookup_table = 105 : ui8} : !ct_ty
+    %39 = cggi.lut3 %34, %35, %38 {lookup_table = 105 : ui8} : !ct_ty
     %40 = lwe.encode %36 {encoding = #encoding} : i1 to !pt_ty
     %41 = lwe.trivial_encrypt %40 : !pt_ty to !ct_ty
-    %42 = cggi.lut3(%34, %35, %41) {lookup_table = 43 : ui8} : !ct_ty
+    %42 = cggi.lut3 %34, %35, %41 {lookup_table = 43 : ui8} : !ct_ty
     %43 = memref.load %arg0[%c7] : memref<8x!ct_ty>
     %44 = memref.load %alloc[%c7] : memref<8xi1>
     %45 = lwe.encode %44 {encoding = #encoding} : i1 to !pt_ty
     %46 = lwe.trivial_encrypt %45 : !pt_ty to !ct_ty
-    %47 = cggi.lut3(%42, %43, %46) {lookup_table = 105 : ui8} : !ct_ty
+    %47 = cggi.lut3 %42, %43, %46 {lookup_table = 105 : ui8} : !ct_ty
     %48 = lwe.encode %1 {encoding = #encoding} : i1 to !pt_ty
     %49 = lwe.trivial_encrypt %48 : !pt_ty to !ct_ty
     %50 = lwe.encode %false {encoding = #encoding} : i1 to !pt_ty
     %51 = lwe.trivial_encrypt %50 : !pt_ty to !ct_ty
-    %52 = cggi.lut3(%0, %49, %51) {lookup_table = 6 : ui8} : !ct_ty
+    %52 = cggi.lut3 %0, %49, %51 {lookup_table = 6 : ui8} : !ct_ty
     %53 = lwe.encode %16 {encoding = #encoding} : i1 to !pt_ty
     %54 = lwe.trivial_encrypt %53 : !pt_ty to !ct_ty
-    %55 = cggi.lut3(%14, %15, %54) {lookup_table = 105 : ui8} : !ct_ty
+    %55 = cggi.lut3 %14, %15, %54 {lookup_table = 105 : ui8} : !ct_ty
     %56 = lwe.encode %21 {encoding = #encoding} : i1 to !pt_ty
     %57 = lwe.trivial_encrypt %56 : !pt_ty to !ct_ty
-    %58 = cggi.lut3(%19, %20, %57) {lookup_table = 105 : ui8} : !ct_ty
+    %58 = cggi.lut3 %19, %20, %57 {lookup_table = 105 : ui8} : !ct_ty
     %59 = lwe.encode %26 {encoding = #encoding} : i1 to !pt_ty
     %60 = lwe.trivial_encrypt %59 : !pt_ty to !ct_ty
-    %61 = cggi.lut3(%24, %25, %60) {lookup_table = 105 : ui8} : !ct_ty
+    %61 = cggi.lut3 %24, %25, %60 {lookup_table = 105 : ui8} : !ct_ty
     %62 = lwe.encode %31 {encoding = #encoding} : i1 to !pt_ty
     %63 = lwe.trivial_encrypt %62 : !pt_ty to !ct_ty
-    %64 = cggi.lut3(%29, %30, %63) {lookup_table = 105 : ui8} : !ct_ty
+    %64 = cggi.lut3 %29, %30, %63 {lookup_table = 105 : ui8} : !ct_ty
     %alloc_0 = memref.alloc() : memref<8x!ct_ty>
     memref.store %47, %alloc_0[%c0] : memref<8x!ct_ty>
     memref.store %39, %alloc_0[%c1] : memref<8x!ct_ty>

--- a/tests/comb_to_cggi/truth_table.mlir
+++ b/tests/comb_to_cggi/truth_table.mlir
@@ -3,7 +3,7 @@
 // CHECK-NOT: secret
 // CHECK: @truth_table_all_secret([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]) -> [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]
 func.func @truth_table_all_secret(%arg0: !secret.secret<i1>) -> !secret.secret<i1> {
-  // CHECK: [[VAL:%.+]] = cggi.lut3([[ARG]], [[ARG]], [[ARG]])
+  // CHECK: [[VAL:%.+]] = cggi.lut3 [[ARG]], [[ARG]], [[ARG]]
   %0 = secret.generic
       ins(%arg0:  !secret.secret<i1>) {
       ^bb0(%ARG0: i1) :
@@ -27,8 +27,8 @@ func.func @truth_table_partial_secret(%arg0: !secret.secret<i1>) -> !secret.secr
   // CHECK: [[LWEFALSE:%.+]] = lwe.trivial_encrypt [[ENCFALSE]]
   // CHECK: [[ENCTRUE:%.+]] = lwe.encode [[TRUE]]
   // CHECK: [[LWETRUE:%.+]] = lwe.trivial_encrypt [[ENCTRUE]]
-  // CHECK: [[VAL1:%.+]] = cggi.lut3([[LWEFALSE]], [[LWETRUE]], [[ARG]])
-  // CHECK: [[VAL2:%.+]] = cggi.lut3([[LWEFALSE]], [[LWETRUE]], [[VAL1]])
+  // CHECK: [[VAL1:%.+]] = cggi.lut3 [[LWEFALSE]], [[LWETRUE]], [[ARG]]
+  // CHECK: [[VAL2:%.+]] = cggi.lut3 [[LWEFALSE]], [[LWETRUE]], [[VAL1]]
   %0 = secret.generic
       ins(%false, %true, %arg0: i1, i1, !secret.secret<i1>) {
       ^bb0(%FALSE: i1, %TRUE: i1, %ARG0: i1) :
@@ -53,7 +53,7 @@ func.func @truth_table_no_secret(%arg0: !secret.secret<i1>, %bool1: i1, %bool2: 
   // CHECK: [[LWETRUE:%.+]] = lwe.trivial_encrypt [[ENCTRUE]]
   // CHECK: [[VALENCODE:%.+]] = lwe.encode [[VAL]]
   // CHECK: [[VAL1:%.+]] = lwe.trivial_encrypt [[VALENCODE]]
-  // CHECK: [[VAL2:%.+]] = cggi.lut3([[ARG]], [[LWETRUE]], [[VAL1]])
+  // CHECK: [[VAL2:%.+]] = cggi.lut3 [[ARG]], [[LWETRUE]], [[VAL1]]
   %0 = secret.generic
       ins(%false, %true, %bool1, %bool2, %arg0: i1, i1, i1, i1, !secret.secret<i1>) {
       ^bb0(%FALSE: i1, %TRUE: i1, %BOOL1: i1, %BOOL2: i1, %ARG0: i1) :

--- a/tests/lwe/add.mlir
+++ b/tests/lwe/add.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s
+
+#encoding = #lwe.bit_field_encoding<
+  cleartext_start=14,
+  cleartext_bitwidth=3>
+#params = #lwe.lwe_params<cmod=7917, dimension=10>
+!ct = !lwe.lwe_ciphertext<encoding = #encoding, lwe_params = #params>
+
+// CHECK-LABEL: test_add
+func.func @test_add(%0: !ct, %1: !ct) -> !ct {
+  // CHECK: lwe.add
+  %2 = lwe.add %0, %1 : !ct
+  return %2 : !ct
+}
+
+// CHECK-LABEL: test_mul_scalar
+func.func @test_mul_scalar(%0: !ct, %1: i3) -> !ct {
+  // CHECK: lwe.mul_scalar
+  %2 = lwe.mul_scalar %0, %1 : (!ct, i3) -> !ct
+  return %2 : !ct
+}

--- a/tests/lwe/set_default_parameters.mlir
+++ b/tests/lwe/set_default_parameters.mlir
@@ -19,6 +19,6 @@ func.func @test_adds_attribute(%arg0 : !ciphertext) -> !ciphertext {
   %5 = lwe.trivial_encrypt %3 : !plaintext to !ciphertext
   // CHECK: lwe.lwe_ciphertext
   // CHECK-SAME: lwe_params
-  %7 = cggi.lut3 (%arg0, %4, %5) {lookup_table = 127 : index} : !ciphertext
+  %7 = cggi.lut3 %arg0, %4, %5 {lookup_table = 127 : index} : !ciphertext
   return %7 : !ciphertext
 }

--- a/tests/tfhe_rust/end_to_end/test_add_one.mlir
+++ b/tests/tfhe_rust/end_to_end/test_add_one.mlir
@@ -33,49 +33,49 @@ module {
     %3 = lwe.trivial_encrypt %2 : !pt_ty to !ct_ty
     %4 = lwe.encode %0 {encoding = #encoding} : i1 to !pt_ty
     %5 = lwe.trivial_encrypt %4 : !pt_ty to !ct_ty
-    %6 = cggi.lut3(%3, %5, %1) {lookup_table = 8 : ui8} : !ct_ty
+    %6 = cggi.lut3 %3, %5, %1 {lookup_table = 8 : ui8} : !ct_ty
     %7 = memref.load %alloc[%c1] : memref<8xi1>
     %8 = memref.load %arg0[%c1] : memref<8x!ct_ty>
     %9 = lwe.encode %7 {encoding = #encoding} : i1 to !pt_ty
     %10 = lwe.trivial_encrypt %9 : !pt_ty to !ct_ty
-    %11 = cggi.lut3(%10, %8, %6) {lookup_table = 150 : ui8} : !ct_ty
-    %12 = cggi.lut3(%10, %8, %6) {lookup_table = 23 : ui8} : !ct_ty
+    %11 = cggi.lut3 %10, %8, %6 {lookup_table = 150 : ui8} : !ct_ty
+    %12 = cggi.lut3 %10, %8, %6 {lookup_table = 23 : ui8} : !ct_ty
     %13 = memref.load %alloc[%c2] : memref<8xi1>
     %14 = memref.load %arg0[%c2] : memref<8x!ct_ty>
     %15 = lwe.encode %13 {encoding = #encoding} : i1 to !pt_ty
     %16 = lwe.trivial_encrypt %15 : !pt_ty to !ct_ty
-    %17 = cggi.lut3(%16, %14, %12) {lookup_table = 43 : ui8} : !ct_ty
+    %17 = cggi.lut3 %16, %14, %12 {lookup_table = 43 : ui8} : !ct_ty
     %18 = memref.load %alloc[%c3] : memref<8xi1>
     %19 = memref.load %arg0[%c3] : memref<8x!ct_ty>
     %20 = lwe.encode %18 {encoding = #encoding} : i1 to !pt_ty
     %21 = lwe.trivial_encrypt %20 : !pt_ty to !ct_ty
-    %22 = cggi.lut3(%21, %19, %17) {lookup_table = 43 : ui8} : !ct_ty
+    %22 = cggi.lut3 %21, %19, %17 {lookup_table = 43 : ui8} : !ct_ty
     %23 = memref.load %alloc[%c4] : memref<8xi1>
     %24 = memref.load %arg0[%c4] : memref<8x!ct_ty>
     %25 = lwe.encode %23 {encoding = #encoding} : i1 to !pt_ty
     %26 = lwe.trivial_encrypt %25 : !pt_ty to !ct_ty
-    %27 = cggi.lut3(%26, %24, %22) {lookup_table = 43 : ui8} : !ct_ty
+    %27 = cggi.lut3 %26, %24, %22 {lookup_table = 43 : ui8} : !ct_ty
     %28 = memref.load %alloc[%c5] : memref<8xi1>
     %29 = memref.load %arg0[%c5] : memref<8x!ct_ty>
     %30 = lwe.encode %28 {encoding = #encoding} : i1 to !pt_ty
     %31 = lwe.trivial_encrypt %30 : !pt_ty to !ct_ty
-    %32 = cggi.lut3(%31, %29, %27) {lookup_table = 43 : ui8} : !ct_ty
+    %32 = cggi.lut3 %31, %29, %27 {lookup_table = 43 : ui8} : !ct_ty
     %33 = memref.load %alloc[%c6] : memref<8xi1>
     %34 = memref.load %arg0[%c6] : memref<8x!ct_ty>
     %35 = lwe.encode %33 {encoding = #encoding} : i1 to !pt_ty
     %36 = lwe.trivial_encrypt %35 : !pt_ty to !ct_ty
-    %37 = cggi.lut3(%36, %34, %32) {lookup_table = 105 : ui8} : !ct_ty
-    %38 = cggi.lut3(%36, %34, %32) {lookup_table = 43 : ui8} : !ct_ty
+    %37 = cggi.lut3 %36, %34, %32 {lookup_table = 105 : ui8} : !ct_ty
+    %38 = cggi.lut3 %36, %34, %32 {lookup_table = 43 : ui8} : !ct_ty
     %39 = memref.load %alloc[%c7] : memref<8xi1>
     %40 = memref.load %arg0[%c7] : memref<8x!ct_ty>
     %41 = lwe.encode %39 {encoding = #encoding} : i1 to !pt_ty
     %42 = lwe.trivial_encrypt %41 : !pt_ty to !ct_ty
-    %43 = cggi.lut3(%42, %40, %38) {lookup_table = 105 : ui8} : !ct_ty
-    %44 = cggi.lut3(%3, %5, %1) {lookup_table = 6 : ui8} : !ct_ty
-    %45 = cggi.lut3(%16, %14, %12) {lookup_table = 105 : ui8} : !ct_ty
-    %46 = cggi.lut3(%21, %19, %17) {lookup_table = 105 : ui8} : !ct_ty
-    %47 = cggi.lut3(%26, %24, %22) {lookup_table = 105 : ui8} : !ct_ty
-    %48 = cggi.lut3(%31, %29, %27) {lookup_table = 105 : ui8} : !ct_ty
+    %43 = cggi.lut3 %42, %40, %38 {lookup_table = 105 : ui8} : !ct_ty
+    %44 = cggi.lut3 %3, %5, %1 {lookup_table = 6 : ui8} : !ct_ty
+    %45 = cggi.lut3 %16, %14, %12 {lookup_table = 105 : ui8} : !ct_ty
+    %46 = cggi.lut3 %21, %19, %17 {lookup_table = 105 : ui8} : !ct_ty
+    %47 = cggi.lut3 %26, %24, %22 {lookup_table = 105 : ui8} : !ct_ty
+    %48 = cggi.lut3 %31, %29, %27 {lookup_table = 105 : ui8} : !ct_ty
     %alloc_0 = memref.alloc() : memref<8x!ct_ty>
     memref.store %44, %alloc_0[%c0] : memref<8x!ct_ty>
     memref.store %11, %alloc_0[%c1] : memref<8x!ct_ty>


### PR DESCRIPTION
Also make the `cggi.lut*` syntax more consistent by removing parens from the operands.

This is to prepare for a new optimization pass involving more finely-crafted LUT ops by qu4ternion on Discord