### PR TITLE
Cornami, Inc : contribute CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.13.4)
+
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
+project(HEIR LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
+
+find_package(MLIR REQUIRED CONFIG)
+
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+option(ENABLE_YOSYS "Enable YOSYS for yosys-optimizer pass (optional)" FALSE)
+option(ENABLE_INSTALLED_MLIR "Use installed MLIR" FALSE)
+
+if(ENABLE_YOSYS)
+   message("Yosys enabled! Make sure ABC and Yosys development files and libraries are on the path")
+else()
+   add_compile_options(-DHEIR_NO_YOSYS=1)
+endif()
+
+
+set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+
+
+
+list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
+
+set(INCLUDE_MLIR_LLVM_HEADERS "${CMAKE_BINARY_DIR}/inc/")
+add_custom_command(OUTPUT ${INCLUDE_MLIR_LLVM_HEADERS}
+  COMMAND mkdir -p inc/llvm/include
+  COMMAND mkdir -p inc/mlir/include
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Creating link to LLVM and MLIR headers"
+  VERBATIM
+)
+
+if(ENABLE_INSTALLED_MLIR)
+add_custom_target(HEIRIncludeLLVM
+                  BYPRODUCTS ${CMAKE_BINARY_DIR}/inc/llvm/include/llvm
+                  COMMAND [ -e llvm ] && echo "" || ln -s ${LLVM_INCLUDE_DIRS}/llvm/ ./
+                  DEPENDS ${INCLUDE_MLIR_LLVM_HEADERS}
+                  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/inc/llvm/include/"
+                  )
+
+add_custom_target(HEIRIncludeMLIR
+                  BYPRODUCTS ${CMAKE_BINARY_DIR}/inc/mlir/include/mlir
+                  COMMAND [ -e mlir ] && echo "" || ln -s ${MLIR_INCLUDE_DIRS}/mlir/ ./
+                  DEPENDS ${INCLUDE_MLIR_LLVM_HEADERS}
+                  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/inc/mlir/include/")
+message(STATUS "Adding MLIR and LLVM includes.")
+else()
+add_custom_target(HEIRIncludeLLVM
+          COMMAND echo "")
+add_custom_target(HEIRIncludeMLIR
+          COMMAND echo "")
+message(STATUS "Using MLIR and LLVM from build folders of ${MLIR_DIR} and ${LLVM_DIR}")
+endif()
+
+include_directories(${CMAKE_BINARY_DIR}/inc)
+if(ENABLE_INSTALLED_MLIR)
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+else()
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${LLVM_INCLUDE_DIRS}/../..)
+include_directories(${MLIR_INCLUDE_DIRS}/../..)
+endif()
+include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_BINARY_DIR})
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+add_definitions(${LLVM_DEFINITIONS})
+
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+set(HEIRLIBDIR ${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(lib)
+add_subdirectory(tools)

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(RotationAnalysis)
+add_subdirectory(TargetSlotAnalysis)
+add_subdirectory(SelectVariableNames)
+add_subdirectory(MulDepthAnalysis)
+add_subdirectory(SecretnessAnalysis)

--- a/lib/Analysis/MulDepthAnalysis/CMakeLists.txt
+++ b/lib/Analysis/MulDepthAnalysis/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_conversion_library(MLIRHEIRMulDepthAnalysis
+        MulDepthAnalysis.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}
+
+        DEPENDS
+        MLIROpenfheOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIROpenfhe
+        LLVMSupport
+        MLIRAnalysis
+        MLIRIR
+        MLIRSupport
+)

--- a/lib/Analysis/RotationAnalysis/CMakeLists.txt
+++ b/lib/Analysis/RotationAnalysis/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_conversion_library(MLIRHEIRAnalysisROT
+        RotationAnalysis.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}
+
+        DEPENDS
+        MLIRTensorExtOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRTensorExt
+        LLVMSupport
+        MLIRAnalysis
+        MLIRArithDialect
+        MLIRIR
+        MLIRSupport
+)

--- a/lib/Analysis/SecretnessAnalysis/CMakeLists.txt
+++ b/lib/Analysis/SecretnessAnalysis/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_conversion_library(MLIRHEIRSecretnessAnalysis
+        SecretnessAnalysis.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}
+
+        DEPENDS
+        MLIRSecretIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRSecret
+        LLVMSupport
+        MLIRAnalysis
+        MLIRSCFDialect
+        MLIRIR
+        MLIRSupport
+)

--- a/lib/Analysis/SelectVariableNames/CMakeLists.txt
+++ b/lib/Analysis/SelectVariableNames/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_mlir_conversion_library(MLIRHEIRAnalysisSVN
+        SelectVariableNames.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        LLVMSupport
+)

--- a/lib/Analysis/TargetSlotAnalysis/CMakeLists.txt
+++ b/lib/Analysis/TargetSlotAnalysis/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_conversion_library(MLIRHEIRAnalysisTSN
+        TargetSlotAnalysis.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}
+
+        DEPENDS
+        MLIROpenfheOpsIncGen
+
+        LINK_LIBS PUBLIC
+        LLVMSupport
+        MLIRAnalysis
+        MLIRSupport
+        MLIRIR
+        MLIRTensorDialect
+        MLIRInferTypeOpInterface
+)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(Dialect)
+add_subdirectory(Analysis)
+add_subdirectory(Graph)
+add_subdirectory(Target)
+add_subdirectory(Conversion)
+add_subdirectory(Transforms)
+add_subdirectory(Source)

--- a/lib/Conversion/ArithExtToArith/CMakeLists.txt
+++ b/lib/Conversion/ArithExtToArith/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(LLVM_TARGET_DEFINITIONS ArithExtToArith.td)
+mlir_tablegen(ArithExtToArith.h.inc -gen-pass-decls -name ArithExtToArith)
+mlir_tablegen(ArithExtToArith.cpp.inc -gen-rewriters -name ArithExtToArith)
+add_public_tablegen_target(MLIRArithExtTransformsIncGen)
+
+add_mlir_dialect_library(MLIRArithExtTransforms
+    ArithExtToArith.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRArithExtTransformsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRPass
+    MLIRTransformUtils
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+)

--- a/lib/Conversion/BGVToOpenfhe/CMakeLists.txt
+++ b/lib/Conversion/BGVToOpenfhe/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(LLVM_TARGET_DEFINITIONS BGVToOpenfhe.td)
+mlir_tablegen(BGVToOpenfhe.h.inc -gen-pass-decls -name BGVToOpenfhe)
+add_public_tablegen_target(MLIRBGVOpenfheTransformsIncGen)
+
+add_mlir_dialect_library(MLIRBGVOpenfheTransforms
+    BGVToOpenfhe.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRBGVOpenfheTransformsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRUtils
+    MLIRBGV
+    MLIRLWE
+    MLIROpenfhe
+
+    MLIRIR
+    MLIRPass
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRFuncDialect
+    LLVMSupport
+    MLIRSupport
+    MLIRDialect
+    MLIRTransformUtils
+    MLIRIR
+)

