### PR TITLE
pre-compile HEIR in bazel devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,9 @@
     "ghcr.io/devcontainers/features/ruby:1": {},
     // Bazel (and Buildifier) + Bazel extension
     "ghcr.io/devcontainers-community/features/bazel:1": {},
-    // install clang and lld
+    // install clang, lld and clangd
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "clang, lld"
+      "packages": "clang, lld, clangd"
     }
   },
   "customizations": {
@@ -53,6 +53,5 @@
     }
   },
   "onCreateCommand": "pip3 install --user -r requirements-dev.txt && pre-commit install",
-  // TODO (#1009): uncomment the updateContentCommand line once prebuilds are enabled
-  //"updateContentCommand": "bazel build @heir//tools:all && bazel run @hedron_compile_commands//:refresh_all"
+  "updateContentCommand": "bazel build @heir//tools:all && bazel run @hedron_compile_commands//:refresh_all"
 }


### PR DESCRIPTION
With pre-builds now enabled (at least for the default bazel-based devontainer, see #1009), we can also pre-compile HEIR/LLVM as part of the devcontainer build so people get a ready-to-use codespace.

This "only" compiles the `@heir//tools:all` target as there were some issues with running out of storage space when building everything (see discussion in #1001)  but for a quick "playground" this should already be a good start.

EDIT: added another small improvement while I was at it: the devcontainer now installs the clangd langauge server via apt, so that the vscode clangd extension does not need to download it after the codespace is created.