### PR TITLE
register `-apply-folders` pass in heir-opt

### DIFF
--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -503,6 +503,7 @@ int main(int argc, char **argv) {
   registerElementwiseToAffinePasses();
   registerSecretizePasses();
   registerFullLoopUnrollPasses();
+  registerApplyFoldersPasses();
   registerForwardStoreToLoadPasses();
   registerStraightLineVectorizerPasses();
   registerUnusedMemRefPasses();


### PR DESCRIPTION
As mentioned in #716: registers the `-apply-folders` pass in `heir-opt` so it can be used from the command line.