### PR TITLE
ci: fix require-hashes for pip upgrade

### DIFF
--- a/.github/workflows/scripts_test.yml
+++ b/.github/workflows/scripts_test.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip --require-hashes
+          python -m pip install --upgrade pip
           pip install -r requirements-dev.txt --require-hashes
       - name: Run tests
         run: |


### PR DESCRIPTION
pip upgrade doesn't need the hashes, this starting failing CI since now there's a new pip version