### PR TITLE
Add `arith.select` Pattern to `--secret-to-bgv`

### DIFF
--- a/lib/Conversion/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Conversion/SecretToBGV/SecretToBGV.cpp
@@ -74,11 +74,11 @@ class SecretToBGVTypeConverter : public TypeConverter {
 
     // Convert secret types to BGV ciphertext types
     addConversion([ctx, this](secret::SecretType type) -> Type {
-      int bitWidth = getElementTypeOrSelf(type).getIntOrFloatBitWidth();
+      int bitWidth = 32;
       return lwe::RLWECiphertextType::get(
           ctx,
           lwe::PolynomialEvaluationEncodingAttr::get(ctx, bitWidth, bitWidth),
-          lwe::RLWEParamsAttr::get(ctx, 2, ring_), type.getValueType());
+          lwe::RLWEParamsAttr::get(ctx, 2, ring_), IntegerType::get(ctx, 32));
     });
 
     ring_ = rlweRing;

--- a/lib/Conversion/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Conversion/SecretToBGV/SecretToBGV.cpp
@@ -162,7 +162,9 @@ class SecretGenericOpSelectConversion
   void replaceOp(secret::GenericOp op, TypeRange outputTypes, ValueRange inputs,
                  ConversionPatternRewriter &rewriter) const override {
     // inputs = [condition, true_value, false_value]
+    // TODO: This should use mul_scalar if one of the sides is plaintext!
     auto t = rewriter.create<bgv::MulOp>(op.getLoc(), inputs[0], inputs[1]);
+    // TODO: this should not be `negate` (which would give -c) but sub (1-c)
     auto neg = rewriter.create<bgv::NegateOp>(op.getLoc(), inputs[0]);
     auto f = rewriter.create<bgv::MulOp>(op.getLoc(), neg, inputs[2]);
     auto add = rewriter.create<bgv::AddOp>(op.getLoc(), t, f);

--- a/tests/secret_to_bgv/ops.mlir
+++ b/tests/secret_to_bgv/ops.mlir
@@ -1,6 +1,7 @@
 // RUN: heir-opt --canonicalize --secret-to-bgv %s | FileCheck %s
 
 !eui1 = !secret.secret<tensor<1024xi1>>
+!eui32 = !secret.secret<tensor<1024xi32>>
 
 module {
   // CHECK-LABEL: func @test_arith_ops
@@ -22,4 +23,14 @@ module {
     // CHECK-SAME: coefficientType = i32, coefficientModulus = 463187969 : i32, polynomialModulus = <1 + x**1024>
     return %1 : !eui1
   }
+}
+
+//CHECK-LABEL: func @test_arith_select
+func.func @test_arith_select(%cond : !eui1, %lhs : !eui32, %rhs : !eui32) ->  !eui32 {
+    %0 = secret.generic ins(%cond, %lhs, %rhs :  !eui1, !eui32, !eui32) {
+    ^bb0(%COND : tensor<1024xi1>, %LHS : tensor<1024xi32>, %RHS : tensor<1024xi32>):
+      %1 = arith.select %COND, %LHS, %RHS : tensor<1024xi1>, tensor<1024xi32>
+      secret.yield %1 : tensor<1024xi32>
+  } -> !eui32
+  return %0 : !eui32
 }


### PR DESCRIPTION
This adds the following rewrite pattern:
```llvm
%res = arith.select %c, %t, %f
// turns into
%ct = bgv.mul %c, %t
%nc = bgv.negate %c  // EDIT: actually a bug, this should be logical negation, i.e., bgv.sub %one, %c 
%ncf = bgv.mul %nc, %f
%sum = bgv.add %nc, %ncf
%res = bgv.relinearize %sum 
```

However, as-is, this pattern actually produces invalid IR: `%c` has (element/self) type `i1` while `%t` and `%f` can have any IntegerLike type, e.g., `i32`. In the current TypeConverter, this means that the condition is mapped to a ciphertext with encoding `#lwe.polynomial_evaluation_encoding<cleartext_start = 1, cleartext_bitwidth = 1>` while the other values are mapped to ciphertexts with encoding `#lwe.polynomial_evaluation_encoding<cleartext_start = 32, cleartext_bitwidth = 32>`.  Since `bgv.mul` requires the types of its operands to match, this is invalid IR.

In the current draft, I've simply hardcoded the typeconverter to map everything to 32 bits (that's why this is a Draft PR only for now), but we'll need to think about how to handle such cases. I think this is a special case of "what is the plaintext-FHE semantics mapping" (Step 1 in #785).