### PR TITLE
add_heir_transforms build macro for bazel

### DIFF
--- a/lib/Transforms/ApplyFolders/BUILD
+++ b/lib/Transforms/ApplyFolders/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -19,27 +19,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# ApplyFolders tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ApplyFolders",
-            ],
-            "ApplyFolders.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ApplyFoldersPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ApplyFolders.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ApplyFolders",
 )

--- a/lib/Transforms/BUILD
+++ b/lib/Transforms/BUILD
@@ -1,0 +1,4 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)

--- a/lib/Transforms/ConvertIfToSelect/BUILD
+++ b/lib/Transforms/ConvertIfToSelect/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -24,25 +24,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ConvertIfToSelect",
-            ],
-            "ConvertIfToSelect.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ConvertIfToSelectPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ConvertIfToSelect.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ConvertIfToSelect",
 )

--- a/lib/Transforms/ConvertSecretExtractToStaticExtract/BUILD
+++ b/lib/Transforms/ConvertSecretExtractToStaticExtract/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -26,25 +26,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ConvertSecretExtractToStaticExtract",
-            ],
-            "ConvertSecretExtractToStaticExtract.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ConvertSecretExtractToStaticExtractPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ConvertSecretExtractToStaticExtract.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ConvertSecretExtractToStaticExtract",
 )

--- a/lib/Transforms/ConvertSecretForToStaticFor/BUILD
+++ b/lib/Transforms/ConvertSecretForToStaticFor/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -25,25 +25,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ConvertSecretForToStaticFor",
-            ],
-            "ConvertSecretForToStaticFor.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ConvertSecretForToStaticForPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ConvertSecretForToStaticFor.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ConvertSecretForToStaticFor",
 )

--- a/lib/Transforms/ConvertSecretInsertToStaticInsert/BUILD
+++ b/lib/Transforms/ConvertSecretInsertToStaticInsert/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -26,25 +26,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ConvertSecretInsertToStaticInsert",
-            ],
-            "ConvertSecretInsertToStaticInsert.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ConvertSecretInsertToStaticInsertPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ConvertSecretInsertToStaticInsert.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ConvertSecretInsertToStaticInsert",
 )

--- a/lib/Transforms/ConvertSecretWhileToStaticFor/BUILD
+++ b/lib/Transforms/ConvertSecretWhileToStaticFor/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -25,25 +25,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ConvertSecretWhileToStaticFor",
-            ],
-            "ConvertSecretWhileToStaticFor.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ConvertSecretWhileToStaticForPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ConvertSecretWhileToStaticFor.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ConvertSecretWhileToStaticFor",
 )

--- a/lib/Transforms/ElementwiseToAffine/BUILD
+++ b/lib/Transforms/ElementwiseToAffine/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -23,27 +23,8 @@ cc_library(
         "@llvm-project//mlir:TransformUtils",
     ],
 )
-# ElementwiseToAffine tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ElementwiseToAffine",
-            ],
-            "ElementwiseToAffine.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ElementwiseToAffinePasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ElementwiseToAffine.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ElementwiseToAffine",
 )

--- a/lib/Transforms/ForwardInsertToExtract/BUILD
+++ b/lib/Transforms/ForwardInsertToExtract/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -25,27 +25,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# ForwardInsertToExtract tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ForwardInsertToExtract",
-            ],
-            "ForwardInsertToExtract.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ForwardInsertToExtractPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ForwardInsertToExtract.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ForwardInsertToExtract",
 )

--- a/lib/Transforms/ForwardStoreToLoad/BUILD
+++ b/lib/Transforms/ForwardStoreToLoad/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -24,27 +24,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# ForwardStoreToLoad tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ForwardStoreToLoad",
-            ],
-            "ForwardStoreToLoad.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ForwardStoreToLoadPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "ForwardStoreToLoad.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ForwardStoreToLoad",
 )

--- a/lib/Transforms/FullLoopUnroll/BUILD
+++ b/lib/Transforms/FullLoopUnroll/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -19,27 +19,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# FullLoopUnroll tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=FullLoopUnroll",
-            ],
-            "FullLoopUnroll.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "FullLoopUnrollPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "FullLoopUnroll.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "FullLoopUnroll",
 )

--- a/lib/Transforms/LinalgCanonicalizations/BUILD
+++ b/lib/Transforms/LinalgCanonicalizations/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -21,27 +21,8 @@ cc_library(
         "@llvm-project//mlir:TransformUtils",
     ],
 )
-# LinalgCanonicalizations tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=LinalgCanonicalizations",
-            ],
-            "LinalgCanonicalizations.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "LinalgCanonicalizationsPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "LinalgCanonicalizations.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "LinalgCanonicalizations",
 )

--- a/lib/Transforms/MemrefToArith/BUILD
+++ b/lib/Transforms/MemrefToArith/BUILD
@@ -1,6 +1,6 @@
 # MemrefToArith pass eliminates memrefs in favor of inline arithmetic constants.
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -124,25 +124,7 @@ cc_library(
     alwayslink = 1,
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=MemrefToArith",
-            ],
-            "MemrefToArith.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "MemrefToArith.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "MemrefToArith.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "MemrefToArith",
 )

--- a/lib/Transforms/OperationBalancer/BUILD
+++ b/lib/Transforms/OperationBalancer/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -26,30 +26,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# OperationBalancer tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=OperationBalancer",
-            ],
-            "OperationBalancer.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "OperationBalancerPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "OperationBalancer.td",
-    deps = [
-        "@heir//lib/Dialect/Secret/IR:SecretOps",
-        "@heir//lib/Dialect/Secret/IR:SecretPatterns",
-        "@llvm-project//mlir:ArithDialect",
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "OperationBalancer",
 )

