### PR TITLE
re-enable end-to-end openFHE tests (tmp workaround)

### DIFF
--- a/tests/openfhe/end_to_end/BUILD
+++ b/tests/openfhe/end_to_end/BUILD
@@ -1,50 +1,49 @@
 # See README.md for setup required to run these tests
 
-# load("@heir//tests/openfhe/end_to_end:test.bzl", "openfhe_end_to_end_test")
+load("@heir//tests/openfhe/end_to_end:test.bzl", "openfhe_end_to_end_test")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
-# TODO(#729): Re-enable tests when upstream dialect loader is fixed
-# openfhe_end_to_end_test(
-#     name = "binops_test",
-#     generated_lib_header = "binops_lib.h",
-#     mlir_src = "binops.mlir",
-#     tags = ["notap"],
-#     test_src = "binops_test.cpp",
-# )
+openfhe_end_to_end_test(
+    name = "binops_test",
+    generated_lib_header = "binops_lib.h",
+    mlir_src = "binops.mlir",
+    tags = ["notap"],
+    test_src = "binops_test.cpp",
+)
 
-# openfhe_end_to_end_test(
-#     name = "simple_sum_test",
-#     generated_lib_header = "simple_sum_lib.h",
-#     heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=simple_sum ciphertext-degree=32",
-#     mlir_src = "simple_sum.mlir",
-#     tags = ["notap"],
-#     test_src = "simple_sum_test.cpp",
-# )
+openfhe_end_to_end_test(
+    name = "simple_sum_test",
+    generated_lib_header = "simple_sum_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=simple_sum ciphertext-degree=32",
+    mlir_src = "simple_sum.mlir",
+    tags = ["notap"],
+    test_src = "simple_sum_test.cpp",
+)
 
-# openfhe_end_to_end_test(
-#     name = "dot_product_8_test",
-#     generated_lib_header = "dot_product_8_lib.h",
-#     heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=dot_product ciphertext-degree=8",
-#     mlir_src = "dot_product_8.mlir",
-#     tags = ["notap"],
-#     test_src = "dot_product_8_test.cpp",
-# )
+openfhe_end_to_end_test(
+    name = "dot_product_8_test",
+    generated_lib_header = "dot_product_8_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=dot_product ciphertext-degree=8",
+    mlir_src = "dot_product_8.mlir",
+    tags = ["notap"],
+    test_src = "dot_product_8_test.cpp",
+)
 
-# openfhe_end_to_end_test(
-#     name = "box_blur_64x64_test",
-#     generated_lib_header = "box_blur_64x64_lib.h",
-#     heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=box_blur ciphertext-degree=4096",
-#     mlir_src = "box_blur_64x64.mlir",
-#     tags = ["notap"],
-#     test_src = "box_blur_test.cpp",
-# )
+openfhe_end_to_end_test(
+    name = "box_blur_64x64_test",
+    generated_lib_header = "box_blur_64x64_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=box_blur ciphertext-degree=4096",
+    mlir_src = "box_blur_64x64.mlir",
+    tags = ["notap"],
+    test_src = "box_blur_test.cpp",
+)
 
-# openfhe_end_to_end_test(
-#     name = "roberts_cross_64x64_test",
-#     generated_lib_header = "roberts_cross_64x64_lib.h",
-#     heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=roberts_cross ciphertext-degree=4096",
-#     mlir_src = "roberts_cross_64x64.mlir",
-#     tags = ["notap"],
-#     test_src = "roberts_cross_test.cpp",
-# )
+openfhe_end_to_end_test(
+    name = "roberts_cross_64x64_test",
+    generated_lib_header = "roberts_cross_64x64_lib.h",
+    heir_opt_flags = "--mlir-to-openfhe-bgv=entry-function=roberts_cross ciphertext-degree=4096",
+    mlir_src = "roberts_cross_64x64.mlir",
+    tags = ["notap"],
+    test_src = "roberts_cross_test.cpp",
+)


### PR DESCRIPTION
This is a temporary workaround for the upstream dialect loading bug (See #727). It simply prepends a dummy polynomial attribute to the input file before calling heir_translate. To-Do's still reference #729 (re-enable tests) as this doesn't really "resolve" the issue.

Even for a temporary hack, I guess it'd be nicer to do this only in `openfhe_end_to_end_test` and not the general `heir_translate` rule, but this was quicker and I just wanted the ability to run end-to-end tests back 😉 (This might also be nice to have back for the mult-depth analysis tests in #760).

I'm not sure if we actually want to merge this, but I'm guessing this might be useful to others for debugging/testing until the upstream issue is fixed ([llvm PR #96667](https://github.com/llvm/llvm-project/pull/96667)), even just as something to cherry-pick.

