### PR TITLE
replace `X64` & `AArch64` llvm targets with `Native`

### DIFF
--- a/bazel/setup_llvm.bzl
+++ b/bazel/setup_llvm.bzl
@@ -6,8 +6,7 @@ load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
 
 # The subset of LLVM targets that HEIR cares about.
 _LLVM_TARGETS = [
-    "AArch64",
-    "X86",
+    "Native",
     # The bazel dependency graph for mlir-opt fails to load (at the analysis step) without the NVPTX
     # target in this list, because mlir/test:TestGPU depends on the //llvm:NVPTXCodeGen target,
     # which is not defined unless this is included. jkun@ asked the llvm maintiners for tips on how

--- a/bazel/setup_llvm.bzl
+++ b/bazel/setup_llvm.bzl
@@ -7,6 +7,7 @@ load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
 # The subset of LLVM targets that HEIR cares about.
 _LLVM_TARGETS = [
     "Native",
+    "X86",
     # The bazel dependency graph for mlir-opt fails to load (at the analysis step) without the NVPTX
     # target in this list, because mlir/test:TestGPU depends on the //llvm:NVPTXCodeGen target,
     # which is not defined unless this is included. jkun@ asked the llvm maintiners for tips on how


### PR DESCRIPTION
It should be both more efficient and safer to specify the special "Native" target unless we expect people to cross-compile things with HEIR.

(Unless there's some need for this due to internal google build server magic?)

EDIT: motivated by #847 / #1001 