### PR TITLE
Move int64_t casting from translate to opt bgv_to_openfhe

### DIFF
--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -45,6 +45,7 @@ class OpenFhePkeEmitter {
   // Functions for printing individual ops
   LogicalResult printOperation(::mlir::ModuleOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  LogicalResult printOperation(::mlir::arith::ExtSIOp op);
   LogicalResult printOperation(::mlir::arith::IndexCastOp op);
   LogicalResult printOperation(::mlir::func::FuncOp op);
   LogicalResult printOperation(::mlir::func::ReturnOp op);

--- a/tests/bgv_to_openfhe/cast.mlir
+++ b/tests/bgv_to_openfhe/cast.mlir
@@ -1,0 +1,42 @@
+// RUN: heir-opt --bgv-to-openfhe %s | FileCheck %s
+
+#encoding_i16 = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
+#encoding_i32 = #lwe.polynomial_evaluation_encoding<cleartext_start = 32, cleartext_bitwidth = 32>
+#encoding_i64 = #lwe.polynomial_evaluation_encoding<cleartext_start = 64, cleartext_bitwidth = 64>
+
+#my_poly = #polynomial.int_polynomial<1 + x**32>
+
+#ring = #polynomial.ring<coefficientType = i32, coefficientModulus = 463187969 : i32, polynomialModulus = #my_poly>
+#params = #lwe.rlwe_params<ring = #ring>
+
+!pt_i16 = !lwe.rlwe_plaintext<encoding = #encoding_i16, ring = #ring, underlying_type = tensor<32xi16>>
+!pt_i32 = !lwe.rlwe_plaintext<encoding = #encoding_i32, ring = #ring, underlying_type = tensor<32xi32>>
+!pt_i64 = !lwe.rlwe_plaintext<encoding = #encoding_i64, ring = #ring, underlying_type = tensor<32xi64>>
+
+!pk = !lwe.rlwe_public_key<rlwe_params = #params>
+
+//The function is adapted from the BGV form of the simple_sum.mlir test
+// CHECK-LABEL: @encode_i16
+func.func @encode_i16(%arg0: tensor<32xi16>, %arg1: !pk) -> !pt_i16 {
+  %0 = lwe.rlwe_encode %arg0 {encoding = #encoding_i16, ring = #ring} : tensor<32xi16> -> !pt_i16
+  // CHECK:     %[[v0:.*]] = arith.extsi %arg0 : tensor<32xi16> to tensor<32xi64>
+  // CHECK:     lwe.rlwe_encode %[[v0]] {{.*}} : tensor<32xi64> -> !lwe.rlwe_plaintext{{.*}} tensor<32xi16>>
+  // CHECK-NOT: lwe.rlwe_encode {{.*}} : tensor<32xi16> -> !lwe.rlwe_plaintext{{.*}} tensor<32xi16>>
+  return %0 : !pt_i16
+}
+
+// CHECK-LABEL: @encode_i32
+func.func @encode_i32(%arg0: tensor<32xi32>, %arg1: !pk) -> !pt_i32 {
+  %0 = lwe.rlwe_encode %arg0 {encoding = #encoding_i32, ring = #ring} : tensor<32xi32> -> !pt_i32
+  // CHECK:     %[[v0:.*]] = arith.extsi %arg0 : tensor<32xi32> to tensor<32xi64>
+  // CHECK:     lwe.rlwe_encode %[[v0]] {{.*}} : tensor<32xi64> -> !lwe.rlwe_plaintext{{.*}} tensor<32xi32>>
+  // CHECK-NOT: lwe.rlwe_encode {{.*}} : tensor<32xi32> -> !lwe.rlwe_plaintext{{.*}} tensor<32xi32>>
+  return %0 : !pt_i32
+}
+
+// CHECK-LABEL: @encode_i64
+func.func @encode_i64(%arg0: tensor<32xi64>, %arg1: !pk) -> !pt_i64 {
+  %0 = lwe.rlwe_encode %arg0 {encoding = #encoding_i64, ring = #ring} : tensor<32xi64> -> !pt_i64
+  // CHECK:     lwe.rlwe_encode {{.*}} : tensor<32xi64> -> !lwe.rlwe_plaintext{{.*}} tensor<32xi64>>
+  return %0 : !pt_i64
+}

--- a/tests/openfhe/ops.mlir
+++ b/tests/openfhe/ops.mlir
@@ -19,6 +19,13 @@ module {
     return
   }
 
+  // CHECK-LABEL: func @test_encode
+  func.func @test_encode(%arg0: tensor<32xi3>, %pt : !pt, %pk: !pk) {
+    %0 = arith.extsi %arg0 : tensor<32xi3> to tensor<32xi64>
+    %out = lwe.rlwe_encode %0 {encoding=#encoding, ring=#ring} : tensor<32xi64> -> !pt
+    return
+  }
+
   // CHECK-LABEL: func @test_negate
   func.func @test_negate(%cc : !cc, %pt : !pt, %pk: !pk) {
     %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct


### PR DESCRIPTION
OpenFHE `MakePackedPlaintext` function used for encoding
accepts `std::vector<int64_t>` as input requiring casting
for smaller sized ints. The casting is moved to the `bgv_to_openfhe`
pass by emitting an `arith.extsi` cast op in the higher level.
This simplifies the emission and better represents openfhe dialect
constraints.

Resolves #647
