### PR TITLE
docs: fix hugo shortcodes with mdformat

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -30,8 +30,8 @@ HEIR is built in the [MLIR](https://mlir.llvm.org/) framework.
 For an overview of the project's goals, see
 [our talk at FHE.org](https://www.youtube.com/watch?v=kqDFdKUTNA4).
 
-To see the dialects and possible flows, take a look at the diagram below: {{\<
-figure src="/images/dialects.svg" link="/images/dialects.svg" >}}
+To see the dialects and possible flows, take a look at the diagram below: {{%
+figure src="/images/dialects.svg" link="/images/dialects.svg" %}}
 
 ## Project Goals
 

--- a/docs/content/en/community/_index.md
+++ b/docs/content/en/community/_index.md
@@ -3,7 +3,7 @@ title: Community
 menu: {main: {weight: 40}}
 ---
 
-{{\< blocks/section color="white" type="row" >}}
+{{% blocks/section color="white" type="row" %}}
 
 {{% blocks/feature icon="fa-brands fa-github" title="Contribute" %}} Use
 [GitHub](https://github.com/google/heir) for pull requests. New users are always
@@ -20,6 +20,6 @@ channel. {{% /blocks/feature %}}
 design meetings to discuss project direction (see calendar below). {{%
 /blocks/feature %}}
 
-{{\< /blocks/section >}}
+{{% /blocks/section %}}
 
 <iframe src="https://calendar.google.com/calendar/embed?src=c85ecb3cda4bfb7daa3da95d5aeb19672930501b49d17896e65fa3f963f17a80%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0; display:block; margin: 0 auto" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/docs/content/en/docs/contributing.md
+++ b/docs/content/en/docs/contributing.md
@@ -162,8 +162,9 @@ Notable aspects:
   approved migrations (e.g., migrating HEIR to support changes in MLIR or
   abseil).
 
-{{\< figure title="A diagram summarizing the copybara flow for HEIR internally
-to Google" src="/images/heir-copybara.png" link="/images/heir-copybara.png" >}}
+{{% figure src="/images/heir-copybara.png" link="/images/heir-copybara.png"
+title="A diagram summarizing the copybara flow for HEIR internally to Google"
+%}}
 
 ### Why bother with Copybara?
 


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/956

mdformat escaped angle brackets which were delimiters for hugo shortcodes.

changed the delimiter to `%` and it seems to work -e.g. no more braces in the community page:
![image](https://github.com/user-attachments/assets/d37084d3-50bf-4327-bf8d-1c237de7ce76)


