### PR TITLE
adds a devcontainer.json

### DIFF
--- a/.devcontainer/cmake/devcontainer.json
+++ b/.devcontainer/cmake/devcontainer.json
@@ -1,0 +1,56 @@
+{
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
+  // This devcontainer is based on Ubuntu 24.04 LTS
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    // we must install a non-os-provided python to get around
+    // the "externally managed environment" restrictions
+    // that were added in Ubuntu 23+ and prevent pip global/user
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12",
+      "installJupyterlab": true,
+      "configureJupyterlabAllowOrigin": "*"
+    },
+    // ruby is used by some of the pre-commit tools
+    "ghcr.io/devcontainers/features/ruby:1": {},
+    // install clang and lld
+    // install cmake and ninja (as CMake generator, as it's faster)
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "clang, lld, cmake, ninja-build"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "llvm-vs-code-extensions.vscode-mlir",
+        "ms-vscode.cpptools-extension-pack"
+      ],
+      "settings": {
+        "cmake.generator": "Ninja",
+        "cmake.configureArgs": [
+          "-DMLIR_DIR=/workspaces/llvm-project/build/lib/cmake/mlir"
+        ],
+        "mlir.server_path": "/workspaces/heir/build/bin/heir-lsp",
+        "python.analysis.exclude": [
+          "bazel-bin",
+          "bazel-heir",
+          "bazel-out",
+          "bazel-testlogs",
+          "build",
+          ".git",
+          "venv",
+          ".venv"
+        ]
+      }
+    }
+  },
+  // install pre-commit,
+  "onCreateCommand": "pip install --user -r requirements-dev.txt && pre-commit install",
+  // fetch and install LLVM/MLIR
+  // TODO (#1009): uncomment the updateContentCommand line once prebuilds are enabled
+  // "updateContentCommand": "/workspaces/heir/.devcontainer/cmake/setup_mlir.sh"
+}

--- a/.devcontainer/cmake/setup_mlir.sh
+++ b/.devcontainer/cmake/setup_mlir.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Repository URL
+REPO_URL="https://github.com/llvm/llvm-project.git"
+
+# Extract the commit hash from bazel/import_llvm.bzl
+COMMIT_HASH=$(grep -oP 'LLVM_COMMIT = "\K[0-9a-f]{40}' /workspaces/heir/bazel/import_llvm.bzl)
+
+# Create a new directory for the MLIR repository
+mkdir -p /workspaces/llvm-project && cd /workspaces/llvm-project
+
+# This uses a somewhat round-about way to fetch only a specific commit
+# thereby avoiding the (apparent) need to first shallow-clone the repo HEAD
+# Note that fetching a single commit by hash is not supported by all git servers
+
+# Initialize a new git repository
+git init
+
+# Add the target repository as a remote
+git remote add origin $REPO_URL
+
+# Fetch only the specific commit with a shallow depth
+git fetch origin $COMMIT_HASH --depth 1
+
+# Checkout the fetched commit
+git checkout FETCH_HEAD
+
+# Create a new directory for the build
+mkdir -p build && cd build
+
+# Configure the build
+cmake -G Ninja ../llvm \
+    -DLLVM_ENABLE_PROJECTS=mlir \
+    -DLLVM_TARGETS_TO_BUILD=Native \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DLLVM_USE_SPLIT_DWARF=ON \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DLLVM_USE_LINKER=lld \
+    -DLLVM_OPTIMIZED_TABLEGEN=ON \
+    -DLLVM_CCACHE_BUILD=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DLLVM_INSTALL_UTILS=ON \
+    -DMLIR_INCLUDE_INTEGRATION_TESTS=OFF
+
+# Build MLIR
+cmake --build . --target mlir-libraries

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+  // Most GH accounts only have access to 2-core/4-core machines by default,
+  // however, the 32GB of storage these machines have are not sufficient to build @heir//...
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
+  // This devcontainer is based on Ubuntu 24.04 LTS
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    // we must install a non-os-provided python to get around
+    // the "externally managed environment" restrictions
+    // that were added in Ubuntu 23+ and prevent pip global/user
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12",
+      "installJupyterlab": true,
+      "configureJupyterlabAllowOrigin": "*"
+    },
+    // ruby is used by some of the pre-commit tools
+    "ghcr.io/devcontainers/features/ruby:1": {},
+    // Bazel (and Buildifier) + Bazel extension
+    "ghcr.io/devcontainers-community/features/bazel:1": {},
+    // install clang and lld
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "clang, lld"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      // Note: Bazel feature already adds the Bazel extension
+      "extensions": [
+        "llvm-vs-code-extensions.vscode-mlir",
+        "llvm-vs-code-extensions.vscode-clangd"
+      ],
+      "settings": {
+        "clangd.arguments": [
+          "--compile-commands-dir=${workspaceFolder}/",
+          "--completion-style=detailed",
+          "--query-driver=**"
+        ],
+        "python.analysis.exclude": [
+          "bazel-bin",
+          "bazel-heir",
+          "bazel-out",
+          "bazel-testlogs",
+          "build",
+          ".git",
+          "venv",
+          ".venv"
+        ]
+      }
+    }
+  },
+  "onCreateCommand": "pip3 install --user -r requirements-dev.txt && pre-commit install",
+  // TODO (#1009): uncomment the updateContentCommand line once prebuilds are enabled
+  //"updateContentCommand": "bazel build @heir//tools:all && bazel run @hedron_compile_commands//:refresh_all"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+# bazel
 bazel-bin
 bazel-heir
 bazel-out
 bazel-testlogs
+
+# cmake
+build
 
 # Generated files by hugo
 docs/public/


### PR DESCRIPTION
Another “quality of life” thing for getting people started with HEIR quickly.
This adds a .devcontainer json, so that code spaces created from HEIR have (almost) everything set-up already, basically saving people the working of going through the getting-started setup.

Currently, this still requires running a full bazel build + hedron_compile_commands after the container is created, as adding that to the container creation would make launching a codespace really slow. If we enable pre-built containers, this would not be an issue, so we could have it come pre-built + clangd-ready, too.

If someone wants to contribute back, they’d of course still need to manually create a fork and add it as a new remote, but I think that’s inevitable.