### PR TITLE
Loop Transformation: Secret-dependent scf.for to affine.for with constant bounds

### DIFF
--- a/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
+++ b/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
@@ -40,6 +40,8 @@ class Secretness {
     if (!lhs.isInitialized()) return rhs;
     if (!rhs.isInitialized()) return lhs;
 
+    if (lhs.getSecretness() == rhs.getSecretness()) return lhs;
+
     return Secretness{lhs.getSecretness() || rhs.getSecretness()};
   }
 

--- a/lib/Transforms/ConvertSecretForToStaticFor/BUILD
+++ b/lib/Transforms/ConvertSecretForToStaticFor/BUILD
@@ -1,0 +1,48 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ConvertSecretForToStaticFor",
+    srcs = ["ConvertSecretForToStaticFor.cpp"],
+    hdrs = ["ConvertSecretForToStaticFor.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SideEffectInterfaces",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=ConvertSecretForToStaticFor",
+            ],
+            "ConvertSecretForToStaticFor.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "ConvertSecretForToStaticForPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ConvertSecretForToStaticFor.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.cpp
+++ b/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.cpp
@@ -1,0 +1,204 @@
+#include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <utility>
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"    // from @llvm-project
+#include "llvm/include/llvm/Support/Casting.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
+#include "mlir/include/mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_CONVERTSECRETFORTOSTATICFOR
+#include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h.inc"
+
+struct SecretForToStaticForConversion : OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+ public:
+  SecretForToStaticForConversion(DataFlowSolver *solver, MLIRContext *context)
+      : OpRewritePattern(context), solver(solver){};
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    auto *lowerBoundSecretnessLattice =
+        solver->lookupState<SecretnessLattice>(forOp.getLowerBound());
+
+    auto *upperBoundSecretnessLattice =
+        solver->lookupState<SecretnessLattice>(forOp.getUpperBound());
+
+    if (!lowerBoundSecretnessLattice && !upperBoundSecretnessLattice)
+      return failure();
+
+    // Get secretness state of the lower and upper bounds
+    bool isLowerBoundSecret =
+        lowerBoundSecretnessLattice &&
+        lowerBoundSecretnessLattice->getValue().getSecretness();
+    bool isUpperBoundSecret =
+        upperBoundSecretnessLattice &&
+        upperBoundSecretnessLattice->getValue().getSecretness();
+
+    // If both bounds are non-secret constants, return
+    if (!isLowerBoundSecret && !isUpperBoundSecret) return failure();
+
+    int newLowerBound, newUpperBound;
+
+    if (isLowerBoundSecret) {
+      // If static lower bound is not provided, emit a warning and return
+      // failure
+      if (!forOp->getAttrOfType<IntegerAttr>("lower")) {
+        InFlightDiagnostic diag = mlir::emitWarning(
+            forOp.getLoc(),
+            "Cannot convert secret scf.for to static affine.for "
+            "since a static lower bound attribute has not been provided:");
+
+        return failure();
+      }
+      // If lowerBound is secret, get value from "lower" attribute
+      newLowerBound = forOp->getAttrOfType<IntegerAttr>("lower").getInt();
+    }
+
+    if (isUpperBoundSecret) {
+      // If static upper bound is not provided, emit a warning and return
+      // failure
+      if (!forOp->getAttrOfType<IntegerAttr>("upper")) {
+        InFlightDiagnostic diag = mlir::emitWarning(
+            forOp.getLoc(),
+            "Cannot convert secret scf.for to static affine.for "
+            "since a static upper bound attribute has not been provided:");
+
+        return failure();
+      }
+      // If upperBound is secret, get value from "upper" attribute
+      newUpperBound = forOp->getAttrOfType<IntegerAttr>("upper").getInt();
+    }
+
+    ImplicitLocOpBuilder builder(forOp->getLoc(), rewriter);
+
+    auto newForOp = builder.create<affine::AffineForOp>(
+        isLowerBoundSecret ? newLowerBound
+                           : forOp.getLowerBound()
+                                 .getDefiningOp()
+                                 ->getAttrOfType<IntegerAttr>("value")
+                                 .getInt(),
+        isUpperBoundSecret ? newUpperBound
+                           : forOp.getUpperBound()
+                                 .getDefiningOp()
+                                 ->getAttrOfType<IntegerAttr>("value")
+                                 .getInt(),
+        forOp.getStep()
+            .getDefiningOp()
+            ->getAttrOfType<IntegerAttr>("value")
+            .getInt(),
+        forOp.getInitArgs());
+
+    newForOp->setAttrs(forOp->getAttrs());
+
+    auto inductionVariable = newForOp.getInductionVar();
+
+    builder.setInsertionPointToStart(newForOp.getBody());
+
+    arith::CmpIOp cmpIUpper, cmpILower;
+    arith::AndIOp andI;
+
+    if (isLowerBoundSecret) {
+      // Create arith.cmpi (iv >= oldLowerBound)
+      cmpILower = builder.create<arith::CmpIOp>(
+          arith::CmpIPredicate::sge, inductionVariable, forOp.getLowerBound());
+    }
+
+    if (isUpperBoundSecret) {
+      // Create arith.cmpi (iv < oldUpperBound)
+      cmpIUpper = builder.create<arith::CmpIOp>(
+          arith::CmpIPredicate::slt, inductionVariable, forOp.getUpperBound());
+    }
+
+    // If both lowerBound and upperBound are secret, join the two arith.cmpi
+    // with an arith.andi
+    if (isLowerBoundSecret && isUpperBoundSecret) {
+      andI = builder.create<arith::AndIOp>(cmpILower, cmpIUpper);
+    }
+
+    // Create scf.if to conditionally execute the body of scf.for
+    auto cond = isLowerBoundSecret ? isUpperBoundSecret ? andI.getResult()
+                                                        : cmpILower.getResult()
+                                   : cmpIUpper.getResult();
+    scf::IfOp ifOp = builder.create<scf::IfOp>(
+        cond,
+        // 'Then' region
+        [&](OpBuilder &b, Location loc) {
+          // Copy body of the scf::ForOp
+          IRMapping mp;
+          for (BlockArgument blockArg : forOp.getBody()->getArguments()) {
+            mp.map(blockArg,
+                   newForOp.getBody()->getArguments()[blockArg.getArgNumber()]);
+          }
+          for (auto &op : forOp.getBody()->getOperations()) {
+            b.clone(op, mp);
+          }
+        },
+        // 'Else' region
+        [&](OpBuilder &b, Location loc) {
+          b.create<scf::YieldOp>(loc, newForOp.getRegionIterArgs());
+        });
+
+    // Create YieldOp for affine.for
+    builder.create<affine::AffineYieldOp>(ifOp.getResults());
+
+    // Replace scf.for with affine.for
+    rewriter.replaceOp(forOp, newForOp);
+
+    return success();
+  }
+
+ private:
+  DataFlowSolver *solver;
+};
+
+struct ConvertSecretForToStaticFor
+    : impl::ConvertSecretForToStaticForBase<ConvertSecretForToStaticFor> {
+  using ConvertSecretForToStaticForBase::ConvertSecretForToStaticForBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+
+    DataFlowSolver solver;
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::SparseConstantPropagation>();
+    solver.load<SecretnessAnalysis>();
+
+    auto result = solver.initializeAndRun(getOperation());
+
+    if (failed(result)) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    patterns.add<SecretForToStaticForConversion>(&solver, context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h
+++ b/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_CONVERTSECRETFORTOSTATICFOR_CONVERTSECRETFORTOSTATICFOR_H_
+#define LIB_TRANSFORMS_CONVERTSECRETFORTOSTATICFOR_CONVERTSECRETFORTOSTATICFOR_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_CONVERTSECRETFORTOSTATICFOR_CONVERTSECRETFORTOSTATICFOR_H_

--- a/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.td
+++ b/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.td
@@ -1,0 +1,62 @@
+#ifndef LIB_TRANSFORMS_CONVERTSECRETFORTOSTATICFOR_CONVERTSECRETFORTOSTATICFOR_TD_
+#define LIB_TRANSFORMS_CONVERTSECRETFORTOSTATICFOR_CONVERTSECRETFORTOSTATICFOR_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertSecretForToStaticFor : Pass<"convert-secret-for-to-static-for"> {
+  let summary = "Convert secret scf.for ops to affine.for ops with constant bounds.";
+  let description = [{
+  Conversion for For-operation that evaluate secret bound(s) to alternative affine For-operation with constant bound(s).
+
+  It replaces data-dependent bounds with an If-operation to check the bounds, and conditionally execute and yield values from the For-operation's body.
+  Note: Running this pass alone does not result in a data-oblivious program; we have to run the `--convert-if-to-select` pass to the resulting program to convert the secret-dependent If-operation to a Select-operation.
+
+  Example input:
+    ```mlir
+      func.func @main(%secretTensor: !secret.secret<tensor<16xi32>>, %secretLower: !secret.secret<index>, %secretUpper: !secret.secret<index>) -> !secret.secret<i32> {
+       ...
+       %0 = secret.generic ins(%secretTensor, %secretLower, %secretUpper : !secret.secret<tensor<16xi32>>, !secret.secret<index>, !secret.secret<index>){
+        ^bb0(%tensor: tensor<16xi32>, %lower : index, %upper : index ):
+          ...
+          %1 = scf.for %i = %lower to %upper step %step iter_args(%arg = %val) -> (i32) {
+            %extracted = tensor.extract %input[%i] : tensor<16xi32>
+            %sum = arith.addi %extracted, %arg : i32
+            scf.yield %sum : i32
+          } {lower = 0, upper = 16}
+          secret.yield %1 : i32
+      } -> !secret.secret<i32>
+      return %0 : !secret.secret<i32>
+    ```
+
+    Output:
+    ```mlir
+      func.func @main(%secretTensor: !secret.secret<tensor<16xi32>>, %secretIndex: !secret.secret<index> {secret.secret}) -> !secret.secret<i32> {
+       ...
+       %0 = secret.generic ins(%secretTensor, %secretLower, %secretUpper : !secret.secret<tensor<16xi32>>, !secret.secret<index>, !secret.secret<index>){
+        ^bb0(%tensor: tensor<16xi32>, %lower : index, %upper : index ):
+          ...
+          %1 = affine.for %i = 0 to 16 step %step iter_args(%arg = %val) -> (i32) {
+            %lowerCond = arith.cmpi sge, %i, %index : index
+            %upperCond = arith.cmpi slt, %i, %index : index
+            %cond = arith.andi %lowerCond, %upperCond : i1
+            %result = scf.if(%cond) -> (i32) {
+              %extracted = tensor.extract %input[%i] : tensor<16xi32>
+              %sum = arith.addi %extracted, %arg : i32
+              scf.yield %sum : i32
+            } else {
+              scf.yield %arg : i32
+            }
+            affine.yield %result : i32
+          } {lower = 0, upper = 16}
+          secret.yield %1 : i32
+      } -> !secret.secret<i32>
+      return %0 : !secret.secret<i32>
+    ```
+  }];
+  let dependentDialects = [
+    "mlir::scf::SCFDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_CONVERTSECRETFORTOSTATICFOR_CONVERTSECRETFORTOSTATICFOR_TD_

--- a/tests/convert_secret_for_to_static_for/BUILD
+++ b/tests/convert_secret_for_to_static_for/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/convert_secret_for_to_static_for/invalid_for_loops.mlir
+++ b/tests/convert_secret_for_to_static_for/invalid_for_loops.mlir
@@ -1,0 +1,37 @@
+// RUN: heir-opt --convert-secret-for-to-static-for --split-input-file --verify-diagnostics %s
+
+func.func @for_loop_with_data_dependent_upper_bound(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
+    %c0 = arith.constant 0 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1 = arith.constant 1 : index
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+    // unexpected-warning@+1 {{Cannot convert secret scf.for to static affine.for since a static upper bound attribute has not been provided:}}
+      %1 = scf.for %arg4 = %c0 to %arg3 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {
+        %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
+        %2 = arith.addi %extracted, %arg5 : i16
+        scf.yield %2 : i16
+      }
+      secret.yield %1 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}
+
+// -----
+
+func.func @for_loop_with_data_dependent_lower_bound(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
+    %c32 = arith.constant 32 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1 = arith.constant 1 : index
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+    // unexpected-warning@+1 {{Cannot convert secret scf.for to static affine.for since a static lower bound attribute has not been provided:}}
+      %1 = scf.for %arg4 = %arg3 to %c32 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {
+        %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
+        %2 = arith.addi %extracted, %arg5 : i16
+        scf.yield %2 : i16
+      }
+      secret.yield %1 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}

--- a/tests/convert_secret_for_to_static_for/secret_dependent_for_loops.mlir
+++ b/tests/convert_secret_for_to_static_for/secret_dependent_for_loops.mlir
@@ -1,0 +1,191 @@
+// RUN: heir-opt --convert-secret-for-to-static-for %s | FileCheck %s
+
+// CHECK-LABEL: @for_loop_with_data_dependent_upper_bound
+func.func @for_loop_with_data_dependent_upper_bound(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
+    // CHECK-NEXT: %[[C0_I16:.*]] = arith.constant 0 : i16
+    // CHECK-NEXT: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[ARG1:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    // CHECK-NEXT:  ^bb0(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
+    // CHECK-NEXT:   %[[FOR:.*]] = affine.for %[[IV:.*]] = 0 to 42 iter_args(%[[ACC:.*]] = %[[C0_I16]]) -> (i16) {
+    // CHECK-NEXT:   %[[COND:.*]] = arith.cmpi slt, %[[IV]], %[[ARG3]] : index
+    // CHECK-NEXT:    %[[IF:.*]] = scf.if %[[COND]] -> (i16) {
+    // CHECK-NEXT:      %[[EXTRACTED:.*]] = tensor.extract %[[ARG2]][%[[IV]]] : tensor<32xi16>
+    // CHECK-NEXT:      %[[ADD:.*]] = arith.addi %[[EXTRACTED]], %[[ACC]] : i16
+    // CHECK-NEXT:      scf.yield %[[ADD]] : i16
+    // CHECK-NEXT:     } else {
+    // CHECK-NEXT:      scf.yield %[[ACC]] : i16
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:    affine.yield %[[IF]] : i16
+    // CHECK-NEXT:  } {lower = 0 : i64, upper = 42 : i64}
+    // CHECK-NEXT:  secret.yield %[[FOR]] : i16
+    // CHECK-NEXT: } -> !secret.secret<i16>
+    // CHECK-NEXT: return %[[RESULT]] : !secret.secret<i16>
+    %c0 = arith.constant 0 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1 = arith.constant 1 : index
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+      %1 = scf.for %arg4 = %c0 to %arg3 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {
+        %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
+        %2 = arith.addi %extracted, %arg5 : i16
+        scf.yield %2 : i16
+      } {lower = 0, upper = 42}
+      secret.yield %1 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}
+
+// CHECK-LABEL: @for_loop_with_data_dependent_lower_bound
+func.func @for_loop_with_data_dependent_lower_bound(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
+    // CHECK-NEXT: %[[C0_I16:.*]] = arith.constant 0 : i16
+    // CHECK-NEXT: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[ARG1:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    // CHECK-NEXT:  ^bb0(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
+    // CHECK-NEXT:   %[[FOR:.*]] = affine.for %[[IV:.*]] = 0 to 32 iter_args(%[[ACC:.*]] = %[[C0_I16]]) -> (i16) {
+    // CHECK-NEXT:   %[[COND:.*]] = arith.cmpi sge, %[[IV]], %[[ARG3]] : index
+    // CHECK-NEXT:    %[[IF:.*]] = scf.if %[[COND]] -> (i16) {
+    // CHECK-NEXT:      %[[EXTRACTED:.*]] = tensor.extract %[[ARG2]][%[[IV]]] : tensor<32xi16>
+    // CHECK-NEXT:      %[[ADD:.*]] = arith.addi %[[EXTRACTED]], %[[ACC]] : i16
+    // CHECK-NEXT:      scf.yield %[[ADD]] : i16
+    // CHECK-NEXT:     } else {
+    // CHECK-NEXT:      scf.yield %[[ACC]] : i16
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:    affine.yield %[[IF]] : i16
+    // CHECK-NEXT:  } {lower = 0 : i64, upper = 42 : i64}
+    // CHECK-NEXT:  secret.yield %[[FOR]] : i16
+    // CHECK-NEXT: } -> !secret.secret<i16>
+    // CHECK-NEXT: return %[[RESULT]] : !secret.secret<i16>
+    %c32 = arith.constant 32 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1 = arith.constant 1 : index
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+      %1 = scf.for %arg4 = %arg3 to %c32 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {
+        %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
+        %2 = arith.addi %extracted, %arg5 : i16
+        scf.yield %2 : i16
+      } {lower = 0, upper = 42}
+      secret.yield %1 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}
+
+// CHECK-LABEL: @for_loop_with_data_dependent_upper_and_lower_bounds
+func.func @for_loop_with_data_dependent_upper_and_lower_bounds(%arg0: !secret.secret<tensor<32xi16>>, %lower: !secret.secret<index>, %upper: !secret.secret<index>) -> !secret.secret<i16> {
+    // CHECK-NEXT: %[[C0_I16:.*]] = arith.constant 0 : i16
+    // CHECK-NEXT: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[LOWER:.*]], %[[UPPER:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>, !secret.secret<index>) {
+    // CHECK-NEXT:  ^bb0(%[[ARG3:.*]]: tensor<32xi16>, %[[ARG4:.*]]: index, %[[ARG5:.*]]: index):
+    // CHECK-NEXT:   %[[FOR:.*]] = affine.for %[[IV:.*]] = 0 to 42 iter_args(%[[ACC:.*]] = %[[C0_I16]]) -> (i16) {
+    // CHECK-NEXT:   %[[CMPIL:.*]] = arith.cmpi sge, %[[IV]], %[[ARG4]] : index
+    // CHECK-NEXT:   %[[CMPIU:.*]] = arith.cmpi slt, %[[IV]], %[[ARG5]] : index
+    // CHECK-NEXT:   %[[ANDI:.*]] = arith.andi %[[CMPIL]], %[[CMPIU]] : i1
+    // CHECK-NEXT:    %[[IF:.*]] = scf.if %[[ANDI]] -> (i16) {
+    // CHECK-NEXT:      %[[EXTRACTED:.*]] = tensor.extract %[[ARG3]][%[[IV]]] : tensor<32xi16>
+    // CHECK-NEXT:      %[[ADD:.*]] = arith.addi %[[EXTRACTED]], %[[ACC]] : i16
+    // CHECK-NEXT:      scf.yield %[[ADD]] : i16
+    // CHECK-NEXT:     } else {
+    // CHECK-NEXT:      scf.yield %[[ACC]] : i16
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:    affine.yield %[[IF]] : i16
+    // CHECK-NEXT:  } {lower = 0 : i64, upper = 42 : i64}
+    // CHECK-NEXT:  secret.yield %[[FOR]] : i16
+    // CHECK-NEXT: } -> !secret.secret<i16>
+    // CHECK-NEXT: return %[[RESULT]] : !secret.secret<i16>
+    %c0_i16 = arith.constant 0 : i16
+    %c1 = arith.constant 1 : index
+    %0 = secret.generic ins(%arg0, %lower, %upper : !secret.secret<tensor<32xi16>>, !secret.secret<index>,  !secret.secret<index>) {
+    ^bb0(%arg3: tensor<32xi16>, %arg4: index, %arg5: index):
+      %1 = scf.for %arg6 = %arg4 to %arg5 step %c1 iter_args(%arg7 = %c0_i16) -> (i16) {
+        %extracted = tensor.extract %arg3[%arg6] : tensor<32xi16>
+        %2 = arith.addi %extracted, %arg7 : i16
+        scf.yield %2 : i16
+      } {lower = 0, upper = 42}
+      secret.yield %1 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}
+
+// CHECK-LABEL: @for_loop_with_data_dependent_upper_bound_multiple_iter_args
+func.func @for_loop_with_data_dependent_upper_bound_multiple_iter_args(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
+    // CHECK: %[[C0_I16:.*]] = arith.constant 0 : i16
+    // CHECK: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[ARG1:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    // CHECK:  ^bb0(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
+    // CHECK:   %[[FOR:.*]]:2 = affine.for %[[I:.*]] = 0 to 42 iter_args(%[[ARG5:.*]] = %[[C0_I16]], %[[ARG6:.*]] = %[[C0_I16]]) -> (i16, i16) {
+    // CHECK:      %[[CMPIU:.*]] = arith.cmpi slt, %[[I]], %[[ARG3]] : index
+    // CHECK:      %[[IF:.*]]:2 = scf.if %[[CMPIU]] -> (i16, i16) {
+    // CHECK:        %[[EXTRACTED:.*]] = tensor.extract %[[ARG2]][%[[I]]] : tensor<32xi16>
+    // CHECK:        %[[ADD:.*]] = arith.addi %[[EXTRACTED]], %[[ARG5]] : i16
+    // CHECK:        %[[MUL:.*]] = arith.muli %[[EXTRACTED]], %[[ARG6]] : i16
+    // CHECK:        scf.yield %[[ADD]], %[[MUL]] : i16, i16
+    // CHECK:      } else {
+    // CHECK:        scf.yield %[[ARG5]], %[[ARG6]] : i16, i16
+    // CHECK:      }
+    // CHECK:      affine.yield %[[IF]]#0, %[[IF]]#1 : i16, i16
+    // CHECK:    } {lower = 0 : i64, upper = 42 : i64}
+    // CHECK:      %[[OUT:.*]] = arith.addi %[[FOR]]#0, %[[FOR]]#1 : i16
+    // CHECK:      secret.yield %[[OUT]] : i16
+    // CHECK:    } -> !secret.secret<i16>
+    // CHECK:    return %[[RESULT]] : !secret.secret<i16>
+    %c0 = arith.constant 0 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1 = arith.constant 1 : index
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
+    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+      %1, %2 = scf.for %arg4 = %c0 to %arg3 step %c1 iter_args(%arg5 = %c0_i16, %arg6 = %c0_i16) -> (i16, i16) {
+        %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
+        %3 = arith.addi %extracted, %arg5 : i16
+        %4 = arith.muli %extracted, %arg6 : i16
+        scf.yield %3, %4 : i16, i16
+      } {lower = 0, upper = 42}
+      %5 = arith.addi %1, %2 : i16
+      secret.yield %5 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}
+
+// CHECK-LABEL: @partial_sum_with_secret_threshold
+func.func @partial_sum_with_secret_threshold(%secretInput :!secret.secret<tensor<16xi16>>, %secretIndex: !secret.secret<index>, %secretThreshold: !secret.secret<i16>) -> (!secret.secret<i16>, !secret.secret<i16>) {
+  // CHECK: %[[C0:.*]] = arith.constant 0 : i16
+  // CHECK: %[[RESULT:.*]]:2 = secret.generic ins(%[[SECRET_INPUT:.*]], %[[SECRET_INDEX:.*]], %[[SECRET_THRESHOLD:.*]] : !secret.secret<tensor<16xi16>>, !secret.secret<index>, !secret.secret<i16>) {
+  // CHECK:  ^bb0(%[[INPUT:.*]]: tensor<16xi16>, %[[INDEX:.*]]: index, %[[THRESHOLD:.*]]: i16):
+  // CHECK:   %[[FOR:.*]]:2 = affine.for %[[I:.*]] = 0 to 16 iter_args(%[[ARG1:.*]] = %[[C0]], %[[ARG2:.*]] = %[[C0]]) -> (i16, i16) {
+  // CHECK:     %[[CMPI:.*]] = arith.cmpi slt, %[[I]], %[[INDEX]] : index
+  // CHECK:     %[[IF:.*]]:2 = scf.if %[[CMPI]] -> (i16, i16) {
+  // CHECK:        %[[COND:.*]] = arith.cmpi slt, %[[ARG1]], %[[THRESHOLD]] : i16
+  // CHECK:        %[[EXTRACTED:.*]] = tensor.extract %[[INPUT]][%[[I]]] : tensor<16xi16>
+  // CHECK:        %[[IFF:.*]]:2 = scf.if %[[COND]] -> (i16, i16) {
+  // CHECK:          %[[SUM:.*]] = arith.addi %[[ARG1]], %[[EXTRACTED]] : i16
+  // CHECK:          scf.yield %[[SUM]], %[[ARG2]] : i16, i16
+  // CHECK:          } else {
+  // CHECK:            %[[SUM:.*]] = arith.addi %[[ARG2]], %[[EXTRACTED]] : i16
+  // CHECK:            scf.yield %[[ARG1]], %[[SUM]] : i16, i16
+  // CHECK:           }
+  // CHECK:        scf.yield %[[IFF]]#0, %[[IFF]]#1 : i16, i16
+  // CHECK:       } else {
+  // CHECK:        scf.yield %[[ARG1]], %[[ARG2]] : i16, i16
+  // CHECK:      }
+  // CHECK:        affine.yield %[[IF]]#0, %[[IF]]#1 : i16, i16
+  // CHECK:     } {lower = 0 : i64, upper = 16 : i64}
+  // CHECK:    secret.yield %[[FOR]]#0, %[[FOR]]#1 : i16, i16
+  // CHECK: } -> (!secret.secret<i16>, !secret.secret<i16>)
+  // CHECK: return %[[RESULT]]#0, %[[RESULT]]#1 : !secret.secret<i16>, !secret.secret<i16>
+  // CHECK: }
+  %start = arith.constant 0 : index
+  %step = arith.constant 1 : index
+  %c0 = arith.constant 0 : i16
+  %0, %1 = secret.generic ins(%secretInput, %secretIndex, %secretThreshold : !secret.secret<tensor<16xi16>>, !secret.secret<index>, !secret.secret<i16>) {
+  ^bb0(%input: tensor<16xi16>, %index: index, %threshold: i16):
+      %2, %3 = scf.for %i = %start to %index step %step iter_args(%arg1 = %c0, %arg2 = %c0) -> (i16, i16) {
+          %cond = arith.cmpi slt, %arg1, %threshold : i16
+          %extracted = tensor.extract %input[%i] : tensor<16xi16>
+          %sum1, %sum2 = scf.if %cond -> (i16, i16) {
+              %sum = arith.addi %arg1, %extracted : i16
+              scf.yield %sum, %arg2 : i16, i16
+          } else {
+              %sum = arith.addi %arg2, %extracted : i16
+              scf.yield %arg1, %sum : i16, i16
+          }
+          scf.yield %sum1, %sum2 : i16, i16
+      } {lower = 0, upper = 16}
+      secret.yield %2, %3 : i16, i16
+  }-> (!secret.secret<i16>, !secret.secret<i16>)
+  return %0, %1 : !secret.secret<i16>, !secret.secret<i16>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -73,6 +73,7 @@ cc_binary(
         "@heir//lib/Dialect/TfheRustBool/IR:Dialect",
         "@heir//lib/Transforms/ApplyFolders",
         "@heir//lib/Transforms/ConvertIfToSelect",
+        "@heir//lib/Transforms/ConvertSecretForToStaticFor",
         "@heir//lib/Transforms/ElementwiseToAffine",
         "@heir//lib/Transforms/ForwardStoreToLoad",
         "@heir//lib/Transforms/FullLoopUnroll",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -43,6 +43,7 @@
 #include "lib/Dialect/TfheRustBool/IR/TfheRustBoolDialect.h"
 #include "lib/Transforms/ApplyFolders/ApplyFolders.h"
 #include "lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.h"
+#include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h"
 #include "lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.h"
 #include "lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.h"
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
@@ -521,6 +522,7 @@ int main(int argc, char **argv) {
   registerSecretizePasses();
   registerFullLoopUnrollPasses();
   registerConvertIfToSelectPasses();
+  registerConvertSecretForToStaticForPasses();
   registerApplyFoldersPasses();
   registerForwardStoreToLoadPasses();
   registerStraightLineVectorizerPasses();


### PR DESCRIPTION
Fixes #801. Rewrites scf.for operations with secret loop bound(s) to use data independent affine.for operations with (static/constant) loop bound(s). Uses scf.if operation to check the current index with the secret bounds and conditionally set the for-loop's result. 

This is built as part of the data-oblivious transformation pipeline (#777) where an If-Transformation pass is then applied to get a data-oblivious program (assuming we don't have secret-dependent memory reads/writes). 