### PR TITLE
bgv-to-openfhe: populate ConvertAddPlainOp pattern

### DIFF
--- a/lib/Dialect/BGV/Conversions/BGVToOpenfhe/BGVToOpenfhe.cpp
+++ b/lib/Dialect/BGV/Conversions/BGVToOpenfhe/BGVToOpenfhe.cpp
@@ -88,12 +88,12 @@ struct BGVToOpenfhe : public impl::BGVToOpenfheBase<BGVToOpenfhe> {
               hasCryptoContextArg);
     });
 
-    patterns
-        .add<AddCryptoContextArg<bgv::BGVDialect>, ConvertAddOp, ConvertSubOp,
-             ConvertMulOp, ConvertMulPlainOp, ConvertNegateOp, ConvertRotateOp,
-             ConvertRelinOp, ConvertModulusSwitchOp, ConvertExtractOp,
-             lwe::ConvertEncryptOp, lwe::ConvertDecryptOp>(typeConverter,
-                                                           context);
+    patterns.add<AddCryptoContextArg<bgv::BGVDialect>, ConvertAddOp,
+                 ConvertSubOp, ConvertAddPlainOp, ConvertMulOp,
+                 ConvertMulPlainOp, ConvertNegateOp, ConvertRotateOp,
+                 ConvertRelinOp, ConvertModulusSwitchOp, ConvertExtractOp,
+                 lwe::ConvertEncryptOp, lwe::ConvertDecryptOp>(typeConverter,
+                                                               context);
     patterns.add<lwe::ConvertEncodeOp>(typeConverter, context, /*ckks=*/false);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {


### PR DESCRIPTION
Otherwise the following code would fail to `--mlir-to-openfhe-bgv="entry-function=func ciphertext-degree=8"`

```mlir
func.func @func(%arg0: tensor<8xi16>) -> tensor<8xi16> {
  %c0 = arith.constant dense<10> : tensor<8xi16>
  %0 = arith.addi %arg0, %c0 : tensor<8xi16>
  return %0 : tensor<8xi16>
}

```

With

`error: failed to legalize operation 'bgv.add_plain' that was explicitly marked illegal ` when `bgv-to-openfhe`.