### PR TITLE
Fix warnings with mismatched integral types

### DIFF
--- a/lib/Conversion/MemrefToArith/Utils.cpp
+++ b/lib/Conversion/MemrefToArith/Utils.cpp
@@ -23,7 +23,7 @@ std::optional<std::vector<uint64_t>> materialize(
   affine::AffineValueMap thisMap;
   access.getAccessMap(&thisMap);
   std::vector<uint64_t> accessIndices;
-  for (auto i = 0; i < access.getRank(); ++i) {
+  for (size_t i = 0; i < access.getRank(); ++i) {
     // The access indices of the global memref *must* be constant,
     // meaning that they cannot be a variable access (for example, a
     // loop index) or symbolic, for example, an input symbol.
@@ -66,7 +66,7 @@ llvm::SmallVector<int64_t> unflattenIndex(int64_t index,
 int64_t flattenIndex(const llvm::ArrayRef<int64_t> indices,
                      const llvm::ArrayRef<int64_t> strides, int64_t offset) {
   int64_t index = offset;
-  for (int i = 0; i < strides.size(); ++i) {
+  for (size_t i = 0; i < strides.size(); ++i) {
     index += indices[i] * strides[i];
   }
   return index;

--- a/lib/Target/OpenFhePke/OpenFheUtils.cpp
+++ b/lib/Target/OpenFhePke/OpenFheUtils.cpp
@@ -70,7 +70,7 @@ FailureOr<Value> getContextualCryptoContext(Operation *op) {
                             .front()
                             .getArguments()
                             .front();
-  if (!cryptoContext.getType().isa<openfhe::CryptoContextType>()) {
+  if (!mlir::isa<openfhe::CryptoContextType>(cryptoContext.getType())) {
     return op->emitOpError()
            << "Found op in a function without a crypto context argument.";
   }

--- a/lib/Target/Verilog/VerilogEmitter.cpp
+++ b/lib/Target/Verilog/VerilogEmitter.cpp
@@ -91,7 +91,7 @@ void printRawDataFromAttr(DenseElementsAttr attr, raw_ostream &os) {
   int32_t hexWidth = iType.getWidth() / 4;
   os << iType.getWidth() * attr.size() << "'h";
   auto attrIt = attr.value_end<APInt>();
-  for (uint64_t i = 0; i < attr.size(); ++i) {
+  for (size_t i = 0; i < (size_t)attr.size(); ++i) {
     llvm::SmallString<40> s;
     (*--attrIt).toString(s, 16, false);
     os << std::string(hexWidth - s.str().size(), '0') << s;
@@ -955,7 +955,7 @@ LogicalResult VerilogEmitter::emitWireDeclaration(OpResult result) {
 }
 
 StringRef VerilogEmitter::getOrCreateOutputWireName(int resultIndex) {
-  if (resultIndex < output_wire_names_.size()) {
+  if (resultIndex < (int)output_wire_names_.size()) {
     return output_wire_names_[resultIndex];
   }
   output_wire_names_.push_back(
@@ -964,7 +964,7 @@ StringRef VerilogEmitter::getOrCreateOutputWireName(int resultIndex) {
 }
 
 StringRef VerilogEmitter::getOutputWireName(int resultIndex) {
-  if (resultIndex < output_wire_names_.size()) {
+  if (resultIndex < (int)output_wire_names_.size()) {
     return output_wire_names_[resultIndex];
   }
   llvm_unreachable(

--- a/lib/Transforms/OperationBalancer/OperationBalancer.cpp
+++ b/lib/Transforms/OperationBalancer/OperationBalancer.cpp
@@ -55,7 +55,7 @@ OpType recursiveProduceBalancedTree(OpBuilder &builder, Location &loc,
     rightOperands.reserve(flattenedOperands.size() - leftSize);
 
     for (size_t i = 0; i < flattenedOperands.size(); i++) {
-      if (i < leftSize) {
+      if (i < (size_t)leftSize) {
         leftOperands.push_back(flattenedOperands[i]);
       } else {
         rightOperands.push_back(flattenedOperands[i]);


### PR DESCRIPTION
- Fix warnings with mismatched integral types
- make check-heir continues passing locally
- Still few more instances of warnings are present but in next PR perhaps