--- a/lib/Conversion/BGVToPolynomial/CMakeLists.txt
+++ b/lib/Conversion/BGVToPolynomial/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(LLVM_TARGET_DEFINITIONS BGVToPolynomial.td)
+mlir_tablegen(BGVToPolynomial.h.inc -gen-pass-decls -name BGVToPolynomial)
+add_public_tablegen_target(MLIRBGVPolynomialTransformsIncGen)
+
+add_mlir_dialect_library(MLIRBGVPolynomialTransforms
+    BGVToPolynomial.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRBGVPolynomialTransformsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRUtils
+    MLIRBGV
+    MLIRLWE
+    MLIRArithDialect
+
+    MLIRIR
+    MLIRPass
+    MLIRPolynomialDialect
+
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTransformUtils
+)

--- a/lib/Conversion/CGGIToTfheRust/CMakeLists.txt
+++ b/lib/Conversion/CGGIToTfheRust/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(LLVM_TARGET_DEFINITIONS CGGIToTfheRust.td)
+mlir_tablegen(CGGIToTfheRust.h.inc -gen-pass-decls -name CGGIToTfheRust)
+add_public_tablegen_target(MLIRCGGIToTfheRustTransformsIncGen)
+
+add_mlir_dialect_library(MLIRCGGIToTfheRustTransforms
+    CGGIToTfheRust.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRCGGIToTfheRustTransformsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRUtils
+    MLIRCGGI
+    MLIRLWE
+    MLIRTfheRust
+
+    MLIRSupport
+    MLIRArithDialect
+    MLIRFuncDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTransformUtils
+)

--- a/lib/Conversion/CGGIToTfheRustBool/CMakeLists.txt
+++ b/lib/Conversion/CGGIToTfheRustBool/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(LLVM_TARGET_DEFINITIONS CGGIToTfheRustBool.td)
+mlir_tablegen(CGGIToTfheRustBool.h.inc -gen-pass-decls -name=CGGIToTfheRustBool)
+add_public_tablegen_target(MLIRCGGIToTfheRustBoolTransformsIncGen)
+
+add_mlir_dialect_library(MLIRCGGIToTfheRustBoolTransforms
+    CGGIToTfheRustBool.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRCGGIToTfheRustBoolTransformsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRUtils
+    MLIRCGGI
+    MLIRLWE
+    MLIRTfheRustBool
+    LLVMSupport
+
+    MLIRFuncDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTransformUtils
+)

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,0 +1,31 @@
+add_mlir_dialect_library(MLIRHEIRUtils
+    PARTIAL_SOURCES_INTENDED
+    Utils.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRTensorExtOpsIncGen
+    MLIRTensorExtPassesIncGen
+    MLIRTensorExtInsertRotateIncGen
+    MLIRTensorExtCanonicalizationIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)
+
+add_subdirectory(ArithExtToArith)
+add_subdirectory(BGVToOpenfhe)
+add_subdirectory(BGVToPolynomial)
+add_subdirectory(CGGIToTfheRust)
+add_subdirectory(CGGIToTfheRustBool)
+add_subdirectory(CombToCGGI)
+add_subdirectory(MemrefToArith)
+add_subdirectory(PolynomialToStandard)
+add_subdirectory(SecretToBGV)

--- a/lib/Conversion/CombToCGGI/CMakeLists.txt
+++ b/lib/Conversion/CombToCGGI/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(LLVM_TARGET_DEFINITIONS CombToCGGI.td)
+mlir_tablegen(CombToCGGI.h.inc -gen-pass-decls -name CombToCGGI)
+add_public_tablegen_target(MLIRCombtTransformsIncGen)
+
+add_mlir_dialect_library(MLIRCombTransforms
+    CombToCGGI.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRCombtTransformsIncGen
+
+    LINK_LIBS PUBLIC
+
+    MLIRHEIRUtils
+    MLIRCGGI
+    MLIRComb
+    MLIRLWE
+    MLIRSecret
+
+    LLVMSupport
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRArithDialect
+    MLIRDialectUtils
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+    MLIRSupport
+    MLIRTransformUtils
+)

--- a/lib/Conversion/MemrefToArith/CMakeLists.txt
+++ b/lib/Conversion/MemrefToArith/CMakeLists.txt
@@ -1,0 +1,118 @@
+set(LLVM_TARGET_DEFINITIONS MemrefToArith.td)
+mlir_tablegen(MemrefToArith.h.inc -gen-pass-decls -name MemrefToArith)
+add_public_tablegen_target(MLIRMemrefToArithPassIncGen)
+
+add_mlir_library(MLIRMemrefToArithMemrefGlobalReplace
+    PARTIAL_SOURCES_INTENDED
+    MemrefGlobalReplace.cpp
+
+    DEPENDS
+    MLIRMemrefToArithPassIncGen
+
+    LINK_LIBS PUBLIC
+    LLVMSupport
+    MLIRAffineAnalysis
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRArithDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+    MLIRSCFDialect
+    MLIRTransformUtils
+    MLIRSupport
+)
+
+add_mlir_library(MLIRMemrefToArithExpandCopy
+    PARTIAL_SOURCES_INTENDED
+    ExpandCopy.cpp
+
+    DEPENDS
+    MLIRMemrefToArithPassIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRAffineAnalysis
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRArithDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+    MLIRSCFDialect
+    MLIRSupport
+    MLIRTransformUtils
+)
+
+add_mlir_library(MLIRMemrefToArithExtractLoopBody
+    PARTIAL_SOURCES_INTENDED
+    ExtractLoopBody.cpp
+
+    DEPENDS
+    MLIRMemrefToArithPassIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRAffineAnalysis
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRFuncDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+    MLIRTransformUtils
+)
+
+add_mlir_library(MLIRMemrefToArithUnrollAndForward
+    PARTIAL_SOURCES_INTENDED
+    UnrollAndForward.cpp
+
+    DEPENDS
+    MLIRMemrefToArithPassIncGen
+
+    LINK_LIBS PUBLIC
+    LLVMSupport
+    MLIRAffineAnalysis
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRArithDialect
+    MLIRFuncDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRPass
+    MLIRSCFDialect
+    MLIRSupport
+    MLIRTransformUtils
+)
+
+add_mlir_library(MLIRMemrefToArithRegistration
+    PARTIAL_SOURCES_INTENDED
+    PassRegistration.cpp
+
+    DEPENDS
+    MLIRMemrefToArithPassIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRMemrefToArithExpandCopy
+    MLIRMemrefToArithExtractLoopBody
+    MLIRMemrefToArithMemrefGlobalReplace
+    MLIRMemrefToArithUnrollAndForward
+)
+
+add_mlir_library(MLIRMemrefToArithUtils
+    PARTIAL_SOURCES_INTENDED
+    Utils.cpp
+
+    DEPENDS
+    MLIRMemrefToArithPassIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRAffineDialect
+    MLIRAffineAnalysis
+    MLIRAffineUtils
+    LLVMSupport
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Conversion/PolynomialToStandard/CMakeLists.txt
+++ b/lib/Conversion/PolynomialToStandard/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(LLVM_TARGET_DEFINITIONS PolynomialToStandard.td)
+mlir_tablegen(PolynomialToStandard.h.inc -gen-pass-decls -name PolynomialToStandard)
+add_public_tablegen_target(MLIRPolynomialTransformsIncGen)
+
+add_mlir_dialect_library(MLIRPolynomialTransforms
+    PolynomialToStandard.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRPolynomialTransformsIncGen
+
+    LINK_LIBS PUBLIC
+
+    MLIRHEIRUtils
+    LLVMSupport
+    MLIRAffineDialect
+    MLIRArithDialect
+    MLIRDialectUtils
+    MLIRFuncDialect
+    MLIRFuncTransforms
+    MLIRIR
+    MLIRLLVMDialect
+    MLIRLinalgDialect
+    MLIRPass
+    MLIRPolynomialDialect
+    MLIRSCFDialect
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTransformUtils
+)

--- a/lib/Conversion/SecretToBGV/CMakeLists.txt
+++ b/lib/Conversion/SecretToBGV/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(LLVM_TARGET_DEFINITIONS SecretToBGV.td)
+mlir_tablegen(SecretToBGV.h.inc -gen-pass-decls -name SecretToBGV)
+add_public_tablegen_target(MLIRSecretTransformsIncGen)
+
+add_mlir_dialect_library(MLIRSecretTransforms
+    SecretToBGV.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRSecretTransformsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRUtils
+
+    MLIRBGV
+    MLIRLWE
+    MLIRSecret
+    MLIRTensorExt
+    LLVMSupport
+
+    MLIRArithDialect
+    MLIRIR
+    MLIRPass
+    MLIRPolynomialDialect
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTransformUtils
+)

--- a/lib/DRR/CMakeLists.txt
+++ b/lib/DRR/CMakeLists.txt
@@ -1,0 +1,1 @@
+message("no-op")

--- a/lib/Dialect/ArithExt/CMakeLists.txt
+++ b/lib/Dialect/ArithExt/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRArithExtDialect
+        IR/ArithExtDialect.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRArithExtIncGen
+        MLIRArithExtOpsIncGen
+
+        LINK_LIBS PUBLIC
+        LLVMSupport
+        MLIRArithDialect
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRSupport
+)

