### PR TITLE
fix inconsistent op class names in bgv dialect

### DIFF
--- a/lib/Conversion/BGVToOpenfhe/BGVToOpenfhe.cpp
+++ b/lib/Conversion/BGVToOpenfhe/BGVToOpenfhe.cpp
@@ -140,7 +140,7 @@ struct ConvertBinOp : public OpConversionPattern<BinOp> {
   }
 };
 
-using ConvertNegateOp = ConvertUnaryOp<Negate, openfhe::NegateOp>;
+using ConvertNegateOp = ConvertUnaryOp<NegateOp, openfhe::NegateOp>;
 
 using ConvertAddOp = ConvertBinOp<AddOp, openfhe::AddOp>;
 using ConvertSubOp = ConvertBinOp<SubOp, openfhe::SubOp>;
@@ -192,14 +192,14 @@ bool checkRelinToBasis(llvm::ArrayRef<int> toBasis) {
   return toBasis[0] == 0 && toBasis[1] == 1;
 }
 
-struct ConvertRelinOp : public OpConversionPattern<Relinearize> {
+struct ConvertRelinOp : public OpConversionPattern<RelinearizeOp> {
   ConvertRelinOp(mlir::MLIRContext *context)
-      : OpConversionPattern<Relinearize>(context) {}
+      : OpConversionPattern<RelinearizeOp>(context) {}
 
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
-      Relinearize op, OpAdaptor adaptor,
+      RelinearizeOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     FailureOr<Value> result = getContextualCryptoContext(op.getOperation());
     if (failed(result)) return result;
@@ -221,14 +221,14 @@ struct ConvertRelinOp : public OpConversionPattern<Relinearize> {
   }
 };
 
-struct ConvertModulusSwitchOp : public OpConversionPattern<ModulusSwitch> {
+struct ConvertModulusSwitchOp : public OpConversionPattern<ModulusSwitchOp> {
   ConvertModulusSwitchOp(mlir::MLIRContext *context)
-      : OpConversionPattern<ModulusSwitch>(context) {}
+      : OpConversionPattern<ModulusSwitchOp>(context) {}
 
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
-      ModulusSwitch op, OpAdaptor adaptor,
+      ModulusSwitchOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     FailureOr<Value> result = getContextualCryptoContext(op.getOperation());
     if (failed(result)) return result;

--- a/lib/Conversion/BGVToPolynomial/BGVToPolynomial.cpp
+++ b/lib/Conversion/BGVToPolynomial/BGVToPolynomial.cpp
@@ -78,14 +78,14 @@ struct ConvertSub : public OpConversionPattern<SubOp> {
   }
 };
 
-struct ConvertNegate : public OpConversionPattern<Negate> {
+struct ConvertNegate : public OpConversionPattern<NegateOp> {
   ConvertNegate(mlir::MLIRContext *context)
-      : OpConversionPattern<Negate>(context) {}
+      : OpConversionPattern<NegateOp>(context) {}
 
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
-      Negate op, OpAdaptor adaptor,
+      NegateOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto arg = adaptor.getOperands()[0];
@@ -165,7 +165,7 @@ struct BGVToPolynomial : public impl::BGVToPolynomialBase<BGVToPolynomial> {
 
     patterns.add<ConvertAdd, ConvertSub, ConvertNegate, ConvertMul>(
         typeConverter, context);
-    target.addIllegalOp<AddOp, SubOp, Negate, MulOp>();
+    target.addIllegalOp<AddOp, SubOp, NegateOp, MulOp>();
 
     addStructuralConversionPatterns(typeConverter, patterns, target);
 

--- a/lib/Conversion/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Conversion/SecretToBGV/SecretToBGV.cpp
@@ -149,7 +149,7 @@ class SecretGenericOpMulConversion
 
   void replaceOp(secret::GenericOp op, TypeRange outputTypes, ValueRange inputs,
                  ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<bgv::Relinearize>(
+    rewriter.replaceOpWithNewOp<bgv::RelinearizeOp>(
         op, rewriter.create<bgv::MulOp>(op.getLoc(), inputs),
         rewriter.getDenseI32ArrayAttr({0, 1, 2}),
         rewriter.getDenseI32ArrayAttr({0, 1}));

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -79,7 +79,7 @@ LogicalResult EncryptOp::verify() {
   return success();
 }
 
-LogicalResult Relinearize::verify() {
+LogicalResult RelinearizeOp::verify() {
   auto x = getInput().getType();
   auto out = getOutput().getType();
   if (x.getRlweParams().getDimension() != getFromBasis().size()) {
@@ -91,7 +91,7 @@ LogicalResult Relinearize::verify() {
   return success();
 }
 
-LogicalResult ModulusSwitch::verify() {
+LogicalResult ModulusSwitchOp::verify() {
   auto x = getInput().getType();
   auto xRing = x.getRlweParams().getRing();
 
@@ -130,8 +130,8 @@ LogicalResult MulOp::inferReturnTypes(
   return success();
 }
 
-LogicalResult Relinearize::inferReturnTypes(
-    MLIRContext *ctx, std::optional<Location>, Relinearize::Adaptor adaptor,
+LogicalResult RelinearizeOp::inferReturnTypes(
+    MLIRContext *ctx, std::optional<Location>, RelinearizeOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   auto x = cast<lwe::RLWECiphertextType>(adaptor.getInput().getType());
   inferredReturnTypes.push_back(lwe::RLWECiphertextType::get(

--- a/lib/Dialect/BGV/IR/BGVOps.td
+++ b/lib/Dialect/BGV/IR/BGVOps.td
@@ -153,7 +153,7 @@ def BGV_ExtractOp : BGV_Op<"extract", [SameOperandsAndResultRings]> {
   let hasVerifier = 1;
 }
 
-def BGV_Negate : BGV_Op<"negate", [SameOperandsAndResultType]> {
+def BGV_NegateOp : BGV_Op<"negate", [SameOperandsAndResultType]> {
   let summary = "Negate the coefficients of the ciphertext.";
 
   let arguments = (ins
@@ -167,7 +167,7 @@ def BGV_Negate : BGV_Op<"negate", [SameOperandsAndResultType]> {
   let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
 }
 
-def BGV_Relinearize : BGV_Op<"relinearize", [SameOperandsAndResultRings, InferTypeOpAdaptor]> {
+def BGV_RelinearizeOp : BGV_Op<"relinearize", [SameOperandsAndResultRings, InferTypeOpAdaptor]> {
   let summary = "Relinearize the ciphertext.";
 
   let description = [{
@@ -194,7 +194,7 @@ def BGV_Relinearize : BGV_Op<"relinearize", [SameOperandsAndResultRings, InferTy
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 
-def BGV_ModulusSwitch : BGV_Op<"modulus_switch"> {
+def BGV_ModulusSwitchOp : BGV_Op<"modulus_switch"> {
   let summary = "Lower the modulus level of the ciphertext.";
 
   let arguments = (ins


### PR DESCRIPTION
small fix/cleanup: some BGV ops lacked the "Op" suffix in their td/cpp class name, this simply renames them to be consistent with the remaining ops/the general MLIR convention.