### PR TITLE
Fix RingAttr alias and Add RNSType alias

### DIFF
--- a/tests/Dialect/RNS/IR/alias.mlir
+++ b/tests/Dialect/RNS/IR/alias.mlir
@@ -1,0 +1,16 @@
+// RUN: heir-opt %s | FileCheck %s
+
+!Zp = !mod_arith.int<17 : i10>
+!Zp1 = !mod_arith.int<17 : i32>
+!Zp2 = !mod_arith.int<65536 : i32>
+!Zp3 = !mod_arith.int<65537 : i32>
+
+// CHECK: !rns_Z17_i32_Z65536_i32_ = !rns.rns<!Z17_i32_, !Z65536_i32_>
+!rns = !rns.rns<!Zp1, !Zp2>
+// CHECK: !rns_Z17_i32_Z65536_i32_Z65537_i32_ = !rns.rns<!Z17_i32_, !Z65536_i32_, !Z65537_i32_>
+!rns1 = !rns.rns<!Zp1, !Zp2, !Zp3>
+
+// CHECK-LABEL: @test_alias
+func.func @test_alias(%0 : !rns, %1 : !rns1) -> !rns {
+    return %0 : !rns
+}


### PR DESCRIPTION
Cc @AlexanderViand-Intel

With this change, the example in https://github.com/google/heir/pull/1131#issuecomment-2517969073 becomes

```mlir
!Z463187969_i32_ = !mod_arith.int<463187969 : i32>
!Z463187970_i32_ = !mod_arith.int<463187970 : i32>
!Z463187971_i32_ = !mod_arith.int<463187971 : i32>
#ring__1_x8_ = #polynomial.ring<coefficientType = !rns.rns<!Z463187969_i32_, !Z463187970_i32_, !Z463187971_i32_>, polynomialModulus = <1 + x**8>>
!rlwe_ct = !lwe.rlwe_ciphertext<encoding = #lwe.polynomial_evaluation_encoding<cleartext_start = 16, cleartext_bitwidth = 16>, rlwe_params = <ring = #ring__1_x8_>, underlying_type = tensor<8xi16>>
module {
  func.func @foo(%arg0: !rlwe_ct, %arg1: !rlwe_ct) -> !rlwe_ct {
    %0 = bgv.add %arg0, %arg1 : !rlwe_ct
    return %0 : !rlwe_ct
  }
}
``` 

The reason is that it is assumed that when `AliasResult::NoAlias` is returned `raw_ostream` does not have any content. MLIR reused this buffer so ModArithType accidentally gets the `ring_` prefix.

This fix is safe in that although `#ring__1_x8_` is a `FinalResult`, MLIR can still assign trailing number to it if found duplicate.

Note that it is tricky to have a `std::string` as temp buffer as Type/Attribute often does not have the toString method; they only have the interface to raw_stream.

For example:
```mlir
#ring__1_x8_ = #polynomial.ring<coefficientType = !rns.rns<!Z463187969_i32_, !Z463187970_i32_, !Z463187971_i32_>, polynomialModulus = <1 + x**8>>
#ring__1_x8_1 = #polynomial.ring<coefficientType = !rns.rns<!Z463187969_i32_, !Z463187970_i32_>, polynomialModulus = <1 + x**8>>
```