### PR TITLE
#708: Canonicalize cggi.lut2, cggi.lut3 as cggi.lut_lincomb

### DIFF
--- a/lib/Dialect/CGGI/IR/CGGIOps.cpp
+++ b/lib/Dialect/CGGI/IR/CGGIOps.cpp
@@ -15,8 +15,27 @@ namespace cggi {
 
 ValueRange Lut2Op::getLookupTableInputs() { return ValueRange{getB(), getA()}; }
 
+LogicalResult Lut2Op::canonicalize(Lut2Op op, PatternRewriter &rewriter) {
+  SmallVector<int32_t> coeffs2 = {1, 2};
+  auto createLutLinCombOp = rewriter.create<LutLinCombOp>(
+      op.getLoc(), op.getOutput().getType(), op.getOperands(), coeffs2,
+      op.getLookupTable());
+  rewriter.replaceOp(op, createLutLinCombOp);
+  return success();
+}
+
 ValueRange Lut3Op::getLookupTableInputs() {
   return ValueRange{getC(), getB(), getA()};
+}
+
+LogicalResult Lut3Op::canonicalize(Lut3Op op, PatternRewriter &rewriter) {
+  SmallVector<int> coeffs3 = {1, 2, 4};
+
+  auto createLutLinCombOp = rewriter.create<LutLinCombOp>(
+      op.getLoc(), op.getOutput().getType(), op.getOperands(), coeffs3,
+      op.getLookupTable());
+  rewriter.replaceOp(op, createLutLinCombOp);
+  return success();
 }
 
 ValueRange LutLinCombOp::getLookupTableInputs() {

--- a/lib/Dialect/CGGI/IR/CGGIOps.h
+++ b/lib/Dialect/CGGI/IR/CGGIOps.h
@@ -8,6 +8,7 @@
 #include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/CGGI/IR/CGGIOps.td
+++ b/lib/Dialect/CGGI/IR/CGGIOps.td
@@ -104,12 +104,14 @@ class CGGI_LutOp<string mnemonic, list<Trait> traits = []>
 def CGGI_Lut2Op : CGGI_LutOp<"lut2", [AllTypesMatch<["a", "b", "output"]>]> {
   let summary = "A lookup table on two inputs.";
   let arguments = (ins LWECiphertextLike:$b, LWECiphertextLike:$a, Builtin_IntegerAttr:$lookup_table);
+  let hasCanonicalizeMethod = 1;
 }
 
 def CGGI_Lut3Op : CGGI_LutOp<"lut3", [AllTypesMatch<["a", "b", "c", "output"]>]> {
   let summary = "A lookup table on three inputs.";
   let arguments = (ins LWECiphertextLike:$c, LWECiphertextLike:$b, LWECiphertextLike:$a, Builtin_IntegerAttr:$lookup_table);
   let results = (outs LWECiphertextLike:$output);
+  let hasCanonicalizeMethod = 1;
 }
 
 def CGGI_LutLinCombOp : CGGI_Op<"lut_lincomb", [

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(Secretize)
 add_subdirectory(StraightLineVectorizer)
 add_subdirectory(UnusedMemRef)
 add_subdirectory(ConvertSecretForToStaticFor)
+add_subdirectory(ConvertSecretWhileToStaticFor)
 
 if(ENABLE_YOSYS)
     # TODO (#797): Support Yosys in cmake build.

--- a/lib/Transforms/ConvertSecretWhileToStaticFor/CMakeLists.txt
+++ b/lib/Transforms/ConvertSecretWhileToStaticFor/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(LLVM_TARGET_DEFINITIONS ConvertSecretWhileToStaticFor.td)
+mlir_tablegen(ConvertSecretWhileToStaticFor.h.inc -gen-pass-decls -name ConvertSecretWhileToStaticFor)
+add_public_tablegen_target(MLIRHeirConvertSecretWhileToStaticForIncGen)
+
+add_mlir_dialect_library(MLIRHeirConvertSecretWhileToStaticFor
+    ConvertSecretWhileToStaticFor.cpp
+
+    DEPENDS
+    MLIRHeirConvertSecretWhileToStaticForIncGen
+
+    LINK_LIBS PUBLIC
+    MLIRHEIRSecretnessAnalysis
+    LLVMSupport
+    MLIRAnalysis
+    MLIRArithDialect
+    MLIRIR
+    MLIRPass
+    MLIRSCFDialect
+    MLIRSideEffectInterfaces
+    MLIRSupport
+    MLIRTransformUtils
+)

--- a/tests/cggi/lut_canonicalize.mlir
+++ b/tests/cggi/lut_canonicalize.mlir
@@ -1,0 +1,34 @@
+// RUN: heir-opt --canonicalize %s | FileCheck %s
+#encoding = #lwe.unspecified_bit_field_encoding<cleartext_bitwidth = 3>
+!ct_ty = !lwe.lwe_ciphertext<encoding = #encoding>
+!pt_ty = !lwe.lwe_plaintext<encoding = #encoding>
+
+func.func @require_post_pass_toposort_lut3(%arg0: tensor<8x!ct_ty>) -> !ct_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+  %2 = tensor.extract %arg0[%c2] : tensor<8x!ct_ty>
+
+  // CHECK: cggi.lut_lincomb %extracted, %extracted_0, %extracted_1 {coefficients = array<i32: 1, 2, 4>, lookup_table = 8 : ui8}
+  %r1 = cggi.lut3 %0, %1, %2 {lookup_table = 8 : ui8} : !ct_ty
+
+  return %r1 : !ct_ty
+}
+
+func.func @require_post_pass_toposort_lut2(%arg0: tensor<8x!ct_ty>) -> !ct_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+  %2 = tensor.extract %arg0[%c2] : tensor<8x!ct_ty>
+
+  // CHECK: cggi.lut_lincomb %extracted, %extracted_0 {coefficients = array<i32: 1, 2>, lookup_table = 8 : ui8}
+  %r1 = cggi.lut2 %0, %1 {lookup_table = 8 : ui8} : !ct_ty
+
+  return %r1 : !ct_ty
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -147,12 +147,12 @@ function(make_heiropt_exec  TARGET_NAME SOURCES)
         MLIRBGVOpenfheTransforms
         MLIRLWEToPolynomial
         MLIRHeirConvertSecretForToStaticFor
+        MLIRHeirConvertSecretWhileToStaticFor
 
-    MLIRRandom
-    MLIRCGGIToJaxiteTransforms
+        MLIRRandom
+        MLIRCGGIToJaxiteTransforms
 
-
-    MLIRCKKS
+        MLIRCKKS
 )
 add_dependencies(${TARGET_NAME} MLIRPolynomialPassesIncGen)
 add_dependencies(${TARGET_NAME} MLIRPolynomialNTTRewritePassesIncGen)
@@ -162,10 +162,8 @@ endfunction()
 message(STATUS "Configuring heir-translate")
 make_heirtx_exec(heir-translate heir-translate.cpp)
 
-
 message(STATUS "Configuring heir-lsp")
 make_heirlsp_exec(heir-lsp heir-lsp.cpp)
-
 
 message(STATUS "Configuring heir-opt")
 make_heiropt_exec(heir-opt heir-opt.cpp)


### PR DESCRIPTION
#708: Canonicalize cggi.lut2, cggi.lut3 as cggi.lut_lincomb
- CGGI Lut3, Lut2 canonicalize added

Additionally some CMakeLists.txt changes to support SecretWhileToStaticFor transform is piggyback on this change