### PR TITLE
Mod arith docs

### DIFF
--- a/lib/Dialect/ModArith/Conversions/ModArithToArith/BUILD
+++ b/lib/Dialect/ModArith/Conversions/ModArithToArith/BUILD
@@ -36,6 +36,10 @@ gentbl_cc_library(
             ["-gen-rewriters"],
             "ModArithToArith.cpp.inc",
         ),
+        (
+            ["-gen-pass-doc"],
+            "ModArithToArith.md",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "ModArithToArith.td",


### PR DESCRIPTION
The gen-pass-doc call was omitted, so this pass is not on the website.