### PR TITLE
Loop Transformation: Converts a while loop written in scf.while to affine.for

### DIFF
--- a/lib/Transforms/ConvertSecretWhileToStaticFor/BUILD
+++ b/lib/Transforms/ConvertSecretWhileToStaticFor/BUILD
@@ -1,0 +1,49 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ConvertSecretWhileToStaticFor",
+    srcs = ["ConvertSecretWhileToStaticFor.cpp"],
+    hdrs = ["ConvertSecretWhileToStaticFor.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SideEffectInterfaces",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=ConvertSecretWhileToStaticFor",
+            ],
+            "ConvertSecretWhileToStaticFor.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "ConvertSecretWhileToStaticForPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ConvertSecretWhileToStaticFor.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.cpp
+++ b/lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.cpp
@@ -1,0 +1,187 @@
+#include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"    // from @llvm-project
+#include "llvm/include/llvm/Support/Casting.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
+#include "mlir/include/mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_CONVERTSECRETWHILETOSTATICFOR
+#include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h.inc"
+
+struct SecretWhileToStaticForConversion : OpRewritePattern<scf::WhileOp> {
+  using OpRewritePattern<scf::WhileOp>::OpRewritePattern;
+
+ public:
+  SecretWhileToStaticForConversion(DataFlowSolver *solver, MLIRContext *context)
+      : OpRewritePattern(context), solver(solver){};
+
+  // TODO(#846): Add support for do-while loops
+  LogicalResult matchAndRewrite(scf::WhileOp whileOp,
+                                PatternRewriter &rewriter) const override {
+    auto conditionOp = whileOp.getConditionOp();
+    auto whileCondition = conditionOp->getOperand(0);
+
+    auto *beforeRegionArgs = whileOp.getBefore().front().getArguments().data();
+
+    auto conditionOpArgs =
+        // Get Loop variables: includes all arguments without the condition
+        conditionOp->getOperands().drop_front(1);
+
+    int counter = 0;
+    for (auto arg : conditionOpArgs) {
+      // Check if the defining operation of the loop variable passed in
+      // scf.condition is the same as the operation defining the block argument
+      // passed by scf.while. A true value implies that the loop variable is the
+      // same as the block argument, i.e., the original block argument passed by
+      // scf.while has not been changed.
+      bool isEqual =
+          arg.getDefiningOp() == beforeRegionArgs[counter].getDefiningOp();
+      if (!isEqual) {
+        InFlightDiagnostic diag =
+            whileOp.emitWarning()
+            << "Current loop transformation has no support for do-while loops:";
+        return failure();
+      }
+      counter++;
+    }
+
+    auto *conditionSecretnessLattice =
+        solver->lookupState<SecretnessLattice>(whileCondition);
+
+    if (!conditionSecretnessLattice) {
+      InFlightDiagnostic diag =
+          whileOp.emitWarning()
+          << "Secretness for scf.while condition has not been set";
+      return failure();
+    }
+
+    bool isConditionSecret =
+        conditionSecretnessLattice->getValue().getSecretness();
+
+    // If condition is not secret, no transformation is needed
+    if (!isConditionSecret) {
+      return failure();
+    }
+
+    auto maxIterAttr = whileOp->getAttrOfType<IntegerAttr>("max_iter");
+
+    // If maximum iteration attribute is not provided, emit a warning and return
+    // failure
+    if (!maxIterAttr) {
+      whileOp.emitWarning()
+          << "Cannot convert secret scf.while to static affine.for "
+             "since a static maximum iteration attribute (`max_iter`) has not "
+             "been provided on the scf.while op:";
+      return failure();
+    }
+
+    ImplicitLocOpBuilder builder(whileOp->getLoc(), rewriter);
+
+    int upperBound = maxIterAttr.getInt();
+
+    SmallVector<Value> iterArgs(whileOp.getInits());
+
+    auto newForOp =
+        builder.create<affine::AffineForOp>(0, upperBound, 1, iterArgs);
+    newForOp->setAttrs(whileOp->getAttrs());
+
+    builder.setInsertionPointToStart(newForOp.getBody());
+
+    IRMapping mp;
+    for (BlockArgument blockArg : whileOp.getBody()->getArguments()) {
+      mp.map(blockArg,
+             /* Adding 1 to bypass the first block argument of newForOp, i.e.,
+                the induction variable  */
+             newForOp.getBody()->getArguments()[blockArg.getArgNumber() + 1]);
+    }
+
+    Value condition;
+    for (auto &op : whileOp.getBefore().getOps()) {
+      if (auto conditionOp = dyn_cast<scf::ConditionOp>(op)) {
+        // Get condition used in scf.condition op
+        condition = mp.lookup(conditionOp.getOperand(0));
+      } else {
+        // Copy op in "before" region to the forOp's body
+        builder.clone(op, mp);
+      }
+    }
+
+    auto ifOp = builder.create<scf::IfOp>(
+        condition,
+        [&](OpBuilder &b, Location loc) {
+          for (BlockArgument blockArg : whileOp.getAfterArguments()) {
+            mp.map(blockArg, newForOp.getBody()
+                                 ->getArguments()[blockArg.getArgNumber() + 1]);
+          }
+          for (auto &op : whileOp.getAfter().getOps()) {
+            // Copy op in "after" region to the ifOp's "then" region
+            b.clone(op, mp);
+          }
+        },
+        [&](OpBuilder &b, Location loc) {
+          b.create<scf::YieldOp>(loc, newForOp.getRegionIterArgs());
+        });
+
+    // Create YieldOp for affine.for
+    builder.create<affine::AffineYieldOp>(ifOp.getResults());
+
+    // Replace scf.while with affine.for
+    rewriter.replaceOp(whileOp, newForOp);
+
+    return success();
+  }
+
+ private:
+  DataFlowSolver *solver;
+};
+
+struct ConvertSecretWhileToStaticFor
+    : impl::ConvertSecretWhileToStaticForBase<ConvertSecretWhileToStaticFor> {
+  using ConvertSecretWhileToStaticForBase::ConvertSecretWhileToStaticForBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+
+    DataFlowSolver solver;
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::SparseConstantPropagation>();
+    solver.load<SecretnessAnalysis>();
+
+    auto result = solver.initializeAndRun(getOperation());
+
+    if (failed(result)) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    patterns.add<SecretWhileToStaticForConversion>(&solver, context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h
+++ b/lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_CONVERTSECRETWHILETOSTATICFOR_CONVERTSECRETWHILETOSTATICFOR_H_
+#define LIB_TRANSFORMS_CONVERTSECRETWHILETOSTATICFOR_CONVERTSECRETWHILETOSTATICFOR_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_CONVERTSECRETWHILETOSTATICFOR_CONVERTSECRETWHILETOSTATICFOR_H_

--- a/lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.td
+++ b/lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.td
@@ -1,0 +1,74 @@
+#ifndef LIB_TRANSFORMS_CONVERTSECRETWHILETOSTATICFOR_CONVERTSECRETWHILETOSTATICFOR_TD_
+#define LIB_TRANSFORMS_CONVERTSECRETWHILETOSTATICFOR_CONVERTSECRETWHILETOSTATICFOR_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertSecretWhileToStaticFor : Pass<"convert-secret-while-to-static-for"> {
+  let summary = "Convert secret scf.while ops to affine.for ops that have constant bounds.";
+  let description = [{
+  Convert scf.while with a secret condition to affine.for with constant bounds. It replaces the scf.condition operation found in the scf.while loop with an scf.if operation that conditionally executes operations in the while operation's body and yields values.
+
+  A "max_iter" attribute should be specified as part of the secret-dependent scf.while operation to successfully transform to a secret-independent affine.for operation. This attribute determines the maximum number of iterations for the new affine.for operation.
+
+  Note: Running this pass alone does not result in a data-oblivious program; we have to run the `--convert-if-to-select` pass to the resulting program to convert the secret-dependent If-operation to a Select-operation.
+
+  Example input:
+
+    ```mlir
+    // C-like code
+    int main(int secretInput) {
+      while (secretInput > 100) {
+        secretInput = secretInput * secretInput;
+      }
+      return secretInput;
+    }
+
+    // MLIR
+    func.func @main(%secretInput: !secret.secret<i16>) -> !secret.secret<i16> {
+      %c100 = arith.constant 100 : i16
+      %0 = secret.generic ins(%secretInput : !secret.secret<i16>) {
+      ^bb0(%input: i16):
+        %1 = scf.while (%arg1 = %input) : (i16) -> i16 {
+          %2 = arith.cmpi sgt, %arg1, %c100 : i16
+          scf.condition(%2) %arg1 : i16
+        } do {
+        ^bb0(%arg1: i16):
+          %3 = arith.muli %arg1, %arg1 : i16
+          scf.yield %3 : i16
+        } attributes {max_iter = 16 : i64}
+        secret.yield %1 : i16
+      } -> !secret.secret<i16>
+      return %0 : !secret.secret<i16>
+    }
+
+    ```
+    Output:
+    ```mlir
+    func.func @main(%secretInput: !secret.secret<i16>) -> !secret.secret<i16> {
+      %c100 = arith.constant 100 : i16
+      %0 = secret.generic ins(%secretInput : !secret.secret<i16>) {
+      ^bb0(%input: i16):
+        %1 = affine.for 0 to 16 iter_args(%arg1 = %input) -> (i16) {
+          %2 = arith.cmpi sgt, %arg1, %c100 : i16
+          %3 = scf.if (%2) -> i16{
+            %4 = arith.muli %arg1, %arg1 : i16
+            scf.yield %4 : i16
+          } else {
+            scf.yield %arg1 : i16
+          }
+          affine.yield %3 : i16
+        } attributes {max_iter = 16 : i64}
+        secret.yield %1 : i16
+      } -> !secret.secret<i16>
+      return %0 : !secret.secret<i16>
+    }
+    ```
+  }];
+  let dependentDialects = [
+    "mlir::scf::SCFDialect",
+    "mlir::affine::AffineDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_CONVERTSECRETWHILETOSTATICFOR_CONVERTSECRETWHILETOSTATICFOR_TD_

--- a/tests/convert_secret_while_to_static_for/BUILD
+++ b/tests/convert_secret_while_to_static_for/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/convert_secret_while_to_static_for/invalid_while_loop.mlir
+++ b/tests/convert_secret_while_to_static_for/invalid_while_loop.mlir
@@ -1,0 +1,43 @@
+// RUN: heir-opt --convert-secret-while-to-static-for --split-input-file --verify-diagnostics %s
+
+func.func @while_loop_without_max_iter(%input: !secret.secret<i16>) -> !secret.secret<i16> {
+  %c100 = arith.constant 100 : i16
+  %c20 = arith.constant 20 : i16
+  %0 = secret.generic ins(%input : !secret.secret<i16>) {
+  ^bb0(%arg1: i16):
+    // expected-warning@+1 {{Cannot convert secret scf.while to static affine.for since a static maximum iteration attribute (`max_iter`) has not been provided on the scf.while op:}}
+    %1 = scf.while (%arg2 = %arg1) : (i16) -> i16 {
+      %3 = arith.cmpi slt, %arg2, %c100 : i16
+      scf.condition(%3) %arg2 : i16
+    } do {
+    ^bb0(%arg2: i16):
+      %2 = arith.muli %arg2, %arg2 : i16
+      scf.yield %2 : i16
+    }
+    secret.yield %1 : i16
+  } -> !secret.secret<i16>
+  return %0 : !secret.secret<i16>
+}
+
+// ----
+
+// CHECK-LABEL: @do_while_not_supported
+func.func @do_while_not_supported(%input: !secret.secret<i16>) -> !secret.secret<i16> {
+  %c100 = arith.constant 100 : i16
+  %c20 = arith.constant 20 : i16
+  %0 = secret.generic ins(%input : !secret.secret<i16>) {
+  ^bb0(%arg1: i16):
+    // expected-warning@+1 {{Current loop transformation has no support for do-while loops:}}
+    %1 = scf.while (%arg2 = %arg1) : (i16) -> i16 {
+      %3 = arith.cmpi sgt, %arg2, %c100 : i16
+      %arg4  = arith.muli %arg2, %c100 : i16
+      scf.condition(%3) %arg4 : i16
+    } do {
+    ^bb0(%arg4: i16):
+      %2 = arith.muli %arg4, %arg4 : i16
+      scf.yield %2 : i16
+    } attributes {max_iter = 16 : i64}
+    secret.yield %1 : i16
+  } -> !secret.secret<i16>
+  return %0 : !secret.secret<i16>
+}

--- a/tests/convert_secret_while_to_static_for/secret_dependent_while_loop.mlir
+++ b/tests/convert_secret_while_to_static_for/secret_dependent_while_loop.mlir
@@ -1,0 +1,51 @@
+// RUN: heir-opt --convert-secret-while-to-static-for %s | FileCheck %s
+
+// CHECK-LABEL: @basic_while_loop_with_secret_condition
+func.func @basic_while_loop_with_secret_condition(%input: !secret.secret<i16>) -> !secret.secret<i16> {
+  // CHECK-NOT: scf.while
+  // CHECK: %[[RESULT:.*]] = secret.generic ins(%[[SECRET_INPUT:.*]]: !secret.secret<i16>)
+  // CHECK-NEXT: ^bb0(%[[INPUT:.*]]: i16):
+  // CHECK: %[[FOR:.*]] = affine.for %[[I:.*]] = 0 to 16 iter_args(%[[ARG:.*]] = %[[INPUT]]) -> (i16)
+  // CHECK-NEXT: arith.cmpi
+  %c100 = arith.constant 100 : i16
+  %c20 = arith.constant 20 : i16
+  %0 = secret.generic ins(%input : !secret.secret<i16>) {
+  ^bb0(%arg1: i16):
+    %1 = scf.while (%arg2 = %arg1) : (i16) -> i16 {
+      %3 = arith.cmpi sgt, %arg2, %c100 : i16
+      scf.condition(%3) %arg2 : i16
+    } do {
+    ^bb0(%arg2: i16):
+      %2 = arith.muli %arg2, %arg2 : i16
+      scf.yield %2 : i16
+    } attributes {max_iter = 16 : i64}
+    secret.yield %1 : i16
+  } -> !secret.secret<i16>
+  return %0 : !secret.secret<i16>
+}
+
+// CHECK-LABEL: @while_loop_with_joint_secret_condition
+func.func @while_loop_with_joint_secret_condition(%input: !secret.secret<i16>) -> !secret.secret<i16> {
+  // CHECK-NOT: scf.while
+  // CHECK: %[[RESULT:.*]] = secret.generic ins(%[[SECRET_INPUT:.*]]: !secret.secret<i16>)
+  // CHECK-NEXT: ^bb0(%[[INPUT:.*]]: i16):
+  // CHECK: %[[FOR:.*]] = affine.for %[[I:.*]] = 0 to 16 iter_args(%[[ARG:.*]] = %[[INPUT]]) -> (i16)
+  // CHECK: arith.andi
+  %c100 = arith.constant 100 : i16
+  %c20 = arith.constant 20 : i16
+  %0 = secret.generic ins(%input : !secret.secret<i16>) {
+  ^bb0(%arg1: i16):
+    %1 = scf.while (%arg2 = %arg1) : (i16) -> i16 {
+      %3 = arith.cmpi slt, %arg2, %c100 : i16
+      %4 = arith.cmpi sgt, %arg2, %c20 : i16
+      %5 = arith.andi %3, %4 : i1
+      scf.condition(%5) %arg2 : i16
+    } do {
+    ^bb0(%arg2: i16):
+      %2 = arith.muli %arg2, %arg2 : i16
+      scf.yield %2 : i16
+    } attributes {max_iter = 16 : i64}
+    secret.yield %1 : i16
+  } -> !secret.secret<i16>
+  return %0 : !secret.secret<i16>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -76,6 +76,7 @@ cc_binary(
         "@heir//lib/Transforms/ApplyFolders",
         "@heir//lib/Transforms/ConvertIfToSelect",
         "@heir//lib/Transforms/ConvertSecretForToStaticFor",
+        "@heir//lib/Transforms/ConvertSecretWhileToStaticFor",
         "@heir//lib/Transforms/ElementwiseToAffine",
         "@heir//lib/Transforms/ForwardStoreToLoad",
         "@heir//lib/Transforms/FullLoopUnroll",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -46,6 +46,7 @@
 #include "lib/Transforms/ApplyFolders/ApplyFolders.h"
 #include "lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.h"
 #include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h"
+#include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h"
 #include "lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.h"
 #include "lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.h"
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
@@ -526,6 +527,7 @@ int main(int argc, char **argv) {
   registerFullLoopUnrollPasses();
   registerConvertIfToSelectPasses();
   registerConvertSecretForToStaticForPasses();
+  registerConvertSecretWhileToStaticForPasses();
   registerApplyFoldersPasses();
   registerForwardStoreToLoadPasses();
   registerStraightLineVectorizerPasses();


### PR DESCRIPTION
Converts `scf.while` with secret condition to `affine.for` with constant bounds. The transformation is built as part of the data-oblivious transformation pipeline (#777). 
 
TODO(#846): Current transformation doesn't support do-while loops
