### PR TITLE
bump heir_play to 0.0.4

### DIFF
--- a/scripts/jupyter/pyproject.toml
+++ b/scripts/jupyter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "heir_play"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="Jeremy Kun", email="jkun@google.com" },
   { name="Asra Ali", email="asraa@google.com" },


### PR DESCRIPTION
I built at head with this version bump, and pushed to https://pypi.org/project/heir-play/, so this is just retroactively updating the version number.