### PR TITLE
extend `--convert-elementwise-to-affine` to support ops with scalar operands

### DIFF
--- a/lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.cpp
+++ b/lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.cpp
@@ -27,9 +27,7 @@ namespace heir {
 static bool isElementwiseMappableOpOnRankedTensors(Operation *op) {
   if (!OpTrait::hasElementwiseMappableTraits(op)) return false;
 
-  // TODO(#534): Test ElementwiseToAffine with `any_of` constraints
-  // as the pass should (in theory) support scalar operands, too
-  return llvm::all_of(op->getOperandTypes(),
+  return llvm::any_of(op->getOperandTypes(),
                       [](Type type) { return isa<RankedTensorType>(type); });
 }
 
@@ -133,6 +131,8 @@ struct ElementwiseToAffine
 
     patterns.add<ConvertAnyElementwiseMappableOpOnRankedTensors>(context);
     target.markUnknownOpDynamicallyLegal([](Operation *op) {
+      // TODO (#768): to make this pass more widely applicable, it should take
+      // a dialect and/or list of operations to restrict the conversion to
       return !isElementwiseMappableOpOnRankedTensors(op);
     });
 

--- a/tests/polynomial/elementwise_to_affine.mlir
+++ b/tests/polynomial/elementwise_to_affine.mlir
@@ -18,26 +18,17 @@ func.func @test_elementwise(%arg0: tensor<2x!poly>, %arg1: tensor<2x!poly>) ->  
   return %0 :  tensor<2x!poly>
 }
 
-// This is just here to make sure the FileCheck commands above work as expected
-// CHECK-LABEL: @lowered_elementwise
-// CHECK: {{.*}} -> [[T:tensor<2x!polynomial.*33538049.*]] {
-func.func @lowered_elementwise(%arg0: tensor<2x!poly>, %arg1: tensor<2x!poly>) ->  tensor<2x!poly> {
+// CHECK-LABEL:  @test_partially_elementwise
+// CHECK: ([[ARG0:%.+]]: [[T:tensor<2x!polynomial.*33538049.*]], [[ARG1:%.+]]: i32) -> [[T]] {
+func.func @test_partially_elementwise(%arg0: tensor<2x!poly>, %arg1: i32) ->  tensor<2x!poly> {
   // CHECK: [[EMPTY:%.+]] = tensor.empty() : [[T:tensor<2x!polynomial.*33538049.*]]
-  %empty = tensor.empty() : tensor<2x!poly>
   // CHECK: [[LOOP:%.+]] = affine.for [[I:%.+]] = 0 to 2 iter_args([[T0:%.+]] = [[EMPTY]]) -> ([[T]]) {
-  %0 = affine.for %i = 0 to 2 iter_args(%t0 = %empty) -> (tensor<2x!poly>) {
-    // CHECK: [[A:%.+]] = tensor.extract %arg0[[[I]]] : [[T]]
-    %a = tensor.extract %arg0[%i] :  tensor<2x!poly>
-    // CHECK: [[B:%.+]] = tensor.extract %arg1[[[I]]] : [[T]]
-    %b = tensor.extract %arg1[%i] :  tensor<2x!poly>
-    // CHECK: [[S:%.+]] = polynomial.add [[A]], [[B]] : [[P:!polynomial.*33538049.*]]
-    // CHECK-NOT: polynomial.add{{.*}} : [[T]]
-    %s = polynomial.add %a, %b : !poly
+    // CHECK: [[A:%.+]] = tensor.extract [[ARG0]][[[I]]] : [[T]]
+    // CHECK: [[S:%.+]] = polynomial.mul_scalar [[A]], [[ARG1]] : [[P:!polynomial.*33538049.*]], i32
+    // CHECK-NOT: polynomial.mul_scalar{{.*}} : [[T]], i32
     // CHECK: [[R:%.+]] = tensor.insert [[S]] into [[T0]][[[I]]] : [[T]]
-    %r = tensor.insert %s into %t0[%i] : tensor<2x!poly>
     // CHECK: affine.yield [[R]] : [[T]]
-    affine.yield %r : tensor<2x!poly>
-  }
+  %0 = polynomial.mul_scalar %arg0, %arg1 : tensor<2x!poly>, i32
   // CHECK: return [[LOOP]] : [[T]]
   return %0 :  tensor<2x!poly>
 }
@@ -58,33 +49,4 @@ func.func @test_elementwise_multidim(%arg0: tensor<2x3x!poly>, %arg1: tensor<2x3
       // CHECK: affine.yield [[R]] : [[T]]
     // CHECK: affine.yield [[INNERLOOP]] : [[T]]
   // CHECK: return [[LOOP]] : [[T]]
-}
-
-// This is just here to make sure the FileCheck commands above work as expected
-// CHECK-LABEL:  @lowered_elementwise_multidim
-// CHECK: {{.*}} -> [[T:tensor<2x3x!polynomial.*33538049.*]] {
-func.func @lowered_elementwise_multidim(%arg0: tensor<2x3x!poly>, %arg1: tensor<2x3x!poly>) ->  tensor<2x3x!poly> {
-  // CHECK: [[EMPTY:%.+]] = tensor.empty() : [[T:tensor<2x3x!polynomial.*33538049.*]]
-  %empty = tensor.empty() : tensor<2x3x!poly>
-  // CHECK: [[LOOP:%.+]] = affine.for [[I:%.+]] = 0 to 2 iter_args([[T0:%.+]] = [[EMPTY]]) -> ([[T]]) {
-  %0 = affine.for %i = 0 to 2 iter_args(%t0 = %empty) -> (tensor<2x3x!poly>) {
-    // CHECK: [[INNERLOOP:%.+]] = affine.for [[J:%.+]] = 0 to 3 iter_args([[T1:%.+]] = [[T0]]) -> ([[T]]) {
-    %1 = affine.for %j = 0 to 3 iter_args(%t1 = %t0) -> (tensor<2x3x!poly>) {
-      // CHECK: [[A:%.+]] = tensor.extract %arg0[[[I]], [[J]]] : [[T]]
-      %a = tensor.extract %arg0[%i, %j] :  tensor<2x3x!poly>
-      // CHECK: [[B:%.+]] = tensor.extract %arg1[[[I]], [[J]]] : [[T]]
-      %b = tensor.extract %arg1[%i, %j] :  tensor<2x3x!poly>
-      // CHECK: [[S:%.+]] = polynomial.add [[A]], [[B]] : [[P:!polynomial.*33538049.*]]
-      // CHECK-NOT: polynomial.add{{.*}} : [[T]]
-      %s = polynomial.add %a, %b : !poly
-      // CHECK: [[R:%.+]] = tensor.insert [[S]] into [[T1]][[[I]], [[J]]] : [[T]]
-      %r = tensor.insert %s into %t1[%i, %j] : tensor<2x3x!poly>
-      // CHECK: affine.yield [[R]] : [[T]]
-      affine.yield %r : tensor<2x3x!poly>
-    }
-    // CHECK: affine.yield [[INNERLOOP]] : [[T]]
-    affine.yield %1 : tensor<2x3x!poly>
-  }
-  // CHECK: return [[LOOP]] : [[T]]
-  return %0 :  tensor<2x3x!poly>
 }


### PR DESCRIPTION
As originally pointed out in #143 and recently mentioned in #763, the `--convert-elementwise-to-affine` pass did not handle ops with "mixed" tensor/scalar operands, such as  `polynomial.mul_scalar`.

It turns out this was a much easier fix than anticipated, at least for `mul_scalar` as `ElementwiseMappable` does not (as I wrongly assumed) imply `SameOperandsAndResultType`. In fact, there was already a ToDo (#534) that suggested the three-character change necessary to make this work.
However, this still does not work for `polynomial.ntt/intt`, as `ElementwiseMappable` _does_ require all _tensor_ operands to agree, and that wouldn't hold for a "tensorized" ntt/intt (cf. https://github.com/google/heir/issues/143#issuecomment-2108448494)

With this change, any `ElementwiseMappable` operation with at least one tensor operand is converted into an `affine.for`, and tensor operands are replaced with `tensor.extract`s, while scalar operands are left unmodified. This result is probably what one would expect (despite the semantics for this not being formally noted anywhere upstream, afaik), effectively "broadcasting" the scalar to the tensor operand(s).

PS: I noticed the tests for this pass also had some mostly meaningless "expected output" "tests" in it from development so I used the opportunity to remove those.

-------
Resolves #534
(Mostly, see https://github.com/google/heir/pull/763#issuecomment-2211012794) Resolves #143 