### PR TITLE
ArithExt Improvements: Arbitrary Coefficient Bitwidth + lowerings of modular add/sub/mul to arith

### DIFF
--- a/lib/Conversion/ArithExtToArith/ArithExtToArith.td
+++ b/lib/Conversion/ArithExtToArith/ArithExtToArith.td
@@ -33,4 +33,121 @@ def ConvertSubIfGE : Pattern<
   ]
 >;
 
+
+def HasEnoughSpaceAddSub: Constraint<CPred<"llvm::cast<IntegerType>(getElementTypeOrSelf($_self.getType())).getWidth() >= ($0.getValue() - 1).getActiveBits() + 1">,
+"underlying type is sufficient for modular add/sub operation without overflow">;
+
+def HasEnoughSpaceMul: Constraint<CPred<"llvm::cast<IntegerType>(getElementTypeOrSelf($_self.getType())).getWidth() >= 2 * ($0.getValue() - 1).getActiveBits()">,
+ "underlying type is sufficient for modular mul operation without overflow">;
+
+def CastModulusAttributeAddSub : NativeCodeCall<"modulusHelper($0,$1,false)">;
+def CastModulusAttributeMul : NativeCodeCall<"modulusHelper($0,$1,true)">;
+
+def ConvertAddSimple : Pattern<
+  (ArithExt_AddOp:$op $x, $y, $mod),
+  [
+    (Arith_AddIOp:$add $x, $y, DefOverflow),
+    (Arith_RemUIOp $add, (Arith_ConstantOp (CastModulusAttributeAddSub $mod, $x)))
+  ],
+  [(HasEnoughSpaceAddSub:$op $mod)],
+  [],
+  (addBenefit 2)
+>;
+
+def ConvertSubSimple : Pattern<
+  (ArithExt_SubOp:$op $x, $y, $mod),
+  [
+    (Arith_SubIOp:$sub $x, $y, DefOverflow),
+    (Arith_RemUIOp $sub, (Arith_ConstantOp (CastModulusAttributeAddSub $mod, $x)))
+  ],
+  [(HasEnoughSpaceAddSub:$op $mod)],
+  [],
+  (addBenefit 2)
+>;
+
+def ConvertMulSimple : Pattern<
+  (ArithExt_MulOp:$op $x, $y, $mod),
+  [
+    (Arith_MulIOp:$mul $x, $y, DefOverflow),
+    (Arith_RemUIOp $mul, (Arith_ConstantOp (CastModulusAttributeMul $mod, $x)))
+  ],
+  [(HasEnoughSpaceMul:$op $mod)],
+  [],
+  (addBenefit 2)
+>;
+
+def ConvertMacSimple : Pattern<
+  (ArithExt_MacOp:$op $x, $y, $acc, $mod),
+  [
+    (Arith_MulIOp:$mul $x, $y, DefOverflow),
+    (Arith_AddIOp:$add $mul, $acc, DefOverflow),
+    (Arith_RemUIOp $add, (Arith_ConstantOp (CastModulusAttributeMul $mod, $x)))
+  ],
+  [(HasEnoughSpaceMul:$op $mod)],
+  [],
+  (addBenefit 2)
+>;
+
+def ConvertAdd : Pattern<
+  (ArithExt_AddOp $x, $y, $mod),
+  [
+    (Arith_ConstantOp:$newmod (CastModulusAttributeAddSub $mod, $x)),
+    (Arith_AddIOp:$add
+      (Arith_ExtUIOp $x,
+        (returnType $newmod)),
+      (Arith_ExtUIOp $y,
+        (returnType $newmod)),
+      DefOverflow),
+    (Arith_TruncIOp:$res
+      (Arith_RemUIOp $add, $newmod))
+  ]
+>;
+
+def ConvertSub : Pattern<
+  (ArithExt_SubOp $x, $y, $mod),
+  [
+    (Arith_ConstantOp:$newmod (CastModulusAttributeAddSub $mod, $x)),
+    (Arith_SubIOp:$sub
+      (Arith_ExtUIOp $x,
+        (returnType $newmod)),
+      (Arith_ExtUIOp $y,
+        (returnType $newmod)),
+      DefOverflow),
+    (Arith_TruncIOp:$res
+      (Arith_RemUIOp $sub, $newmod))
+  ]
+>;
+
+def ConvertMul : Pattern<
+  (ArithExt_MulOp $x, $y, $mod),
+  [
+    (Arith_ConstantOp:$newmod (CastModulusAttributeMul $mod, $x)),
+    (Arith_MulIOp:$mul
+      (Arith_ExtUIOp $x,
+        (returnType $newmod)),
+      (Arith_ExtUIOp $y,
+        (returnType $newmod)),
+      DefOverflow),
+    (Arith_TruncIOp:$res
+      (Arith_RemUIOp $mul, $newmod))
+  ]
+>;
+
+def ConvertMac : Pattern<
+  (ArithExt_MacOp $x, $y, $acc, $mod),
+  [
+    (Arith_ConstantOp:$newmod (CastModulusAttributeMul $mod, $x)),
+    (Arith_MulIOp:$mul
+      (Arith_ExtUIOp $x,
+        (returnType $newmod)),
+      (Arith_ExtUIOp $y,
+        (returnType $newmod)),
+      DefOverflow),
+    (Arith_AddIOp:$add $mul,
+      (Arith_ExtUIOp:$extacc $acc, (returnType $newmod)), DefOverflow),
+    (Arith_TruncIOp:$res
+      (Arith_RemUIOp $add, $newmod))
+  ]
+>;
+
 #endif  // LIB_CONVERSION_ARITHEXTTOARITH_ARITHEXTTOARITH_TD_

