### PR TITLE
transforms: re-run analysis when needed by subsequent rewrite

### DIFF
--- a/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
+++ b/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
@@ -106,6 +106,8 @@ class SecretnessAnalysis
                                ArrayRef<SecretnessLattice *> results) override;
 };
 
+void annotateSecretness(Operation *top, DataFlowSolver *solver);
+
 }  // namespace heir
 }  // namespace mlir
 


### PR DESCRIPTION
Fixes #1153 

Analysis should be re-run across different match of RewritePattern, otherwise even if the Lattice exists, it does not propagate and would result in incorrect result.

Also cleanup of annotate-secretness used in multiple places.