### PR TITLE
add a new arith_ext dialect

### DIFF
--- a/lib/Dialect/ArithExt/IR/ArithExtDialect.cpp
+++ b/lib/Dialect/ArithExt/IR/ArithExtDialect.cpp
@@ -1,0 +1,49 @@
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
+
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// NOLINTNEXTLINE(misc-include-cleaner): Required to define ArithExtOps
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.h"
+
+// Generated definitions
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+void ArithExtDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.cpp.inc"
+      >();
+}
+
+LogicalResult BarrettReduceOp::verify() {
+  auto inputType = getInput().getType();
+  unsigned bitWidth;
+  if (auto tensorType = dyn_cast<RankedTensorType>(inputType)) {
+    bitWidth = tensorType.getElementTypeBitWidth();
+  } else if (auto integerType = dyn_cast<IntegerType>(inputType)) {
+    bitWidth = integerType.getWidth();
+  }
+  auto cmod = APInt(64, getModulus());
+  auto expectedBitWidth = (cmod - 1).getActiveBits();
+  if (bitWidth < expectedBitWidth || 2 * expectedBitWidth < bitWidth) {
+    return emitOpError()
+           << "input bitwidth is required to be in the range [w, 2w], where w "
+              "is the smallest bit-width that contains the range [0, modulus). "
+              "Got "
+           << bitWidth << " but w is " << expectedBitWidth << ".";
+  }
+
+  return success();
+}
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/ArithExt/IR/ArithExtDialect.h
+++ b/lib/Dialect/ArithExt/IR/ArithExtDialect.h
@@ -1,0 +1,10 @@
+#ifndef HEIR_LIB_DIALECT_ARITHEXT_IR_ARITHEXTDIALECT_H_
+#define HEIR_LIB_DIALECT_ARITHEXT_IR_ARITHEXTDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"   // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h.inc"
+
+#endif  // HEIR_LIB_DIALECT_ARITHEXT_IR_ARITHEXTDIALECT_H_

--- a/lib/Dialect/ArithExt/IR/ArithExtDialect.td
+++ b/lib/Dialect/ArithExt/IR/ArithExtDialect.td
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_ARITHEXT_IR_ARITHEXTDIALECT_TD_
+#define LIB_DIALECT_ARITHEXT_IR_ARITHEXTDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def ArithExt_Dialect : Dialect {
+  let name = "arith_ext";
+  let description = [{
+    The `arith_ext` dialect contains operations used with polynomial arithmetic,
+    but are unlikely to be upstreamed to MLIR due to their specificity to FHE.
+  }];
+
+  let cppNamespace = "::mlir::heir::arith_ext";
+  let dependentDialects = [
+    "arith::ArithDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_ARITHEXT_IR_ARITHEXTDIALECT_TD_

--- a/lib/Dialect/ArithExt/IR/ArithExtOps.h
+++ b/lib/Dialect/ArithExt/IR/ArithExtOps.h
@@ -1,0 +1,11 @@
+#ifndef LIB_DIALECT_ARITHEXT_IR_ARITHEXTOPS_H_
+#define LIB_DIALECT_ARITHEXT_IR_ARITHEXTOPS_H_
+
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.h.inc"
+
+#endif  // LIB_DIALECT_ARITHEXT_IR_ARITHEXTOPS_H_

--- a/lib/Dialect/ArithExt/IR/ArithExtOps.td
+++ b/lib/Dialect/ArithExt/IR/ArithExtOps.td
@@ -1,0 +1,48 @@
+#ifndef LIB_DIALECT_ARITHEXT_IR_ARITHEXTOPS_TD_
+#define LIB_DIALECT_ARITHEXT_IR_ARITHEXTOPS_TD_
+
+include "lib/Dialect/ArithExt/IR/ArithExtDialect.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+
+class ArithExt_Op<string mnemonic, list<Trait> traits = [Pure]> :
+        Op<ArithExt_Dialect, mnemonic, traits> {
+  let cppNamespace = "::mlir::heir::arith_ext";
+}
+
+def ArithExt_BarrettReduceOp : ArithExt_Op<"barrett_reduce", [SameOperandsAndResultType]> {
+  let summary = "Compute the first step of the Barrett reduction.";
+  let description = [{
+    Let $q$ denote a statically known modulus and $b = 4^{w}$, where $w$ is the
+    smallest bit-width that contains the range $[0, q)$. The Barrett reduce
+    operation computes `barret_reduce x = x - floor(x * floor(b / q) / b) * q`.
+
+    Given $0 <= x < q^2$, then this will compute $(x \mod q)$ or $(x \mod q) + p$.
+  }];
+
+  let arguments = (ins
+    SignlessIntegerLike:$input,
+    I64Attr:$modulus
+  );
+  let results = (outs SignlessIntegerLike:$output);
+  let assemblyFormat = "operands attr-dict `:` qualified(type($input))";
+
+  let hasVerifier = 1;
+}
+
+def ArithExt_SubIfGEOp : ArithExt_Op<"subifge", [SameOperandsAndResultType]> {
+  let summary = "Compute (x >= y) ? x - y : x.";
+
+  let arguments = (ins
+    SignlessIntegerLike:$lhs,
+    SignlessIntegerLike:$rhs
+  );
+  let results = (outs SignlessIntegerLike:$output);
+  let assemblyFormat = "operands attr-dict `:` qualified(type($output))";
+}
+
+#endif  // LIB_DIALECT_ARITHEXT_IR_ARITHEXTOPS_TD_

--- a/lib/Dialect/ArithExt/IR/BUILD
+++ b/lib/Dialect/ArithExt/IR/BUILD
@@ -1,0 +1,93 @@
+# ArithExt dialect
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "ArithExtDialect.cpp",
+    ],
+    hdrs = [
+        "ArithExtDialect.h",
+        "ArithExtOps.h",
+    ],
+    deps = [
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "ArithExtDialect.td",
+        "ArithExtOps.td",
+    ],
+    # include from the heir-root to enable fully-qualified include-paths
+    includes = ["../../../.."],
+    deps = [
+        "@heir//lib/DRR",
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "ArithExtDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "ArithExtDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ArithExtDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "ArithExtOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "ArithExtOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "ArithExtOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ArithExtOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        "@heir//lib/Dialect/Polynomial/IR:td_files",
+    ],
+)

