### PR TITLE
polynomial: pretty print RingAttr

### DIFF
--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.cpp
@@ -204,6 +204,20 @@ Attribute FloatPolynomialAttr::parse(AsmParser &parser, Type type) {
   return FloatPolynomialAttr::get(parser.getContext(), result.value());
 }
 
+// ring
+LogicalResult parseRingIntPolyAttr(AsmParser &parser, IntPolynomialAttr &attr) {
+  auto parsed = IntPolynomialAttr::parse(parser, nullptr);
+  if (parsed) {
+    attr = mlir::dyn_cast<IntPolynomialAttr>(parsed);
+    return success();
+  }
+  return failure();
+}
+
+void printRingIntPolyAttr(AsmPrinter &p, IntPolynomialAttr attr) {
+  attr.print(p);
+}
+
 }  // namespace polynomial
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.h
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.h
@@ -7,4 +7,15 @@
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h.inc"
 
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+LogicalResult parseRingIntPolyAttr(AsmParser &parser, IntPolynomialAttr &attr);
+void printRingIntPolyAttr(AsmPrinter &p, IntPolynomialAttr attr);
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir
+
 #endif  // LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALATTRIBUTES_H_

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
@@ -157,7 +157,7 @@ def Polynomial_RingAttr : Polynomial_Attr<"Ring", "ring"> {
     "Type": $coefficientType,
     OptionalParameter<"::mlir::heir::polynomial::IntPolynomialAttr">: $polynomialModulus
   );
-  let assemblyFormat = "`<` struct(params) `>`";
+  let assemblyFormat = "`<` $coefficientType (`,` custom<RingIntPolyAttr>($polynomialModulus)^)?`>`";
   let builders = [
     AttrBuilderWithInferredContext<
         (ins "::mlir::Type":$coefficientTy,

--- a/lib/Dialect/Polynomial/IR/PolynomialTypes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialTypes.td
@@ -15,7 +15,7 @@ def Polynomial_PolynomialType : Polynomial_Type<"Polynomial", "polynomial"> {
     A type for polynomials in a polynomial quotient ring.
   }];
   let parameters = (ins Polynomial_RingAttr:$ring);
-  let assemblyFormat = "`<` struct(params) `>`";
+  let assemblyFormat = "`<` $ring `>`";
 }
 
 def PolynomialLike: TypeOrContainer<Polynomial_PolynomialType, "polynomial-like">;


### PR DESCRIPTION
This PR tries to reduce the verbosity of polynomial type assembly format.

With this change, we get a much cleaner output

```mlir
module {
  func.func @main(%arg0: !polynomial.polynomial<<!mod_arith.int<65537 : i64>, <1 + x**8192>>>) -> !polynomial.polynomial<<!mod_arith.int<65537 : i64>, <1 + x**8192>>> {
    return %arg0 : !polynomial.polynomial<<!mod_arith.int<65537 : i64>, <1 + x**8192>>>
  }
}
```

Instead of

```mlir
module {
  func.func @main(%arg0: !polynomial.polynomial<ring = <coefficientType = !mod_arith.int<65537 : i64>, polynomialModulus = <1 + x**1024>>>) -> !polynomial.polynomial<ring = <coefficientType = !mod_arith.int<65537 : i64>, polynomialModulus = <1 + x**1024>>> {
    return %arg0 : !polynomial.polynomial<ring = <coefficientType = !mod_arith.int<65537 : i64>, polynomialModulus = <1 + x**1024>>>
  }
}
```

Other examples:

```mlir
module {
  func.func @main(%arg0: !polynomial.polynomial<<!rns.rns<!mod_arith.int<65537 : i64>, !mod_arith.int<17 : i64>>, <1 + x**1024>>>) -> !polynomial.polynomial<<!rns.rns<!mod_arith.int<65537 : i64>, !mod_arith.int<17 : i64>>, <1 + x**1024>>> {
    return %arg0 : !polynomial.polynomial<<!rns.rns<!mod_arith.int<65537 : i64>, !mod_arith.int<17 : i64>>, <1 + x**1024>>>
  }
}
```

If such change is favored, I'll change corresponding tests.