### PR TITLE
add `--operation-balancer` to `--mlir-to-secret-arithmetic` pipeline

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -18,6 +18,7 @@
 #include "lib/Transforms/ApplyFolders/ApplyFolders.h"
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
 #include "lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.h"
+#include "lib/Transforms/OperationBalancer/OperationBalancer.h"
 #include "lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.h"
 #include "lib/Transforms/Secretize/Passes.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"         // from @llvm-project
@@ -84,6 +85,9 @@ void mlirToSecretArithmeticPipelineBuilder(OpPassManager &pm) {
 
   // Vectorize and optimize rotations
   heirSIMDVectorizerPipelineBuilder(pm);
+
+  // Balance Operations
+  pm.addPass(createOperationBalancer());
 }
 
 void mlirToRLWEPipeline(OpPassManager &pm,

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -104,6 +104,7 @@ cc_library(
         "@heir//lib/Transforms/FullLoopUnroll",
         "@heir//lib/Transforms/LinalgCanonicalizations",
         "@heir//lib/Transforms/MemrefToArith:MemrefToArithRegistration",
+        "@heir//lib/Transforms/OperationBalancer",
         "@heir//lib/Transforms/OptimizeRelinearization",
         "@heir//lib/Transforms/Secretize",
         "@llvm-project//llvm:Support",


### PR DESCRIPTION
Does what it says on the tin and, surprisingly, doesn't seem to break any tests?

Part of #1107
