### PR TITLE
ci: disable flakey part of test and fix upstream llvm build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,5 @@ repos:
     additional_dependencies:
     - mdformat-gfm
     - mdformat-frontmatter
+
+exclude: bazel/llvm.patch

--- a/bazel/import_llvm.bzl
+++ b/bazel/import_llvm.bzl
@@ -14,6 +14,9 @@ def import_llvm(name):
         # this BUILD file is intentionally empty, because the LLVM project
         # internally contains a set of bazel BUILD files overlaying the project.
         build_file_content = "# empty",
+        # this patch should be removed once is merged
+        patches = ["@heir//bazel:llvm.patch"],
+        patch_args = ["-p1"],
         commit = LLVM_COMMIT,
         init_submodules = False,
         remote = "https://github.com/llvm/llvm-project.git",

--- a/bazel/llvm.patch
+++ b/bazel/llvm.patch
@@ -1,0 +1,36 @@
+From bc6d76364d716da5aba324dcf9fdccd9f3d86967 Mon Sep 17 00:00:00 2001
+From: Danial Klimkin <dklimkin@google.com>
+Date: Wed, 2 Oct 2024 13:59:02 +0200
+Subject: [PATCH] [bazel] Fix build past
+ 66f84c8b8a762832af39e91370018f8f8307a0fc
+
+---
+ mlir/lib/Dialect/Tensor/Utils/Utils.cpp           | 2 +-
+ utils/bazel/llvm-project-overlay/mlir/BUILD.bazel | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/mlir/lib/Dialect/Tensor/Utils/Utils.cpp b/mlir/lib/Dialect/Tensor/Utils/Utils.cpp
+index 1cb040b6dca414..e0b91f323b0e64 100644
+--- a/mlir/lib/Dialect/Tensor/Utils/Utils.cpp
++++ b/mlir/lib/Dialect/Tensor/Utils/Utils.cpp
+@@ -16,7 +16,7 @@
+ #include "mlir/Dialect/Arith/IR/Arith.h"
+ #include "mlir/Dialect/Arith/Utils/Utils.h"
+ #include "mlir/Dialect/Utils/IndexingUtils.h"
+-#include "mlir/Dialect/Vector/IR//VectorOps.h"
++#include "mlir/Dialect/Vector/IR/VectorOps.h"
+ #include "mlir/Interfaces/ValueBoundsOpInterface.h"
+ 
+ using namespace mlir;
+diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+index 4d65a4e2bf6809..51fd82c995f75b 100644
+--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+@@ -7694,6 +7694,7 @@ cc_library(
+         ":DialectUtils",
+         ":TensorDialect",
+         ":ValueBoundsOpInterface",
++        ":VectorDialect",
+     ],
+ )
+ 


### PR DESCRIPTION
CI improvements because i'm sick of the red X

* I mangled the flakey test from https://github.com/google/heir/issues/987 to pass reliably in both the cases
* Patched the upstream bazel LLVM build