### PR TITLE
RNS Support

### DIFF
--- a/bazel/import_llvm.bzl
+++ b/bazel/import_llvm.bzl
@@ -7,7 +7,7 @@ load(
 
 def import_llvm(name):
     """Imports LLVM."""
-    LLVM_COMMIT = "0c25f85e5b88102363c0cd55e1946053d5827e99"
+    LLVM_COMMIT = "28727812fbf7ac5223aa9418a2ba8dd0e86fb2e9"
 
     new_git_repository(
         name = name,
@@ -16,5 +16,5 @@ def import_llvm(name):
         build_file_content = "# empty",
         commit = LLVM_COMMIT,
         init_submodules = False,
-        remote = "https://github.com/llvm/llvm-project.git",
+        remote = "https://github.com/AlexanderViand-Intel/llvm-project.git",
     )

--- a/lib/Conversion/BGVToOpenfhe/BGVToOpenfhe.cpp
+++ b/lib/Conversion/BGVToOpenfhe/BGVToOpenfhe.cpp
@@ -322,17 +322,18 @@ struct ConvertExtractOp : public OpConversionPattern<ExtractOp> {
     }
     int64_t offset = offsetAttr.getInt();
 
-    auto ctTy = op.getInput().getType();
+    // FIXME: add RNS support to OpenFHE lowering!
+    auto ctTy = cast<lwe::RLWECiphertextType>(op.getInput().getType());
+    auto outTy = cast<lwe::RLWECiphertextType>(op.getOutput().getType());
     auto ring = ctTy.getRlweParams().getRing();
     auto degree = ring.getPolynomialModulus().getPolynomial().getDegree();
-    auto elementTy =
-        dyn_cast<IntegerType>(op.getOutput().getType().getUnderlyingType());
+    auto elementTy = dyn_cast<IntegerType>(outTy.getUnderlyingType());
     if (!elementTy) {
       op.emitError() << "Expected extract op to extract scalar from tensor "
                         "type, but found input underlying type "
-                     << op.getInput().getType().getUnderlyingType()
+                     << ctTy.getUnderlyingType()
                      << " and output underlying type "
-                     << op.getOutput().getType().getUnderlyingType();
+                     << outTy.getUnderlyingType();
     }
     auto tensorTy = RankedTensorType::get({degree}, elementTy);
 

--- a/lib/Conversion/LWEToPolynomial/LWEToPolynomial.cpp
+++ b/lib/Conversion/LWEToPolynomial/LWEToPolynomial.cpp
@@ -43,6 +43,18 @@ class CiphertextTypeConverter : public TypeConverter {
 
       return RankedTensorType::get({rlweParams.getDimension()}, polyTy);
     });
