### PR TITLE
Use rotation analysis for extraction in rotate-and-reduce transform

### DIFF
--- a/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
+++ b/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
@@ -7,6 +7,7 @@
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
 #include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
@@ -18,11 +19,14 @@ namespace rotation_analysis {
 
 void RotationAnalysis::run(Operation *op) {
   op->walk<WalkOrder::PreOrder>([&](Operation *op) {
-    // If the op has no tensor results and no regions, then there's nothing to
-    // do. The operation may consume a tensor but cannot further reduce it.
+    // If the op has no tensor results and no regions and no operand
+    // with existing partial reduction, then there's nothing to do.
     if (op->getNumRegions() == 0 &&
-        llvm::none_of(op->getResultTypes(), [](Type type) {
-          return mlir::isa<RankedTensorType>(type);
+        llvm::none_of(
+            op->getResultTypes(),
+            [](Type type) { return mlir::isa<RankedTensorType>(type); }) &&
+        llvm::none_of(op->getOperands(), [&](Value operand) {
+          return rootToPartialReductions.contains(operand);
         })) {
       return WalkResult::advance();
     }
@@ -83,12 +87,62 @@ void RotationAnalysis::run(Operation *op) {
                 PartialReduction::rotate(reduction, shiftValue, result));
           }
         })
+        .Case<tensor::ExtractOp>([&](auto extractOp) {
+          LLVM_DEBUG({ llvm::dbgs() << "Visiting: " << *op << "\n"; });
+
+          if (extractOp.getIndices().size() != 1) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "Not replacing op due to >1D input tensor\n");
+            return;
+          }
+
+          const dataflow::Lattice<dataflow::ConstantValue> *indexLattice =
+              solver.lookupState<dataflow::Lattice<dataflow::ConstantValue>>(
+                  extractOp.getIndices().front());
+
+          if (indexLattice) {
+            LLVM_DEBUG(llvm::dbgs() << "At " << extractOp
+                                    << " SCCP analysis gives lattice of "
+                                    << *indexLattice << "\n");
+          }
+
+          // If the rotation index can't be statically determined, we can't
+          // propagate anything through the IR.
+          if (!indexLattice || indexLattice->getValue().isUninitialized() ||
+              !indexLattice->getValue().getConstantValue()) {
+            LLVM_DEBUG(
+                llvm::dbgs()
+                << "At " << extractOp
+                << " can't statically determine constant insertion index\n");
+            return;
+          }
+          auto indexValue = mlir::dyn_cast<IntegerAttr>(
+                                indexLattice->getValue().getConstantValue())
+                                .getInt();
+
+          // For each partial reduction the tensor operand is a root of,
+          // rotate the accessed indices appropriately.
+          Value tensor = extractOp.getTensor();
+          Value result = extractOp.getResult();
+          for (const auto &reduction : rootToPartialReductions[tensor]) {
+            addPartialReduction(
+                PartialReduction::rotate(reduction, indexValue, result));
+          }
+        })
         .Case<arith::AddIOp, arith::MulIOp>([&](auto arithOp) {
           LLVM_DEBUG({ llvm::dbgs() << "Visiting: " << arithOp << "\n"; });
           Value lhs = arithOp.getLhs();
           Value rhs = arithOp.getRhs();
           Value newRoot = arithOp.getResult();
           OperationName opName = arithOp.getOperation()->getName();
+
+          // TODO(#522): support these non-tensor-extract operands by
+          // saving the values, and applying them again to the final
+          // result.
+          if (!rootToPartialReductions.contains(lhs) ||
+              !rootToPartialReductions.contains(rhs)) {
+            return;
+          }
 
           // This is inefficient, but what can we do better here? I suspect a
           // better approach may be to identify cases in which only one of these

--- a/lib/Analysis/RotationAnalysis/RotationAnalysis.h
+++ b/lib/Analysis/RotationAnalysis/RotationAnalysis.h
@@ -253,6 +253,10 @@ class RotationAnalysis {
     return rootToPartialReductions.at(value);
   }
 
+  const bool containsRootedReductions(Value value) const {
+    return rootToPartialReductions.contains(value);
+  }
+
  private:
   // The constant propagation analysis used to determine the static values of
   // rotation shifts.


### PR DESCRIPTION
Fixes #523. Trying to get familiar with heir with a good first issue.

Turned out the `PartialReduction` from #575 already took extraction reduction tree into account so a simple rewriting makes things work.

Interestingly, now a mixture of rotation and extraction can work, check tests for example.

In `RotationAnalysis.cpp`, `.Case<tensor::ExtractOp>` shares many logic with `.Case<tensor_ext::RotateOp>`, it can be further reused if you ask to do but that would be harder to understand.

As for the TODO of #522, I think it can be solved by storing those non-tensor-extract operands in PartialReduction struct and add them back when we build new ops. Could be done in further PR.