### PR TITLE
Save non-tensor scalar value in rotation analysis and apply later

### DIFF
--- a/lib/Dialect/Secret/IR/SecretPatterns.cpp
+++ b/lib/Dialect/Secret/IR/SecretPatterns.cpp
@@ -560,7 +560,9 @@ LogicalResult HoistPlaintextOps::matchAndRewrite(
     if (isa<YieldOp>(op)) {
       return false;
     }
-    // complex op
+    // Conservatively preserve a complex op with a nested region
+    // This could be a replaced with a recursive call to check that all of the
+    // regions' operations can be hoisted.
     if (op.getNumRegions() != 0) {
       return false;
     }

--- a/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
+++ b/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
@@ -65,10 +65,12 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
       auto extractOp = b.create<tensor::ExtractOp>(
           finalOp->getResult(0),
           b.create<arith::ConstantIndexOp>(0).getResult());
-      op->replaceAllUsesWith(extractOp);
-    } else {
-      op->replaceAllUsesWith(finalOp);
+      finalOp = extractOp;
     }
+    for (auto value : reduction.getSavedValues()) {
+      finalOp = b.create<ArithOp>(finalOp->getResult(0), value);
+    }
+    op->replaceAllUsesWith(finalOp);
     LLVM_DEBUG(llvm::dbgs() << "Post-replacement: " << *parentOp << "\n");
   }
 

--- a/tests/heir_simd_vectorizer/simple_sum.mlir
+++ b/tests/heir_simd_vectorizer/simple_sum.mlir
@@ -1,4 +1,6 @@
-// RUN: heir-opt --secretize=entry-function=simple_sum --wrap-generic --canonicalize --cse \
+// RUN: heir-opt --secretize=entry-function=simple_sum \
+// RUN:   --secretize=entry-function=simple_sum_nested \
+// RUN:   --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
 // Sum all entries of a tensor into a single scalar
