### PR TITLE
Generate Alias for RLWE, ModArith, and Polynomial

### DIFF
--- a/lib/Dialect/LWE/IR/LWEDialect.cpp
+++ b/lib/Dialect/LWE/IR/LWEDialect.cpp
@@ -34,6 +34,25 @@ namespace mlir {
 namespace heir {
 namespace lwe {
 
+class LWEOpAsmDialectInterface : public OpAsmDialectInterface {
+ public:
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+
+  AliasResult getAlias(Type type, raw_ostream& os) const override {
+    auto res = llvm::TypeSwitch<Type, AliasResult>(type)
+                   .Case<RLWECiphertextType>([&](Type) {
+                     os << "rlwe_ct";
+                     return AliasResult::FinalAlias;
+                   })
+                   .Case<RLWEPlaintextType>([&](Type) {
+                     os << "rlwe_pt";
+                     return AliasResult::FinalAlias;
+                   })
+                   .Default([&](Type) { return AliasResult::NoAlias; });
+    return res;
+  }
+};
+
 void LWEDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
@@ -47,6 +66,8 @@ void LWEDialect::initialize() {
 #define GET_OP_LIST
 #include "lib/Dialect/LWE/IR/LWEOps.cpp.inc"
       >();
+
+  addInterface<LWEOpAsmDialectInterface>();
 }
 
 LogicalResult RMulOp::verify() {

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -33,6 +33,24 @@ namespace mlir {
 namespace heir {
 namespace mod_arith {
 
+class ModArithOpAsmDialectInterface : public OpAsmDialectInterface {
+ public:
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+
+  AliasResult getAlias(Type type, raw_ostream &os) const override {
+    auto res = llvm::TypeSwitch<Type, AliasResult>(type)
+                   .Case<ModArithType>([&](auto &modArithType) {
+                     os << "Z";
+                     os << modArithType.getModulus().getValue();
+                     os << "_";
+                     os << modArithType.getModulus().getType();
+                     return AliasResult::FinalAlias;
+                   })
+                   .Default([&](Type) { return AliasResult::NoAlias; });
+    return res;
+  }
+};
+
 void ModArithDialect::initialize() {
   addTypes<
 #define GET_TYPEDEF_LIST
@@ -46,6 +64,8 @@ void ModArithDialect::initialize() {
 #define GET_OP_LIST
 #include "lib/Dialect/ModArith/IR/ModArithOps.cpp.inc"
       >();
+
+  addInterface<ModArithOpAsmDialectInterface>();
 }
 
 /// Ensures that the underlying integer type is wide enough for the coefficient

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/bgv_to_openfhe.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/bgv_to_openfhe.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --bgv-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --bgv-to-openfhe %s | FileCheck %s
 
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
 

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/cast.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/cast.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --bgv-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --bgv-to-openfhe %s | FileCheck %s
 
 #encoding_i16 = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
 #encoding_i32 = #lwe.polynomial_evaluation_encoding<cleartext_start = 32, cleartext_bitwidth = 32>

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/linear_polynomial.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/linear_polynomial.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --bgv-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --bgv-to-openfhe %s | FileCheck %s
 
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
 #ring = #polynomial.ring<coefficientType=!mod_arith.int<463187969:i32>, polynomialModulus=#polynomial.int_polynomial<1 + x**64>>

--- a/tests/Dialect/BGV/Conversions/bgv_to_polynomial/to_polynomial.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_polynomial/to_polynomial.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --bgv-to-lwe --lwe-to-polynomial %s > %t
+// RUN: heir-opt --mlir-print-local-scope --bgv-to-lwe --lwe-to-polynomial %s > %t
 // RUN: FileCheck %s < %t
 
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>

--- a/tests/Dialect/BGV/IR/ops.mlir
+++ b/tests/Dialect/BGV/IR/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --color %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --color %s | FileCheck %s
 
 // This simply tests for syntax.
 

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/cast.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/cast.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --ckks-to-openfhe %s | FileCheck %s
 
 #encoding_i16 = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
 #encoding_i32 = #lwe.polynomial_evaluation_encoding<cleartext_start = 32, cleartext_bitwidth = 32>

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --ckks-to-openfhe %s | FileCheck %s
 
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
 

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/linear_polynomial.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/linear_polynomial.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --ckks-to-openfhe %s | FileCheck %s
 
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>
 #ring = #polynomial.ring<coefficientType=!mod_arith.int<463187969:i32>, polynomialModulus=#polynomial.int_polynomial<1 + x**64>>

--- a/tests/Dialect/CKKS/IR/ops.mlir
+++ b/tests/Dialect/CKKS/IR/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --color %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --color %s | FileCheck %s
 
 // This simply tests for syntax.
 

--- a/tests/Dialect/LWE/Conversions/lwe_to_polynomial/types.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_polynomial/types.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s --lwe-to-polynomial | FileCheck %s
+// RUN: heir-opt %s --mlir-print-local-scope --lwe-to-polynomial | FileCheck %s
 
 #encoding = #lwe.polynomial_coefficient_encoding<cleartext_start=15, cleartext_bitwidth=4>
 #my_poly = #polynomial.int_polynomial<1 + x**1024>

--- a/tests/Dialect/LWE/IR/alias.mlir
+++ b/tests/Dialect/LWE/IR/alias.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt %s | FileCheck %s
+
+#encoding = #lwe.bit_field_encoding<
+  cleartext_start=14,
+  cleartext_bitwidth=3>
+#my_poly = #polynomial.int_polynomial<1 + x**1024>
+#ring = #polynomial.ring<coefficientType=!mod_arith.int<7917:i32>, polynomialModulus=#my_poly>
+#rlwe_params = #lwe.rlwe_params<dimension=10, ring=#ring>
+#rlwe_params1 = #lwe.rlwe_params<dimension=3, ring=#ring>
+// CHECK: ![[RLWE_CT:rlwe_ct[0-9]*]]
+!ciphertext_rlwe = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #rlwe_params, underlying_type=i3>
+// CHECK: ![[RLWE_CT1:rlwe_ct[0-9]*]]
+!ciphertext_rlwe1 = !lwe.rlwe_ciphertext<encoding = #encoding, rlwe_params = #rlwe_params1, underlying_type=i4>
+
+// CHECK-LABEL: @test_alias
+// CHECK: (%[[ARG0:.*]]: ![[RLWE_CT]], %[[ARG1:.*]]: ![[RLWE_CT1]]) -> ![[RLWE_CT]]
+func.func @test_alias(%0 : !ciphertext_rlwe, %1 : !ciphertext_rlwe1) -> !ciphertext_rlwe {
+    return %0 : !ciphertext_rlwe
+}

--- a/tests/Dialect/ModArith/IR/alias.mlir
+++ b/tests/Dialect/ModArith/IR/alias.mlir
@@ -1,0 +1,13 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// CHECK: !Z17_i10_ = !mod_arith.int<17 : i10>
+!Zp = !mod_arith.int<17 : i10>
+// CHECK: !Z17_i32_ = !mod_arith.int<17 : i32>
+!Zp1 = !mod_arith.int<17 : i32>
+// CHECK: !Z65536_i32_ = !mod_arith.int<65536 : i32>
+!Zp2 = !mod_arith.int<65536 : i32>
+
+// CHECK-LABEL: @test_alias
+func.func @test_alias(%0 : !Zp, %1 : !Zp1, %2 : !Zp2) -> !Zp {
+    return %0 : !Zp
+}

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope %s | FileCheck %s
 
 !Zp = !mod_arith.int<17 : i10>
 !Zp_vec = tensor<4x!Zp>

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_add.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_add.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --polynomial-to-mod-arith %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --polynomial-to-mod-arith %s | FileCheck %s
 
 #cycl_2048 = #polynomial.int_polynomial<1 + x**1024>
 !coeff_ty = !mod_arith.int<4294967296:i64>

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_monomial_mul.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_monomial_mul.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --polynomial-to-mod-arith %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --polynomial-to-mod-arith %s | FileCheck %s
 
 #poly = #polynomial.int_polynomial<-1 + x**1024>
 !coeff_ty = !mod_arith.int<65536:i32>

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul.mlir
@@ -5,19 +5,20 @@
 #ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl_2048>
 !poly_ty = !polynomial.polynomial<ring=#ring>
 
+// CHECK: !Z65536_i32_ = !mod_arith.int<65536 : i32>
 // CHECK: #[[LHS_MAP:.*]] = affine_map<(d0, d1) -> (d0)>
 // CHECK: #[[RHS_MAP:.*]] = affine_map<(d0, d1) -> (d1)>
 // CHECK: #[[OUTPUT_MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1)>
 
-// CHECK: func.func @lower_poly_mul(%[[poly0:.*]]: [[INPUT_TENSOR_TY:tensor<1024x!mod_arith.int<65536 : i32>>]], %[[poly1:.*]]: [[INPUT_TENSOR_TY]]) -> [[INPUT_TENSOR_TY]] {
+// CHECK: func.func @lower_poly_mul(%[[poly0:.*]]: [[INPUT_TENSOR_TY:tensor<1024x!Z65536_i32_>]], %[[poly1:.*]]: [[INPUT_TENSOR_TY]]) -> [[INPUT_TENSOR_TY]] {
 // CHECK:      %[[NAIVE_POLYMUL_OUTPUT_STORAGE:.*]] = arith.constant dense<0> : [[NAIVE_POLYMUL_TENSOR_TY_STORAGE:tensor<2047xi32>]]
-// CHECK:      %[[NAIVE_POLYMUL_OUTPUT:.*]] = mod_arith.encapsulate %[[NAIVE_POLYMUL_OUTPUT_STORAGE]] : [[NAIVE_POLYMUL_TENSOR_TY_STORAGE]] -> [[NAIVE_POLYMUL_TENSOR_TY:tensor<2047x!mod_arith.int<65536 : i32>>]]
+// CHECK:      %[[NAIVE_POLYMUL_OUTPUT:.*]] = mod_arith.encapsulate %[[NAIVE_POLYMUL_OUTPUT_STORAGE]] : [[NAIVE_POLYMUL_TENSOR_TY_STORAGE]] -> [[NAIVE_POLYMUL_TENSOR_TY:tensor<2047x!Z65536_i32_>]]
 // CHECK:      %[[GENERIC_RESULT:.*]] = linalg.generic
 // CHECK-SAME:     indexing_maps = [#[[LHS_MAP]], #[[RHS_MAP]], #[[OUTPUT_MAP]]]
 // CHECK-SAME:     iterator_types = ["parallel", "parallel"]
 // CHECK-SAME:     ins(%[[generic_arg0:.*]], %[[generic_arg1:.*]] : [[INPUT_TENSOR_TY]], [[INPUT_TENSOR_TY]])
 // CHECK-SAME:     outs(%[[NAIVE_POLYMUL_OUTPUT]] : [[NAIVE_POLYMUL_TENSOR_TY]])
-// CHECK:     ^[[BB0:.*]](%[[LHS_IN:.*]]: [[COEFF_TY:!mod_arith.int<65536 : i32>]], %[[RHS_IN:.*]]: [[COEFF_TY]], %[[OUT:.*]]: [[COEFF_TY]]):
+// CHECK:     ^[[BB0:.*]](%[[LHS_IN:.*]]: [[COEFF_TY:!Z65536_i32_]], %[[RHS_IN:.*]]: [[COEFF_TY]], %[[OUT:.*]]: [[COEFF_TY]]):
 // CHECK:       %[[MULTED:.*]] = mod_arith.mul %[[LHS_IN]], %[[RHS_IN]]
 // CHECK:       %[[SUMMED:.*]] = mod_arith.add %[[MULTED]], %[[OUT]]
 // CHECK:       linalg.yield %[[SUMMED]]

--- a/tests/Dialect/Polynomial/IR/alias.mlir
+++ b/tests/Dialect/Polynomial/IR/alias.mlir
@@ -1,0 +1,24 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// CHECK: !Z17_i32_ = !mod_arith.int<17 : i32>
+!Zp1 = !mod_arith.int<17 : i32>
+// CHECK: !Z65536_i32_ = !mod_arith.int<65536 : i32>
+!Zp2 = !mod_arith.int<65536 : i32>
+
+#ideal1 = #polynomial.int_polynomial<x**1024 + 1>
+#ideal2 = #polynomial.int_polynomial<x**2048 + 1>
+
+// CHECK: #ring_Z17_i32_1_x1024_ = #polynomial.ring<coefficientType = !Z17_i32_, polynomialModulus = <1 + x**1024>>
+#ring1 = #polynomial.ring<coefficientType=!Zp1, polynomialModulus=#ideal1>
+// CHECK: #ring_Z65536_i32_1_x2048_ = #polynomial.ring<coefficientType = !Z65536_i32_, polynomialModulus = <1 + x**2048>>
+#ring2 = #polynomial.ring<coefficientType=!Zp2, polynomialModulus=#ideal2>
+
+// CHECK: !poly = !polynomial.polynomial<ring = #ring_Z17_i32_1_x1024_>
+!poly = !polynomial.polynomial<ring = #ring1>
+// CHECK: !poly1 = !polynomial.polynomial<ring = #ring_Z65536_i32_1_x2048_>
+!poly1 = !polynomial.polynomial<ring = #ring2>
+
+// CHECK-LABEL: @test_alias
+func.func @test_alias(%0 : !poly, %1 : !poly1) -> !poly {
+    return %0 : !poly
+}

--- a/tests/Dialect/Polynomial/Transforms/elementwise_to_affine.mlir
+++ b/tests/Dialect/Polynomial/Transforms/elementwise_to_affine.mlir
@@ -1,60 +1,60 @@
 // THE FOLLOWING SHOULD CONVERT BOTH ADD AND MUL
 
-// RUN: heir-opt --convert-elementwise-to-affine %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_MUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-ops=polynomial.add,polynomial.mul_scalar' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-ops=polynomial.add,polynomial.mul_scalar' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_MUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-ops=polynomial.add,polynomial.mul_scalar  convert-dialects=arith' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-ops=polynomial.add,polynomial.mul_scalar  convert-dialects=arith' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_MUL %s
 
-// RUN: heir-opt --convert-elementwise-to-affine=convert-dialects=polynomial %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-dialects=polynomial %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_MUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-dialects=polynomial convert-ops=arith.addi' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects=polynomial convert-ops=arith.addi' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_MUL %s
 
 // THE FOLLOWING SHOULD ONLY CONVERT ADD (AND "ARITH" OPS FOR SOME, BUT THERE ARE NONE IN THE TESTS)
 
-// RUN: heir-opt --convert-elementwise-to-affine=convert-ops=polynomial.add %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-ops=polynomial.add %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-dialects= convert-ops=polynomial.add' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects= convert-ops=polynomial.add' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-dialects=arith convert-ops=polynomial.add' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects=arith convert-ops=polynomial.add' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_ADD --check-prefix=CHECK_NOTMUL %s
 
 // THE FOLLOWING SHOULD ONLY CONVERT MUL (AND "ARITH" OPS FOR SOME, BUT THERE ARE NONE IN THE TESTS)
 
-// RUN: heir-opt --convert-elementwise-to-affine=convert-ops=polynomial.mul_scalar %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-ops=polynomial.mul_scalar %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_MUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-dialects= convert-ops=polynomial.mul_scalar' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects= convert-ops=polynomial.mul_scalar' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_MUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-dialects=arith convert-ops=polynomial.mul_scalar' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects=arith convert-ops=polynomial.mul_scalar' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_MUL %s
 
 // THE FOLLOWING SHOULD CONVERT NOTHING (EXCEPT "ARITH" OPS FOR SOME, BUT THERE ARE NONE IN THE TESTS)
 
-// RUN: heir-opt --convert-elementwise-to-affine=convert-ops= %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-ops= %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt --convert-elementwise-to-affine=convert-dialects= %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-dialects= %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-ops= convert-dialects=' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-ops= convert-dialects=' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-dialects=arith' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects=arith' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-ops=arith.addi' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-ops=arith.addi' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt '--convert-elementwise-to-affine=convert-ops=artih.addi convert-dialects=arith' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-ops=artih.addi convert-dialects=arith' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
 !coeff_ty = !mod_arith.int<33538049:i32>

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/ciphertext_plaintext.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/ciphertext_plaintext.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --canonicalize --secret-to-bgv %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --canonicalize --secret-to-bgv %s | FileCheck %s
 
 !eui1 = !secret.secret<tensor<1024xi1>>
 

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --canonicalize --secret-to-bgv %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --canonicalize --secret-to-bgv %s | FileCheck %s
 
 !eui1 = !secret.secret<tensor<1024xi1>>
 

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/ciphertext_plaintext.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/ciphertext_plaintext.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --canonicalize --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --canonicalize --secret-to-ckks %s | FileCheck %s
 
 !eui1 = !secret.secret<tensor<1024xi1>>
 !efi1 = !secret.secret<tensor<1024xf32>>

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/matmul_loop.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/matmul_loop.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt -affine-loop-normalize='promote-single-iter=1' --secretize --wrap-generic --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope -affine-loop-normalize='promote-single-iter=1' --secretize --wrap-generic --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
 
 module {
   // CHECK-LABEL: func @main

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/matmul_unrolled.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/matmul_unrolled.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --secretize --wrap-generic --full-loop-unroll --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --secretize --wrap-generic --full-loop-unroll --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
 
 module {
   // CHECK-LABEL: func @main

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --canonicalize --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --canonicalize --secret-to-ckks %s | FileCheck %s
 
 !eui1 = !secret.secret<tensor<1024xi1>>
 !efi1 = !secret.secret<tensor<1024xf32>>

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/type_converter.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/type_converter.mlir
@@ -1,7 +1,7 @@
 // Tests that the type converter handles both converting tensors to SIMD slots
 // if aligned, or to tensors of ciphertext.
 
-// RUN: heir-opt --secret-distribute-generic --canonicalize --secret-to-ckks --split-input-file %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --secret-distribute-generic --canonicalize --secret-to-ckks --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: func @test_arg_packed
 // CHECK-SAME: %[[arg0:.*]]: !lwe.rlwe_ciphertext<{{.*}}, underlying_type = tensor<1024xf32>>

--- a/tests/Transforms/mlir_to_openfhe_ckks/matmul.mlir
+++ b/tests/Transforms/mlir_to_openfhe_ckks/matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --affine-loop-normalize='promote-single-iter=1' --mlir-to-openfhe-ckks %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --affine-loop-normalize='promote-single-iter=1' --mlir-to-openfhe-ckks %s | FileCheck %s
 
 // This pipeline fully loop unrolls the matmul.
 

--- a/tests/Transforms/optimize_relinearization/optimize_relinearization.mlir
+++ b/tests/Transforms/optimize_relinearization/optimize_relinearization.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --optimize-relinearization %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --optimize-relinearization %s | FileCheck %s
 
 #encoding = #lwe.polynomial_evaluation_encoding<cleartext_start=30, cleartext_bitwidth=3>
 #my_poly = #polynomial.int_polynomial<1 + x**1024>


### PR DESCRIPTION
Check https://github.com/google/heir/pull/1130#issuecomment-2508866775

Cc @j2kun Definitely worth a blog post. Never seen a tutorial on this.

With this change, `--mlir-to-openfhe-bgv` result would be much cleaner.

<del>Though a lot of tests failed due to this change...</del>Can be mitigated by `--mlir-print-local-scope`

```mlir
!Z463187969_i32_ = !mod_arith.int<463187969 : i32>
#ring_Z463187969_i32_1_x8_ = #polynomial.ring<coefficientType = !Z463187969_i32_, polynomialModulus = <1 + x**8>>
!rlwe_pt = !lwe.rlwe_plaintext<encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>, ring = #ring_Z463187969_i32_1_x8_, underlying_type = i16>
!rlwe_ct = !lwe.rlwe_ciphertext<encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>, rlwe_params = <ring = #ring_Z463187969_i32_1_x8_>, underlying_type = i16>
!rlwe_ct1 = !lwe.rlwe_ciphertext<encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>, rlwe_params = <dimension = 3, ring = #ring_Z463187969_i32_1_x8_>, underlying_type = i16>
module {
  func.func @func(%arg0: !openfhe.crypto_context, %arg1: !rlwe_ct, %arg2: !rlwe_ct) -> !rlwe_ct {
    %0 = openfhe.mul_no_relin %arg0, %arg1, %arg1 : (!openfhe.crypto_context, !rlwe_ct, !rlwe_ct) -> !rlwe_ct1
    %1 = openfhe.relin %arg0, %0 : (!openfhe.crypto_context, !rlwe_ct1) -> !rlwe_ct
    return %1 : !rlwe_ct
  }
  func.func @func__encrypt__arg0(%arg0: !openfhe.crypto_context, %arg1: i16, %arg2: !openfhe.public_key) -> !rlwe_ct {
    %splat = tensor.splat %arg1 : tensor<8xi16>
    %0 = arith.extsi %splat : tensor<8xi16> to tensor<8xi64>
    %1 = openfhe.make_packed_plaintext %arg0, %0 : (!openfhe.crypto_context, tensor<8xi64>) -> !rlwe_pt
    %2 = openfhe.encrypt %arg0, %1, %arg2 : (!openfhe.crypto_context, !rlwe_pt, !openfhe.public_key) -> !rlwe_ct
    return %2 : !rlwe_ct
  }
```