### PR TITLE
arith_ext: add transforms for arith.remui patterns

### DIFF
--- a/lib/Conversion/ArithExtToArith/ArithExtToArith.cpp
+++ b/lib/Conversion/ArithExtToArith/ArithExtToArith.cpp
@@ -92,7 +92,8 @@ void ArithExtToArith::runOnOperation() {
   target.addLegalDialect<arith::ArithDialect>();
 
   RewritePatternSet patterns(context);
-  patterns.add<rewrites::ConvertSubIfGE, ConvertBarrettReduce>(context);
+  patterns.add<ConvertBarrettReduce, rewrites::ConvertNormalised,
+               rewrites::ConvertSubIfGE>(context);
 
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();

--- a/lib/Conversion/ArithExtToArith/ArithExtToArith.cpp
+++ b/lib/Conversion/ArithExtToArith/ArithExtToArith.cpp
@@ -1,0 +1,104 @@
+#include "lib/Conversion/ArithExtToArith/ArithExtToArith.h"
+
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.h"
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+#define GEN_PASS_DEF_ARITHEXTTOARITH
+#include "lib/Conversion/ArithExtToArith/ArithExtToArith.h.inc"
+
+namespace rewrites {
+// In an inner namespace to avoid conflicts with canonicalization patterns
+#include "lib/Conversion/ArithExtToArith/ArithExtToArith.cpp.inc"
+}  // namespace rewrites
+
+struct ConvertBarrettReduce : public OpConversionPattern<BarrettReduceOp> {
+  ConvertBarrettReduce(mlir::MLIRContext *context)
+      : OpConversionPattern<BarrettReduceOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      BarrettReduceOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+    // Compute B = 4^{bitWidth} and ratio = floordiv(B / modulus)
+    auto input = adaptor.getInput();
+    auto mod = APInt(64, op.getModulus());
+    auto bitWidth = (mod - 1).getActiveBits();
+    mod = mod.trunc(3 * bitWidth);
+    auto B = APInt(3 * bitWidth, 1).shl(2 * bitWidth);
+    auto barrettRatio = B.udiv(mod);
+
+    Type intermediateType = IntegerType::get(b.getContext(), 3 * bitWidth);
+
+    // Create our pre-computed constants
+    TypedAttr ratioAttr, shiftAttr, modAttr;
+    if (auto tensorType = dyn_cast<RankedTensorType>(input.getType())) {
+      tensorType = tensorType.clone(tensorType.getShape(), intermediateType);
+      ratioAttr = DenseElementsAttr::get(tensorType, barrettRatio);
+      shiftAttr =
+          DenseElementsAttr::get(tensorType, APInt(3 * bitWidth, 2 * bitWidth));
+      modAttr = DenseElementsAttr::get(tensorType, mod);
+      intermediateType = tensorType;
+    } else if (auto integerType = dyn_cast<IntegerType>(input.getType())) {
+      ratioAttr = IntegerAttr::get(intermediateType, barrettRatio);
+      shiftAttr =
+          IntegerAttr::get(intermediateType, APInt(3 * bitWidth, 2 * bitWidth));
+      modAttr = IntegerAttr::get(intermediateType, mod);
+    }
+
+    auto ratioValue = b.create<arith::ConstantOp>(intermediateType, ratioAttr);
+    auto shiftValue = b.create<arith::ConstantOp>(intermediateType, shiftAttr);
+    auto modValue = b.create<arith::ConstantOp>(intermediateType, modAttr);
+
+    // Intermediate value will be in the range [0,p^3) so we need to extend to
+    // 3*bitWidth
+    auto extendOp = b.create<arith::ExtUIOp>(intermediateType, input);
+
+    // Compute x - floordiv(x * ratio, B) * mod
+    auto mulRatioOp = b.create<arith::MulIOp>(extendOp, ratioValue);
+    auto shrOp = b.create<arith::ShRUIOp>(mulRatioOp, shiftValue);
+    auto mulModOp = b.create<arith::MulIOp>(shrOp, modValue);
+    auto subOp = b.create<arith::SubIOp>(extendOp, mulModOp);
+
+    auto truncOp = b.create<arith::TruncIOp>(input.getType(), subOp);
+
+    rewriter.replaceOp(op, truncOp);
+
+    return success();
+  }
+};
+
+struct ArithExtToArith : impl::ArithExtToArithBase<ArithExtToArith> {
+  using ArithExtToArithBase::ArithExtToArithBase;
+
+  void runOnOperation() override;
+};
+
+void ArithExtToArith::runOnOperation() {
+  MLIRContext *context = &getContext();
+  ModuleOp module = getOperation();
+
+  ConversionTarget target(*context);
+  target.addIllegalDialect<ArithExtDialect>();
+  target.addLegalDialect<arith::ArithDialect>();
+
+  RewritePatternSet patterns(context);
+  patterns.add<rewrites::ConvertSubIfGE, ConvertBarrettReduce>(context);
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
+    signalPassFailure();
+  }
+}
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Conversion/ArithExtToArith/ArithExtToArith.h
+++ b/lib/Conversion/ArithExtToArith/ArithExtToArith.h
@@ -1,0 +1,21 @@
+#ifndef LIB_DIALECT_ARITHEXT_TRANSFORMS_ARITHEXTTOARITH_H_
+#define LIB_DIALECT_ARITHEXT_TRANSFORMS_ARITHEXTTOARITH_H_
+
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"               // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+#define GEN_PASS_DECL
+#include "lib/Conversion/ArithExtToArith/ArithExtToArith.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Conversion/ArithExtToArith/ArithExtToArith.h.inc"
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ARITHEXT_TRANSFORMS_ARITHEXTTOARITH_H_

