### PR TITLE
add `--convert-tensor-to-scalars` pass

### DIFF
--- a/lib/Transforms/TensorToScalars/BUILD
+++ b/lib/Transforms/TensorToScalars/BUILD
@@ -1,0 +1,44 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "TensorToScalars",
+    srcs = ["TensorToScalars.cpp"],
+    hdrs = ["TensorToScalars.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Utils/ConversionUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=TensorToScalars",
+            ],
+            "TensorToScalars.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "TensorToScalarsPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "TensorToScalars.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Transforms/TensorToScalars/TensorToScalars.cpp
+++ b/lib/Transforms/TensorToScalars/TensorToScalars.cpp
@@ -1,0 +1,149 @@
+#include "lib/Transforms/TensorToScalars/TensorToScalars.h"
+
+#include <optional>
+
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/OneToNFuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/OneToNTypeConversion.h"  // from @llvm-project
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_TENSORTOSCALARS
+#include "lib/Transforms/TensorToScalars/TensorToScalars.h.inc"
+
+static std::optional<Value> buildFromElementsOp(OpBuilder &builder,
+                                                RankedTensorType resultType,
+                                                ValueRange inputs,
+                                                Location loc) {
+  return builder.create<tensor::FromElementsOp>(loc, resultType, inputs);
+}
+
+static std::optional<SmallVector<Value>> buildExtractOps(OpBuilder &builder,
+                                                         TypeRange resultTypes,
+                                                         Value input,
+                                                         Location loc) {
+  // This pass only operates on tensors of static shape
+  RankedTensorType inputType = dyn_cast<RankedTensorType>(input.getType());
+  if (!inputType || !inputType.hasStaticShape()) return {};
+
+  // Create extract ops in "natural" order (dimension-by-dimension)
+  SmallVector<Value> values;
+  for (auto dim : inputType.getShape()) {
+    for (int i = 0; i < dim; ++i) {
+      Value index = builder.create<arith::ConstantIndexOp>(loc, i);
+      Value element = builder.create<tensor::ExtractOp>(loc, input, index);
+      values.push_back(element);
+    }
+  }
+  return values;
+}
+
+class ConvertFromElementsOp
+    : public OneToNOpConversionPattern<tensor::FromElementsOp> {
+ public:
+  using OneToNOpConversionPattern<
+      tensor::FromElementsOp>::OneToNOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor::FromElementsOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const override {
+    // OneToNConversion has no Conversion-level illegality handling
+    if (typeConverter->isLegal(op)) return failure();
+
+    // This pass only operates on tensors of static shape,
+    // but no check is necessary here as from_elements' shape is always static
+
+    // Replace the current op with the flattened operands.
+    // This should already match the "natural" order expected by this pass.
+    rewriter.replaceOp(op, adaptor.getFlatOperands(),
+                       adaptor.getResultMapping());
+    return success();
+  }
+};
+
+class ConvertInsertOp : public OneToNOpConversionPattern<tensor::InsertOp> {
+ public:
+  using OneToNOpConversionPattern<tensor::InsertOp>::OneToNOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor::InsertOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const override {
+    // OneToNConversion has no Conversion-level illegality handling
+    if (typeConverter->isLegal(op)) return failure();
+
+    // This pass only operates on tensors of static shape
+    if (!op.getResult().getType().hasStaticShape()) return failure();
+
+    // Compute the insertion offset (in dimension-by-dimension order):
+    int64_t multiplier = 1;
+    int64_t offset = 0;
+    for (auto [dim, idx] :
+         llvm::zip(op.getResult().getType().getShape(), op.getIndices())) {
+      // We can only support statically known indices
+      // that have been constant-folded to a single arith.constant op
+      auto cidx = idx.getDefiningOp<arith::ConstantIndexOp>();
+      if (!cidx) return failure();
+      offset += cidx.value() * multiplier;
+      multiplier *= dim;
+    }
+
+    // get converted "tensor" operand from op (likely a unrealized_builtin_cast)
+    SmallVector<Value> elements = adaptor.getOperands()[1];
+    // replace element at offset with the "scalar" operand to be inserted
+    elements[offset] = adaptor.getOperands()[0].front();
+    // replace the current op with the converted operands.
+    rewriter.replaceOp(op, elements, adaptor.getResultMapping());
+    return success();
+  }
+};
+
+struct TensorToScalars : impl::TensorToScalarsBase<TensorToScalars> {
+  using TensorToScalarsBase::TensorToScalarsBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    // do not unroll tensors with more than maxSize elements
+    int maxSizeInt = maxSize.getValue();
+    OneToNTypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    typeConverter.addConversion(
+        [maxSizeInt](
+            RankedTensorType tensorType,
+            SmallVectorImpl<Type> &types) -> std::optional<LogicalResult> {
+          if (!tensorType.hasStaticShape()) return std::nullopt;
+          if (tensorType.getNumElements() > maxSizeInt) return std::nullopt;
+          types = SmallVector<Type>(tensorType.getNumElements(),
+                                    tensorType.getElementType());
+          return success();
+        });
+    typeConverter.addArgumentMaterialization(buildFromElementsOp);
+    typeConverter.addSourceMaterialization(buildFromElementsOp);
+    typeConverter.addTargetMaterialization(buildExtractOps);
+
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertFromElementsOp, ConvertInsertOp>(typeConverter,
+                                                         context);
+    scf::populateSCFStructuralOneToNTypeConversions(typeConverter, patterns);
+    populateFuncTypeConversionPatterns(typeConverter, patterns);
+
+    if (mlir::failed(mlir::applyPartialOneToNConversion(
+            getOperation(), typeConverter, std::move(patterns))))
+      signalPassFailure();
+
+    // Empty PatternSet = only run folders (should never fail)
+    RewritePatternSet emptyPatterns(context);
+    (void)applyPatternsAndFoldGreedily(getOperation(),
+                                       std::move(emptyPatterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/TensorToScalars/TensorToScalars.h
+++ b/lib/Transforms/TensorToScalars/TensorToScalars.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_TENSORTOSCALARS_TENSORTOSCALARS_H_
+#define LIB_TRANSFORMS_TENSORTOSCALARS_TENSORTOSCALARS_H_
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"                // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/TensorToScalars/TensorToScalars.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/TensorToScalars/TensorToScalars.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_TENSORTOSCALARS_TENSORTOSCALARS_H_

--- a/lib/Transforms/TensorToScalars/TensorToScalars.td
+++ b/lib/Transforms/TensorToScalars/TensorToScalars.td
@@ -1,0 +1,47 @@
+#ifndef LIB_TRANSFORMS_TENSORTOSCALARS_TENSORTOSCALARS_TD_
+#define LIB_TRANSFORMS_TENSORTOSCALARS_TENSORTOSCALARS_TD_
+
+include "mlir/Pass/PassBase.td"
+
+
+def TensorToScalars : Pass<"convert-tensor-to-scalars"> {
+
+  let summary = "Effectively 'unrolls' tensors of static shape to scalars.";
+
+  let description = [{
+    This pass will convert a static-shaped tensor type to a TypeRange
+    containing product(dim) copies of the element type of the tensor.
+    This pass currently includes two patterns:
+
+    1. It converts tensor.from_elements operations to
+    the corresponding scalar inputs.
+    2. It converts tensor.insert operations by updating the
+    ValueRange corresponding to the converted input and
+    updating it with the scalar to be inserted.
+
+    It also applies folders greedily to simplify, e.g., extract(from_elements).
+
+    Note: The pass is designed to be run on an IR, where the only operations
+    with tensor typed operands are tensor "management" operations such as insert/extract,
+    with all other operations (e.g., arith operations) already taking (extracted) scalar inputs.
+    For example, an IR where elementwise operations have been converted to scalar operations via
+    `--convert-elementwise-to-affine`.
+
+    The pass might insert new tensor.from_elements operations or manually create the scalar ValueRange
+    via inserting tensor.extract operations if any operations remain that operate on tensors.
+    The pass currently applies irrespective of tensor size, i.e., might be very slow for large tensors.
+
+    TODO (#1023): Extend this pass to support more tensor operations, e.g., `tensor.slice`
+  }];
+
+  let dependentDialects = [
+    "tensor::TensorDialect"
+  ];
+
+  let options = [
+    Option<"maxSize", "max-size", "int", /*default=*/"8",
+           "Limits `unrolling` to tensors with at most max-size elements">,
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_TENSORTOSCALARS_TENSORTOSCALARS_TD_

--- a/tests/Transforms/convert_tensor_to_scalars/BUILD
+++ b/tests/Transforms/convert_tensor_to_scalars/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/convert_tensor_to_scalars/convert_tensor_to_scalars.mlir
+++ b/tests/Transforms/convert_tensor_to_scalars/convert_tensor_to_scalars.mlir
@@ -1,0 +1,96 @@
+// RUN: heir-opt --convert-tensor-to-scalars %s | FileCheck --check-prefix=COMMONCHECK --check-prefix=CHECK %s
+// RUN: heir-opt --convert-tensor-to-scalars=max-size=0 %s | FileCheck --check-prefix=COMMONCHECK --check-prefix=NOOPCHECK %s
+!t = tensor<2xi32>
+
+//COMMONCHECK-LABEL: @test_fn
+//CHECK: [[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32
+//NOOPCHECK: [[ARG0:%.+]]: tensor<2xi32>
+func.func @test_fn(%arg0: tensor<2xi32>) -> tensor<2xi32> {
+    //CHECK: return [[ARG0]], [[ARG1]] : i32, i32
+    //NOOPCHECK: return [[ARG0]] : tensor<2xi32>
+    return %arg0 : tensor<2xi32>
+}
+
+//COMMONCHECK-LABEL: @test_scf
+//CHECK: [[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32, [[COND:%.+]]: i1
+//NOOPCHECK: [[ARG0:%.+]]: tensor<2xi32>, [[ARG1:%.+]]: tensor<2xi32>, [[COND:%.+]]: i1
+func.func @test_scf(%arg0: tensor<2xi32>, %arg1 : tensor<2xi32>, %cond : i1) -> tensor<2xi32> {
+    //CHECK: [[IF:%.+]]:2 = scf.if [[COND]] -> (i32, i32)
+    //NOOPCHECK: [[IF:%.+]] = scf.if [[COND]] -> (tensor<2xi32>)
+    %0 = scf.if %cond -> (tensor<2xi32>) {
+        //CHECK: scf.yield [[ARG0]], [[ARG1]] : i32, i32
+        //NOOPCHECK: scf.yield [[ARG0]] : tensor<2xi32>
+        scf.yield %arg0 : tensor<2xi32>
+    } else {
+        //CHECK: scf.yield [[ARG2]], [[ARG3]] : i32, i32
+        //NOOPCHECK: scf.yield [[ARG1]] : tensor<2xi32>
+        scf.yield %arg1 : tensor<2xi32>
+    }
+    //CHECK: return [[IF]]#0, [[IF]]#1 : i32, i32
+    //NOOPCHECK: return [[IF]] : tensor<2xi32>
+    return %0 : tensor<2xi32>
+}
+
+//COMMONCHECK-LABEL: @test_dyn_noop
+//COMMONCHECK: [[ARG0:%.+]]: tensor<?xi32>
+func.func @test_dyn_noop(%arg0: tensor<?xi32>) -> tensor<?xi32> {
+    //COMMONCHECK: return [[ARG0]] : tensor<?xi32>
+    return %arg0 : tensor<?xi32>
+}
+
+//COMMONCHECK-LABEL: @test_extract_insert
+//CHECK: [[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32
+//NOOPCHECK: [[ARG0:%.+]]: tensor<2xi32>, [[ARG1:%.+]]: tensor<2xi32>
+func.func @test_extract_insert(%arg0: tensor<2xi32>, %arg1 : tensor<2xi32>) -> tensor<2xi32> {
+    //CHECK-NOT: arith.constant
+    //NOOPCHECK: [[C0:%.+]] = arith.constant 0 : index
+    %c0 = arith.constant 0 : index
+    //NOOPCHECK: [[C1:%.+]] = arith.constant 1 : index
+    %c1 = arith.constant 1 : index
+    //CHECK-NOT: tensor.empty
+    //NOOPCHECK: [[T:%.+]] = tensor.empty() : tensor<2xi32>
+    %t = tensor.empty() : tensor<2xi32>
+    //CHECK-NOT: tensor.extract
+    //NOOPCHECK: [[X0:%.+]] = tensor.extract [[ARG0]][[[C0]]] : tensor<2xi32>
+    %x0 = tensor.extract %arg0[%c0] : tensor<2xi32>
+    //NOOPCHECK: [[Y0:%.+]] = tensor.extract [[ARG1]][[[C0]]] : tensor<2xi32>
+    %y0 = tensor.extract %arg1[%c0] : tensor<2xi32>
+    //CHECK: [[ADD0:%.+]] = arith.addi [[ARG0]], [[ARG2]] : i32
+    //NOOPCHECK: [[ADD0:%.+]] = arith.addi [[X0]], [[Y0]] : i32
+    %a0 = arith.addi %x0, %y0: i32
+    //CHECK-NOT: tensor.insert
+    //NOOPCHECK: [[TT:%.+]] = tensor.insert [[ADD0]] into [[T]][[[C0]]] : tensor<2xi32>
+    %tt = tensor.insert %a0 into %t[%c0] : tensor<2xi32>
+    //CHECK-NOT: tensor.extract
+    //NOOPCHECK: [[X1:%.+]] = tensor.extract [[ARG0]][[[C1]]] : tensor<2xi32>
+    %x1 = tensor.extract %arg0[%c1] : tensor<2xi32>
+    //NOOPCHECK: [[Y1:%.+]] = tensor.extract [[ARG1]][[[C1]]] : tensor<2xi32>
+    %y1 = tensor.extract %arg1[%c1] : tensor<2xi32>
+    //CHECK: [[ADD1:%.+]] = arith.addi [[ARG1]], [[ARG3]] : i32
+    //NOOPCHECK: [[ADD1:%.+]] = arith.addi [[X1]], [[Y1]] : i32
+    %a1 = arith.addi %x1, %y1: i32
+    //CHECK-NOT: tensor.insert
+    //NOOPCHECK: [[TTT:%.+]] = tensor.insert [[ADD1]] into [[TT]][[[C1]]] : tensor<2xi32>
+    %ttt = tensor.insert %a1 into %tt[%c1] : tensor<2xi32>
+    //CHECK: return [[ADD0]], [[ADD1]] : i32, i32
+    //NOOPCHECK: return [[TTT]] : tensor<2xi32>
+    return %ttt : tensor<2xi32>
+}
+
+//COMMONCHECK-LABEL: @test_materialize
+//CHECK: [[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32
+//NOOPCHECK: [[ARG0:%.+]]: tensor<2xi32>, [[ARG1:%.+]]: tensor<2xi32>
+func.func @test_materialize(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) -> tensor<2xi32> {
+    //CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+    //CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
+    //CHECK-DAG: [[T0:%.+]] = tensor.from_elements [[ARG0]], [[ARG1]] : tensor<2xi32>
+    //CHECK-DAG: [[T1:%.+]] = tensor.from_elements [[ARG2]], [[ARG3]] : tensor<2xi32>
+    //CHECK: [[ADD:%.+]] = arith.addi [[T0]], [[T1]] : tensor<2xi32>
+    //NOOPCHECK: [[ADD:%.+]] = arith.addi [[ARG0]], [[ARG1]] : tensor<2xi32>
+    %0 = arith.addi %arg0, %arg1 : tensor<2xi32>
+    //CHECK-DAG: [[ADD0:%.+]] = tensor.extract [[ADD]][[[C0]]] : tensor<2xi32>
+    //CHECK-DAG: [[ADD1:%.+]] = tensor.extract [[ADD]][[[C1]]] : tensor<2xi32>
+    //CHECK: return [[ADD0]], [[ADD1]] : i32, i32
+    //NOOPCHECK: return [[ADD]] : tensor<2xi32>
+    return %0 : tensor<2xi32>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -90,6 +90,7 @@ cc_binary(
         "@heir//lib/Transforms/OperationBalancer",
         "@heir//lib/Transforms/Secretize",
         "@heir//lib/Transforms/StraightLineVectorizer",
+        "@heir//lib/Transforms/TensorToScalars",
         "@heir//lib/Transforms/UnusedMemRef",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -62,6 +62,7 @@
 #include "lib/Transforms/OperationBalancer/OperationBalancer.h"
 #include "lib/Transforms/Secretize/Passes.h"
 #include "lib/Transforms/StraightLineVectorizer/StraightLineVectorizer.h"
+#include "lib/Transforms/TensorToScalars/TensorToScalars.h"
 #include "lib/Transforms/UnusedMemRef/UnusedMemRef.h"
 #include "llvm/include/llvm/ADT/SmallVector.h"      // from @llvm-project
 #include "llvm/include/llvm/Support/CommandLine.h"  // from @llvm-project
@@ -805,6 +806,7 @@ int main(int argc, char **argv) {
   registerStraightLineVectorizerPasses();
   registerUnusedMemRefPasses();
   registerLinalgCanonicalizationsPasses();
+  registerTensorToScalarsPasses();
   // Register yosys optimizer pipeline if configured.
 #ifndef HEIR_NO_YOSYS
 #ifndef HEIR_ABC_BINARY


### PR DESCRIPTION
This is a helper pass to remove `tensor.insert/extract`  (with constant indices) and (statically shaped) `tensor<...>` types from the IR by effectively "unrolling" `tensor<axbx!element_type>` into a `TypeRange` of a*b copies of `!element_type`.

This is necessary for targeting RLWE HW accelerators, the first generation of which "understand" only polynomial operations and datatypes. Specifically, this is necessary as passes such as `-bgv-to-polynomial` produce polynomial ops on tensors (e.g., adding two standard ciphertext lowers to a polynomial addition of  two `tensor<2x!polynomial.polynomial>`).
While `-convert-elementwise-to-affine` (see #524) lowers this to (loops over) polynomial operations on individual polynomial values (and the loops can be unrolled via `-full-loop-unroll`), the resulting IR still contains various tensor operations, primarily `tensor.insert/extract`.

This PR introduces a simple pass that replaces tensor types (with static shape) by a `TypeRange`  of dim1xdim2...  copies of the element type via the `OneToNTypeConversion` framework. Note: this framework apparently exists because the standard `DialectConversion` and associated `TypeConverter` are _very_ broken when it comes to handling 1->N type conversions (as I found out the hard way). 

In addition to doing the type conversion, there are also patterns to translate `tensor` operations to corresponding operations on the `ValueRange`, but the list is fairly incomplete right now, as there are only patterns for `tensor.from_elements` and `tensor.insert`. Surprisingly, together with folding (which, because left-over `ValueRanges` are materialized as `tensor.from_elements`, takes care of `tensor.extract`) this is actually already enough for my primary use case. However, I'd like to make this more robust and actually support any tensor ops that can conceptually be "unrolled" this way.

**Remaining ToDos**
- [ ] #1023 (+ more tests)
- [x] Add a cut-off size as a pass argument with a sane default, to prevent very large tensors from being "unrolled" accidentally (In our use case, tensors will be of single-digit sizes)

**Related ToDos:**
- [x] Address `polynomial.ntt/intt/mul_scalar` which aren't `ElementwiseMappable` and therefore not handled by `-convert-elementwise-to-affine` (#143)
- [ ] #1024 