--- a/lib/Dialect/ArithExt/IR/ArithExtOps.td
+++ b/lib/Dialect/ArithExt/IR/ArithExtOps.td
@@ -12,13 +12,15 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class ArithExt_Op<string mnemonic, list<Trait> traits = [Pure]> :
         Op<ArithExt_Dialect, mnemonic, traits> {
   let cppNamespace = "::mlir::heir::arith_ext";
+  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 class ArithExt_BinaryOp<string mnemonic, list<Trait> traits = []> :
     ArithExt_Op<mnemonic, traits # [SameOperandsAndResultType, Pure, ElementwiseMappable]>,
-    Arguments<(ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs, I64Attr:$modulus)>,
+    Arguments<(ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs, APIntAttr:$modulus)>,
     Results<(outs SignlessIntegerLike:$output)> {
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` qualified(type($output))";
+  let hasVerifier = 1;
+  let assemblyFormat ="operands attr-dict `:` type($output)";
 }
 
 def ArithExt_AddOp : ArithExt_BinaryOp<"add", [Commutative]> {
@@ -42,6 +44,17 @@ def ArithExt_MulOp : ArithExt_BinaryOp<"mul", [Commutative]> {
   }];
 }
 
+def ArithExt_MacOp : ArithExt_Op<"mac", [SameOperandsAndResultType, Pure, ElementwiseMappable]> {
+  let summary = "modular multiplication-and-accumulation operation";
+
+  let description = [{
+    `arith_ext.mac x, y, z {modulus = q}` computes $(x * y) + z \mod q$
+  }];
+  let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs, SignlessIntegerLike:$acc, APIntAttr:$modulus);
+  let results = (outs SignlessIntegerLike:$output);
+  let hasVerifier = 1;
+  let assemblyFormat = "operands attr-dict `:` type($output)";
+}
 
 def ArithExt_BarrettReduceOp : ArithExt_Op<"barrett_reduce", [SameOperandsAndResultType]> {
   let summary = "Compute the first step of the Barrett reduction.";
@@ -55,7 +68,7 @@ def ArithExt_BarrettReduceOp : ArithExt_Op<"barrett_reduce", [SameOperandsAndRes
 
   let arguments = (ins
     SignlessIntegerLike:$input,
-    I64Attr:$modulus
+    APIntAttr:$modulus
   );
   let results = (outs SignlessIntegerLike:$output);
   let assemblyFormat = "operands attr-dict `:` qualified(type($input))";

--- a/tests/arith_ext/arith-ext-to-arith.mlir
+++ b/tests/arith_ext/arith-ext-to-arith.mlir
@@ -1,4 +1,229 @@
-// RUN: heir-opt -arith-ext-to-arith --split-input-file %s | FileCheck %s
+// RUN: heir-opt -arith-ext-to-arith --split-input-file %s | FileCheck %s --enable-var-scope
+
+// CHECK-LABEL: @test_lower_simple_add
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_add(%lhs : i8, %rhs : i8) -> i8 {
+  // CHECK-NOT: arith_ext.add
+  // CHECK: %[[ADD:.*]] = arith.addi %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant 17 : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.add %lhs, %rhs {modulus = 17 }: i8
+  return %res : i8
+}
+
+// CHECK-LABEL: @test_lower_simple_add_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_add_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK-NOT: arith_ext.add
+  // CHECK: %[[ADD:.*]] = arith.addi %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<17> : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.add %lhs, %rhs {modulus = 17}: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// CHECK-LABEL: @test_lower_add
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_add(%lhs : i8, %rhs : i8) -> i8 {
+  // CHECK-NOT: arith_ext.add
+  // CHECK: %[[CMOD:.*]] = arith.constant 217 : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[ADD:.*]] = arith.addi %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.add %lhs, %rhs {modulus = 217 }: i8
+  return %res : i8
+}
+
+// CHECK-LABEL: @test_lower_add_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_add_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK-NOT: arith_ext.add
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<217> : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[ADD:.*]] = arith.addi %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.add %lhs, %rhs {modulus = 217 }: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// CHECK-LABEL: @test_lower_simple_sub
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_sub(%lhs : i8, %rhs : i8) -> i8 {
+  // CHECK-NOT: arith_ext.sub
+  // CHECK: %[[SUB:.*]] = arith.subi %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant 17 : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[SUB]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.sub %lhs, %rhs {modulus = 17}: i8
+  return %res : i8
+}
+
+// CHECK-LABEL: @test_lower_simple_sub_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_sub_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK-NOT: arith_ext.sub
+  // CHECK: %[[SUB:.*]] = arith.subi %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<17> : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[SUB]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.sub %lhs, %rhs {modulus = 17}: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// CHECK-LABEL: @test_lower_sub
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_sub(%lhs : i8, %rhs : i8) -> i8 {
+  // CHECK-NOT: arith_ext.sub
+  // CHECK: %[[CMOD:.*]] = arith.constant 217 : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[SUB:.*]] = arith.subi %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[SUB]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.sub %lhs, %rhs {modulus = 217 }: i8
+  return %res : i8
+}
+
+// CHECK-LABEL: @test_lower_sub_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_sub_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK-NOT: arith_ext.sub
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<217> : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[SUB:.*]] = arith.subi %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[SUB]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.sub %lhs, %rhs {modulus = 217 }: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// CHECK-LABEL: @test_lower_simple_mul
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_mul(%lhs : i16, %rhs : i16) -> i16 {
+  // CHECK-NOT: arith_ext.mul
+  // CHECK: %[[MUL:.*]] = arith.muli %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant 17 : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[MUL]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.mul %lhs, %rhs {modulus = 17}: i16
+  return %res : i16
+}
+
+// CHECK-LABEL: @test_lower_simple_mul_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_mul_vec(%lhs : tensor<4xi16>, %rhs : tensor<4xi16>) -> tensor<4xi16> {
+  // CHECK-NOT: arith_ext.mul
+  // CHECK: %[[MUL:.*]] = arith.muli %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<17> : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[MUL]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.mul %lhs, %rhs {modulus = 17}: tensor<4xi16>
+  return %res : tensor<4xi16>
+}
+
+// CHECK-LABEL: @test_lower_mul
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_mul(%lhs : i8, %rhs : i8) -> i8 {
+  // CHECK-NOT: arith_ext.mul
+  // CHECK: %[[CMOD:.*]] = arith.constant 217 : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[MUL:.*]] = arith.muli %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[MUL]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.mul %lhs, %rhs {modulus = 217 }: i8
+  return %res : i8
+}
+
+// CHECK-LABEL: @test_lower_mul_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_mul_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK-NOT: arith_ext.mul
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<217> : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[MUL:.*]] = arith.muli %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[MUL]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.mul %lhs, %rhs {modulus = 217 }: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// CHECK-LABEL: @test_lower_simple_mac
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]], %[[ACC:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_mac(%lhs : tensor<4xi16>, %rhs : tensor<4xi16>, %acc : tensor<4xi16>) -> tensor<4xi16> {
+  // CHECK-NOT: arith_ext.mac
+  // CHECK: %[[MUL:.*]] = arith.muli %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[ADD:.*]] = arith.addi %[[MUL]], %[[ACC]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<17> : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.mac %lhs, %rhs, %acc {modulus = 17}: tensor<4xi16>
+  return %res : tensor<4xi16>
+}
+
+// CHECK-LABEL: @test_lower_simple_mac_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]], %[[ACC:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_simple_mac_vec(%lhs : i16, %rhs : i16, %acc : i16) -> i16 {
+  // CHECK-NOT: arith_ext.mac
+  // CHECK: %[[MUL:.*]] = arith.muli %[[LHS]], %[[RHS]] : [[TYPE]]
+  // CHECK: %[[ADD:.*]] = arith.addi %[[MUL]], %[[ACC]] : [[TYPE]]
+  // CHECK: %[[CMOD:.*]] = arith.constant 17 : [[TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[TYPE]]
+  // CHECK: return %[[REM]] : [[TYPE]]
+  %res = arith_ext.mac %lhs, %rhs, %acc{modulus = 17}: i16
+  return %res : i16
+}
+
+// CHECK-LABEL: @test_lower_mac
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]], %[[ACC:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_mac(%lhs : i8, %rhs : i8, %acc : i8) -> i8 {
+  // CHECK-NOT: arith_ext.mac
+  // CHECK: %[[CMOD:.*]] = arith.constant 217 : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[MUL:.*]] = arith.muli %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT2:.*]] = arith.extui %[[ACC]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[ADD:.*]] = arith.addi %[[MUL]], %[[EXT2]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.mac %lhs, %rhs, %acc {modulus = 217 }: i8
+  return %res : i8
+}
+
+// CHECK-LABEL: @test_lower_mac_vec
+// CHECK-SAME: (%[[LHS:.*]]: [[TYPE:.*]], %[[RHS:.*]]: [[TYPE]], %[[ACC:.*]]: [[TYPE]]) -> [[TYPE]] {
+func.func @test_lower_mac_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>, %acc : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK-NOT: arith_ext.mac
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<217> : [[INTERMEDIATE_TYPE:.*]]
+  // CHECK: %[[EXT0:.*]] = arith.extui %[[LHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT1:.*]] = arith.extui %[[RHS]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[MUL:.*]] = arith.muli %[[EXT0]], %[[EXT1]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[EXT2:.*]] = arith.extui %[[ACC]] : [[TYPE]] to [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[ADD:.*]] = arith.addi %[[MUL]], %[[EXT2]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[REM:.*]] = arith.remui %[[ADD]], %[[CMOD]] : [[INTERMEDIATE_TYPE]]
+  // CHECK: %[[TRUNC:.*]] = arith.trunci %[[REM]] : [[INTERMEDIATE_TYPE]] to [[TYPE]]
+  // CHECK: return %[[TRUNC]] : [[TYPE]]
+  %res = arith_ext.mac %lhs, %rhs, %acc {modulus = 217 }: tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+
+// -----
 
 // CHECK-LABEL: @test_lower_subifge
 // CHECK-SAME: (%[[LHS:.*]]: [[TENSOR_TYPE:.*]], %[[RHS:.*]]: [[TENSOR_TYPE]]) -> [[TENSOR_TYPE]] {

--- a/tests/arith_ext/invalid-ops.mlir
+++ b/tests/arith_ext/invalid-ops.mlir
@@ -11,3 +11,19 @@ func.func @test_bad_arith_syntax() {
 }
 
 // -----
+
+// CHECK-NOT: @test_bad_mod
+func.func @test_bad_mod(%lhs : i8, %rhs : i8) -> i8 {
+  // expected-error@+1 {{underlying type's bitwidth must be at least as large as the modulus bitwidth, but got 8 while modulus requires width 23.}}
+  %res = arith_ext.add %lhs, %rhs {modulus = 6666666 }: i8
+  return %res : i8
+}
+
+// -----
+
+// CHECK: @test_bad_mod_warning
+func.func @test_bad_mod_warning(%lhs : i8, %rhs : i8) -> i8 {
+  // expected-warning@+1 {{for signed (or signless) underlying types, the bitwidth of the underlying type must be at least as large as modulus bitwidth + 1 (for the sign bit), but found 8 while modulus requires width 8.}}
+  %res = arith_ext.add %lhs, %rhs {modulus = 135 }: i8
+  return %res : i8
+}

--- a/tests/arith_ext/syntax.mlir
+++ b/tests/arith_ext/syntax.mlir
@@ -3,11 +3,13 @@
 // CHECK-LABEL: @test_arith_syntax
 func.func @test_arith_syntax() {
   %zero = arith.constant 1 : i10
+  %c4 = arith.constant 4 : i10
   %c5 = arith.constant 5 : i10
   %c6 = arith.constant 6 : i10
   %cmod = arith.constant 17 : i10
   %c_vec = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi10>
-  %c_vec2 = arith.constant dense<[4,3,2,1]> : tensor<4xi10>
+  %c_vec2 = arith.constant dense<[4, 3, 2, 1]> : tensor<4xi10>
+  %c_vec3 = arith.constant dense<[1, 1, 1, 1]> : tensor<4xi10>
   %cmod_vec = arith.constant dense<17> : tensor<4xi10>
 
   // CHECK: arith_ext.add
@@ -24,6 +26,11 @@ func.func @test_arith_syntax() {
   // CHECK: arith_ext.mul
   %mul = arith_ext.mul %c5, %c6 { modulus = 17 } : i10
   %mul_vec = arith_ext.mul %c_vec, %c_vec2 { modulus = 17 } : tensor<4xi10>
+
+  // CHECK: arith_ext.mac
+  // CHECK: arith_ext.mac
+  %mac = arith_ext.mac %c5, %c6, %c4 { modulus = 17 } : i10
+  %mac_vec = arith_ext.mac %c_vec, %c_vec2, %c_vec3 { modulus = 17 } : tensor<4xi10>
 
   // CHECK: arith_ext.barrett_reduce
   // CHECK: arith_ext.barrett_reduce


### PR DESCRIPTION
This does three things
* removes the `I64Attr` constraint (replacing it with `APIntAttr`) and adds a verifier to ensure that the modulus can actually fit into the underlying operand type.
* adds an `arith_ext.mac %lhs, %rhs, %acc` operation that multiplies the two first operands and then adds the third. 
 This not only saves one remainder operation compared to doing the operations separately, but is also a native operation in some RLWE accelerators, so it's useful to have a way to model it in HEIR
* adds lowerings for `arith_ext.add`/sub/mul/mac to arith. If the results of a modular operation can fit into the underlying operand type, it's just a straighforward operation + remainder, otherwise it'll create `extui` and `remui` operations to temporarily increase the bitwidth. 