### PR TITLE
ModArith: cleanup on dump()

### DIFF
--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -179,7 +179,6 @@ void ConstantOp::print(OpAsmPrinter &p) {
 LogicalResult ConstantOp::inferReturnTypes(
     mlir::MLIRContext *context, std::optional<mlir::Location> loc,
     ConstantOpAdaptor adaptor, llvm::SmallVectorImpl<mlir::Type> &returnTypes) {
-  adaptor.getValue().dump();
   returnTypes.push_back(adaptor.getValue().getType());
   return success();
 }


### PR DESCRIPTION
Otherwise when `polynomial-to-mod-arith` we would get these in stderr
```
#mod_arith<int 1 : i32 : <65536 : i32>> : !mod_arith.int<65536 : i32>
#mod_arith<int 1 : i32 : <65536 : i32>> : !mod_arith.int<65536 : i32>
#mod_arith<int 1 : i32 : <65536 : i32>> : !mod_arith.int<65536 : i32>
```