### PR TITLE
[heir-www] Fix broken links in TOSA to Arith pipeline

### DIFF
--- a/docs/content/en/docs/pipelines.md
+++ b/docs/content/en/docs/pipelines.md
@@ -41,10 +41,10 @@ a memref with a variable index).
 
 The pass pipeline assumes that the input is a valid TOSA MLIR model with
 stripped quantized types. The
-[iree-import-tflite](https://openxla.github.io/iree/getting-started/tflite/)
+[iree-import-tflite](https://iree.dev/guides/ml-frameworks/tflite)
 tool can lower a TFLite FlatBuffer to textual MLIR with
 `--output-format=mlir-ir`. See
-[hello_world.tosa.mlir](https://github.com/google/heir/blob/main/tests/hello_world.tosa.mlir)
+[hello_world.tosa.mlir](https://github.com/google/heir/blob/main/tests/verilog/hello_world.tosa.mlir)
 for an example.
 
 


### PR DESCRIPTION
Fixed broken links in the website `Pipelines` section. IREE seems to have its own website and the mentioned test's location has changed.