### PR TITLE
Refactoring per issue #449

### DIFF
--- a/lib/Target/TfheRust/TfheRustEmitter.cpp
+++ b/lib/Target/TfheRust/TfheRustEmitter.cpp
@@ -703,15 +703,12 @@ void TfheRustEmitter::printLoadOp(memref::LoadOp op) {
   os << variableNames->getNameForValue(op.getMemref());
   if (dyn_cast_or_null<memref::GetGlobalOp>(op.getMemRef().getDefiningOp())) {
     // Global arrays are 1-dimensional, so flatten the index
-    // TODO(#449): Share with Verilog Emitter.
-    const auto [strides, offset] =
-        getStridesAndOffset(cast<MemRefType>(op.getMemRefType()));
-    os << "[" << std::to_string(offset);
-    for (size_t i = 0; i < strides.size(); ++i) {
-      os << llvm::formatv(" + {0} * {1}",
-                          variableNames->getNameForValue(op.getIndices()[i]),
-                          strides[i]);
-    }
+
+    os << "["
+       << flattenIndexExpressionSOP(
+              op.getMemRefType(), op.getIndices(), [&](Value value) {
+                return variableNames->getNameForValue(value);
+              });
     os << "]";
   } else if (isa<BlockArgument>(op.getMemRef())) {
     // This is a block argument array.

--- a/lib/Target/Utils.cpp
+++ b/lib/Target/Utils.cpp
@@ -67,5 +67,19 @@ std::string flattenIndexExpression(
   return accum;
 }
 
+// sum of products
+std::string flattenIndexExpressionSOP(
+    MemRefType memRefType, ValueRange indices,
+    std::function<std::string(Value)> valueToString) {
+  const auto [strides, offset] = getStridesAndOffset(memRefType);
+  std::string accum = std::to_string(offset);
+  for (int i = 0; i < indices.size(); ++i) {
+    accum = llvm::formatv("{2} + {0} * {1}", valueToString(indices[i]),
+                          strides[i], accum);
+  }
+
+  return accum;
+}
+
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Target/Utils.h
+++ b/lib/Target/Utils.h
@@ -37,6 +37,11 @@ std::string flattenIndexExpression(
     MemRefType memRefType, ValueRange indices,
     std::function<std::string(Value)> valueToString);
 
+// sum of products
+std::string flattenIndexExpressionSOP(
+    MemRefType memRefType, ValueRange indices,
+    std::function<std::string(Value)> valueToString);
+
 }  // namespace heir
 }  // namespace mlir
 


### PR DESCRIPTION
Refactoring per issue #449
#449: cleanup: share components of verilog emitter and tfhe-rs emitter;
    - the Verilog code is refactored with TfheRustBool; however the TfheRust code is different in being a sum of products
      which is handled here.
Fixes #449