### PR TITLE
fix: fix heir magic to capture output for colab

### DIFF
--- a/scripts/jupyter/heir_play/heir_opt.py
+++ b/scripts/jupyter/heir_play/heir_opt.py
@@ -28,6 +28,7 @@ class BinaryMagic(Magics):
             [os.path.abspath(self.binary_path)] + shlex.split(line),
             input=cell,
             text=True,
+            capture_output=True,
         )
         if completed_process.returncode != 0:
             print(f"Error running {self.binary_path}")


### PR DESCRIPTION
previously, using the custom magic command for heir-opt and heir-translate did not print any output from the subprocess command running the binaries in google colab. it did work in external jupyter notebooks.

it turns out that the subprocess outputs weren't explicitly captured - google colab is on an older version of subprocess that may be missing some kinds of standard outs. https://ipykernel.readthedocs.io/en/stable/changelog.html#id268

@AlexanderViand-Intel 