--- a/lib/Dialect/ArithExt/IR/CMakeLists.txt
+++ b/lib/Dialect/ArithExt/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(LLVM_TARGET_DEFINITIONS ArithExtDialect.td)
+mlir_tablegen(ArithExtDialect.h.inc -gen-dialect-decls)
+mlir_tablegen(ArithExtDialect.cpp.inc -gen-dialect-defs)
+add_public_tablegen_target(MLIRArithExtIncGen)
+
+set(LLVM_TARGET_DEFINITIONS ArithExtOps.td)
+mlir_tablegen(ArithExtOps.h.inc -gen-op-decls)
+mlir_tablegen(ArithExtOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRArithExtOpsIncGen)

--- a/lib/Dialect/BGV/CMakeLists.txt
+++ b/lib/Dialect/BGV/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)
+add_mlir_dialect_library(MLIRBGV
+        IR/BGVDialect.cpp
+        Transforms/AddClientInterface.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRBGVIncGen
+        MLIRBGVOpsIncGen
+        MLIRBGVPassesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/BGV/IR/CMakeLists.txt
+++ b/lib/Dialect/BGV/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(LLVM_TARGET_DEFINITIONS BGVDialect.td)
+mlir_tablegen(BGVDialect.h.inc -gen-dialect-decls -dialect=bgv)
+mlir_tablegen(BGVDialect.cpp.inc -gen-dialect-defs -dialect=bgv)
+add_public_tablegen_target(MLIRBGVIncGen)
+
+set(LLVM_TARGET_DEFINITIONS BGVOps.td)
+mlir_tablegen(BGVOps.h.inc -gen-op-decls)
+mlir_tablegen(BGVOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRBGVOpsIncGen)

--- a/lib/Dialect/BGV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/BGV/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name BGV)
+add_public_tablegen_target(MLIRBGVPassesIncGen)

--- a/lib/Dialect/CGGI/CMakeLists.txt
+++ b/lib/Dialect/CGGI/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)
+add_mlir_dialect_library(MLIRCGGI
+        IR/CGGIDialect.cpp
+        IR/CGGIOps.cpp
+        Transforms/SetDefaultParameters.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRCGGIIncGen
+        MLIRCGGIOpsIncGen
+        MLIRCGGIPassesIncGen
+        MLIRCGGIAttributesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRHEIRInterfaces
+        MLIRLWE
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)
+add_dependencies(MLIRCGGI MLIRCGGIAttributesIncGen)

--- a/lib/Dialect/CGGI/IR/CMakeLists.txt
+++ b/lib/Dialect/CGGI/IR/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_TARGET_DEFINITIONS CGGIDialect.td)
+mlir_tablegen(CGGIDialect.h.inc -gen-dialect-decls -dialect=cggi)
+mlir_tablegen(CGGIDialect.cpp.inc -gen-dialect-defs -dialect=cggi)
+add_public_tablegen_target(MLIRCGGIIncGen)
+
+set(LLVM_TARGET_DEFINITIONS CGGIOps.td)
+mlir_tablegen(CGGIOps.h.inc -gen-op-decls)
+mlir_tablegen(CGGIOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRCGGIOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS CGGIAttributes.td)
+mlir_tablegen(CGGIAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect="cggi")
+mlir_tablegen(CGGIAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect="cggi")
+add_public_tablegen_target(MLIRCGGIAttributesIncGen)

--- a/lib/Dialect/CGGI/Transforms/CMakeLists.txt
+++ b/lib/Dialect/CGGI/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name=CGGI)
+add_public_tablegen_target(MLIRCGGIPassesIncGen)

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -1,0 +1,46 @@
+add_subdirectory(ArithExt)
+# IR + Transforms
+add_subdirectory(LWE)
+
+
+add_subdirectory(Jaxite)
+add_subdirectory(PolyExt)
+add_subdirectory(Openfhe)
+add_subdirectory(RNS)
+add_subdirectory(TfheRust)
+add_subdirectory(TfheRustBool)
+add_subdirectory(Polynomial)
+
+add_subdirectory(BGV)
+add_subdirectory(CGGI)
+add_subdirectory(Secret)
+
+set(LLVM_TARGET_DEFINITIONS HEIRInterfaces.td)
+mlir_tablegen(HEIRInterfaces.h.inc  --gen-op-interface-decls  -name heir)
+mlir_tablegen(HEIRInterfaces.cpp.inc  --gen-op-interface-defs -name heir)
+add_public_tablegen_target(MLIRHEIRInterfacesOpsIncGen)
+
+add_mlir_dialect_library(MLIRHEIRInterfaces
+    HEIRInterfaces.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+    DEPENDS
+    MLIRHEIRInterfacesOpsIncGen
+    HEIRIncludeMLIR
+    HEIRIncludeLLVM
+
+    LINK_LIBS PUBLIC
+    LLVMSupport
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRSupport
+    MLIRDialect
+)
+
+
+add_subdirectory(Comb) #- requires HEIR interface
+add_dependencies(MLIRCombOpsIncGen MLIRHEIRInterfacesOpsIncGen)
+
+add_subdirectory(TensorExt)

