### PR TITLE
Add Secretness Analysis to convert-if-to-select 

### DIFF
--- a/lib/Analysis/SecretnessAnalysis/BUILD
+++ b/lib/Analysis/SecretnessAnalysis/BUILD
@@ -1,0 +1,20 @@
+# SecretnessAnalysis analysis class
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "SecretnessAnalysis",
+    srcs = ["SecretnessAnalysis.cpp"],
+    hdrs = ["SecretnessAnalysis.h"],
+    deps = [
+        "@heir//lib/Dialect:Utils",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.cpp
+++ b/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.cpp
@@ -1,0 +1,60 @@
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+
+#include <llvm/Support/raw_ostream.h>
+
+#include <optional>
+
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"        // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+void SecretnessAnalysis::setToEntryState(SecretnessLattice *lattice) {
+  auto operand = lattice->getPoint();
+  bool isSecret = isa<secret::SecretType>(operand.getType());
+
+  Operation *operation = nullptr;
+  // Get defining operation for operand
+  if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
+    operation = blockArg.getOwner()->getParentOp();
+  } else {
+    operation = operand.getDefiningOp();
+  }
+
+  // If operand is defined by a secret.generic operation,
+  // check if operand is of secret type
+  if (auto genericOp = dyn_cast<secret::GenericOp>(*operation)) {
+    if (OpOperand *genericOperand =
+            genericOp.getOpOperandForBlockArgument(operand)) {
+      isSecret = isa<secret::SecretType>(genericOperand->get().getType());
+    }
+  }
+  propagateIfChanged(lattice, lattice->join(Secretness(isSecret)));
+}
+
+void SecretnessAnalysis::visitOperation(
+    Operation *operation, ArrayRef<const SecretnessLattice *> operands,
+    ArrayRef<SecretnessLattice *> results) {
+  Secretness resultSecretness;
+  for (const SecretnessLattice *operand : operands) {
+    const Secretness operandSecretness = operand->getValue();
+    if (operandSecretness.isInitialized()) {
+      resultSecretness = Secretness::join(resultSecretness, operandSecretness);
+      if (resultSecretness.getSecretness()) break;
+    }
+  }
+
+  for (SecretnessLattice *result : results) {
+    propagateIfChanged(result, result->join(resultSecretness));
+  }
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
+++ b/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
@@ -1,0 +1,86 @@
+#ifndef LIB_ANALYSIS_SECRETNESSANALYSIS_SECRETNESSANALYSIS_H_
+#define LIB_ANALYSIS_SECRETNESSANALYSIS_SECRETNESSANALYSIS_H_
+
+#include <optional>
+
+#include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"      // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// Secretness describes if an SSA value is of secret type or not. An SSA value
+// is considered to be of secret type if one of the following is true:
+//      (1) the value defined is wrapped by the secret.secret type
+//      (2) the value is produced by an operation that uses an operand of
+//      secret.secret type
+class Secretness {
+ public:
+  Secretness() : secretness(std::nullopt) {}
+  explicit Secretness(bool value) : secretness(value) {}
+  ~Secretness() = default;
+
+  const bool &getSecretness() const {
+    assert(isInitialized());
+    return *secretness;
+  }
+  void setSecretness(bool value) { secretness = value; }
+
+  // Check if the Secretness state is initialized. It can be uninitialized if
+  // the state hasn't yet been set during the analysis.
+  bool isInitialized() const { return secretness.has_value(); }
+
+  bool operator==(const Secretness &rhs) const {
+    return secretness == rhs.secretness;
+  }
+
+  // Join two Secretness states
+  static Secretness join(const Secretness &lhs, const Secretness &rhs) {
+    if (!lhs.isInitialized()) return rhs;
+    if (!rhs.isInitialized()) return lhs;
+
+    return Secretness{lhs.getSecretness() || rhs.getSecretness()};
+  }
+
+  void print(raw_ostream &os) const { os << "Secretness: " << secretness; }
+
+ private:
+  // Stores the Secretness state if known
+  std::optional<bool> secretness;
+};
+
+inline raw_ostream &operator<<(raw_ostream &os, const Secretness &value) {
+  value.print(os);
+  return os;
+}
+class SecretnessLattice : public dataflow::Lattice<Secretness> {
+ public:
+  using Lattice::Lattice;
+};
+
+// An analysis that identifies and assigns the Secretness of an SSA value in a
+// program. This is used by other passes to selectively apply transformations on
+// operations that evaluate secret types. We use a forward dataflow analysis
+// because the Secretness state propagates forward from the input arguments of a
+// function down to values produced from operations that use these arguments.
+
+class SecretnessAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<SecretnessLattice> {
+ public:
+  explicit SecretnessAnalysis(DataFlowSolver &solver)
+      : SparseForwardDataFlowAnalysis(solver) {}
+  ~SecretnessAnalysis() override = default;
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  // Set Secretness state for an initialized SSA value
+  void setToEntryState(SecretnessLattice *lattice) override;
+  // Set Secretness state for SSA value(s) produced by an operation
+  void visitOperation(Operation *operation,
+                      ArrayRef<const SecretnessLattice *> operands,
+                      ArrayRef<SecretnessLattice *> results) override;
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_ANALYSIS_SECRETNESSANALYSIS_SECRETNESSANALYSIS_H_

--- a/lib/Transforms/ConvertIfToSelect/BUILD
+++ b/lib/Transforms/ConvertIfToSelect/BUILD
@@ -11,6 +11,7 @@ cc_library(
     hdrs = ["ConvertIfToSelect.h"],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/tests/convert_if_to_select/non_secret_conditionals.mlir
+++ b/tests/convert_if_to_select/non_secret_conditionals.mlir
@@ -1,0 +1,33 @@
+// RUN: heir-opt --convert-if-to-select %s | FileCheck %s
+
+// CHECK-LABEL: @non_secret_condition_outside_of_secret_generic_with_secret_tensor
+func.func @non_secret_condition_outside_of_secret_generic_with_secret_tensor(%inp: !secret.secret<tensor<16xi16>>, %cond: i1) -> !secret.secret<tensor<16xi16>> {
+  // CHECK-NOT: arith.select
+  %0 = secret.generic ins(%inp : !secret.secret<tensor<16xi16>>) {
+  ^bb0(%arg2: tensor<16xi16>):
+    %1 = scf.if %cond -> (tensor<16xi16>) {
+      %2 = arith.addi %arg2, %arg2 : tensor<16xi16>
+      scf.yield %2 : tensor<16xi16>
+    } else {
+      scf.yield %arg2 : tensor<16xi16>
+    }
+    secret.yield %1 : tensor<16xi16>
+  } -> !secret.secret<tensor<16xi16>>
+  return %0 : !secret.secret<tensor<16xi16>>
+}
+
+// CHECK-LABEL: @non_secret_condition_with_secret_tensor
+func.func @non_secret_condition_with_secret_tensor(%inp: !secret.secret<tensor<16xi16>>, %cond: i1) -> !secret.secret<tensor<16xi16>> {
+  // CHECK-NOT: arith.select
+  %0 = secret.generic ins(%inp : !secret.secret<tensor<16xi16>>) {
+  ^bb0(%arg2: tensor<16xi16>):
+    %1 = scf.if %cond -> (tensor<16xi16>) {
+      %2 = arith.addi %arg2, %arg2 : tensor<16xi16>
+      scf.yield %2 : tensor<16xi16>
+    } else {
+      scf.yield %arg2 : tensor<16xi16>
+    }
+    secret.yield %1 : tensor<16xi16>
+  } -> !secret.secret<tensor<16xi16>>
+  return %0 : !secret.secret<tensor<16xi16>>
+}


### PR DESCRIPTION
Added a static dataflow analysis for secret types and used it in the convert-if-to-select transformation pass to selectively apply the transformation on scf.if operations that evaluate secret conditions.