--- a/lib/Transforms/OptimizeRelinearization/BUILD
+++ b/lib/Transforms/OptimizeRelinearization/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -25,25 +25,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=OptimizeRelinearization",
-            ],
-            "OptimizeRelinearization.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "OptimizeRelinearizationPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "OptimizeRelinearization.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "OptimizeRelinearization",
 )

--- a/lib/Transforms/Secretize/BUILD
+++ b/lib/Transforms/Secretize/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -24,27 +24,9 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# Secretize tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=Secretize",
-            ],
-            "Passes.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "SecretizePasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+add_heir_transforms(
+    header_filename = "Passes.h.inc",
+    pass_name = "Secretize",
     td_file = "Passes.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
 )

--- a/lib/Transforms/StraightLineVectorizer/BUILD
+++ b/lib/Transforms/StraightLineVectorizer/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -25,27 +25,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# StraightLineVectorizer tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=StraightLineVectorizer",
-            ],
-            "StraightLineVectorizer.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "StraightLineVectorizerPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "StraightLineVectorizer.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "StraightLineVectorizer",
 )

--- a/lib/Transforms/TensorToScalars/BUILD
+++ b/lib/Transforms/TensorToScalars/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -24,25 +24,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=TensorToScalars",
-            ],
-            "TensorToScalars.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "TensorToScalarsPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "TensorToScalars.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "TensorToScalars",
 )

--- a/lib/Transforms/UnusedMemRef/BUILD
+++ b/lib/Transforms/UnusedMemRef/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -21,27 +21,8 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-# UnusedMemRef tablegen and headers.
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=UnusedMemRef",
-            ],
-            "UnusedMemRef.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "UnusedMemRefPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "UnusedMemRef.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "UnusedMemRef",
 )

--- a/lib/Transforms/YosysOptimizer/BUILD
+++ b/lib/Transforms/YosysOptimizer/BUILD
@@ -1,6 +1,6 @@
 # YosysOptimizer pass
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -112,25 +112,7 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=YosysOptimizer",
-            ],
-            "YosysOptimizer.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "YosysOptimizerPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "YosysOptimizer.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "YosysOptimizer",
 )

--- a/lib/Transforms/transforms.bzl
+++ b/lib/Transforms/transforms.bzl
@@ -1,0 +1,101 @@
+"""Macros to streamline the generation of HEIR transform tablegen-generated
+files."""
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+def add_heir_transforms(
+        pass_name = None,
+        td_file = None,
+        header_filename = None,
+        registration_name = None,
+        doc_filename = None,
+        generated_target_name = "pass_inc_gen",
+        name = None,
+        deps = None):
+    """A HEIR standard way to invoke tablegen for transforms.
+
+    This macro calls `gentbl_cc_library` with appropriate parameters, generating:
+
+    - A header file, called `{pass_name}.h.inc` by default.
+    - A documentation file, called `${pass_name}Passes.md` by default.
+    - A bazel target containing the generated headers, called `pass_inc_gen` by
+      default.
+
+    Args:
+      td_file: A string containing the path to the tablegen file to process. Uses
+        "{pass_name}.td" by default. This file should contain a `def`
+        inheriting from `Pass` for each pass defined. Multiple passes may be
+        defined in the same file.
+      pass_name: A string containing the name of the pass to generate.
+        This produces:
+          - A registration function called `register${pass_name}Passes`
+          - A markdown file for the documentation called `${pass_name}Passes.md`
+      header_filename: An override for the generated header filename.
+      registration_name: An override for the registration function defined by
+        pass_name: generated as `register${registration_name}Passes`.
+      doc_filename: An override for the documentation filename set by pass_name.
+      generated_target_name: An override for the generated bazel target name.
+      name: A synonym for generated_target_name, for buildifier.
+      deps: A list of tablegen dependencies required to generate the target.
+        Defaults to OpBaseTdFiles and PassBaseTdFiles.
+    """
+    _td_file = td_file
+    if _td_file == None:
+        _td_file = pass_name + ".td"
+
+    if pass_name == None and registration_name == None and doc_filename == None:
+        fail("pass_name must be provided to add_heir_transforms, or overrides for" +
+             "registration_name and doc_filename must be provided.")
+
+    _doc_filename = None
+    _header_filename = None
+    pass_decls_name = None
+
+    if pass_name != None:
+        pass_decls_name = pass_name
+        _doc_filename = pass_name + "Passes.md"
+        _header_filename = pass_name + ".h.inc"
+
+    if registration_name != None:
+        pass_decls_name = registration_name
+
+    if doc_filename != None:
+        _doc_filename = doc_filename
+
+    if header_filename != None:
+        _header_filename = header_filename
+
+    _deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ]
+    if deps != None:
+        _deps = deps
+
+    if name == None and generated_target_name == None:
+        fail("generated_target_name must be provided to add_heir_transforms, " +
+             "but the default was overridden explicitly to None.")
+
+    _target_name = generated_target_name
+    if _target_name == None:
+        _target_name = name
+
+    gentbl_cc_library(
+        name = _target_name,
+        tbl_outs = [
+            (
+                [
+                    "-gen-pass-decls",
+                    "-name=" + pass_decls_name,
+                ],
+                _header_filename,
+            ),
+            (
+                ["-gen-pass-doc"],
+                _doc_filename,
+            ),
+        ],
+        tblgen = "@llvm-project//mlir:mlir-tblgen",
+        td_file = _td_file,
+        deps = _deps,
+    )


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/1045#issuecomment-2412100449

The part that I don't like about this is how much it hides from the person using the macro. How are they supposed to know, for example, that the generated target is `pass_inc_gen`? Among all these other "smart defaults", it adds more of a burden on the coder to keep the defaults in the back of their mind, or else re-read the source of the macro (on top of knowing what tblgen does).