+    addConversion([ctx](lwe::RNSRLWECiphertextType type) -> Type {
+      auto rlweParams = type.getRlweParams();
+      auto rings = rlweParams.getRing().getBasisTypes();
+      SmallVector<Type> ps;
+      for (auto r : rings) {
+        auto p = ::mlir::polynomial::PolynomialType::get(ctx, r);
+        ps.push_back(p);
+      }
+      auto polyTy = ::mlir::polynomial::RNSType::get(ctx, ps);
+
+      return RankedTensorType::get({rlweParams.getDimension()}, polyTy);
+    });
     addConversion([ctx](lwe::RLWEPlaintextType type) -> Type {
       auto ring = type.getRing();
       auto polyTy = ::mlir::polynomial::PolynomialType::get(ctx, ring);

--- a/lib/Conversion/SecretToBGV/SecretToBGV.td
+++ b/lib/Conversion/SecretToBGV/SecretToBGV.td
@@ -30,9 +30,9 @@ def SecretToBGV : Pass<"secret-to-bgv"> {
     Option<"polyModDegree", "poly-mod-degree", "int",
            /*default=*/"1024", "Default degree of the cyclotomic polynomial "
            "modulus to use for ciphertext space.">,
-    Option<"coefficientModBits", "coefficient-mod-bits", "int",
-           /*default=*/"29", "Default number of bits of the prime "
-           "coefficient modulus to use " "for the ciphertext space.">
+    ListOption<"coefficientModuli", "coefficient-moduli", "int",
+          "coefficient modulus/moduli to use for the ciphertext space. "
+          "If no value(s) are provided, uses a single 29-bit modulus.">
   ];
 }
 

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -37,29 +37,141 @@ void BGVDialect::initialize() {
       >();
 }
 
-LogicalResult MulOp::verify() { return verifyMulOp(this); }
-
-LogicalResult RotateOp::verify() { return verifyRotateOp(this); }
-
-LogicalResult RelinearizeOp::verify() { return verifyRelinearizeOp(this); }
-
-LogicalResult ModulusSwitchOp::verify() {
-  return verifyModulusSwitchOrRescaleOp(this);
-}
+// TODO: re-enable verifiers with RNS support
+// LogicalResult MulOp::verify() {
+//   auto x = getLhs().getType();
+//   auto y = getRhs().getType();
+//   if (x.getRlweParams().getDimension() != y.getRlweParams().getDimension()) {
+//     return emitOpError() << "input dimensions do not match";
+//   }
+//   auto out = getOutput().getType();
+//   if (out.getRlweParams().getDimension() !=
+//       y.getRlweParams().getDimension() + x.getRlweParams().getDimension() -
+//       1) {
+//     return emitOpError() << "output.dim == x.dim + y.dim - 1 does not hold";
+//   }
+//   return success();
+// }
+//
+// LogicalResult RotateOp::verify() {
+//   auto x = getInput().getType();
+//   if (x.getRlweParams().getDimension() != 2) {
+//     return emitOpError() << "x.dim == 2 does not hold";
+//   }
+//   auto out = getOutput().getType();
+//   if (out.getRlweParams().getDimension() != 2) {
+//     return emitOpError() << "output.dim == 2 does not hold";
+//   }
+//   return success();
+// }
+//
+// LogicalResult RelinearizeOp::verify() {
+//   auto x = getInput().getType();
+//   auto out = getOutput().getType();
+//   if (x.getRlweParams().getDimension() != getFromBasis().size()) {
+//     return emitOpError() << "input dimension does not match from_basis";
+//   }
+//   if (out.getRlweParams().getDimension() != getToBasis().size()) {
+//     return emitOpError() << "output dimension does not match to_basis";
+//   }
+//   return success();
+// }
+//
+// LogicalResult ModulusSwitchOp::verify() {
+//   auto x = getInput().getType();
+//   auto xRing = x.getRlweParams().getRing();
+//
+//   auto out = getOutput().getType();
+//   auto outRing = out.getRlweParams().getRing();
+//   if (outRing != getToRing()) {
+//     return emitOpError() << "output ring should match to_ring";
+//   }
+//   if (xRing.getCoefficientModulus().getValue().ule(
+//           outRing.getCoefficientModulus().getValue())) {
+//     return emitOpError()
+//            << "output ring modulus should be less than the input ring
+//            modulus";
+//   }
+//   if (!xRing.getCoefficientModulus()
+//            .getValue()
+//            .urem(outRing.getCoefficientModulus().getValue())
+//            .isZero()) {
+//     return emitOpError()
+//            << "output ring modulus should divide the input ring modulus";
+//   }
+//
+//   return success();
+// }
 
 LogicalResult MulOp::inferReturnTypes(
     MLIRContext *ctx, std::optional<Location>, MulOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
-  return inferMulOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+  if (auto x = dyn_cast<lwe::RLWECiphertextType>(adaptor.getLhs().getType())) {
+    auto y = cast<lwe::RLWECiphertextType>(adaptor.getRhs().getType());
+    auto newDim =
+        x.getRlweParams().getDimension() + y.getRlweParams().getDimension() - 1;
+    inferredReturnTypes.push_back(lwe::RLWECiphertextType::get(
+        ctx, x.getEncoding(),
+        lwe::RLWEParamsAttr::get(ctx, newDim, x.getRlweParams().getRing()),
+        x.getUnderlyingType()));
+    return success();
+  }
+  if (auto xr =
+          dyn_cast<lwe::RNSRLWECiphertextType>(adaptor.getLhs().getType())) {
+    auto yr = cast<lwe::RNSRLWECiphertextType>(adaptor.getRhs().getType());
+    auto newDim = xr.getRlweParams().getDimension() +
+                  yr.getRlweParams().getDimension() - 1;
+    inferredReturnTypes.push_back(lwe::RNSRLWECiphertextType::get(
+        ctx, xr.getEncoding(),
+        lwe::RNSRLWEParamsAttr::get(ctx, newDim, xr.getRlweParams().getRing()),
+        xr.getUnderlyingType()));
+    return success();
+  }
+  return failure();
 }
 
 LogicalResult RelinearizeOp::inferReturnTypes(
     MLIRContext *ctx, std::optional<Location>, RelinearizeOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
-  return inferRelinearizeOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+  if (auto x =
+          dyn_cast<lwe::RLWECiphertextType>(adaptor.getInput().getType())) {
+    inferredReturnTypes.push_back(lwe::RLWECiphertextType::get(
+        ctx, x.getEncoding(),
+        lwe::RLWEParamsAttr::get(ctx, 2, x.getRlweParams().getRing()),
+        x.getUnderlyingType()));
+    return success();
+  }
+  if (auto xr =
+          dyn_cast<lwe::RNSRLWECiphertextType>(adaptor.getInput().getType())) {
+    inferredReturnTypes.push_back(lwe::RNSRLWECiphertextType::get(
+        ctx, xr.getEncoding(),
+        lwe::RNSRLWEParamsAttr::get(ctx, 2, xr.getRlweParams().getRing()),
+        xr.getUnderlyingType()));
+    return success();
+  }
+  return failure();
 }
 
-LogicalResult ExtractOp::verify() { return verifyExtractOp(this); }
+// LogicalResult ExtractOp::verify() {
+//   auto inputTy = getInput().getType();
+//   auto tensorTy = dyn_cast<RankedTensorType>(inputTy.getUnderlyingType());
+//   if (!tensorTy) {
+//     return emitOpError() << "input RLWE ciphertext type must have a ranked "
+//                             "tensor as its underlying_type, but found "
+//                          << inputTy.getUnderlyingType();
+//   }
+//
+//   auto outputScalarType = getOutput().getType().getUnderlyingType();
+//   if (tensorTy.getElementType() != outputScalarType) {
+//     return emitOpError() << "output RLWE ciphertext's underlying_type must be
+//     "
+//                             "the element type of the input ciphertext's "
+//                             "underlying tensor type, but found tensor type "
+//                          << tensorTy << " and output type " <<
+//                          outputScalarType;
+//   }
+//   return success();
+// }
 
 }  // namespace bgv
 }  // namespace heir

