### PR TITLE
pre-compile HEIR in cmake devcontainer

### DIFF
--- a/.devcontainer/cmake/devcontainer.json
+++ b/.devcontainer/cmake/devcontainer.json
@@ -48,9 +48,8 @@
       }
     }
   },
-  // install pre-commit,
+  // install pre-commit
   "onCreateCommand": "pip install --user -r requirements-dev.txt && pre-commit install",
-  // fetch and install LLVM/MLIR
-  // TODO (#1009): uncomment the updateContentCommand line once prebuilds are enabled
-  // "updateContentCommand": "/workspaces/heir/.devcontainer/cmake/setup_mlir.sh"
+  // fetch and install LLVM/MLIR +  compile HEIR
+  "updateContentCommand": "cd /workspaces/heir/.devcontainer/cmake && ./setup_mlir.sh && ./setup_heir.sh"
 }

--- a/.devcontainer/cmake/setup_heir.sh
+++ b/.devcontainer/cmake/setup_heir.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Create the build directory
+mkdir -p /workspaces/heir/build && cd /workspaces/heir/build
+
+# Configure the build
+cmake -G Ninja -DMLIR_DIR=/workspaces/llvm-project/build/lib/cmake/mlir ..
+
+# Build HEIR
+cmake --build . --target all


### PR DESCRIPTION
With prebuilds now also enabled for the cmake devcontainer (see #1009), this is basically the same as PR #1017 but for cmake.

This builds the sort-of-catch-all CMake target `mlir-libraries` for the MLIR dependency (which can probably be optimized in the future) and uses the `-DMLIR_DIR=...` method to let HEIR know about LLVM/MLIR. It then builds the `all` target for HEIR (though the name is a bit misleading, as CMake lets you exclude targets from the "all" target). 

I've ran this on a (4 core / 16GB RAM/ 32GB storage) codespace and it seems to work (probably because the CMake build does not yet include everything + defaults to no yosys). I'm asssuming we'll have to revisit this as we expand the CMake build, but with a bit of luck any additions in HEIR can be offset by better scoping of the MLIR dependencies with a more integrated/bazel-style CMake setup.