### PR TITLE
llvm: patch llvm build until next integrate merges BUILD fix

### DIFF
--- a/bazel/import_llvm.bzl
+++ b/bazel/import_llvm.bzl
@@ -14,6 +14,9 @@ def import_llvm(name):
         # this BUILD file is intentionally empty, because the LLVM project
         # internally contains a set of bazel BUILD files overlaying the project.
         build_file_content = "# empty",
+        # this patch should be removed once https://github.com/llvm/llvm-project/commit/0309709a6786653da7164334c83b09c9f37b943a is merged
+        patches = ["@heir//bazel:llvm.patch"],
+        patch_args = ["-p1"],
         commit = LLVM_COMMIT,
         init_submodules = False,
         remote = "https://github.com/llvm/llvm-project.git",

--- a/bazel/llvm.patch
+++ b/bazel/llvm.patch
@@ -1,0 +1,25 @@
+From 0309709a6786653da7164334c83b09c9f37b943a Mon Sep 17 00:00:00 2001
+From: Chenguang Wang <w3cing@gmail.com>
+Date: Mon, 15 Jul 2024 08:44:56 -0700
+Subject: [PATCH] [bazel] Add missing dependency for mlir:SCFTransformOps
+ (#98919)
+
+Bazel build failure was introduced in commit acc159ae.
+---
+ utils/bazel/llvm-project-overlay/mlir/BUILD.bazel | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+index ab3757342c76..af542bba57d5 100644
+--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+@@ -2900,6 +2900,7 @@ cc_library(
+         ":IR",
+         ":LoopLikeInterface",
+         ":SCFDialect",
++        ":SCFToControlFlow",
+         ":SCFTransformOpsIncGen",
+         ":SCFTransforms",
+         ":SCFUtils",
+--
+2.45.2.1089.g2a221341d9-goog


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/812

Patch generated from https://github.com/llvm/llvm-project/commit/0309709a6786653da7164334c83b09c9f37b943a

Like mentioned in chat / the issue, the integrate commit had a locally patched BUILD file that allowed the presubmits internally to pass. That BUILD file diverges from the open source llvm BUILD, and the llvm integrate docs mention that this breaks open source projects like us and tensorflow, and that we should patch our build until the next llvm integrate reconciles the open source BUILD.