--- a/lib/Dialect/BGV/IR/BGVOps.td
+++ b/lib/Dialect/BGV/IR/BGVOps.td
@@ -19,6 +19,7 @@ class BGV_Op<string mnemonic, list<Trait> traits = []> :
   }];
 }
 
+//TODO: How to add RNS support?
 class BGV_CiphertextPlaintextOp<string mnemonic, list<Trait> traits =
     [Pure, AllTypesMatch<["ciphertextInput", "output"]>,
     TypesMatchWith<"type of 'plaintextInput' matches encoding type of 'ciphertextInput'",
@@ -29,12 +30,12 @@ class BGV_CiphertextPlaintextOp<string mnemonic, list<Trait> traits =
                       "::llvm::cast<lwe::RLWECiphertextType>($_self).getUnderlyingType())">]> :
         BGV_Op<mnemonic, traits> {
   let arguments = (ins
-    RLWECiphertext:$ciphertextInput,
+    RNSorNonRNSRLWECiphertext:$ciphertextInput,
     RLWEPlaintext:$plaintextInput
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 }
 
@@ -42,12 +43,12 @@ def BGV_AddOp : BGV_Op<"add", [Pure, Commutative, SameOperandsAndResultType]> {
   let summary = "Addition operation between ciphertexts.";
 
   let arguments = (ins
-    RLWECiphertext:$lhs,
-    RLWECiphertext:$rhs
+    RNSorNonRNSRLWECiphertext:$lhs,
+    RNSorNonRNSRLWECiphertext:$rhs
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
   let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
@@ -61,12 +62,12 @@ def BGV_SubOp : BGV_Op<"sub", [Pure, SameOperandsAndResultType]> {
   let summary = "Subtraction operation between ciphertexts.";
 
   let arguments = (ins
-    RLWECiphertext:$lhs,
-    RLWECiphertext:$rhs
+    RNSorNonRNSRLWECiphertext:$lhs,
+    RNSorNonRNSRLWECiphertext:$rhs
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
   let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
@@ -80,15 +81,15 @@ def BGV_MulOp : BGV_Op<"mul", [Pure, Commutative, SameOperandsAndResultRings, Sa
   let summary = "Multiplication operation between ciphertexts.";
 
   let arguments = (ins
-    RLWECiphertext:$lhs,
-    RLWECiphertext:$rhs
+    RNSorNonRNSRLWECiphertext:$lhs,
+    RNSorNonRNSRLWECiphertext:$rhs
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
-  let hasVerifier = 1;
+  //let hasVerifier = 1;
 }
 
 def BGV_MulPlainOp : BGV_CiphertextPlaintextOp<"mul_plain"> {
@@ -99,15 +100,15 @@ def BGV_RotateOp : BGV_Op<"rotate", [Pure, AllTypesMatch<["input", "output"]>]> 
   let summary = "Rotate the coefficients of the ciphertext using a Galois automorphism.";
 
   let arguments = (ins
-    RLWECiphertext:$input,
+    RNSorNonRNSRLWECiphertext:$input,
     Builtin_IntegerAttr:$offset
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
-  let hasVerifier = 1;
+  //let hasVerifier = 1;
   let assemblyFormat = "operands attr-dict `:` qualified(type($input))" ;
 }
 
@@ -128,26 +129,26 @@ def BGV_ExtractOp : BGV_Op<"extract", [Pure, SameOperandsAndResultRings]> {
   }];
 
   let arguments = (ins
-    RLWECiphertext:$input,
+    RNSorNonRNSRLWECiphertext:$input,
     AnySignlessIntegerOrIndex:$offset
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
-  let hasVerifier = 1;
+  //let hasVerifier = 1;
 }
 
 def BGV_NegateOp : BGV_Op<"negate", [Pure, Involution, SameOperandsAndResultType]> {
   let summary = "Negate the coefficients of the ciphertext.";
 
   let arguments = (ins
-    RLWECiphertext:$input
+    RNSorNonRNSRLWECiphertext:$input
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
   let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
@@ -167,16 +168,16 @@ def BGV_RelinearizeOp : BGV_Op<"relinearize", [SameOperandsAndResultRings, Infer
   }];
 
   let arguments = (ins
-    RLWECiphertext:$input,
+    RNSorNonRNSRLWECiphertext:$input,
     DenseI32ArrayAttr:$from_basis,
     DenseI32ArrayAttr:$to_basis
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
-  let hasVerifier = 1;
+  //let hasVerifier = 1;
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 
@@ -184,15 +185,15 @@ def BGV_ModulusSwitchOp : BGV_Op<"modulus_switch"> {
   let summary = "Lower the modulus level of the ciphertext.";
 
   let arguments = (ins
-    RLWECiphertext:$input,
+    RNSorNonRNSRLWECiphertext:$input,
     Polynomial_RingAttr:$to_ring
   );
 
   let results = (outs
-    RLWECiphertext:$output
+    RNSorNonRNSRLWECiphertext:$output
   );
 
-  let hasVerifier = 1;
+  //let hasVerifier = 1;
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 

--- a/lib/Dialect/LWE/IR/LWEAttributes.td
+++ b/lib/Dialect/LWE/IR/LWEAttributes.td
@@ -320,4 +320,22 @@ def LWE_RLWEParams : AttrDef<LWE_Dialect, "RLWEParams"> {
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
+def LWE_RNSRLWEParams : AttrDef<LWE_Dialect, "RNSRLWEParams"> {
+  let mnemonic = "rns_rlwe_params";
+  let description = [{
+    An attribute describing classical RLWE parameters:
+
+    - `dimension`: the number of polynomials used in an RLWE sample, analogous
+      to LWEParams.dimension.
+    - `ring`: the polynomial ring to use.
+  }];
+
+  let parameters = (ins
+    DefaultValuedParameter<"unsigned", "2">:$dimension,
+    "::mlir::polynomial::RNSRingAttr":$ring
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
 #endif  // LIB_DIALECT_LWE_IR_LWEATTRIBUTES_TD_

--- a/lib/Dialect/LWE/IR/LWETypes.td
+++ b/lib/Dialect/LWE/IR/LWETypes.td
@@ -46,7 +46,17 @@ def RLWECiphertext : LWE_Type<"RLWECiphertext", "rlwe_ciphertext"> {
   );
 }
 
-def RLWECiphertextLike : TypeOrContainer<RLWECiphertext, "ciphertext-like">;
+def RNSRLWECiphertext : LWE_Type<"RNSRLWECiphertext", "rns_rlwe_ciphertext"> {
+  let summary = "A type for RLWE ciphertexts";
+  let parameters = (ins
+    "::mlir::Attribute":$encoding,
+    "RNSRLWEParamsAttr":$rlwe_params,
+    "Type":$underlying_type
+  );
+}
+
+def RNSorNonRNSRLWECiphertext : AnyTypeOf<[RLWECiphertext,RNSRLWECiphertext], "rns or non-rns rlwe ctxt">;
+def RLWECiphertextLike : TypesOrContainer<[RLWECiphertext,RNSRLWECiphertext], "ciphertext-like">;
 
 def RLWESecretKey : LWE_Type<"RLWESecretKey", "rlwe_secret_key"> {
   let summary = "A secret key for RLWE";

--- a/lib/Dialect/Polynomial/Transforms/BUILD
+++ b/lib/Dialect/Polynomial/Transforms/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "Passes.h",
     ],
     deps = [
+        ":ExpandRNS",
         ":NTTRewrites",
         ":pass_inc_gen",
         "@llvm-project//mlir:IR",
@@ -35,6 +36,22 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:PolynomialDialect",
         "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+cc_library(
+    name = "ExpandRNS",
+    srcs = ["ExpandRNS.cpp"],
+    hdrs = ["ExpandRNS.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Conversion:Utils",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:PolynomialDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/lib/Dialect/Polynomial/Transforms/ExpandRNS.cpp
+++ b/lib/Dialect/Polynomial/Transforms/ExpandRNS.cpp
@@ -1,0 +1,109 @@
+#include "lib/Dialect/Polynomial/Transforms/ExpandRNS.h"
+
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/OneToNFuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Polynomial/IR/PolynomialOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/OneToNTypeConversion.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+using namespace mlir::polynomial;
+
+#define GEN_PASS_DEF_EXPANDRNS
+#include "lib/Dialect/Polynomial/Transforms/Passes.h.inc"
+
+static std::optional<Value> buildNToOneCast(OpBuilder &builder,
+                                            RNSType resultType,
+                                            ValueRange inputs, Location loc) {
+  auto cast =
+      builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs);
+  return cast->getOpResult(0);
+}
+
+static std::optional<SmallVector<Value>> buildOneToNCast(OpBuilder &builder,
+                                                         TypeRange resultTypes,
+                                                         Value input,
+                                                         Location loc) {
+  // This pass only operates on RNS types
+  RNSType inputType = dyn_cast<RNSType>(input.getType());
+  if (!inputType) return {};
+
+  // Create cast ops
+  SmallVector<Value> values;
+  for (auto t : inputType.getBasisTypes()) {
+    auto cast = builder.create<UnrealizedConversionCastOp>(loc, t, input);
+    values.push_back(cast->getOpResult(0));
+  }
+  return values;
+}
+
+template <typename OpTy>
+class ConvertBinOp : public OneToNOpConversionPattern<OpTy> {
+ public:
+  using OneToNOpConversionPattern<OpTy>::OneToNOpConversionPattern;
+  using OneToNOpConversionPattern<OpTy>::typeConverter;
+
+  LogicalResult matchAndRewrite(
+      OpTy op, typename OneToNOpConversionPattern<OpTy>::OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const override {
+    // OneToNConversion has no Conversion-level illegality handling
+    if (typeConverter->isLegal(op)) return failure();
+
+    // *must* be an RNS Type
+    auto rnsType = llvm::cast<RNSType>(op.getType());
+
+    // For each RNS element, create a new op
+    SmallVector<Value> results;
+    for (size_t i = 0; i < rnsType.getBasisTypes().size(); ++i) {
+      auto r = rewriter.create<OpTy>(op.getLoc(), rnsType.getBasisTypes()[i],
+                                     adaptor.getLhs()[i], adaptor.getRhs()[i]);
+      results.push_back(r);
+    }
+    rewriter.replaceOp(op, results, adaptor.getResultMapping());
+    return success();
+  }
+};
+
+struct ExpandRNS : impl::ExpandRNSBase<ExpandRNS> {
+  using ExpandRNSBase::ExpandRNSBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    OneToNTypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    typeConverter.addConversion(
+        [](RNSType rnsType,
+           SmallVectorImpl<Type> &types) -> std::optional<LogicalResult> {
+          types = SmallVector<Type>(rnsType.getBasisTypes());
+          return success();
+        });
+    typeConverter.addArgumentMaterialization(buildNToOneCast);
+    typeConverter.addSourceMaterialization(buildNToOneCast);
+    typeConverter.addTargetMaterialization(buildOneToNCast);
+
+    RewritePatternSet patterns(context);
+    // TODO: extend to all other polynomial ops!
+    patterns.add<ConvertBinOp<AddOp>, ConvertBinOp<SubOp>, ConvertBinOp<MulOp>>(
+        typeConverter, context);
+    scf::populateSCFStructuralOneToNTypeConversions(typeConverter, patterns);
+    populateFuncTypeConversionPatterns(typeConverter, patterns);
+
+    if (mlir::failed(mlir::applyPartialOneToNConversion(
+            getOperation(), typeConverter, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Polynomial/Transforms/ExpandRNS.h
+++ b/lib/Dialect/Polynomial/Transforms/ExpandRNS.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_POLYNOMIAL_TRANSFORMS_EXPANDRNS_H_
+#define LIB_DIALECT_POLYNOMIAL_TRANSFORMS_EXPANDRNS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+#define GEN_PASS_DECL_EXPANDRNS
+#include "lib/Dialect/Polynomial/Transforms/Passes.h.inc"
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_POLYNOMIAL_TRANSFORMS_EXPANDRNS_H_

--- a/lib/Dialect/Polynomial/Transforms/Passes.h
+++ b/lib/Dialect/Polynomial/Transforms/Passes.h
@@ -1,6 +1,7 @@
 #ifndef LIB_DIALECT_POLYNOMAIL_TRANSFORMS_PASSES_H_
 #define LIB_DIALECT_POLYNOMAIL_TRANSFORMS_PASSES_H_
 
+#include "lib/Dialect/Polynomial/Transforms/ExpandRNS.h"
 #include "lib/Dialect/Polynomial/Transforms/NTTRewrites.h"
 #include "mlir/include/mlir/Dialect/Polynomial/IR/PolynomialDialect.h"  // from @llvm-project
 

--- a/lib/Dialect/Polynomial/Transforms/Passes.td
+++ b/lib/Dialect/Polynomial/Transforms/Passes.td
@@ -17,4 +17,12 @@ def PolyMulToNTT : Pass<"convert-polynomial-mul-to-ntt"> {
   let dependentDialects = ["mlir::polynomial::PolynomialDialect", "heir::arith_ext::ArithExtDialect"];
 }
 
+def ExpandRNS : Pass<"expand-rns"> {
+  // FIXME: add add summary/description
+  let summary = "";
+  let description = [{
+  }];
+  let dependentDialects = ["mlir::polynomial::PolynomialDialect"];
+}
+
 #endif  // LIB_DIALECT_POLYNOMIAL_TRANSFORMS_PASSES_TD_

--- a/tests/polynomial/rns_polynomial.mlir
+++ b/tests/polynomial/rns_polynomial.mlir
@@ -1,0 +1,17 @@
+// RUN: heir-opt --expand-rns %s | FileCheck  %s
+
+!poly1 = !polynomial.polynomial<ring=<coefficientType = i32, coefficientModulus = 1073479681 : i32, polynomialModulus=#polynomial.int_polynomial<1 + x**8192>>>
+!poly2 = !polynomial.polynomial<ring=<coefficientType = i32, coefficientModulus = 1071513601 : i32, polynomialModulus=#polynomial.int_polynomial<1 + x**8192>>>
+!rns = !polynomial.rns<!poly1,!poly2>
+
+func.func @test_rns(%arg0: !rns, %arg1: !rns) ->  !rns {
+  %0 = polynomial.add %arg0, %arg1 : !rns
+  return %0 :  !rns
+}
+
+// // For this to work, you need the "detensorize" PR/branch, which adds `--convert-tensor-to-scalars`.
+// // With that, use --convert-elementwise-to-affine --full-loop-unroll --convert-tensor-to-scalars --expand-rns
+// func.func @test_elementwise_rns(%arg0: tensor<2x!rns>, %arg1: tensor<2x!rns>) ->  tensor<2x!rns> {
+//   %0 = polynomial.add %arg0, %arg1 : tensor<2x!rns>
+//   return %0 :  tensor<2x!rns>
+// }

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -438,6 +438,11 @@ struct MlirToBgvPipelineOptions
                      "equivalently, the number of messages that can be packed "
                      "into a single ciphertext."),
       llvm::cl::init(1024)};
+  PassOptions::ListOption<int> coefficientModuli{
+      *this, "coefficient-moduli",
+      llvm::cl::desc("Ciphertext space modulus or moduli")};
+  // TODO: figure out default value
+  // (ideally, access pass default value somehow)
 };
 
 void mlirToBgvPipelineBuilder(OpPassManager &pm,
@@ -458,6 +463,7 @@ void mlirToBgvPipelineBuilder(OpPassManager &pm,
   // Lower to BGV
   auto secretToBgvOpts = SecretToBGVOptions{};
   secretToBgvOpts.polyModDegree = options.ciphertextDegree;
+  secretToBgvOpts.coefficientModuli = options.coefficientModuli;
   pm.addPass(createSecretToBGV(secretToBgvOpts));
 }
 

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -27,6 +27,7 @@
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/Openfhe/Transforms/Passes.h"
+#include "lib/Dialect/Polynomial/Transforms/ExpandRNS.h"
 #include "lib/Dialect/Polynomial/Transforms/NTTRewrites.h"
 #include "lib/Dialect/Polynomial/Transforms/Passes.h"
 #include "lib/Dialect/RNS/IR/RNSDialect.h"


### PR DESCRIPTION
This a DRAFT to elicit design feedback on how we should handle RNS support in HEIR. Towards that goal, it simply *switches* most things to RNS (rather than supporting RNS and non-RNS), and it also removes various verifiers/etc for ease of implementation.

### Types
This uses an explicit `RNS` type, which is essentially a "Tuple" of Types. Note that the builtin Tuple type is not suitable, as it is not a valid tensor element type, and we want tensors or RNS-polynomials as they are the natural lowering for an (RNS) RLWECiphertext). 

Rather than adding `!rns.rns<...>` and our RNS dialect to the llvm repo, this adds an rns type to the polynomial dialect (See the changes to LLVM in my fork [here](https://github.com/llvm/llvm-project/compare/main...AlexanderViand-Intel:llvm-project:polyfix), but see also below for ideas how to avoid that. 

In order to support polynomial ops on (a) normal polynomials (b) RNS polynomials and (c) tensors of both, it also adds a new TypeConstraint and uses it for Polynomial operations.

In order to track that BGV/LWE operations are happening in RNS (which changes things such as how a "modswitch" is lowered rather dramatically), it currently introduces an RNSRLWECiphertext. This is not very elegant, but I'm not quite sure how to make it nicer. Maybe the "RNS-ness" can instead become an Attribute on RLWECiphertext? See also #876 (PR on LWE Attrs).

### Passes
This PR adds an `--expand-rns` pass that is similar to `--convert-elementwise-to-affine` (which can be used to convert polynomial ops on tensors of (rns-of) polys to loops with operations on "scalar" (rns-of) polynomials). It also updates LWE-to-polynomial to support RNS polynomials.

The intended order of passes is `-<scheme>-to-LWE --LWE-to-polynomial` (which will create poly operations on `tensor<rns<poly1,poly2,poly3>>`) followed by `--convert-elementwise-to-affine` , possibly `--convert-tensor-to-scalars` (from PR #763) and finally `--expand-rns`.

Finally, the PR switches the `--secret-to-bgv` pass to RNS, and changes the pass options from asking for the number of bits in the ctxt modulus to asking for a list of moduli. 