--- a/lib/Conversion/ArithExtToArith/ArithExtToArith.td
+++ b/lib/Conversion/ArithExtToArith/ArithExtToArith.td
@@ -1,0 +1,36 @@
+#ifndef LIB_CONVERSION_ARITHEXTTOARITH_ARITHEXTTOARITH_TD_
+#define LIB_CONVERSION_ARITHEXTTOARITH_ARITHEXTTOARITH_TD_
+
+include "lib/DRR/Utils.td"
+include "lib/Dialect/ArithExt/IR/ArithExtOps.td"
+include "mlir/Dialect/Arith/IR/ArithOps.td"
+include "mlir/IR/PatternBase.td"
+include "mlir/Pass/PassBase.td"
+
+def ArithExtToArith : Pass<"arith-ext-to-arith", "ModuleOp"> {
+  let summary = "Lower `arith_ext` to standard `arith`.";
+
+  let description = [{
+    This pass lowers the `arith_ext` dialect to their `arith` equivalents.
+  }];
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::heir::arith_ext::ArithExtDialect",
+  ];
+}
+
+// Using DRR to generate the lowering patterns for specific operations
+
+defvar DefGE = ConstantEnumCase<Arith_CmpIPredicateAttr, "uge">;
+
+def ConvertSubIfGE : Pattern<
+  (ArithExt_SubIfGEOp $x, $y),
+  [
+    (Arith_SubIOp:$subOp $x, $y, DefOverflow),
+    (Arith_CmpIOp:$cmpOp DefGE, $x, $y),
+    (SelectOp $cmpOp, $subOp, $x)
+  ]
+>;
+
+#endif  // LIB_CONVERSION_ARITHEXTTOARITH_ARITHEXTTOARITH_TD_

