### PR TITLE
clean up LWEOps.td

### DIFF
--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -11,14 +11,6 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/CommonAttrConstraints.td"
 
-class LWE_Op<string mnemonic, list<Trait> traits = []> :
-        Op<LWE_Dialect, mnemonic, traits> {
-  let cppNamespace = "::mlir::heir::lwe";
-  let assemblyFormat = [{
-    operands attr-dict `:`  functional-type(operands, results)
-  }];
-}
-
 class HasEncoding<
   string encodingHolder,
   string encoding,
@@ -60,8 +52,24 @@ class RlweParametersMatch<
     >
   >;
 
-def LWE_EncodeOp : LWE_Op<"encode", [
-    Pure, HasEncoding<"output", "encoding", "LWEPlaintextType">]> {
+
+// LWE Operations are always Pure by design
+class LWE_Op<string mnemonic, list<Trait> traits = []> :
+        Op<LWE_Dialect, mnemonic,  traits # [Pure]> {
+  let cppNamespace = "::mlir::heir::lwe";
+  let assemblyFormat = [{
+    operands attr-dict `:`  functional-type(operands, results)
+  }];
+}
+
+class LWE_BinOp<string mnemonic, list<Trait> traits = []> :
+        LWE_Op<mnemonic,  traits # [ElementwiseMappable]> {
+  let arguments = (ins RLWECiphertext:$lhs, RLWECiphertext:$rhs);
+  let results = (outs RLWECiphertext:$output);
+  let assemblyFormat = "operands attr-dict `:` type($output)";
+}
+
+def LWE_EncodeOp : LWE_Op<"encode", [HasEncoding<"output", "encoding", "LWEPlaintextType">]> {
   let summary = "Encode an integer to yield an LWE plaintext";
   let description = [{
     Encode an integer to yield an LWE plaintext.
@@ -86,7 +94,6 @@ def LWE_EncodeOp : LWE_Op<"encode", [
 }
 
 def LWE_TrivialEncryptOp: LWE_Op<"trivial_encrypt", [
-    Pure,
     EncodingsMatch<"input", "LWEPlaintextType", "output", "LWECiphertextType">]> {
   let summary = "Create a trivial encryption of a plaintext.";
 
@@ -106,54 +113,43 @@ def LWE_TrivialEncryptOp: LWE_Op<"trivial_encrypt", [
   let hasVerifier = 1;
 }
 
-def LWE_AddOp : LWE_Op<"add", [
-    Pure, Commutative, SameOperandsAndResultType]> {
+def LWE_AddOp : LWE_BinOp<"add", [SameOperandsAndResultType,Commutative]> {
+  let arguments = (ins LWECiphertext:$lhs, LWECiphertext:$rhs);
+  let results = (outs LWECiphertext:$output);
   let summary = "Add two LWE ciphertexts";
-  let arguments = (ins LWECiphertextLike:$lhs, LWECiphertextLike:$rhs);
-  let results = (outs LWECiphertextLike:$output);
-  let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
-def LWE_RAddOp : LWE_Op<"radd", [
-    Pure, Commutative, SameOperandsAndResultType]> {
+def LWE_RAddOp : LWE_BinOp<"radd", [SameOperandsAndResultType,Commutative]> {
   let summary = "Add two RLWE ciphertexts";
-  let arguments = (ins RLWECiphertextLike:$lhs, RLWECiphertextLike:$rhs);
-  let results = (outs RLWECiphertextLike:$output);
-  let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
-def LWE_RSubOp : LWE_Op<"rsub", [
-    Pure, Commutative, SameOperandsAndResultType]> {
+def LWE_RSubOp : LWE_BinOp<"rsub", [SameOperandsAndResultType]> {
   let summary = "Subtract two RLWE ciphertexts";
-  let arguments = (ins RLWECiphertextLike:$lhs, RLWECiphertextLike:$rhs);
-  let results = (outs RLWECiphertextLike:$output);
-  let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
-def LWE_RNegateOp : LWE_Op<"rnegate", [
-    Pure, Commutative, SameOperandsAndResultType]> {
+def LWE_RMulOp : LWE_BinOp<"rmul", [SameTypeOperands,InferTypeOpAdaptor, Commutative]> {
+  let summary = "Multiplies two RLWE ciphertexts";
+  let assemblyFormat = [{
+    operands attr-dict `:`  functional-type(operands, results)
+  }];
+  let hasVerifier = 1;
+}
+
+def LWE_RNegateOp : LWE_Op<"rnegate", [SameOperandsAndResultType, ElementwiseMappable]> {
   let summary = "Negate a RLWE ciphertexts";
   let arguments = (ins RLWECiphertextLike:$input);
   let results = (outs RLWECiphertextLike:$output);
   let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
-def LWE_RMulOp : LWE_Op<"rmul", [
-    Pure, Commutative, SameOperandsAndResultRings, SameTypeOperands, InferTypeOpAdaptor]> {
-  let summary = "Multiplies two RLWE ciphertexts";
-  let arguments = (ins RLWECiphertext:$lhs, RLWECiphertext:$rhs);
-  let results = (outs RLWECiphertext:$output);
-  let hasVerifier = 1;
-}
-
-def LWE_MulScalarOp : LWE_Op<"mul_scalar", [
-    Pure, Commutative, AllTypesMatch<["ciphertext", "output"]>]> {
+def LWE_MulScalarOp : LWE_Op<"mul_scalar", [ElementwiseMappable,
+    AllTypesMatch<["ciphertext", "output"]>]> {
   let summary = "Multiply an LWE ciphertext by a scalar";
   let arguments = (ins LWECiphertextLike:$ciphertext, AnyInteger:$scalar);
   let results = (outs LWECiphertextLike:$output);
 }
 
-def LWE_RLWEEncodeOp : LWE_Op<"rlwe_encode", [Pure, HasEncoding<"output", "encoding", "RLWEPlaintextType">]> {
+def LWE_RLWEEncodeOp : LWE_Op<"rlwe_encode", [HasEncoding<"output", "encoding", "RLWEPlaintextType">]> {
   let summary = "Encode an integer to yield an RLWE plaintext";
   let description = [{
     Encode an integer to yield an RLWE plaintext.
@@ -178,8 +174,7 @@ def LWE_RLWEEncodeOp : LWE_Op<"rlwe_encode", [Pure, HasEncoding<"output", "encod
   let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` qualified(type($output))";
 }
 
-def LWE_RLWEDecodeOp : LWE_Op<"rlwe_decode", [
-    Pure, HasEncoding<"input", "encoding", "RLWEPlaintextType">]> {
+def LWE_RLWEDecodeOp : LWE_Op<"rlwe_decode", [HasEncoding<"input", "encoding", "RLWEPlaintextType">]> {
   let summary = "Decode an RLWE plaintext to an underlying type";
 
   let arguments = (ins
@@ -192,7 +187,7 @@ def LWE_RLWEDecodeOp : LWE_Op<"rlwe_decode", [
   let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` qualified(type($output))";
 }
 
-def LWE_RLWEEncryptOp : LWE_Op<"rlwe_encrypt", [Pure,
+def LWE_RLWEEncryptOp : LWE_Op<"rlwe_encrypt", [
     EncodingsMatch<"input", "RLWEPlaintextType", "output", "RLWECiphertextType">]> {
   let summary = "Encrypt an RLWE plaintext to a RLWE ciphertext";
   let description = [{
@@ -207,7 +202,7 @@ def LWE_RLWEEncryptOp : LWE_Op<"rlwe_encrypt", [Pure,
   let hasVerifier = 1;
 }
 
-def LWE_RLWEDecryptOp : LWE_Op<"rlwe_decrypt", [Pure,
+def LWE_RLWEDecryptOp : LWE_Op<"rlwe_decrypt", [
     EncodingsMatch<"input", "RLWECiphertextType", "output", "RLWEPlaintextType">,
     RlweParametersMatch<"secret_key", "RLWESecretKeyType", "input", "RLWECiphertextType">]> {
   let summary = "Decrypt an RLWE ciphertext to a RLWE plaintext";
@@ -222,7 +217,7 @@ def LWE_RLWEDecryptOp : LWE_Op<"rlwe_decrypt", [Pure,
   let results = (outs RLWEPlaintext:$output);
 }
 
-def ReinterpretUnderlyingTypeOp : LWE_Op<"reinterpret_underlying_type", [Pure]> {
+def ReinterpretUnderlyingTypeOp : LWE_Op<"reinterpret_underlying_type", []> {
   let summary = "A placeholder cast from one ciphertext type to another";
   let description = [{
     The `cast` op is thus used to translate `underlying_type` between


### PR DESCRIPTION
Small PR that does two things:
* refactors to declare more things in the "parent" tablegen classes (`LWE_Op` and `LWE_BinOp`)
* cleans up some incorrect traits on the RLWE operations (e.g., `lwe.rsubtract` should not have been `Commutative` 🙈)\

Should not have any conflicts with #876, which (so far) doesn't touch the `LWEOps.td` file.