### PR TITLE
fix dimension check in bgv.mul verifier

### DIFF
--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -44,8 +44,8 @@ LogicalResult MulOp::verify() {
   }
   auto out = getOutput().getType();
   if (out.getRlweParams().getDimension() !=
-      1 + x.getRlweParams().getDimension()) {
-    return emitOpError() << "output.dim == x.dim + 1 does not hold";
+      y.getRlweParams().getDimension() + x.getRlweParams().getDimension() - 1) {
+    return emitOpError() << "output.dim == x.dim + y.dim - 1 does not hold";
   }
   return success();
 }


### PR DESCRIPTION
Verifier logic for `bgv.mul` output degree was incorrect (and did not match type inference logic, which was correct).

With this fix, you should now be able to express multiplications of already multiplied values (without a relinerization in between) which might be helpful for the  layz relin optimization (#599)