--- a/tests/arith/BUILD
+++ b/tests/arith/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/arith/invalid-ops.mlir
+++ b/tests/arith/invalid-ops.mlir
@@ -1,0 +1,13 @@
+// RUN: heir-opt --verify-diagnostics --split-input-file %s | FileCheck %s
+
+// CHECK-NOT: @test_bad_arith_syntax
+func.func @test_bad_arith_syntax() {
+  %c_vec = arith.constant dense<[1, 2, 1, 2]> : tensor<4xi4>
+
+  // expected-error@+1 {{input bitwidth is required to be in the range [w, 2w], where w is the smallest bit-width that contains the range [0, modulus).}}
+  %barrett = arith_ext.barrett_reduce %c_vec { modulus = 17 } : tensor<4xi4>
+
+  return
+}
+
+// -----

--- a/tests/arith/syntax.mlir
+++ b/tests/arith/syntax.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// CHECK-LABEL: @test_arith_syntax
+func.func @test_arith_syntax() {
+  %zero = arith.constant 1 : i10
+  %cmod = arith.constant 17 : i10
+  %c_vec = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi10>
+  %cmod_vec = arith.constant dense<17> : tensor<4xi10>
+
+  // CHECK: arith_ext.barrett_reduce
+  // CHECK: arith_ext.barrett_reduce
+  %barrett = arith_ext.barrett_reduce %zero { modulus = 17 } : i10
+  %barrett_vec = arith_ext.barrett_reduce %c_vec { modulus = 17 } : tensor<4xi10>
+
+  // CHECK: arith_ext.subifge
+  // CHECK: arith_ext.subifge
+  %subifge = arith_ext.subifge %zero, %cmod : i10
+  %subifge_vec = arith_ext.subifge %c_vec, %cmod_vec : tensor<4xi10>
+
+  return
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -41,6 +41,7 @@ cc_binary(
         "@heir//lib/Conversion/MemrefToArith:MemrefToArithRegistration",
         "@heir//lib/Conversion/PolynomialToStandard",
         "@heir//lib/Conversion/SecretToBGV",
+        "@heir//lib/Dialect/ArithExt/IR:Dialect",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/BGV/Transforms",
         "@heir//lib/Dialect/BGV/Transforms:AddClientInterface",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -10,6 +10,7 @@
 #include "lib/Conversion/MemrefToArith/MemrefToArith.h"
 #include "lib/Conversion/PolynomialToStandard/PolynomialToStandard.h"
 #include "lib/Conversion/SecretToBGV/SecretToBGV.h"
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/BGV/Transforms/AddClientInterface.h"
 #include "lib/Dialect/BGV/Transforms/Passes.h"
@@ -466,6 +467,7 @@ void mlirToOpenFheBgvPipelineBuilder(
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
+  registry.insert<arith_ext::ArithExtDialect>();
   registry.insert<bgv::BGVDialect>();
   registry.insert<cggi::CGGIDialect>();
   registry.insert<comb::CombDialect>();


### PR DESCRIPTION
  - Add operations barrett_reduce and subifge to mirror the required operations of the HEaan.mlir paper

Resolve #709 