--- a/lib/Conversion/ArithExtToArith/ArithExtToArith.td
+++ b/lib/Conversion/ArithExtToArith/ArithExtToArith.td
@@ -22,6 +22,13 @@ def ArithExtToArith : Pass<"arith-ext-to-arith", "ModuleOp"> {
 
 // Using DRR to generate the lowering patterns for specific operations
 
+def ConvertNormalised : Pattern<
+  (ArithExt_NormalisedOp $arg, $q),
+  [
+    (replaceWithValue $arg)
+  ]
+>;
+
 defvar DefGE = ConstantEnumCase<Arith_CmpIPredicateAttr, "uge">;
 
 def ConvertSubIfGE : Pattern<

--- a/lib/Conversion/ArithExtToArith/BUILD
+++ b/lib/Conversion/ArithExtToArith/BUILD
@@ -1,0 +1,49 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ArithExtToArith",
+    srcs = ["ArithExtToArith.cpp"],
+    hdrs = [
+        "ArithExtToArith.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/ArithExt/IR:Dialect",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=ArithExtToArith",
+            ],
+            "ArithExtToArith.h.inc",
+        ),
+        (
+            ["-gen-rewriters"],
+            "ArithExtToArith.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ArithExtToArith.td",
+    deps = [
+        "@heir//lib/DRR",
+        "@heir//lib/Dialect/ArithExt/IR:ops_inc_gen",
+        "@heir//lib/Dialect/ArithExt/IR:td_files",
+        "@llvm-project//mlir:ArithOpsTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Dialect/ArithExt/IR/ArithExtDialect.cpp
+++ b/lib/Dialect/ArithExt/IR/ArithExtDialect.cpp
@@ -23,27 +23,6 @@ void ArithExtDialect::initialize() {
       >();
 }
 
-LogicalResult BarrettReduceOp::verify() {
-  auto inputType = getInput().getType();
-  unsigned bitWidth;
-  if (auto tensorType = dyn_cast<RankedTensorType>(inputType)) {
-    bitWidth = tensorType.getElementTypeBitWidth();
-  } else if (auto integerType = dyn_cast<IntegerType>(inputType)) {
-    bitWidth = integerType.getWidth();
-  }
-  auto cmod = APInt(64, getModulus());
-  auto expectedBitWidth = (cmod - 1).getActiveBits();
-  if (bitWidth < expectedBitWidth || 2 * expectedBitWidth < bitWidth) {
-    return emitOpError()
-           << "input bitwidth is required to be in the range [w, 2w], where w "
-              "is the smallest bit-width that contains the range [0, modulus). "
-              "Got "
-           << bitWidth << " but w is " << expectedBitWidth << ".";
-  }
-
-  return success();
-}
-
 }  // namespace arith_ext
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/ArithExt/IR/ArithExtOps.cpp
+++ b/lib/Dialect/ArithExt/IR/ArithExtOps.cpp
@@ -1,0 +1,57 @@
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.h"
+
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+LogicalResult BarrettReduceOp::verify() {
+  auto inputType = getInput().getType();
+  unsigned bitWidth;
+  if (auto tensorType = dyn_cast<RankedTensorType>(inputType)) {
+    bitWidth = tensorType.getElementTypeBitWidth();
+  } else if (auto integerType = dyn_cast<IntegerType>(inputType)) {
+    bitWidth = integerType.getWidth();
+  }
+  auto cmod = APInt(64, getModulus());
+  auto expectedBitWidth = (cmod - 1).getActiveBits();
+  if (bitWidth < expectedBitWidth || 2 * expectedBitWidth < bitWidth) {
+    return emitOpError()
+           << "input bitwidth is required to be in the range [w, 2w], where w "
+              "is the smallest bit-width that contains the range [0, modulus). "
+              "Got "
+           << bitWidth << " but w is " << expectedBitWidth << ".";
+  }
+
+  return success();
+}
+
+ConstantIntRanges initialNormalisedRange(uint64_t q) {
+  return ConstantIntRanges::fromUnsigned(APInt(64, 0), APInt(64, q));
+}
+
+void BarrettReduceOp::inferResultRanges(ArrayRef<ConstantIntRanges> inputRanges,
+                                        SetIntRangeFn setResultRange) {
+  setResultRange(getResult(), initialNormalisedRange(2 * getModulus()));
+}
+
+void NormalisedOp::inferResultRanges(ArrayRef<ConstantIntRanges> inputRanges,
+                                     SetIntRangeFn setResultRange) {
+  setResultRange(getResult(), initialNormalisedRange(getQ()));
+}
+
+void SubIfGEOp::inferResultRanges(ArrayRef<ConstantIntRanges> inputRanges,
+                                  SetIntRangeFn setResultRange) {
+  auto lhsRange = inputRanges[0];
+  auto rhsRange = inputRanges[1];
+  setResultRange(getResult(),
+                 ConstantIntRanges::fromUnsigned(
+                     lhsRange.umin() - rhsRange.umax(), lhsRange.umax()));
+}
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/ArithExt/IR/ArithExtOps.h
+++ b/lib/Dialect/ArithExt/IR/ArithExtOps.h
@@ -3,6 +3,7 @@
 
 #include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
 #include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferIntRangeInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/ArithExt/IR/ArithExtOps.td
+++ b/lib/Dialect/ArithExt/IR/ArithExtOps.td
@@ -5,6 +5,7 @@ include "lib/Dialect/ArithExt/IR/ArithExtDialect.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferIntRangeInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -14,7 +15,9 @@ class ArithExt_Op<string mnemonic, list<Trait> traits = [Pure]> :
   let cppNamespace = "::mlir::heir::arith_ext";
 }
 