--- a/lib/Dialect/Comb/CMakeLists.txt
+++ b/lib/Dialect/Comb/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRComb
+        IR/CombDialect.cpp
+        IR/CombOps.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRCombIncGen
+        MLIRCombOpsIncGen
+        MLIRCombDialectEnumsIncGen
+        MLIRCombTypesIncGen
+
+        LINK_LIBS PUBLIC
+        LLVMSupport
+        MLIRHEIRInterfaces
+        MLIRBytecodeOpInterface
+        MLIRFunctionInterfaces
+        MLIRSideEffectInterfaces
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/Comb/IR/CMakeLists.txt
+++ b/lib/Dialect/Comb/IR/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS Comb.td) #Dialect
+mlir_tablegen(CombDialect.h.inc -gen-dialect-decls -dialect=comb)
+mlir_tablegen(CombDialect.cpp.inc -gen-dialect-defs -dialect=comb)
+add_public_tablegen_target(MLIRCombIncGen)
+
+set(LLVM_TARGET_DEFINITIONS Comb.td) #CombOps
+mlir_tablegen(Comb.h.inc -gen-op-decls --dialect=comb)
+mlir_tablegen(Comb.cpp.inc -gen-op-defs --dialect=comb)
+add_public_tablegen_target(MLIRCombOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS Comb.td)
+mlir_tablegen(CombEnums.h.inc -gen-enum-decls -dialect=comb)
+mlir_tablegen(CombEnums.cpp.inc -gen-enum-defs -dialect=comb)
+add_public_tablegen_target(MLIRCombDialectEnumsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS Comb.td)
+mlir_tablegen(CombTypes.h.inc -gen-typedef-decls -dialect=comb)
+mlir_tablegen(CombTypes.cpp.inc -gen-typedef-defs -dialect=comb)
+add_public_tablegen_target(MLIRCombTypesIncGen)

--- a/lib/Dialect/Jaxite/CMakeLists.txt
+++ b/lib/Dialect/Jaxite/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRJaxite
+        IR/JaxiteDialect.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRJaxiteIncGen
+        MLIRJaxiteOpsIncGen
+        MLIRJaxiteTypesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/Jaxite/IR/CMakeLists.txt
+++ b/lib/Dialect/Jaxite/IR/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_TARGET_DEFINITIONS JaxiteDialect.td)
+mlir_tablegen(JaxiteDialect.h.inc -gen-dialect-decls -dialect=jaxite)
+mlir_tablegen(JaxiteDialect.cpp.inc -gen-dialect-defs -dialect=jaxite)
+add_public_tablegen_target(MLIRJaxiteIncGen)
+
+set(LLVM_TARGET_DEFINITIONS JaxiteOps.td)
+mlir_tablegen(JaxiteOps.h.inc -gen-op-decls)
+mlir_tablegen(JaxiteOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRJaxiteOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS JaxiteTypes.td)
+mlir_tablegen(JaxiteTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(JaxiteTypes.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIRJaxiteTypesIncGen)

--- a/lib/Dialect/LWE/CMakeLists.txt
+++ b/lib/Dialect/LWE/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)
+add_mlir_dialect_library(MLIRLWE
+        IR/LWEDialect.cpp
+        Transforms/SetDefaultParameters.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRLWEIncGen
+        MLIRLWETypesIncGen
+        MLIRLWEOpsIncGen
+        MLIRLWEAttributesIncGen
+        MLIRLWEPassesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)
+add_dependencies(MLIRLWE MLIRLWEIncGen)
+add_dependencies(MLIRLWE MLIRLWEPassesIncGen)

--- a/lib/Dialect/LWE/IR/CMakeLists.txt
+++ b/lib/Dialect/LWE/IR/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(LLVM_TARGET_DEFINITIONS LWEDialect.td)
+mlir_tablegen(LWEDialect.h.inc -gen-dialect-decls -dialect=lwe)
+mlir_tablegen(LWEDialect.cpp.inc -gen-dialect-defs -dialect=lwe)
+add_public_tablegen_target(MLIRLWEIncGen)
+
+set(LLVM_TARGET_DEFINITIONS LWEOps.td)
+mlir_tablegen(LWEOps.h.inc -gen-op-decls -dialect=lwe)
+mlir_tablegen(LWEOps.cpp.inc -gen-op-defs -dialect=lwe)
+add_public_tablegen_target(MLIRLWEOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS LWETypes.td)
+mlir_tablegen(LWETypes.h.inc -gen-typedef-decls -dialect=lwe)
+mlir_tablegen(LWETypes.cpp.inc -gen-typedef-defs -dialect=lwe)
+add_public_tablegen_target(MLIRLWETypesIncGen)
+
+
+set(LLVM_TARGET_DEFINITIONS LWEAttributes.td)
+mlir_tablegen(LWEAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect="lwe")
+mlir_tablegen(LWEAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect="lwe")
+add_public_tablegen_target(MLIRLWEAttributesIncGen)

--- a/lib/Dialect/LWE/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LWE/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name LWE)
+add_public_tablegen_target(MLIRLWEPassesIncGen)

--- a/lib/Dialect/Openfhe/CMakeLists.txt
+++ b/lib/Dialect/Openfhe/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)
+add_mlir_dialect_library(MLIROpenfhe
+        IR/OpenfheDialect.cpp
+        Transforms/ConfigureCryptoContext.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIROpenfheOpsIncGen
+        MLIROpenfheTypesIncGen
+        MLIROpenfheIncGen
+        MLIROpenfhePassesIncGen
+
+        LINK_LIBS PUBLIC
+        LLVMSupport
+        MLIRAnalysis
+        MLIRArithDialect
+        MLIRFuncDialect
+        MLIRIR
+        MLIRPass
+        MLIRSupport
+        MLIRInferTypeOpInterface
+)
+
+add_dependencies(MLIROpenfhe MLIRLWE)

--- a/lib/Dialect/Openfhe/IR/CMakeLists.txt
+++ b/lib/Dialect/Openfhe/IR/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_TARGET_DEFINITIONS OpenfheDialect.td)
+mlir_tablegen(OpenfheDialect.h.inc -gen-dialect-decls)# -dialect=Openfhe)
+mlir_tablegen(OpenfheDialect.cpp.inc -gen-dialect-defs)
+add_public_tablegen_target(MLIROpenfheIncGen)
+
+set(LLVM_TARGET_DEFINITIONS OpenfheOps.td)
+mlir_tablegen(OpenfheOps.h.inc -gen-op-decls -dialect=openfhe)
+mlir_tablegen(OpenfheOps.cpp.inc -gen-op-defs -dialect=openfhe)
+add_public_tablegen_target(MLIROpenfheOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS OpenfheTypes.td)
+mlir_tablegen(OpenfheTypes.h.inc -gen-typedef-decls -dialect=openfhe)
+mlir_tablegen(OpenfheTypes.cpp.inc -gen-typedef-defs -dialect=openfhe)
+add_public_tablegen_target(MLIROpenfheTypesIncGen)

--- a/lib/Dialect/Openfhe/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Openfhe/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name=Openfhe)
+add_public_tablegen_target(MLIROpenfhePassesIncGen)

