### PR TITLE
Fix tensor type for polynomial-mul-to-ntt

### DIFF
--- a/lib/Dialect/Polynomial/Transforms/NTTRewrites.td
+++ b/lib/Dialect/Polynomial/Transforms/NTTRewrites.td
@@ -15,9 +15,7 @@ def GetRingModAttr : NativeCodeCall<
 
 def InputTensorType : NativeCodeCall<
       "RankedTensorType::get({$0.getPolynomialModulus().getPolynomial().getDegree()},"
-      " IntegerType::get($_builder.getContext(),"
-      "  ($0.getCoefficientModulus().getValue() - 1).getActiveBits()),"
-      " $0)">;
+      " $0.getCoefficientType(), $0)">;
 
 def CreateCModConstant : NativeCodeCall<
       "$_builder.create<arith::ConstantOp>($0.getLoc(), $2,"

--- a/tests/Dialect/Polynomial/Transforms/ntt_rewrites.mlir
+++ b/tests/Dialect/Polynomial/Transforms/ntt_rewrites.mlir
@@ -9,12 +9,9 @@
 // CHECK:      %[[NTT_POLY0:.*]] = polynomial.ntt %[[poly0]] : [[POLY_TY]] -> [[INPUT_TENSOR_TYPE:.*]]
 // CHECK:      %[[NTT_POLY1:.*]] = polynomial.ntt %[[poly1]] : [[POLY_TY]] -> [[INPUT_TENSOR_TYPE]]
 // EXT:        %[[NTT_RES:.*]] = mod_arith.mul %[[NTT_POLY0]], %[[NTT_POLY1]] {modulus = 17 : i32} : [[INPUT_TENSOR_TYPE]]
-// ARITH:      %[[CMOD:.*]] = arith.constant dense<17> : [[INTERMEDIATE_TENSOR_TYPE:.*]]
-// ARITH:      %[[NTT_EXT0:.*]] = arith.extui %[[NTT_POLY0]] : [[INPUT_TENSOR_TYPE]] to [[INTERMEDIATE_TENSOR_TYPE]]
-// ARITH:      %[[NTT_EXT1:.*]] = arith.extui %[[NTT_POLY1]] : [[INPUT_TENSOR_TYPE]] to [[INTERMEDIATE_TENSOR_TYPE]]
-// ARITH:      %[[NTT_MUL:.*]] = arith.muli %[[NTT_EXT0]], %[[NTT_EXT1]] : [[INTERMEDIATE_TENSOR_TYPE]]
-// ARITH:      %[[NTT_MOD:.*]] = arith.remui %[[NTT_MUL]], %[[CMOD]] : [[INTERMEDIATE_TENSOR_TYPE]]
-// ARITH:      %[[NTT_RES:.*]] = arith.trunci %[[NTT_MOD]] : [[INTERMEDIATE_TENSOR_TYPE]] to [[INPUT_TENSOR_TYPE]]
+// ARITH:      %[[NTT_MUL:.*]] = arith.muli %[[NTT_POLY0]], %[[NTT_POLY1]] : [[INPUT_TENSOR_TYPE]]
+// ARITH:      %[[CMOD:.*]] = arith.constant dense<17> : [[INPUT_TENSOR_TYPE:.*]]
+// ARITH:      %[[NTT_RES:.*]] = arith.remui %[[NTT_MUL]], %[[CMOD]] : [[INPUT_TENSOR_TYPE]]
 // CHECK:      %[[RES:.*]] = polynomial.intt %[[NTT_RES]] : [[INPUT_TENSOR_TYPE]] -> {{.*}}
 // CHECK:      return %[[RES]] : [[POLY_TY]]
 func.func @rewrite_poly_mul(%poly0: !poly_ty, %poly1: !poly_ty) -> !poly_ty {


### PR DESCRIPTION
Formerly polynomial-mul-to-ntt chooses the immediate tensor type to be just the size of the coefficientModulus. For example, when mod = 7681, its width is 13 and the result would be `tensor<nxi13, #ring>`

```
In #ring, coefficientType is i32 
%0 = polynomial.ntt %arg0 : !polynomial.polynomial<ring #ring> -> tensor<4xi13, #ring>
```

However, when further lower `polynomial.ntt` using `polynomial-to-standard`, we would encounter the following error. Obviously, we can not fit `i32` into `i13`.

```
void writeAPIntsToBuffer(size_t, std::vector<char> &, APRangeT &&) [APRangeT = llvm::ArrayRef<llvm::APInt> &]:
 Assertion `(*it).getBitWidth() <= storageWidth' failed.
```

Code snippet (requires #1036, otherwise the mul-to-ntt rewrite itself wont work). This PR itself does not depend on #1036.

Command `--convert-polynomial-mul-to-ntt --mod-arith-to-arith --polynomial-to-standard`

```
#cycl = #polynomial.int_polynomial<1 + x**4>
#root = #polynomial.primitive_root<value=1925:i32, degree=8:i32>
#ring = #polynomial.ring<coefficientType = i32, coefficientModulus = 7681 : i32, polynomialModulus=#cycl, primitiveRoot=#root>
!p = !polynomial.polynomial<ring=#ring>

module {
  func.func @polymul(%x : !p, %y : !p) -> (!p) {
    %add = polynomial.mul %x, %y : !p
    return %add : !p
  }
}
```

Cc @AlexanderViand for #817