-def ArithExt_BarrettReduceOp : ArithExt_Op<"barrett_reduce", [SameOperandsAndResultType]> {
+def ArithExt_BarrettReduceOp : ArithExt_Op<"barrett_reduce", [
+  SameOperandsAndResultType, DeclareOpInterfaceMethods<InferIntRangeInterface>
+]> {
   let summary = "Compute the first step of the Barrett reduction.";
   let description = [{
     Let $q$ denote a statically known modulus and $b = 4^{w}$, where $w$ is the
@@ -34,7 +37,21 @@ def ArithExt_BarrettReduceOp : ArithExt_Op<"barrett_reduce", [SameOperandsAndRes
   let hasVerifier = 1;
 }
 
-def ArithExt_SubIfGEOp : ArithExt_Op<"subifge", [SameOperandsAndResultType]> {
+def ArithExt_NormalisedOp : ArithExt_Op<"normalised", [
+  SameOperandsAndResultType, DeclareOpInterfaceMethods<InferIntRangeInterface>
+]> {
+  let summary = "Denotes that the output value is in the range [0, q).";
+  let arguments = (ins
+    SignlessIntegerLike:$input,
+    I64Attr:$q
+  );
+  let results = (outs SignlessIntegerLike:$output);
+  let assemblyFormat = "operands attr-dict `:` qualified(type($input))";
+}
+
+def ArithExt_SubIfGEOp : ArithExt_Op<"subifge", [
+  SameOperandsAndResultType, DeclareOpInterfaceMethods<InferIntRangeInterface>
+]> {
   let summary = "Compute (x >= y) ? x - y : x.";
 
   let arguments = (ins

--- a/lib/Dialect/ArithExt/IR/BUILD
+++ b/lib/Dialect/ArithExt/IR/BUILD
@@ -11,6 +11,7 @@ cc_library(
     name = "Dialect",
     srcs = [
         "ArithExtDialect.cpp",
+        "ArithExtOps.cpp",
     ],
     hdrs = [
         "ArithExtDialect.h",
@@ -22,6 +23,7 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferIntRangeInterface",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",
     ],
@@ -38,6 +40,7 @@ td_library(
     deps = [
         "@heir//lib/DRR",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:InferIntRangeInterfaceTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",

--- a/lib/Dialect/ArithExt/Transforms/BUILD
+++ b/lib/Dialect/ArithExt/Transforms/BUILD
@@ -1,0 +1,58 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/ArithExt/IR:Dialect",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "RemToArithExt",
+    srcs = ["RemToArithExt.cpp"],
+    hdrs = [
+        "RemToArithExt.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/ArithExt/IR:Dialect",
+        "@heir//lib/Dialect/Polynomial/IR:PolynomialAttributes",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=ArithExt",
+            ],
+            "Passes.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "ArithExtPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Dialect/ArithExt/Transforms/Passes.h
+++ b/lib/Dialect/ArithExt/Transforms/Passes.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_ARITHEXT_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_ARITHEXT_TRANSFORMS_PASSES_H_
+
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
+#include "lib/Dialect/ArithExt/Transforms/RemToArithExt.h"
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/ArithExt/Transforms/Passes.h.inc"
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ARITHEXT_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/ArithExt/Transforms/Passes.td
+++ b/lib/Dialect/ArithExt/Transforms/Passes.td
@@ -1,0 +1,15 @@
+#ifndef LIB_DIALECT_ARITHEXT_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_ARITHEXT_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def RemToArithExt : Pass<"convert-rem-to-arith-ext"> {
+  let summary = "Rewrites `arith.remui` patterns to their arith_ext equivalents";
+  let description = [{
+    Applies a rewrite pattern to convert the following arith patterns to their
+    equivalent using the arith_ext operations.
+  }];
+  let dependentDialects = ["mlir::heir::arith_ext::ArithExtDialect"];
+}
+
+#endif  // LIB_DIALECT_ARITHEXT_TRANSFORMS_PASSES_TD_

--- a/lib/Dialect/ArithExt/Transforms/RemToArithExt.cpp
+++ b/lib/Dialect/ArithExt/Transforms/RemToArithExt.cpp
@@ -1,0 +1,52 @@
+#include "lib/Dialect/ArithExt/Transforms/RemToArithExt.h"
+
+#include "lib/Dialect/ArithExt/IR/ArithExtOps.h"
+#include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
+
+#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+#define GEN_PASS_DEF_REMTOARITHEXT
+#include "lib/Dialect/ArithExt/Transforms/Passes.h.inc"
+
+struct RemToArithExt : impl::RemToArithExtBase<RemToArithExt> {
+  using RemToArithExtBase::RemToArithExtBase;
+
+  void runOnOperation() override {
+    Operation *module = getOperation();
+
+    DataFlowSolver solver;
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::IntegerRangeAnalysis>();
+    if (failed(solver.initializeAndRun(module)))
+        signalPassFailure();
+
+    auto result = module->walk([&](Operation *op) {
+      if (!llvm::isa<arith::RemUIOp>(*op)) {
+        return WalkResult::advance();
+      }
+
+      const dataflow::IntegerValueRangeLattice *opRange =
+        solver.lookupState<dataflow::IntegerValueRangeLattice>(op->getResult(0));
+      if (!opRange || opRange->getValue().isUninitialized()) {
+        op->emitOpError()
+          << "No op range was given.";
+        return WalkResult::interrupt();
+      }
+      opRange->print(llvm::errs());
+      return WalkResult::advance();
+    });
+  }
+};
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/ArithExt/Transforms/RemToArithExt.h
+++ b/lib/Dialect/ArithExt/Transforms/RemToArithExt.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_ARITHEXT_TRANSFORMS_REMTOARITHEXT_H_
+#define LIB_DIALECT_ARITHEXT_TRANSFORMS_REMTOARITHEXT_H_
+
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"               // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith_ext {
+
+#define GEN_PASS_DECL_REMTOARITHEXT
+#include "lib/Dialect/ArithExt/Transforms/Passes.h.inc"
+
+}  // namespace arith_ext
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ARITHEXT_TRANSFORMS_REMTOARITHEXT_H_

--- a/tests/arith/arith-ext-to-arith.mlir
+++ b/tests/arith/arith-ext-to-arith.mlir
@@ -1,0 +1,72 @@
+// RUN: heir-opt -arith-ext-to-arith --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: @test_lower_subifge
+// CHECK-SAME: (%[[LHS:.*]]: [[TENSOR_TYPE:.*]], %[[RHS:.*]]: [[TENSOR_TYPE]]) -> [[TENSOR_TYPE]] {
+func.func @test_lower_subifge(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
+
+  // CHECK: %[[SUB:.*]] = arith.subi %[[LHS]], %[[RHS]] : [[TENSOR_TYPE]]
+  // CHECK: %[[CMP:.*]] = arith.cmpi uge, %[[LHS]], %[[RHS]] : [[TENSOR_TYPE]]
+  // CHECK: %[[RES:.*]] = arith.select %[[CMP]], %[[SUB]], %[[LHS]] : tensor<4xi1>, [[TENSOR_TYPE]]
+  %res = arith_ext.subifge %lhs, %rhs: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// -----
+
+// CHECK-LABEL: @test_lower_subifge_int
+// CHECK-SAME: (%[[LHS:.*]]: [[INT_TYPE:.*]], %[[RHS:.*]]: [[INT_TYPE]]) -> [[INT_TYPE]] {
+func.func @test_lower_subifge_int(%lhs : i8, %rhs : i8) -> i8 {
+
+  // CHECK: %[[SUB:.*]] = arith.subi %[[LHS]], %[[RHS]] : [[INT_TYPE]]
+  // CHECK: %[[CMP:.*]] = arith.cmpi uge, %[[LHS]], %[[RHS]] : [[INT_TYPE]]
+  // CHECK: %[[RES:.*]] = arith.select %[[CMP]], %[[SUB]], %[[LHS]] : [[INT_TYPE]]
+  %res = arith_ext.subifge %lhs, %rhs: i8
+  return %res : i8
+}
+
+// -----
+
+// CHECK-LABEL: @test_lower_barrett_reduce
+
+// CHECK-SAME: (%[[ARG:.*]]: [[TENSOR_TYPE:.*]]) -> [[TENSOR_TYPE]] {
+func.func @test_lower_barrett_reduce(%arg : tensor<4xi10>) -> tensor<4xi10> {
+
+  // CHECK: %[[RATIO:.*]] = arith.constant dense<60> : [[INTER_TYPE:.*]]
+  // CHECK: %[[BITWIDTH:.*]] = arith.constant dense<10> : [[INTER_TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<17> : [[INTER_TYPE]]
+
+  // CHECK: %[[EXT:.*]] = arith.extui %[[ARG]] : [[TENSOR_TYPE]] to [[INTER_TYPE]]
+  // CHECK: %[[MULRATIO:.*]] = arith.muli %[[EXT]], %[[RATIO]] : [[INTER_TYPE]]
+  // CHECK: %[[SHIFTED:.*]] = arith.shrui %[[MULRATIO]], %[[BITWIDTH]] : [[INTER_TYPE]]
+  // CHECK: %[[MULCMOD:.*]] = arith.muli %[[SHIFTED]], %[[CMOD]] : [[INTER_TYPE]]
+  // CHECK: %[[SUB:.*]] = arith.subi %[[EXT]], %[[MULCMOD]] : [[INTER_TYPE]]
+  // CHECK: %[[RES:.*]] = arith.trunci %[[SUB]] : [[INTER_TYPE]] to [[TENSOR_TYPE]]
+  %res = arith_ext.barrett_reduce %arg { modulus = 17 } : tensor<4xi10>
+
+  // CHECK: return %[[RES]] : [[TENSOR_TYPE]]
+  return %res : tensor<4xi10>
+}
+
+// -----
+
+// CHECK-LABEL: @test_lower_barrett_reduce_int
+// CHECK-SAME: (%[[ARG:.*]]: [[INT_TYPE:.*]]) -> [[INT_TYPE]] {
+func.func @test_lower_barrett_reduce_int(%arg : i10) -> i10 {
+
+  // CHECK: %[[RATIO:.*]] = arith.constant 60 : [[INTER_TYPE:.*]]
+  // CHECK: %[[BITWIDTH:.*]] = arith.constant 10 : [[INTER_TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant 17 : [[INTER_TYPE]]
+
+  // CHECK: %[[EXT:.*]] = arith.extui %[[ARG]] : [[INT_TYPE]] to [[INTER_TYPE]]
+  // CHECK: %[[MULRATIO:.*]] = arith.muli %[[EXT]], %[[RATIO]] : [[INTER_TYPE]]
+  // CHECK: %[[SHIFTED:.*]] = arith.shrui %[[MULRATIO]], %[[BITWIDTH]] : [[INTER_TYPE]]
+  // CHECK: %[[MULCMOD:.*]] = arith.muli %[[SHIFTED]], %[[CMOD]] : [[INTER_TYPE]]
+  // CHECK: %[[SUB:.*]] = arith.subi %[[EXT]], %[[MULCMOD]] : [[INTER_TYPE]]
+  // CHECK: %[[RES:.*]] = arith.trunci %[[SUB]] : [[INTER_TYPE]] to [[INT_TYPE]]
+  %res = arith_ext.barrett_reduce %arg { modulus = 17 } : i10
+
+  // CHECK: return %[[RES]] : [[INT_TYPE]]
+  return %res : i10
+}
+
+// -----

--- a/tests/arith/arith-ext-to-arith.mlir
+++ b/tests/arith/arith-ext-to-arith.mlir
@@ -13,6 +13,28 @@ func.func @test_lower_subifge(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tenso
 
 // -----
 
+// CHECK-LABEL: @test_lower_normalised
+// CHECK-SAME: (%[[ARG:.*]]: [[TENSOR_TYPE:.*]]) -> [[TENSOR_TYPE]] {
+func.func @test_lower_normalised(%arg : tensor<4xi8>) -> tensor<4xi8> {
+  %res = arith_ext.normalised %arg { q = 17 } : tensor<4xi8>
+
+  // CHECK: return %[[ARG]] : [[TENSOR_TYPE]]
+  return %res : tensor<4xi8>
+}
+
+// -----
+
+// CHECK-LABEL: @test_lower_normalised_int
+// CHECK-SAME: (%[[ARG:.*]]: [[INT_TYPE:.*]]) -> [[INT_TYPE]] {
+func.func @test_lower_normalised_int(%arg : i8) -> i8 {
+  %res = arith_ext.normalised %arg { q = 17 } : i8
+
+  // CHECK: return %[[ARG]] : i8
+  return %res : i8
+}
+
+// -----
+
 // CHECK-LABEL: @test_lower_subifge_int
 // CHECK-SAME: (%[[LHS:.*]]: [[INT_TYPE:.*]], %[[RHS:.*]]: [[INT_TYPE]]) -> [[INT_TYPE]] {
 func.func @test_lower_subifge_int(%lhs : i8, %rhs : i8) -> i8 {

--- a/tests/arith/barrett_reduce_runner.mlir
+++ b/tests/arith/barrett_reduce_runner.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt %s --arith-ext-to-arith --heir-polynomial-to-llvm \
+// RUN:   | mlir-cpu-runner -e test_lower_barrett_reduce -entry-point-result=void \
+// RUN:      --shared-libs="%mlir_lib_dir/libmlir_c_runner_utils%shlibext,%mlir_runner_utils" > %t
+// RUN: FileCheck %s --check-prefix=CHECK_TEST_BARRETT < %t
+
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
+
+func.func @test_lower_barrett_reduce() {
+  %coeffs = arith.constant dense<[29498763, 58997760, 17, 7681]> : tensor<4xi26>
+  %1 = arith_ext.barrett_reduce %coeffs { modulus = 7681 } : tensor<4xi26>
+
+  %2 = arith.extui %1 : tensor<4xi26> to tensor<4xi32>
+  %3 = bufferization.to_memref %2 : memref<4xi32>
+  %U = memref.cast %3 : memref<4xi32> to memref<*xi32>
+  func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
+  return
+}
+
+// CHECK_TEST_BARRETT: [3723, 7680, 17, 7681]

--- a/tests/arith/rewrite-modulo.mlir
+++ b/tests/arith/rewrite-modulo.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt -convert-rem-to-arith-ext --split-input-file %s | FileCheck %s
+
+func.func @test_add_rewrite(%lhs : i8, %rhs : i8) -> i8 {
+  %n_lhs = arith_ext.normalised %lhs {q = 17} : i8
+  %n_rhs = arith_ext.normalised %rhs {q = 17} : i8
+
+  %cmod = arith.constant 17 : i8
+
+  %add = arith.addi %n_lhs, %n_rhs : i8
+  %res = arith.remui %add, %cmod : i8
+
+  return %res : i8
+}
+
+// -----

--- a/tests/arith/syntax.mlir
+++ b/tests/arith/syntax.mlir
@@ -12,6 +12,11 @@ func.func @test_arith_syntax() {
   %barrett = arith_ext.barrett_reduce %zero { modulus = 17 } : i10
   %barrett_vec = arith_ext.barrett_reduce %c_vec { modulus = 17 } : tensor<4xi10>
 
+  // CHECK: arith_ext.normalised
+  // CHECK: arith_ext.normalised
+  %normalised = arith_ext.normalised %zero { q = 17 } : i10
+  %normalised_vec = arith_ext.normalised %c_vec { q = 17 } : tensor<4xi10>
+
   // CHECK: arith_ext.subifge
   // CHECK: arith_ext.subifge
   %subifge = arith_ext.subifge %zero, %cmod : i10

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -32,6 +32,7 @@ cc_binary(
     }),
     includes = ["include"],
     deps = [
+        "@heir//lib/Conversion/ArithExtToArith",
         "@heir//lib/Conversion/BGVToOpenfhe",
         "@heir//lib/Conversion/BGVToPolynomial",
         "@heir//lib/Conversion/CGGIToTfheRust",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -43,6 +43,8 @@ cc_binary(
         "@heir//lib/Conversion/PolynomialToStandard",
         "@heir//lib/Conversion/SecretToBGV",
         "@heir//lib/Dialect/ArithExt/IR:Dialect",
+        "@heir//lib/Dialect/ArithExt/Transforms",
+        "@heir//lib/Dialect/ArithExt/Transforms:RemToArithExt",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/BGV/Transforms",
         "@heir//lib/Dialect/BGV/Transforms:AddClientInterface",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/Conversion/ArithExtToArith/ArithExtToArith.h"
 #include "lib/Conversion/BGVToOpenfhe/BGVToOpenfhe.h"
 #include "lib/Conversion/BGVToPolynomial/BGVToPolynomial.h"
 #include "lib/Conversion/CGGIToTfheRust/CGGIToTfheRust.h"
@@ -535,6 +536,7 @@ int main(int argc, char **argv) {
 #endif
 
   // Dialect conversion passes in HEIR
+  arith_ext::registerArithExtToArithPasses();
   bgv::registerBGVToPolynomialPasses();
   bgv::registerBGVToOpenfhePasses();
   comb::registerCombToCGGIPasses();

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -12,6 +12,7 @@
 #include "lib/Conversion/PolynomialToStandard/PolynomialToStandard.h"
 #include "lib/Conversion/SecretToBGV/SecretToBGV.h"
 #include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
+#include "lib/Dialect/ArithExt/Transforms/Passes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/BGV/Transforms/AddClientInterface.h"
 #include "lib/Dialect/BGV/Transforms/Passes.h"
@@ -499,6 +500,7 @@ int main(int argc, char **argv) {
   registerAllPasses();
 
   // Custom passes in HEIR
+  arith_ext::registerArithExtPasses();
   bgv::registerBGVPasses();
   cggi::registerCGGIPasses();
   lwe::registerLWEPasses();


### PR DESCRIPTION
- We can reduce runtime computation by avoiding computing remui and
   instead use a Barrett reduction or SubIfGE operation when possible

Resolve #710 