### PR TITLE
Add mlir-to-secret-arith pipeline

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -71,9 +71,8 @@ void heirSIMDVectorizerPipelineBuilder(OpPassManager &manager) {
   manager.addPass(createCSEPass());
 }
 
-void mlirToRLWEPipeline(OpPassManager &pm,
-                        const MlirToRLWEPipelineOptions &options,
-                        const RLWEScheme scheme) {
+void mlirToSecretArithmeticPipelineBuilder(
+    OpPassManager &pm, const MlirToSecretArithmeticPipelineOptions &options) {
   // Secretize inputs
   pm.addPass(createSecretize(SecretizeOptions{options.entryFunction}));
   pm.addPass(createWrapGeneric());
@@ -87,6 +86,14 @@ void mlirToRLWEPipeline(OpPassManager &pm,
 
   // Vectorize and optimize rotations
   heirSIMDVectorizerPipelineBuilder(pm);
+}
+
+void mlirToRLWEPipeline(OpPassManager &pm,
+                        const MlirToRLWEPipelineOptions &options,
+                        const RLWEScheme scheme) {
+  MlirToSecretArithmeticPipelineOptions mlirToSecretArithmeticPipelineOpts{};
+  mlirToSecretArithmeticPipelineOpts.entryFunction = options.entryFunction;
+  mlirToSecretArithmeticPipelineBuilder(pm, mlirToSecretArithmeticPipelineOpts);
 
   // Prepare to lower to RLWE Scheme
   pm.addPass(secret::createSecretDistributeGeneric());

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -16,6 +16,13 @@ enum RLWEScheme { ckksScheme, bgvScheme };
 
 void heirSIMDVectorizerPipelineBuilder(OpPassManager &manager);
 
+struct MlirToSecretArithmeticPipelineOptions
+    : public PassPipelineOptions<MlirToSecretArithmeticPipelineOptions> {
+  PassOptions::Option<std::string> entryFunction{
+      *this, "entry-function", llvm::cl::desc("Entry function to secretize"),
+      llvm::cl::init("main")};
+};
+
 struct MlirToRLWEPipelineOptions
     : public PassPipelineOptions<MlirToRLWEPipelineOptions> {
   PassOptions::Option<std::string> entryFunction{
@@ -36,6 +43,9 @@ typedef std::function<void(OpPassManager &pm,
 void mlirToRLWEPipeline(OpPassManager &pm,
                         const MlirToRLWEPipelineOptions &options,
                         RLWEScheme scheme);
+
+void mlirToSecretArithmeticPipelineBuilder(
+    OpPassManager &pm, const MlirToSecretArithmeticPipelineOptions &options);
 
 RLWEPipelineBuilder mlirToRLWEPipelineBuilder(RLWEScheme scheme);
 

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -285,6 +285,12 @@ int main(int argc, char **argv) {
       "tensor_ext.rotate",
       mlir::heir::heirSIMDVectorizerPipelineBuilder);
 
+  PassPipelineRegistration<mlir::heir::MlirToSecretArithmeticPipelineOptions>(
+      "mlir-to-secret-arithmetic",
+      "Convert a func using standard MLIR dialects to secret dialect with "
+      "arithmetic ops",
+      mlirToSecretArithmeticPipelineBuilder);
+
   PassPipelineRegistration<mlir::heir::MlirToRLWEPipelineOptions>(
       "mlir-to-bgv",
       "Convert a func using standard MLIR dialects to FHE using "


### PR DESCRIPTION
Split the scheme-agnostic part of existing arith FHE pipeline into a standalone pipeline so that the user can inspect scheme-agnostic optimization result HEIR has done, instead of inspecting the verbose bgv/openfhe dialect.

Before, to check scheme-agonistic optimizations, the user has to call a chain of passes like `--secretize --wrap-generic -heir-simd-vectorizer`, and with a bunch of `cse/canonicalize`.

BTW, I think some FHE ciphertext management operation can be _annotated_ here, like relinearize/mod reduce operation. For example, the lazy realinearization pass operates on the bgv dialect, it deletes the existing relin op then adds them back according to the analysis, which requires bgv type fixing. If annotated early, the secret-to-bgv lowering can directly produce correct type. 