### PR TITLE
Bug fix for visitOperation() not propagating taints for constants and operands with unknown secretness state

### DIFF
--- a/lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.cpp
+++ b/lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.cpp
@@ -108,6 +108,20 @@ struct ConvertIfToSelect : impl::ConvertIfToSelectBase<ConvertIfToSelect> {
 
     auto result = solver.initializeAndRun(getOperation());
 
+    getOperation()->walk([&](Operation *op) {
+      llvm::errs() << "Operation: " << *op << "\n";
+      for (auto operand : op->getOperands()) {
+        Secretness secretness =
+            solver.lookupState<SecretnessLattice>(operand)->getValue();
+        llvm::errs() << "\tOperand : " << operand << "; " << secretness << "\n";
+      }
+      for (auto result : op->getResults()) {
+        Secretness secretness =
+            solver.lookupState<SecretnessLattice>(result)->getValue();
+        llvm::errs() << "\tResult : " << result << "; " << secretness << "\n";
+      }
+    });
+
     if (failed(result)) {
       getOperation()->emitOpError() << "Failed to run the analysis.\n";
       signalPassFailure();


### PR DESCRIPTION
My secretness analysis in PR #778 didn't propagate the Secretness state when operations don't have operands, e.g. a ConstantOp, since my original code only sets the Secretness state if operands exist. 

Theoretically, given an operation, all operands should have a Secretness state set before state propagates to the operation's result. Seeing that it's possible to miss setting the Secretness state due to buggy code, I have also added code to set the Secretness state of an operation's result to 'None' if we in case find an operand whose Secretness state has not been initialized.

