### PR TITLE
register arith_ext dialect in heir-lsp

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -140,6 +140,7 @@ cc_binary(
     srcs = ["heir-lsp.cpp"],
     includes = ["include"],
     deps = [
+        "@heir//lib/Dialect/ArithExt/IR:Dialect",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/CGGI/IR:Dialect",
         "@heir//lib/Dialect/Comb/IR:Dialect",

--- a/tools/heir-lsp.cpp
+++ b/tools/heir-lsp.cpp
@@ -1,3 +1,4 @@
+#include "lib/Dialect/ArithExt/IR/ArithExtDialect.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/CGGI/IR/CGGIDialect.h"
 #include "lib/Dialect/Comb/IR/CombDialect.h"
@@ -26,6 +27,7 @@ using namespace heir;
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
+  registry.insert<arith_ext::ArithExtDialect>();
   registry.insert<bgv::BGVDialect>();
   registry.insert<comb::CombDialect>();
   registry.insert<lwe::LWEDialect>();


### PR DESCRIPTION
spotted another missing registration, this time `arith_ext` wasn't registered in the heir-lsp server :) 