### PR TITLE
openfhe emitter: register mod arith dialect

### DIFF
--- a/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
+++ b/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
@@ -66,7 +66,8 @@ void registerToOpenFhePkeHeaderTranslation() {
         registry.insert<arith::ArithDialect, func::FuncDialect,
                         tensor::TensorDialect, openfhe::OpenfheDialect,
                         lwe::LWEDialect,
-                        ::mlir::heir::polynomial::PolynomialDialect>();
+                        ::mlir::heir::polynomial::PolynomialDialect,
+                        mod_arith::ModArithDialect>();
       });
 }
 


### PR DESCRIPTION
`heir-translate --emit-openfhe-pke-header` would complain

```
 error: `!"mod_arith"<"int<463187969 : i32>">` type created with unregistered dialect. If this is intended, please call allowUnregisteredDialects() on the MLIRContext, or use -allow-unregistered-dialect with the MLIR opt tool used
```