@@ -12,6 +14,33 @@ func.func @simple_sum(%arg0: tensor<32xi16>) -> i16 {
   %0 = affine.for %i = 0 to 32 iter_args(%sum_iter = %c0_si16) -> i16 {
     %1 = tensor.extract %arg0[%i] : tensor<32xi16>
     %2 = arith.addi %1, %sum_iter : i16
+    affine.yield %2 : i16
+  }
+  return %0 : i16
+}
+
+// Sum all entries of 4 tensors into a single scalar
+// CHECK-LABEL: @simple_sum_nested
+// CHECK: secret.generic
+// CHECK-COUNT-20: tensor_ext.rotate
+// CHECK-NOT: tensor_ext.rotate
+// CHECK: tensor.extract
+// CHECK-NOT: tensor.extract
+func.func @simple_sum_nested(%arg0: tensor<32xi16>, %arg1: tensor<32xi16>, %arg2: tensor<32xi16>, %arg3: tensor<32xi16>) -> i16 {
+  %c0_i16 = arith.constant 0 : i16
+  %expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
+  %expanded_0 = tensor.expand_shape %arg1 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
+  %expanded_1 = tensor.expand_shape %arg2 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
+  %expanded_2 = tensor.expand_shape %arg3 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
+  %concat = tensor.concat dim(0) %expanded, %expanded_0, %expanded_1, %expanded_2 : (tensor<1x32xi16>, tensor<1x32xi16>, tensor<1x32xi16>, tensor<1x32xi16>) -> tensor<4x32xi16>
+  %0 = affine.for %arg4 = 0 to 4 iter_args(%arg5 = %c0_i16) -> (i16) {
+    %extracted_slice = tensor.extract_slice %concat[%arg4, 0] [1, 32] [1, 1] : tensor<4x32xi16> to tensor<32xi16>
+    %1 = affine.for %arg6 = 0 to 32 iter_args(%arg7 = %c0_i16) -> (i16) {
+      %extracted = tensor.extract %extracted_slice[%arg6] : tensor<32xi16>
+      %3 = arith.addi %extracted, %arg7 : i16
+      affine.yield %3 : i16
+    }
+    %2 = arith.addi %1, %arg5 : i16
     affine.yield %2 : i16
   }
   return %0 : i16


### PR DESCRIPTION
Partially address #522

As a follow up to #968

Reduction with scalar value mixed in can be handled now. The unhandled case now is the sum of rotated tensors

For example, fully rotate arg0 and fully rotate arg1, then sum all the tensors to one tensor  (arg0 + arg0_r1 + ... + arg0_r7 + arg1 + arg1_r1 + ...) ; current analysis would not optimize the second reduction as the sum process will have a middle point (arg0_r7 + arg1) where PartialReduction can not propagate.

Interestinly, extract all values then sum them up would work now. This might be helpful in simple_sum with multple tensors when loop unrolling as the log reduction tree structure is not present.

A toy example here, though it can not be secretized (so did not put it in tests; believe it's the high rank tensor issue; manually unroll the first layer and use a %sum to sum them up might be some practical code though)

Apply
```
--full-loop-unroll --rotate-and-reduce --cse --canonicalize
```
to this snippet
```mlir
func.func @simple_sum_nested(%arg0: tensor<32xi16>, %arg1: tensor<32xi16>, %arg2: tensor<32xi16>, %arg3: tensor<32xi16>) -> i16 {
  %c0 = arith.constant 0 : index
  %c0_si16 = arith.constant 0 : i16
  %arg0_expanded = tensor.expand_shape %arg0 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
  %arg1_expanded = tensor.expand_shape %arg1 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
  %arg2_expanded = tensor.expand_shape %arg2 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
  %arg3_expanded = tensor.expand_shape %arg3 [[0, 1]] output_shape [1, 32] : tensor<32xi16> into tensor<1x32xi16>
  %tensor = tensor.concat dim(0) %arg0_expanded, %arg1_expanded, %arg2_expanded, %arg3_expanded: (tensor<1x32xi16>, tensor<1x32xi16>, tensor<1x32xi16>, tensor<1x32xi16>) -> tensor<4x32xi16>
  %0 = affine.for %i = 0 to 4 iter_args(%sum_iter = %c0_si16) -> i16 {
    %1 = tensor.extract_slice %tensor[%i, 0][1, 32][1, 1] : tensor<4x32xi16> to tensor<32xi16>
    %2 = affine.for %j = 0 to 32 iter_args(%sum_jter = %c0_si16) -> i16 {
      %3 = tensor.extract %1[%j] : tensor<32xi16>
      %4 = arith.addi %3, %sum_jter : i16
      affine.yield %4 : i16
    }
    %5 = arith.addi %2, %sum_iter : i16
    affine.yield %5 : i16
  }
  return %0 : i16
}
```
produces
```mlir
    %extracted_slice = tensor.extract_slice %concat[0, 0] [1, 32] [1, 1] : tensor<4x32xi16> to tensor<32xi16>
    %0 = tensor_ext.rotate %extracted_slice, %c16 : tensor<32xi16>, index
    %1 = arith.addi %extracted_slice, %0 : tensor<32xi16>
    %2 = tensor_ext.rotate %1, %c8 : tensor<32xi16>, index
    %3 = arith.addi %1, %2 : tensor<32xi16>
    %4 = tensor_ext.rotate %3, %c4 : tensor<32xi16>, index
    %5 = arith.addi %3, %4 : tensor<32xi16>
    %6 = tensor_ext.rotate %5, %c2 : tensor<32xi16>, index
    %7 = arith.addi %5, %6 : tensor<32xi16>
    %8 = tensor_ext.rotate %7, %c1 : tensor<32xi16>, index
    %9 = arith.addi %7, %8 : tensor<32xi16>
    %extracted = tensor.extract %9[%c0] : tensor<32xi16>
    %extracted_slice_3 = tensor.extract_slice %concat[1, 0] [1, 32] [1, 1] : tensor<4x32xi16> to tensor<32xi16>
    ...
    %20 = arith.addi %extracted_4, %extracted : i16
    ...
    %31 = arith.addi %extracted_6, %20 : i16
    ...
    %42 = arith.addi %extracted_8, %31 : i16
    return %42 : i16
```
