### PR TITLE
ci: fix typo in gh token env var

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Delete previous existing nightly tag and release
         env:
-          GH_TOKEN: $${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
             gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag


### PR DESCRIPTION
I found a typo! Hopefully this fixes (maybe) https://github.com/google/heir/issues/813, i'll manually run and close the issue manually if it works. Follow-up to add an auto issue filing on failure