### PR TITLE
Conversion/Utils: remove debug message for TensorOfTensorConversionPatterns

### DIFF
--- a/lib/Conversion/Utils.cpp
+++ b/lib/Conversion/Utils.cpp
@@ -226,7 +226,6 @@ void addTensorOfTensorConversionPatterns(TypeConverter &typeConverter,
 
   typeConverter.addConversion([&](TensorType type) -> Type {
     if (!typeConverter.isLegal(type.getElementType())) {
-      typeConverter.convertType(type.getElementType()).dump();
       if (auto convertedType =
               typeConverter.convertType(type.getElementType())) {
         if (auto castConvertedType =


### PR DESCRIPTION
Found when running the following command

```command
heir-opt --bgv-to-lwe --lwe-to-polynomial -convert-elementwise-to-affine -polynomial-to-standard $PWD/tests/bgv/to_polynomial.mlir
```

Besides the error seen in #990, it prints two `tensor<1024xi32>`

```
tensor<1024xi32>
tensor<1024xi32>
heir/tests/bgv/to_polynomial.mlir:26:12: error: 'arith.extsi' op operand type 'tensor<1024xi32>' and result type 'tensor<1024xi26>' are cast incompatible
    %add = bgv.add %x, %y  : !ct1
           ^
heir/tests/bgv/to_polynomial.mlir:26:12: note: see current operation: %100 = "arith.extsi"(%97) : (tensor<1024xi32>) -> tensor<1024xi26>
```

After debugging, it seems like a not cleaned-up debug message. At least it should be guarded by LLVM_DEBUG. Stacktrace for reference:

```gdb
#0  0x00007ffff7b69887 in __GI___libc_write (fd=2, buf=0x555559a81bf0, nbytes=7) at ../sysdeps/unix/sysv/linux/write.c:26
#1  0x0000555558c4e1a1 in llvm::raw_fd_ostream::write_impl (this=0x55555b3aa040 <llvm::errs()::S>, Ptr=0x555559a81bf0 "tensor<", Size=7)
    at external/llvm-project/llvm/lib/Support/raw_ostream.cpp:766
#2  0x0000555558c4ca19 in llvm::raw_ostream::write (this=0x55555b3aa040 <llvm::errs()::S>, Ptr=0x555559a81bf0 "tensor<", Size=7)
    at external/llvm-project/llvm/lib/Support/raw_ostream.cpp:252
#3  0x0000555555997fb2 in llvm::raw_ostream::operator<< (this=0x55555b3aa040 <llvm::errs()::S>, Str=...) at external/llvm-project/llvm/include/llvm/Support/raw_ostream.h:230
#4  0x000055555599803c in llvm::raw_ostream::operator<< (this=0x55555b3aa040 <llvm::errs()::S>, Str=0x555559a81bf0 "tensor<")
    at external/llvm-project/llvm/include/llvm/Support/raw_ostream.h:257
#5  0x0000555558aba75d in operator() (__closure=0x7fffffffaf00, tensorTy=...) at external/llvm-project/mlir/lib/IR/AsmPrinter.cpp:2633
#6  0x0000555558ac4eaf in llvm::TypeSwitch<mlir::Type, void>::Case<mlir::RankedTensorType, mlir::AsmPrinter::Impl::printTypeImpl(mlir::Type)::<lambda(mlir::RankedTensorType)> >(struc
t {...} &&) (this=0x7fffffffaf40, caseFn=...) at external/llvm-project/llvm/include/llvm/ADT/TypeSwitch.h:149
#7  0x0000555558abb003 in mlir::AsmPrinter::Impl::printTypeImpl (this=0x7fffffffafa0, type=...) at external/llvm-project/mlir/lib/IR/AsmPrinter.cpp:2632
#8  0x0000555558ab9f3c in mlir::AsmPrinter::Impl::printType (this=0x7fffffffafa0, type=...) at external/llvm-project/mlir/lib/IR/AsmPrinter.cpp:2568
#9  0x0000555558ac18b3 in mlir::Type::print (this=0x7fffffffb0e0, os=..., state=...) at external/llvm-project/mlir/lib/IR/AsmPrinter.cpp:3825
#10 0x0000555558ac1834 in mlir::Type::print (this=0x7fffffffb0e0, os=...) at external/llvm-project/mlir/lib/IR/AsmPrinter.cpp:3822
#11 0x0000555558ac18dd in mlir::Type::dump (this=0x7fffffffb0e0) at external/llvm-project/mlir/lib/IR/AsmPrinter.cpp:3829
#12 0x0000555555d55200 in operator() (__closure=0x7fffffffc6b8, type=...) at lib/Conversion/Utils.cpp:229
...
#49 0x0000555555b0e8be in mlir::heir::polynomial::PolynomialToStandard::runOnOperation (this=0x55555b3c60f0) at lib/Conversion/PolynomialToStandard/PolynomialToStandard.cpp:1335
```