### PR TITLE
[mod_arith] add reduce op

### DIFF
--- a/lib/Conversion/ModArithToArith/ModArithToArith.cpp
+++ b/lib/Conversion/ModArithToArith/ModArithToArith.cpp
@@ -17,10 +17,11 @@ namespace mod_arith {
 /// Returns a possibly extended modulus necessary to compute the given operation
 /// without overflow.
 template <typename ValueOrOpResult>
-TypedAttr modulusHelper(IntegerAttr mod, ValueOrOpResult op, bool mul = false) {
+TypedAttr modulusHelper(IntegerAttr mod, ValueOrOpResult op, bool mul = false,
+                        bool reduce = false) {
   auto width = getElementTypeOrSelf(op).getIntOrFloatBitWidth();
   auto modWidth = (mod.getValue() - 1).getActiveBits();
-  width = std::max(width, mul ? 2 * modWidth : modWidth + 1);
+  width = !reduce ? std::max(width, mul ? 2 * modWidth : modWidth + 1) : width;
   auto intType = IntegerType::get(op.getContext(), width);
   auto truncmod = mod.getValue().zextOrTrunc(width);
   if (auto st = mlir::dyn_cast<ShapedType>(op.getType())) {

--- a/lib/Conversion/ModArithToArith/ModArithToArith.td
+++ b/lib/Conversion/ModArithToArith/ModArithToArith.td
@@ -42,6 +42,7 @@ def HasEnoughSpaceMul: Constraint<CPred<"llvm::cast<IntegerType>(getElementTypeO
 
 def CastModulusAttributeAddSub : NativeCodeCall<"modulusHelper($0,$1,false)">;
 def CastModulusAttributeMul : NativeCodeCall<"modulusHelper($0,$1,true)">;
+def CastModulusAttributeReduce : NativeCodeCall<"modulusHelper($0,$1,false,false)">;
 
 def ConvertAddSimple : Pattern<
   (ModArith_AddOp:$op $x, $y, $mod),
@@ -150,6 +151,14 @@ def ConvertMac : Pattern<
       (Arith_ExtUIOp:$extacc $acc, (returnType $newmod)), DefOverflow),
     (Arith_TruncIOp:$res
       (Arith_RemUIOp $add, $newmod))
+  ]
+>;
+
+def ConvertReduce : Pattern<
+  (ModArith_ReduceOp $x, $mod),
+  [
+    (Arith_ConstantOp:$newmod (CastModulusAttributeAddSub $mod, $x)),
+    (Arith_RemUIOp (Arith_AddIOp (Arith_RemSIOp $x, $newmod), $newmod, DefOverflow), $newmod)
   ]
 >;
 

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -56,6 +56,25 @@ def ModArith_MacOp : ModArith_Op<"mac", [SameOperandsAndResultType, Pure, Elemen
   let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
+def ModArith_ReduceOp : ModArith_Op<"reduce", [SameOperandsAndResultType]> {
+  let summary = "reduce a signed integer to its congruence modulo equivalent";
+
+  let description = [{
+    `mod_arith.reduce x {modulus = q}` computes $y \in [0, q)$ such that
+    $x \equiv y \mod n$.
+
+    Note this will interpret `x` as a signed integer. For an unsigned integer,
+    equivalent functionality is: `y = arith.remui x`.
+  }];
+
+  let arguments = (ins
+    SignlessIntegerLike:$input,
+    APIntAttr:$modulus
+  );
+  let results = (outs SignlessIntegerLike:$output);
+  let assemblyFormat = "operands attr-dict `:` type($output)";
+}
+
 def ModArith_BarrettReduceOp : ModArith_Op<"barrett_reduce", [SameOperandsAndResultType]> {
   let summary = "Compute the first step of the Barrett reduction.";
   let description = [{

--- a/tests/mod_arith/mod-arith-to-arith.mlir
+++ b/tests/mod_arith/mod-arith-to-arith.mlir
@@ -229,6 +229,34 @@ func.func @test_lower_mac_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>, %acc : t
 
 // -----
 
+// CHECK-LABEL: @test_lower_reduce
+// CHECK-SAME: (%[[ARG:.*]]: [[TENSOR_TYPE:.*]]) -> [[TENSOR_TYPE]] {
+func.func @test_lower_reduce(%arg : tensor<4xi8>) -> tensor<4xi8> {
+  // CHECK: %[[CMOD:.*]] = arith.constant dense<17> : [[TENSOR_TYPE]]
+
+  // CHECK: %[[MOD:.*]] = arith.remsi %[[ARG]], %[[CMOD]] : [[TENSOR_TYPE]]
+  // CHECK: %[[SHIFT:.*]] = arith.addi %[[MOD]], %[[CMOD]] : [[TENSOR_TYPE]]
+  // CHECK: %[[RES:.*]] = arith.remui %[[SHIFT]], %[[CMOD]] : [[TENSOR_TYPE]]
+  %res = mod_arith.reduce %arg { modulus = 17 } : tensor<4xi8>
+  return %res : tensor<4xi8>
+}
+
+// -----
+
+// CHECK-LABEL: @test_lower_reduce_int
+// CHECK-SAME: (%[[ARG:.*]]: [[INT_TYPE:.*]]) -> [[INT_TYPE]] {
+func.func @test_lower_reduce_int(%arg : i8) -> i8 {
+  // CHECK: %[[CMOD:.*]] = arith.constant 17 : [[INT_TYPE]]
+
+  // CHECK: %[[MOD:.*]] = arith.remsi %[[ARG]], %[[CMOD]] : [[INT_TYPE]]
+  // CHECK: %[[SHIFT:.*]] = arith.addi %[[MOD]], %[[CMOD]] : [[INT_TYPE]]
+  // CHECK: %[[RES:.*]] = arith.remui %[[SHIFT]], %[[CMOD]] : [[INT_TYPE]]
+  %res = mod_arith.reduce %arg { modulus = 17 } : i8
+  return %res : i8
+}
+
+// -----
+
 // CHECK-LABEL: @test_lower_subifge
 // CHECK-SAME: (%[[LHS:.*]]: [[TENSOR_TYPE:.*]], %[[RHS:.*]]: [[TENSOR_TYPE]]) -> [[TENSOR_TYPE]] {
 func.func @test_lower_subifge(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {

--- a/tests/mod_arith/syntax.mlir
+++ b/tests/mod_arith/syntax.mlir
@@ -32,6 +32,11 @@ func.func @test_arith_syntax() {
   %mac = mod_arith.mac %c5, %c6, %c4 { modulus = 17 } : i10
   %mac_vec = mod_arith.mac %c_vec, %c_vec2, %c_vec3 { modulus = 17 } : tensor<4xi10>
 
+  // CHECK: mod_arith.reduce
+  // CHECK: mod_arith.reduce
+  %reduce = mod_arith.reduce %c4 { modulus = 17 } : i10
+  %reduce_vec = mod_arith.reduce %c_vec { modulus = 17 } : tensor<4xi10>
+
   // CHECK: mod_arith.barrett_reduce
   // CHECK: mod_arith.barrett_reduce
   %barrett = mod_arith.barrett_reduce %zero { modulus = 17 } : i10


### PR DESCRIPTION
    - add a reduce operation which will take in an arbitrary integer, x,
      and compute y in [0, q) such that y is congruent to x modulo q

    - includes a naive lowering of the op (does not take into account
      operand ranges)