--- a/lib/Dialect/PolyExt/CMakeLists.txt
+++ b/lib/Dialect/PolyExt/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRPolyExt
+        IR/PolyExtDialect.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRPolyExtOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/PolyExt/IR/CMakeLists.txt
+++ b/lib/Dialect/PolyExt/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(LLVM_TARGET_DEFINITIONS PolyExtDialect.td)
+mlir_tablegen(PolyExtDialect.h.inc -gen-dialect-decls)# -dialect=polyext)
+mlir_tablegen(PolyExtDialect.cpp.inc -gen-dialect-defs)
+add_public_tablegen_target(MLIRPolyExtIncGen)
+
+set(LLVM_TARGET_DEFINITIONS PolyExtOps.td)
+mlir_tablegen(PolyExtOps.h.inc -gen-op-decls -dialect=polyext)
+mlir_tablegen(PolyExtOps.cpp.inc -gen-op-defs -dialect=polyext)
+add_public_tablegen_target(MLIRPolyExtOpsIncGen)

--- a/lib/Dialect/Polynomial/CMakeLists.txt
+++ b/lib/Dialect/Polynomial/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_subdirectory(Transforms)
+
+add_mlir_dialect_library(MLIRHeirPolynomialNTTRewrites
+        Transforms/NTTRewrites.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/Transforms
+
+        DEPENDS
+        MLIRPolynomialPassesIncGen
+        MLIRPolynomialNTTRewritePassesIncGen
+
+        LINK_LIBS PUBLIC
+
+        MLIRArithExtDialect
+        MLIRArithDialect
+        MLIRIR
+        MLIRPass
+        MLIRPolynomialDialect
+        MLIRTransformUtils
+)

--- a/lib/Dialect/Polynomial/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Polynomial/Transforms/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Polynomial)
+add_public_tablegen_target(MLIRPolynomialPassesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS NTTRewrites.td)
+mlir_tablegen(NTTRewrites.cpp.inc -gen-rewriters -name Polynomial)
+add_public_tablegen_target(MLIRPolynomialNTTRewritePassesIncGen)

--- a/lib/Dialect/RNS/CMakeLists.txt
+++ b/lib/Dialect/RNS/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRRNS
+        IR/RNSDialect.cpp
+        IR/RNSTypes.cpp
+        IR/RNSOps.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRRNSIncGen
+        MLIRRNSTypeIncGen
+        MLIRRNSOpsIncGen
+        MLIRRNSTypeInterfaces
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/RNS/IR/CMakeLists.txt
+++ b/lib/Dialect/RNS/IR/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS RNSDialect.td)
+mlir_tablegen(RNSDialect.h.inc -gen-dialect-decls -dialect=rns)
+mlir_tablegen(RNSDialect.cpp.inc -gen-dialect-defs -dialect=rns)
+add_public_tablegen_target(MLIRRNSIncGen)
+
+set(LLVM_TARGET_DEFINITIONS RNSOps.td)
+mlir_tablegen(RNSOps.h.inc -gen-op-decls)
+mlir_tablegen(RNSOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRRNSOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS RNSTypes.td)
+mlir_tablegen(RNSTypes.h.inc  --gen-typedef-decls  -name rns)
+mlir_tablegen(RNSTypes.cpp.inc  --gen-typedef-defs -name rns)
+add_public_tablegen_target(MLIRRNSTypeIncGen)
+
+set(LLVM_TARGET_DEFINITIONS RNSTypeInterfaces.td)
+mlir_tablegen(RNSTypeInterfaces.h.inc  --gen-type-interface-decls  -name rns)
+mlir_tablegen(RNSTypeInterfaces.cpp.inc  --gen-type-interface-defs -name rns)
+add_public_tablegen_target(MLIRRNSTypeInterfaces)

--- a/lib/Dialect/Secret/CMakeLists.txt
+++ b/lib/Dialect/Secret/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)
+add_mlir_dialect_library(MLIRSecret
+        IR/SecretDialect.cpp
+        IR/SecretOps.cpp
+        IR/SecretPatterns.cpp
+        Transforms/BufferizableOpInterfaceImpl.cpp
+        Transforms/CaptureGenericAmbientScope.cpp
+        Transforms/DistributeGeneric.cpp
+        Transforms/ExtractGenericBody.cpp
+        Transforms/ForgetSecrets.cpp
+        Transforms/GenericAbsorbConstants.cpp
+        Transforms/GenericAbsorbDealloc.cpp
+        Transforms/MergeAdjacentGenerics.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRSecretIncGen
+        MLIRSecretTypesIncGen
+        MLIRSecretOpsIncGen
+        MLIRSecretPassesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/Secret/IR/CMakeLists.txt
+++ b/lib/Dialect/Secret/IR/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(LLVM_TARGET_DEFINITIONS SecretDialect.td)
+mlir_tablegen(SecretDialect.h.inc -gen-dialect-decls -dialect=secret)
+mlir_tablegen(SecretDialect.cpp.inc -gen-dialect-defs -dialect=secret)
+add_public_tablegen_target(MLIRSecretIncGen)
+
+set(LLVM_TARGET_DEFINITIONS SecretOps.td)
+mlir_tablegen(SecretOps.h.inc -gen-op-decls)
+mlir_tablegen(SecretOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRSecretOpsIncGen)
+
+
+set(LLVM_TARGET_DEFINITIONS SecretTypes.td)
+mlir_tablegen(SecretTypes.h.inc -gen-typedef-decls -dialect=lwe)
+mlir_tablegen(SecretTypes.cpp.inc -gen-typedef-defs -dialect=lwe)
+add_public_tablegen_target(MLIRSecretTypesIncGen)

--- a/lib/Dialect/Secret/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Secret/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Secret)
+add_public_tablegen_target(MLIRSecretPassesIncGen)

--- a/lib/Dialect/TensorExt/CMakeLists.txt
+++ b/lib/Dialect/TensorExt/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)
+add_mlir_dialect_library(MLIRTensorExt
+        IR/TensorExtDialect.cpp
+        IR/TensorExtOps.cpp
+        Transforms/CollapseInsertionChains.cpp
+        Transforms/InsertRotate.cpp
+        Transforms/RotateAndReduce.cpp
+        Transforms/AlignTensorSizes.cpp
+        Transforms/Passes.h
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRTensorExtIncGen
+        MLIRTensorExtOpsIncGen
+        MLIRTensorExtAttributesIncGen
+        MLIRTensorExtPassesIncGen
+        MLIRTensorExtInsertRotateIncGen
+        MLIRTensorExtCanonicalizationIncGen
+        MLIRSecretIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRSecret
+        MLIRIR
+        MLIRTensorDialect
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/TensorExt/IR/CMakeLists.txt
+++ b/lib/Dialect/TensorExt/IR/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(LLVM_TARGET_DEFINITIONS TensorExtDialect.td)
+mlir_tablegen(TensorExtDialect.h.inc -gen-dialect-decls -dialect=tensor_ext)
+mlir_tablegen(TensorExtDialect.cpp.inc -gen-dialect-defs -dialect=tensor_ext)
+add_public_tablegen_target(MLIRTensorExtIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TensorExtOps.td)
+mlir_tablegen(TensorExtOps.h.inc -gen-op-decls)
+mlir_tablegen(TensorExtOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRTensorExtOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TensorExtAttributes.td)
+mlir_tablegen(TensorExtAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect="tensor_ext")
+mlir_tablegen(TensorExtAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect="tensor_ext")
+add_public_tablegen_target(MLIRTensorExtAttributesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TensorExtCanonicalization.td)
+mlir_tablegen(TensorExtCanonicalization.cpp.inc -gen-rewriters)
+add_public_tablegen_target(MLIRTensorExtCanonicalizationIncGen)

--- a/lib/Dialect/TensorExt/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TensorExt/Transforms/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name TensorExt)
+add_public_tablegen_target(MLIRTensorExtPassesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS InsertRotate.td)
+mlir_tablegen(InsertRotate.cpp.inc -gen-rewriters -name TensorExt)
+add_public_tablegen_target(MLIRTensorExtInsertRotateIncGen)

--- a/lib/Dialect/TfheRust/CMakeLists.txt
+++ b/lib/Dialect/TfheRust/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRTfheRust
+        IR/TfheRustDialect.cpp
+        IR/TfheRustPatterns.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRTfheRustIncGen
+        MLIRTfheRustOpsIncGen
+        MLIRTfheRustTypesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/TfheRust/IR/CMakeLists.txt
+++ b/lib/Dialect/TfheRust/IR/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_TARGET_DEFINITIONS TfheRustDialect.td)
+mlir_tablegen(TfheRustDialect.h.inc -gen-dialect-decls)
+mlir_tablegen(TfheRustDialect.cpp.inc -gen-dialect-defs)
+add_public_tablegen_target(MLIRTfheRustIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TfheRustOps.td)
+mlir_tablegen(TfheRustOps.h.inc -gen-op-decls)
+mlir_tablegen(TfheRustOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRTfheRustOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TfheRustTypes.td)
+mlir_tablegen(TfheRustTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(TfheRustTypes.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIRTfheRustTypesIncGen)

--- a/lib/Dialect/TfheRustBool/CMakeLists.txt
+++ b/lib/Dialect/TfheRustBool/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_subdirectory(IR)
+add_mlir_dialect_library(MLIRTfheRustBool
+        IR/TfheRustBoolDialect.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRTfheRustBoolIncGen
+        MLIRTfheRustBoolOpsIncGen
+        MLIRTfheRustBoolOpsTypesIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRIR
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)

--- a/lib/Dialect/TfheRustBool/IR/CMakeLists.txt
+++ b/lib/Dialect/TfheRustBool/IR/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_TARGET_DEFINITIONS TfheRustBoolDialect.td)
+mlir_tablegen(TfheRustBoolDialect.h.inc -gen-dialect-decls)
+mlir_tablegen(TfheRustBoolDialect.cpp.inc -gen-dialect-defs)
+add_public_tablegen_target(MLIRTfheRustBoolIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TfheRustBoolOps.td)
+mlir_tablegen(TfheRustBoolOps.h.inc -gen-op-decls)
+mlir_tablegen(TfheRustBoolOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(MLIRTfheRustBoolOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TfheRustBoolTypes.td)
+mlir_tablegen(TfheRustBoolTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(TfheRustBoolTypes.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIRTfheRustBoolOpsTypesIncGen)

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -1,0 +1,13 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+function(make_heir_exec  TARGET_NAME SOURCES)
+        add_llvm_executable(${TARGET_NAME} PARTIAL_SOURCES_INTENDED ${SOURCES})
+        llvm_update_compile_flags(${TARGET_NAME})
+        target_link_libraries(${TARGET_NAME} PUBLIC
+        ${dialect_libs} ${conversion_libs}
+        MLIROptLib MLIRSupport LLVMSupport /usr/local/lib/libgtest.a) # /usr/local/lib/libgtest_main.a)
+endfunction()
+
+#FIXME: linking against gtest is funny in Mac OSX
+#make_heir_exec(graphtest GraphTest.cpp)

--- a/lib/Source/AutoHog/CMakeLists.txt
+++ b/lib/Source/AutoHog/CMakeLists.txt
@@ -1,0 +1,47 @@
+include(ExternalProject)
+
+# Download RapidJSON
+# TODO (#818): automatically extract the commit from the bazel WORKSPACE file
+ExternalProject_Add(
+    rapidjson
+    PREFIX "vendor/rapidjson"
+    GIT_REPOSITORY "https://github.com/Tencent/rapidjson.git"
+    GIT_TAG f54b0e47a08782a6131cc3d60f94d038fa6e0a51
+    TIMEOUT 10
+    CMAKE_ARGS
+        -DRAPIDJSON_BUILD_TESTS=OFF
+        -DRAPIDJSON_BUILD_DOC=OFF
+        -DRAPIDJSON_BUILD_EXAMPLES=OFF
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    UPDATE_COMMAND ""
+)
+
+# Prepare RapidJSON (RapidJSON is a header-only library)
+ExternalProject_Get_Property(rapidjson source_dir)
+set(RAPIDJSON_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/vendor/rapidjson/src/rapidjson/include/)
+
+add_mlir_dialect_library(MLIRAutoHogImporter
+    AutoHogImporter.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/
+
+    DEPENDS
+    rapidjson
+
+    DEPENDS
+    rapidjson
+
+    LINK_LIBS PUBLIC
+    MLIRCGGI
+    MLIRLWE
+    LLVMSupport
+    MLIRIR
+    MLIRSupport
+    MLIRArithDialect
+    MLIRTensorDialect
+    MLIRTranslateLib
+)
+target_include_directories(MLIRAutoHogImporter PUBLIC ${RAPIDJSON_INCLUDE_DIR})

--- a/lib/Source/CMakeLists.txt
+++ b/lib/Source/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(AutoHog)

--- a/lib/Target/CMakeLists.txt
+++ b/lib/Target/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_library(MLIRHEIRTargetUtils STATIC
+        Utils.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+        LINK_LIBS PUBLIC
+        MLIRInferTypeOpInterface
+        MLIRArithDialect
+        MLIRSupport
+        MLIRDialect
+        MLIRIR
+)
+add_subdirectory(OpenFhePke)
+add_subdirectory(Jaxite)
+add_subdirectory(Metadata)
+add_subdirectory(TfheRust)
+add_subdirectory(TfheRustBool)
+add_subdirectory(Verilog)

--- a/lib/Target/Jaxite/CMakeLists.txt
+++ b/lib/Target/Jaxite/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+add_mlir_dialect_library(MLIRJaxiteTarget
+        JaxiteEmitter.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRJaxiteOpsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRAnalysisSVN
+    MLIRJaxite
+    MLIRLWE
+    MLIRHEIRTargetUtils
+    LLVMSupport
+    MLIRArithDialect
+    MLIRAffineDialect
+    MLIRFuncDialect
+    MLIRIR
+    MLIRMemRefDialect
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTranslateLib
+)

--- a/lib/Target/Metadata/CMakeLists.txt
+++ b/lib/Target/Metadata/CMakeLists.txt
@@ -1,0 +1,21 @@
+
+add_mlir_dialect_library(MLIRMetadataEmitter
+        MetadataEmitter.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRLWEOpsIncGen
+
+        LINK_LIBS PUBLIC
+        LLVMSupport
+        MLIRAffineDialect
+        MLIRArithDialect
+        MLIRFuncDialect
+        MLIRIR
+        MLIRMemRefDialect
+        MLIRSCFDialect
+        MLIRSupport
+        MLIRTranslateLib
+)

--- a/lib/Target/OpenFhePke/CMakeLists.txt
+++ b/lib/Target/OpenFhePke/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+add_mlir_dialect_library(MLIROpenfheTarget
+        OpenFhePkeEmitter.cpp
+        OpenFhePkeHeaderEmitter.cpp
+        OpenFheUtils.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIROpenfheOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIROpenfhe
+        MLIRIR
+        MLIRInferTypeOpInterface
+)

--- a/lib/Target/TfheRust/CMakeLists.txt
+++ b/lib/Target/TfheRust/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+add_mlir_dialect_library(MLIRTfheRustTarget
+        TfheRustEmitter.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRTfheRustOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRTfheRust
+        MLIRIR
+        MLIRInferTypeOpInterface
+)

--- a/lib/Target/TfheRustBool/CMakeLists.txt
+++ b/lib/Target/TfheRustBool/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+add_mlir_dialect_library(MLIRTfheRustBoolTarget
+        TfheRustBoolEmitter.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRTfheRustBoolOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRTfheRust
+        MLIRIR
+        MLIRInferTypeOpInterface
+)

--- a/lib/Target/Verilog/CMakeLists.txt
+++ b/lib/Target/Verilog/CMakeLists.txt
@@ -1,0 +1,24 @@
+
+add_mlir_dialect_library(MLIRVerilogTarget
+        VerilogEmitter.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/IR
+
+        DEPENDS
+        MLIRSecretOpsIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRMemrefToArithUtils
+    MLIRSecret
+    MLIRHEIRTargetUtils
+    LLVMSupport
+    MLIRTranslateLib
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRFuncDialect
+    MLIRSupport
+    MLIRIR
+    MLIRInferTypeOpInterface
+
+)

--- a/lib/Transforms/ApplyFolders/CMakeLists.txt
+++ b/lib/Transforms/ApplyFolders/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS ApplyFolders.td)
+mlir_tablegen(ApplyFolders.h.inc -gen-pass-decls -name ApplyFolders)
+add_public_tablegen_target(MLIRHeirApplyFoldersIncGen)
+
+add_mlir_dialect_library(MLIRHeirApplyFolders
+    ApplyFolders.cpp
+
+    DEPENDS
+    MLIRHeirApplyFoldersIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_subdirectory(ApplyFolders)
+add_subdirectory(ConvertIfToSelect)
+add_subdirectory(ElementwiseToAffine)
+add_subdirectory(ForwardStoreToLoad)
+add_subdirectory(FullLoopUnroll)
+add_subdirectory(Secretize)
+add_subdirectory(StraightLineVectorizer)
+add_subdirectory(UnusedMemRef)
+
+if(ENABLE_YOSYS)
+    # TODO (#797): Support Yosys in cmake build.
+    message(FATAL_ERROR "Yosys transforms not supported in CMake build yet; use Bazel instead.")
+    add_subdirectory(YosysOptimizer)
+endif()

--- a/lib/Transforms/ConvertIfToSelect/CMakeLists.txt
+++ b/lib/Transforms/ConvertIfToSelect/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS ConvertIfToSelect.td)
+mlir_tablegen(ConvertIfToSelect.h.inc -gen-pass-decls -name ConvertIfToSelect)
+add_public_tablegen_target(MLIRHeirConvertIfToSelectIncGen)
+
+add_mlir_dialect_library(MLIRHeirConvertIfToSelect
+    ConvertIfToSelect.cpp
+
+    DEPENDS
+    MLIRHeirConvertIfToSelectIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/ElementwiseToAffine/CMakeLists.txt
+++ b/lib/Transforms/ElementwiseToAffine/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS ElementwiseToAffine.td)
+mlir_tablegen(ElementwiseToAffine.h.inc -gen-pass-decls -name ElementwiseToAffine)
+add_public_tablegen_target(MLIRHeirElementwiseToAffineIncGen)
+
+add_mlir_dialect_library(MLIRHeiElementwiseToAffine
+    ElementwiseToAffine.cpp
+
+    DEPENDS
+    MLIRHeirElementwiseToAffineIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/ForwardStoreToLoad/CMakeLists.txt
+++ b/lib/Transforms/ForwardStoreToLoad/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS ForwardStoreToLoad.td)
+mlir_tablegen(ForwardStoreToLoad.h.inc -gen-pass-decls -name ForwardStoreToLoad)
+add_public_tablegen_target(MLIRHeirForwardStoreToLoadIncGen)
+
+add_mlir_dialect_library(MLIRHeirForwardStoreToLoad
+    ForwardStoreToLoad.cpp
+
+    DEPENDS
+    MLIRHeirForwardStoreToLoadIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/FullLoopUnroll/CMakeLists.txt
+++ b/lib/Transforms/FullLoopUnroll/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS FullLoopUnroll.td)
+mlir_tablegen(FullLoopUnroll.h.inc -gen-pass-decls -name FullLoopUnroll)
+add_public_tablegen_target(MLIRHeirFullLoopUnrollIncGen)
+
+add_mlir_dialect_library(MLIRHeirFullLoopUnroll
+    FullLoopUnroll.cpp
+
+    DEPENDS
+    MLIRHeirFullLoopUnrollIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRArithDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/Secretize/CMakeLists.txt
+++ b/lib/Transforms/Secretize/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Secretize)
+add_public_tablegen_target(MLIRHeirSecretizeIncGen)
+
+add_mlir_dialect_library(MLIRHeirSecretize
+    Secretize.cpp
+    WrapGeneric.cpp
+
+    DEPENDS
+    MLIRHeirSecretizeIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/StraightLineVectorizer/CMakeLists.txt
+++ b/lib/Transforms/StraightLineVectorizer/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LLVM_TARGET_DEFINITIONS StraightLineVectorizer.td)
+mlir_tablegen(StraightLineVectorizer.h.inc -gen-pass-decls -name StraightLineVectorizer)
+add_public_tablegen_target(MLIRHeirStraightLineVectorizerIncGen)
+
+add_mlir_dialect_library(MLIRHeirStraightLineVectorizer
+    StraightLineVectorizer.cpp
+
+    DEPENDS
+    MLIRHeirStraightLineVectorizerIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/lib/Transforms/UnusedMemRef/CMakeLists.txt
+++ b/lib/Transforms/UnusedMemRef/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(LLVM_TARGET_DEFINITIONS UnusedMemRef.td)
+mlir_tablegen(UnusedMemRef.h.inc -gen-pass-decls -name UnusedMemRef)
+add_public_tablegen_target(MLIRHeirUnusedMemRefIncGen)
+
+add_mlir_dialect_library(MLIRHeirUnusedMemRef
+    PARTIAL_SOURCES_INTENDED
+    UnusedMemRef.cpp
+
+    DEPENDS
+    MLIRHeirUnusedMemRefIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRArithExtDialect
+    MLIRIR
+    MLIRInferTypeOpInterface
+    MLIRArithDialect
+    MLIRSupport
+    MLIRDialect
+    MLIRIR
+)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,164 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+function(make_heirtx_exec  TARGET_NAME SOURCES)
+        add_llvm_executable(${TARGET_NAME} PARTIAL_SOURCES_INTENDED ${SOURCES})
+        llvm_update_compile_flags(${TARGET_NAME})
+        target_link_libraries(${TARGET_NAME} PRIVATE
+        ${dialect_libs} ${conversion_libs}
+
+        MLIRAutoHogImporter
+        MLIRJaxiteTarget
+        MLIRMetadataEmitter
+        MLIROpenfheTarget
+        MLIRTfheRustTarget
+        MLIRTfheRustBoolTarget
+        MLIRVerilogTarget
+        MLIRSupport
+        MLIRTranslateLib
+        MLIRCGGI
+
+        )
+endfunction()
+
+function(make_heirlsp_exec  TARGET_NAME SOURCES)
+        add_llvm_executable(${TARGET_NAME} PARTIAL_SOURCES_INTENDED ${SOURCES})
+        llvm_update_compile_flags(${TARGET_NAME})
+        target_link_libraries(${TARGET_NAME} PRIVATE
+        ${dialect_libs} ${conversion_libs}
+
+        MLIRHEIRInterfaces
+        MLIRHEIRUtils
+        MLIRLspServerLib
+        MLIROptLib
+        MLIRSCFDialect
+        MLIRMemRefDialect
+        MLIRComb
+        MLIRCGGI
+        MLIRBGV
+        MLIRLWE
+        MLIRPolyExt
+        MLIRSecret
+        MLIRArithExtDialect
+        MLIRTensorExt
+        MLIRTensorDialect
+        MLIRHEIRAnalysisROT
+        MLIRAffineDialect
+        MLIRJaxiteTarget
+        MLIRMetadataEmitter
+        MLIRSupport
+        MLIRTranslateLib
+        MLIRVerilogTarget
+        MLIROptLib MLIROpenfhe MLIRLWE MLIROpenfheTarget MLIRSecret MLIRVerilogTarget MLIRHEIRTargetUtils
+        MLIRTfheRust MLIRTfheRustBool MLIRHEIRAnalysisSVN
+        MLIRTfheRustTarget
+        MLIRTfheRustBoolTarget
+        MLIRHEIRTargetUtils
+        )
+endfunction()
+
+function(make_heiropt_exec  TARGET_NAME SOURCES)
+        add_llvm_executable(${TARGET_NAME} PARTIAL_SOURCES_INTENDED ${SOURCES})
+        llvm_update_compile_flags(${TARGET_NAME})
+        target_link_libraries(${TARGET_NAME} PRIVATE
+        ${dialect_libs} ${conversion_libs}
+
+        MLIRJaxiteTarget
+        MLIRArithExtDialect
+        MLIRSupport
+        MLIRTranslateLib
+        MLIRVerilogTarget
+        MLIROpenfhe
+        MLIRLWE
+        MLIROpenfheTarget
+        MLIRSecret
+        MLIRVerilogTarget
+        MLIRHEIRTargetUtils
+        MLIRTfheRust
+        MLIRTfheRustBool
+        MLIRHEIRAnalysisSVN
+        MLIRTfheRustTarget
+        MLIRTfheRustBoolTarget
+        MLIRHEIRTargetUtils
+
+        MLIRBGV
+        MLIRCGGI
+        MLIRComb
+        MLIRJaxite
+        MLIRLWE
+        MLIROpenfhe
+        MLIRPolyExt
+        MLIRRNS
+        MLIRSecret
+        MLIRTensorExt
+        MLIRTfheRust
+        MLIRTfheRustBool
+
+        MLIRSupport
+        MLIRAffineDialect
+        MLIRAffineToStandard
+        MLIRAffineTransforms
+        MLIRFuncAllExtensions
+        MLIRFuncDialect
+        MLIRArithDialect
+        MLIRArithToLLVM
+        MLIRArithTransforms
+        MLIRBufferizationToMemRef
+        MLIRBufferizationTransforms
+        MLIRControlFlowToLLVM
+        MLIRConvertToLLVMPass
+        MLIRFuncDialect
+        MLIRFuncToLLVM
+        MLIRFuncTransforms
+        MLIRIndexToLLVM
+        MLIRLLVMDialect
+        MLIRLinalgTransforms
+        MLIRMemRefDialect
+        MLIRMemrefToArithMemrefGlobalReplace
+        MLIRMemRefToLLVM
+        MLIRMemRefTransforms
+        MLIROptLib
+        MLIRPass
+        MLIRPolynomialDialect
+        MLIRReconcileUnrealizedCasts
+        MLIRSCFDialect
+        MLIRSCFToControlFlow
+        MLIRTensorToLinalg
+        MLIRTensorTransforms
+        MLIRTosaDialect
+        MLIRTosaToArith
+        MLIRTosaToLinalg
+        MLIRTosaToTensor
+        MLIRTransforms
+        MLIRHeirConvertIfToSelect
+        MLIRHeiElementwiseToAffine
+        MLIRHeirForwardStoreToLoad
+        MLIRHeirFullLoopUnroll
+        MLIRHeirSecretize
+        MLIRHeirStraightLineVectorizer
+
+        MLIRPolynomialTransforms
+        MLIRHeirPolynomialNTTRewrites
+
+        MLIRMemrefToArithUtils
+        MLIRMemrefToArithRegistration
+        MLIRMemrefToArithUnrollAndForward
+        MLIRMemrefToArithExtractLoopBody
+        MLIRMemrefToArithExpandCopy
+        MLIRMemrefToArithMemrefGlobalReplace
+)
+add_dependencies(${TARGET_NAME} MLIRPolynomialPassesIncGen)
+add_dependencies(${TARGET_NAME} MLIRPolynomialNTTRewritePassesIncGen)
+
+endfunction()
+
+message(STATUS "Configuring heir-translate")
+make_heirtx_exec(heir-translate heir-translate.cpp)
+
+
+message(STATUS "Configuring heir-lsp")
+make_heirlsp_exec(heir-lsp heir-lsp.cpp)
+
+
+message(STATUS "Configuring heir-opt")
+make_heiropt_exec(heir-opt heir-opt.cpp)


### PR DESCRIPTION
Provide CMakeLists.txt files to build all of the core components of HEIR Project (except Yosys and GTest bits)
Contributed by Cornami, Inc, www.cornami.com 
Two ways to build the code:

## Using LLVM build folder
```bash
$ cmake -B builddir -S ./ -DMLIR_DIR=/path/to/llvm-project/build/lib/cmake/mlir -DLLVM_DIR=/path/to/llvm-project/build/lib/cmake/llvm && cmake --build builddir
```

## Using Installed LLVM / MLIR
```bash
$ cmake -S ./ -B builddir -DENABLE_INSTALLED_MLIR=True -DCMAKE_PREFIX_PATH=/usr/local/lib/cmake -DMLIR_CMAKE_DIR=/usr/local/lib/cmake/mlir/ -DLLVM_CMAKE_DIR=/usr/local/lib/cmake/llvm/ &&  cmake --build builddir
```
