### PR TITLE
Add Lattigo Dialect and Target for BGV

### DIFF
--- a/lib/Dialect/Lattigo/IR/BUILD
+++ b/lib/Dialect/Lattigo/IR/BUILD
@@ -1,0 +1,213 @@
+# Lattigo dialect implementation
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "LattigoDialect.cpp",
+    ],
+    hdrs = [
+        "LattigoAttributes.h",
+        "LattigoDialect.h",
+        "LattigoOps.h",
+        "LattigoTypes.h",
+    ],
+    deps = [
+        "attributes_inc_gen",
+        "dialect_inc_gen",
+        "ops_inc_gen",
+        "types_inc_gen",
+        ":LattigoAttributes",
+        ":LattigoOps",
+        ":LattigoTypes",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "LattigoAttributes",
+    srcs = [
+        "LattigoAttributes.cpp",
+    ],
+    hdrs = [
+        "LattigoAttributes.h",
+        "LattigoDialect.h",
+    ],
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "LattigoTypes",
+    srcs = [
+        "LattigoTypes.cpp",
+    ],
+    hdrs = [
+        "LattigoAttributes.h",
+        "LattigoDialect.h",
+        "LattigoTypes.h",
+    ],
+    deps = [
+        ":LattigoAttributes",
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        ":types_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "LattigoOps",
+    srcs = [
+        "LattigoOps.cpp",
+    ],
+    hdrs = [
+        "LattigoDialect.h",
+        "LattigoOps.h",
+        "LattigoTypes.h",
+    ],
+    deps = [
+        ":LattigoAttributes",
+        ":LattigoTypes",
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        ":types_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "LattigoAttributes.td",
+        "LattigoBGVAttributes.td",
+        "LattigoBGVOps.td",
+        "LattigoBGVTypes.td",
+        "LattigoDialect.td",
+        "LattigoOps.td",
+        "LattigoRLWEOps.td",
+        "LattigoRLWETypes.td",
+        "LattigoTypes.td",
+    ],
+    # include from the heir-root to enable fully-qualified include-paths
+    includes = ["../../../.."],
+    deps = [
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "dialect_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+            ],
+            "LattigoDialect.h.inc",
+        ),
+        (
+            [
+                "-gen-dialect-defs",
+            ],
+            "LattigoDialect.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LattigoDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "attributes_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-attrdef-decls",
+            ],
+            "LattigoAttributes.h.inc",
+        ),
+        (
+            [
+                "-gen-attrdef-defs",
+            ],
+            "LattigoAttributes.cpp.inc",
+        ),
+        (
+            ["-gen-attrdef-doc"],
+            "LattigoAttributes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LattigoAttributes.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "types_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-typedef-decls",
+            ],
+            "LattigoTypes.h.inc",
+        ),
+        (
+            [
+                "-gen-typedef-defs",
+            ],
+            "LattigoTypes.cpp.inc",
+        ),
+        (
+            ["-gen-typedef-doc"],
+            "LattigoTypes.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LattigoTypes.td",
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "ops_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "LattigoOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "LattigoOps.cpp.inc",
+        ),
+        (
+            ["-gen-op-doc"],
+            "LattigoOps.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "LattigoOps.td",
+    deps = [
+        ":dialect_inc_gen",
+        ":td_files",
+        ":types_inc_gen",
+    ],
+)

--- a/lib/Dialect/Lattigo/IR/LattigoAttributes.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoAttributes.cpp
@@ -1,0 +1,7 @@
+#include "lib/Dialect/Lattigo/IR/LattigoAttributes.h"
+
+namespace mlir {
+namespace heir {
+namespace lattigo {}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Lattigo/IR/LattigoAttributes.h
+++ b/lib/Dialect/Lattigo/IR/LattigoAttributes.h
@@ -1,0 +1,9 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOATTRIBUTES_H_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOATTRIBUTES_H_
+
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/Lattigo/IR/LattigoAttributes.h.inc"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOATTRIBUTES_H_

--- a/lib/Dialect/Lattigo/IR/LattigoAttributes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoAttributes.td
@@ -1,0 +1,21 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOATTRIBUTES_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOATTRIBUTES_TD_
+
+include "LattigoDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
+
+class Lattigo_Attribute<string attrName, string attrMnemonic>
+    : AttrDef<Lattigo_Dialect, attrName> {
+    let summary = "Attribute for Lattigo";
+    let description = [{
+        This attribute represents the values for Lattigo.
+    }];
+    let mnemonic = attrMnemonic;
+    let assemblyFormat = "`<` struct(params) `>`";
+}
+
+include "LattigoBGVAttributes.td"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOATTRIBUTES_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoBGVAttributes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVAttributes.td
@@ -1,0 +1,26 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOBGVATTRIBUTES_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOBGVATTRIBUTES_TD_
+
+class Lattigo_BGVAttribute<string attrName, string attrMnemonic>
+      : Lattigo_Attribute<"BGV" # attrName, "bgv." # attrMnemonic> {
+    let summary = "Attribute for Lattigo BGV";
+    let description = [{
+        This attribute represents the values for Lattigo BGV.
+    }];
+}
+
+def Lattigo_BGVParametersLiteral
+    : Lattigo_BGVAttribute<"ParametersLiteral", "parameters_literal"> {
+    let summary = "Literal parameters for Lattigo BGV";
+    let description = [{
+        This attribute represents the literal parameters for Lattigo BGV.
+    }];
+    let parameters = (ins
+      "int":$logN,
+      "DenseI32ArrayAttr":$logQ,
+      "DenseI32ArrayAttr":$logP,
+      "int64_t":$plaintextModulus
+    );
+}
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOBGVATTRIBUTES_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
@@ -1,0 +1,115 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOBGVOPS_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOBGVOPS_TD_
+
+include "LattigoDialect.td"
+include "LattigoTypes.td"
+include "mlir/IR/OpBase.td"
+
+class Lattigo_BGVOp<string mnemonic, list<Trait> traits = []> :
+        Lattigo_Op<"bgv." # mnemonic, traits> {
+}
+
+def Lattigo_BGVNewPlaintextOp : Lattigo_BGVOp<"new_plaintext"> {
+  let summary = "Create a new plaintext in the Lattigo BGV dialect";
+  let description = [{
+    This operation creates a new plaintext value in the Lattigo BGV dialect.
+  }];
+  let arguments = (ins
+    Lattigo_BGVParameter:$params
+  );
+  let results = (outs Lattigo_RLWEPlaintext:$plaintext);
+}
+
+def Lattigo_BGVNewParametersFromLiteralOp : Lattigo_BGVOp<"new_parameters_from_literal"> {
+  let summary = "Create new BGV parameters from a literal in the Lattigo BGV dialect";
+  let description = [{
+    This operation creates new BGV parameters from a given literal value in the Lattigo BGV dialect.
+  }];
+  let arguments = (ins
+    Lattigo_BGVParametersLiteral:$paramsLiteral
+  );
+  let results = (outs Lattigo_BGVParameter:$params);
+}
+
+def Lattigo_BGVNewEncoderOp : Lattigo_BGVOp<"new_encoder"> {
+  let summary = "Create a new encoder in the Lattigo BGV dialect";
+  let description = [{
+    This operation creates a new encoder for encoding plaintext values in the Lattigo BGV dialect.
+  }];
+  let arguments = (ins
+    Lattigo_BGVParameter:$params
+  );
+  let results = (outs Lattigo_BGVEncoder:$encoder);
+}
+
+def Lattigo_BGVEncodeOp : Lattigo_BGVOp<"encode"> {
+  let summary = "Encode a plaintext value in the Lattigo BGV dialect";
+  let description = [{
+    This operation encodes a plaintext value using the specified encoder in the Lattigo BGV dialect.
+  }];
+  let arguments = (ins
+    Lattigo_BGVEncoder:$encoder,
+    AnyType:$value,
+    Lattigo_RLWEPlaintext:$plaintext
+  );
+  let results = (outs Lattigo_RLWEPlaintext:$encoded);
+}
+
+def Lattigo_BGVDecodeOp : Lattigo_BGVOp<"decode"> {
+  let summary = "Decode a plaintext value in the Lattigo BGV dialect";
+  let description = [{
+    This operation decodes a plaintext value using the specified encoder in the Lattigo BGV dialect.
+  }];
+  let arguments = (ins
+    Lattigo_BGVEncoder:$encoder,
+    Lattigo_RLWEPlaintext:$plaintext,
+    AnyType:$value
+  );
+  let results = (outs AnyType:$decoded);
+}
+
+def Lattigo_BGVNewEvaluatorOp : Lattigo_BGVOp<"new_evaluator"> {
+  let summary = "Create a new evaluator in the Lattigo BGV dialect";
+  let description = [{
+    This operation creates a new evaluator for performing operations on ciphertexts in the Lattigo BGV dialect.
+  }];
+  let arguments = (ins
+    Lattigo_BGVParameter:$params
+  );
+  let results = (outs Lattigo_BGVEvaluator:$evaluator);
+}
+
+// ciphertext arithmetic op
+
+class Lattigo_BGVBinaryOp<string mnemonic> :
+        Lattigo_BGVOp<mnemonic> {
+  let arguments = (ins
+    Lattigo_BGVEvaluator:$evaluator,
+    Lattigo_RLWECiphertext:$lhs,
+    Lattigo_RLWECiphertext:$rhs
+  );
+  let results = (outs Lattigo_RLWECiphertext:$result);
+}
+
+def Lattigo_BGVAddOp : Lattigo_BGVBinaryOp<"add"> {
+  let summary = "Add two ciphertexts in the Lattigo BGV dialect";
+  let description = [{
+    This operation adds two ciphertext values in the Lattigo BGV dialect.
+  }];
+}
+
+def Lattigo_BGVSubOp : Lattigo_BGVBinaryOp<"sub"> {
+  let summary = "Subtract two ciphertexts in the Lattigo BGV dialect";
+  let description = [{
+    This operation subtracts one ciphertext value from another in the Lattigo BGV dialect.
+  }];
+}
+
+def Lattigo_BGVMulOp : Lattigo_BGVBinaryOp<"mul"> {
+  let summary = "Multiply two ciphertexts in the Lattigo BGV dialect";
+  let description = [{
+    This operation multiplies two ciphertext values in the Lattigo BGV dialect.
+  }];
+}
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOBGVOPS_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoBGVTypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVTypes.td
@@ -1,0 +1,36 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOBGVTYPES_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOBGVTYPES_TD_
+
+include "LattigoAttributes.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class Lattigo_BGVType<string name, string typeMnemonic>
+    : Lattigo_Type<"BGV" # name, "bgv." # typeMnemonic> {
+}
+
+// BGVParameter type definition
+def Lattigo_BGVParameter : Lattigo_BGVType<"Parameter", "parameter"> {
+  let description = [{
+    This type represents the parameters for the BGV encryption scheme.
+  }];
+}
+
+// BGVEvaluator type definition
+def Lattigo_BGVEvaluator : Lattigo_BGVType<"Evaluator", "evaluator"> {
+  let description = [{
+    This type represents the evaluator for the BGV encryption scheme.
+  }];
+}
+
+// BGVEncoder type definition
+def Lattigo_BGVEncoder : Lattigo_BGVType<"Encoder", "encoder"> {
+  let description = [{
+    This type represents the encoder for the BGV encryption scheme.
+  }];
+}
+
+
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOBGVTYPES_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoDialect.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoDialect.cpp
@@ -1,0 +1,48 @@
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
+
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// NOLINTNEXTLINE(misc-include-cleaner): Required to define LattigoOps
+
+#include "lib/Dialect/Lattigo/IR/LattigoAttributes.h"
+#include "lib/Dialect/Lattigo/IR/LattigoOps.h"
+#include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
+
+// Generated definitions
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/Lattigo/IR/LattigoAttributes.cpp.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/Lattigo/IR/LattigoTypes.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/Lattigo/IR/LattigoOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+void LattigoDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "lib/Dialect/Lattigo/IR/LattigoAttributes.cpp.inc"
+      >();
+
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "lib/Dialect/Lattigo/IR/LattigoTypes.cpp.inc"
+      >();
+
+  addOperations<
+#define GET_OP_LIST
+#include "lib/Dialect/Lattigo/IR/LattigoOps.cpp.inc"
+      >();
+}
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Lattigo/IR/LattigoDialect.h
+++ b/lib/Dialect/Lattigo/IR/LattigoDialect.h
@@ -1,0 +1,10 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_H_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"   // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h.inc"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_H_

--- a/lib/Dialect/Lattigo/IR/LattigoDialect.td
+++ b/lib/Dialect/Lattigo/IR/LattigoDialect.td
@@ -1,0 +1,20 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+
+def Lattigo_Dialect : Dialect {
+  let name = "lattigo";
+  let description = [{
+    The `lattigo` dialect is an exit dialect for generating GO code against the Lattigo library API.
+
+    See https://github.com/tuneinsight/lattigo
+  }];
+
+  let cppNamespace = "::mlir::heir::lattigo";
+
+  let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
+}
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoOps.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoOps.cpp
@@ -1,0 +1,7 @@
+#include "lib/Dialect/Lattigo/IR/LattigoOps.h"
+
+namespace mlir {
+namespace heir {
+namespace lattigo {}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Lattigo/IR/LattigoOps.h
+++ b/lib/Dialect/Lattigo/IR/LattigoOps.h
@@ -1,0 +1,11 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOOPS_H_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOOPS_H_
+
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
+#include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/Lattigo/IR/LattigoOps.h.inc"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOOPS_H_

--- a/lib/Dialect/Lattigo/IR/LattigoOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoOps.td
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOOPS_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOOPS_TD_
+
+include "LattigoDialect.td"
+include "LattigoTypes.td"
+include "mlir/IR/OpBase.td"
+
+class Lattigo_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Lattigo_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+include "LattigoBGVOps.td"
+include "LattigoRLWEOps.td"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOOPS_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
@@ -1,0 +1,84 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGORLWEOPS_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGORLWEOPS_TD_
+
+class Lattigo_RLWEOp<string mnemonic, list<Trait> traits = []> :
+        Lattigo_Op<"rlwe." # mnemonic, traits> {
+}
+
+def Lattigo_RLWENewKeyGeneratorOp : Lattigo_RLWEOp<"new_key_generator"> {
+  let summary = "Generates a new RLWE key generator";
+  let description = [{
+    This operation generates a new RLWE key generator
+  }];
+  let arguments = (ins
+    // accepts only BGV for now
+    Lattigo_BGVParameter:$params
+  );
+  let results = (outs Lattigo_RLWEKeyGenerator:$keyGenerator);
+}
+
+def Lattigo_RLWEGenKeyPairOp : Lattigo_RLWEOp<"gen_key_pair"> {
+  let summary = "Generates a new RLWE key pair";
+  let description = [{
+    This operation generates a new RLWE key pair
+  }];
+  let arguments = (ins
+    Lattigo_RLWEKeyGenerator:$keyGenerator
+  );
+  let results = (outs
+    Lattigo_RLWESecretKey:$secretKey,
+    Lattigo_RLWEPublicKey:$publicKey
+  );
+}
+
+def Lattigo_RLWENewEncryptorOp : Lattigo_RLWEOp<"new_encryptor"> {
+  let summary = "Creates a new RLWE encryptor";
+  let description = [{
+    This operation creates a new RLWE encryptor
+  }];
+  let arguments = (ins
+    // accepts only BGV for now
+    Lattigo_BGVParameter:$params,
+    Lattigo_RLWEPublicKey:$publicKey
+  );
+  let results = (outs Lattigo_RLWEEncryptor:$encryptor);
+}
+
+def Lattigo_RLWENewDecryptorOp : Lattigo_RLWEOp<"new_decryptor"> {
+  let summary = "Creates a new RLWE decryptor";
+  let description = [{
+    This operation creates a new RLWE decryptor
+  }];
+  let arguments = (ins
+    // accepts only BGV for now
+    Lattigo_BGVParameter:$params,
+    Lattigo_RLWESecretKey:$secretKey
+  );
+  let results = (outs Lattigo_RLWEDecryptor:$decryptor);
+}
+
+def Lattigo_RLWEEncryptOp : Lattigo_RLWEOp<"encrypt"> {
+  let summary = "Encrypts a plaintext using RLWE";
+  let description = [{
+    This operation encrypts a plaintext using RLWE
+  }];
+  let arguments = (ins
+    Lattigo_RLWEEncryptor:$encryptor,
+    Lattigo_RLWEPlaintext:$plaintext
+  );
+  let results = (outs Lattigo_RLWECiphertext:$ciphertext);
+}
+
+def Lattigo_RLWEDecryptOp : Lattigo_RLWEOp<"decrypt"> {
+  let summary = "Decrypts a ciphertext using RLWE";
+  let description = [{
+    This operation decrypts a ciphertext using RLWE
+  }];
+  let arguments = (ins
+    Lattigo_RLWEDecryptor:$decryptor,
+    Lattigo_RLWECiphertext:$ciphertext
+  );
+  let results = (outs Lattigo_RLWEPlaintext:$plaintext);
+}
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGORLWEOPS_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
@@ -1,0 +1,55 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGORLWETYPES_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGORLWETYPES_TD_
+
+include "LattigoAttributes.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class Lattigo_RLWEType<string name, string typeMnemonic>
+    : Lattigo_Type<"RLWE" # name, "rlwe." # typeMnemonic> {
+}
+
+def Lattigo_RLWEKeyGenerator : Lattigo_RLWEType<"KeyGenerator", "key_generator"> {
+  let description = [{
+    This type represents the key generator for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWESecretKey : Lattigo_RLWEType<"SecretKey", "secret_key"> {
+  let description = [{
+    This type represents the secret key for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWEPublicKey : Lattigo_RLWEType<"PublicKey", "public_key"> {
+  let description = [{
+    This type represents the public key for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWEEncryptor : Lattigo_RLWEType<"Encryptor", "encryptor"> {
+  let description = [{
+    This type represents the encryptor for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWEDecryptor : Lattigo_RLWEType<"Decryptor", "decryptor"> {
+  let description = [{
+    This type represents the decryptor for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWEPlaintext : Lattigo_RLWEType<"Plaintext", "plaintext"> {
+  let description = [{
+    This type represents the plaintext for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWECiphertext : Lattigo_RLWEType<"Ciphertext", "ciphertext"> {
+  let description = [{
+    This type represents the ciphertext for the RLWE encryption scheme.
+  }];
+}
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGORLWETYPES_TD_

--- a/lib/Dialect/Lattigo/IR/LattigoTypes.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoTypes.cpp
@@ -1,0 +1,7 @@
+#include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
+
+namespace mlir {
+namespace heir {
+namespace lattigo {}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Lattigo/IR/LattigoTypes.h
+++ b/lib/Dialect/Lattigo/IR/LattigoTypes.h
@@ -1,0 +1,10 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOTYPES_H_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOTYPES_H_
+
+#include "lib/Dialect/Lattigo/IR/LattigoAttributes.h"
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/Lattigo/IR/LattigoTypes.h.inc"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOTYPES_H_

--- a/lib/Dialect/Lattigo/IR/LattigoTypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoTypes.td
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_LATTIGO_IR_LATTIGOTYPES_TD_
+#define LIB_DIALECT_LATTIGO_IR_LATTIGOTYPES_TD_
+
+include "LattigoDialect.td"
+include "LattigoAttributes.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+// A base class for all types in this dialect
+class Lattigo_Type<string name, string typeMnemonic>
+    : TypeDef<Lattigo_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+include "LattigoBGVTypes.td"
+include "LattigoRLWETypes.td"
+
+#endif  // LIB_DIALECT_LATTIGO_IR_LATTIGOTYPES_TD_

--- a/lib/Target/Lattigo/BUILD
+++ b/lib/Target/Lattigo/BUILD
@@ -1,0 +1,27 @@
+# Lattigo Emitter
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "LattigoEmitter",
+    srcs = ["LattigoEmitter.cpp"],
+    hdrs = [
+        "LattigoEmitter.h",
+        "LattigoTemplates.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/SelectVariableNames",
+        "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@heir//lib/Utils/TargetUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TranslateLib",
+    ],
+)

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -1,0 +1,312 @@
+#include "lib/Target/Lattigo/LattigoEmitter.h"
+
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
+#include "lib/Dialect/Lattigo/IR/LattigoOps.h"
+#include "lib/Target/Lattigo/LattigoTemplates.h"
+#include "lib/Utils/TargetUtils/TargetUtils.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"             // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/StringExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/FormatVariadic.h"    // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/ValueRange.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+LogicalResult translateToLattigo(Operation *op, llvm::raw_ostream &os) {
+  SelectVariableNames variableNames(op);
+  LattigoEmitter emitter(os, &variableNames);
+  LogicalResult result = emitter.translate(*op);
+  return result;
+}
+
+LogicalResult LattigoEmitter::translate(Operation &op) {
+  LogicalResult status =
+      llvm::TypeSwitch<Operation &, LogicalResult>(op)
+          // Builtin ops
+          .Case<ModuleOp>([&](auto op) { return printOperation(op); })
+          // Func ops
+          .Case<func::FuncOp, func::ReturnOp>(
+              [&](auto op) { return printOperation(op); })
+          .Case<arith::ConstantOp>([&](auto op) { return printOperation(op); })
+          // Lattigo ops
+          .Case<RLWENewEncryptorOp, RLWENewDecryptorOp, RLWENewKeyGeneratorOp,
+                RLWEGenKeyPairOp, RLWEEncryptOp, RLWEDecryptOp,
+                BGVNewParametersFromLiteralOp, BGVNewEncoderOp,
+                BGVNewEvaluatorOp, BGVNewPlaintextOp, BGVEncodeOp, BGVDecodeOp,
+                BGVAddOp, BGVSubOp, BGVMulOp>(
+              [&](auto op) { return printOperation(op); })
+          .Default([&](Operation &) {
+            return emitError(op.getLoc(), "unable to find printer for op");
+          });
+
+  if (failed(status)) {
+    return emitError(op.getLoc(),
+                     llvm::formatv("Failed to translate op {0}", op.getName()));
+  }
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(ModuleOp moduleOp) {
+  os << kModulePreludeTemplate;
+
+  for (Operation &op : moduleOp) {
+    if (failed(translate(op))) {
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(func::FuncOp funcOp) {
+  // if (funcOp.getNumResults() != 1) {
+  //   return emitError(funcOp.getLoc(),
+  //                    llvm::formatv("Only functions with a single return type
+  //                    "
+  //                                  "are supported, but this function has ",
+  //                                  funcOp.getNumResults()));
+  //   return failure();
+  // }
+
+  os << "func " << funcOp.getName() << "() {\n";
+  os.indent();
+
+  for (Block &block : funcOp.getBlocks()) {
+    for (Operation &op : block.getOperations()) {
+      if (failed(translate(op))) {
+        return failure();
+      }
+    }
+  }
+
+  os.unindent();
+  os << "}\n";
+
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(func::ReturnOp op) {
+  // if (op.getNumOperands() != 1) {
+  //   return emitError(op.getLoc(), "Only one return value supported");
+  // }
+  // os << "return " << variableNames->getNameForValue(op.getOperands()[0])
+  //    << ";\n";
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(arith::ConstantOp op) {
+  auto valueAttr = op.getValue();
+  std::string valueString;
+  auto res = llvm::TypeSwitch<Attribute, LogicalResult>(valueAttr)
+                 .Case<IntegerAttr>([&](IntegerAttr intAttr) {
+                   valueString =
+                       "[]int64{" + std::to_string(intAttr.getInt()) + "}";
+                   return success();
+                 })
+                 .Default([&](auto) { return failure(); });
+  if (failed(res)) {
+    return res;
+  }
+  os << getName(op.getResult()) << " := " << valueString << "\n";
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(RLWENewEncryptorOp op) {
+  return printNewMethod(op.getResult(), {op.getParams(), op.getPublicKey()},
+                        "rlwe.NewEncryptor", false);
+}
+
+LogicalResult LattigoEmitter::printOperation(RLWENewDecryptorOp op) {
+  return printNewMethod(op.getResult(), {op.getParams(), op.getSecretKey()},
+                        "rlwe.NewDecryptor", false);
+}
+
+LogicalResult LattigoEmitter::printOperation(RLWENewKeyGeneratorOp op) {
+  return printNewMethod(op.getResult(), {op.getParams()},
+                        "rlwe.NewKeyGenerator", false);
+}
+
+LogicalResult LattigoEmitter::printOperation(RLWEGenKeyPairOp op) {
+  return printEvalNewMethod(op.getResults(), op.getKeyGenerator(), {},
+                            "GenKeyPairNew", false);
+}
+
+LogicalResult LattigoEmitter::printOperation(RLWEEncryptOp op) {
+  return printEvalNewMethod(op.getResult(), op.getEncryptor(),
+                            {op.getPlaintext()}, "EncryptNew", true);
+}
+
+LogicalResult LattigoEmitter::printOperation(RLWEDecryptOp op) {
+  return printEvalNewMethod(op.getResult(), op.getDecryptor(),
+                            {op.getCiphertext()}, "DecryptNew", false);
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVNewEncoderOp op) {
+  return printNewMethod(op.getResult(), {op.getParams()}, "bgv.NewEncoder",
+                        false);
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVNewEvaluatorOp op) {
+  // return printNewMethod(op.getResult(), {op.getParams()}, "bgv.NewEvaluator",
+  //                       false);
+  os << getName(op.getResult()) << " := " << "bgv.NewEvaluator(";
+  os << getName(op.getParams()) << ", nil)\n";
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVNewPlaintextOp op) {
+  // return printNewMethod(op.getResult(), {op.getParams()}, "bgv.NewPlaintext",
+  //                       false);
+  os << getName(op.getResult()) << " := " << "bgv.NewPlaintext(";
+  os << getName(op.getParams()) << ", ";
+  os << getName(op.getParams()) << ".MaxLevel()";
+  os << ")\n";
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVEncodeOp op) {
+  return printEvalInplaceMethod(op.getEncoded(), op.getEncoder(), op.getValue(),
+                                op.getPlaintext(), "Encode", false);
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVDecodeOp op) {
+  return printEvalInplaceMethod(op.getDecoded(), op.getEncoder(),
+                                op.getPlaintext(), op.getValue(), "Decode",
+                                false);
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVAddOp op) {
+  return printEvalNewMethod(op.getResult(), op.getEvaluator(),
+                            {op.getLhs(), op.getRhs()}, "AddNew", true);
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVSubOp op) {
+  return printEvalNewMethod(op.getResult(), op.getEvaluator(),
+                            {op.getLhs(), op.getRhs()}, "SubNew", true);
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVMulOp op) {
+  return printEvalNewMethod(op.getResult(), op.getEvaluator(),
+                            {op.getLhs(), op.getRhs()}, "MulNew", true);
+}
+
+std::string printDenseI32ArrayAttr(DenseI32ArrayAttr attr) {
+  std::string res = "[]int{";
+  res += commaSeparated(attr.asArrayRef());
+  res += "}";
+  return res;
+}
+
+LogicalResult LattigoEmitter::printOperation(BGVNewParametersFromLiteralOp op) {
+  std::string errResult = ", err";
+  os << getName(op.getResult()) << errResult
+     << " := bgv.NewParametersFromLiteral(";
+  os << "bgv.ParametersLiteral{";
+  os.indent();
+  os << "LogN: " << op.getParamsLiteral().getLogN() << ",\n";
+  os << "LogQ: " << printDenseI32ArrayAttr(op.getParamsLiteral().getLogQ())
+     << ",\n";
+  os << "LogP: " << printDenseI32ArrayAttr(op.getParamsLiteral().getLogP())
+     << ",\n";
+  os << "PlaintextModulus: " << op.getParamsLiteral().getPlaintextModulus()
+     << ",\n";
+  os.unindent();
+  os << "})\n";
+  printErrPanic();
+  return success();
+}
+
+void LattigoEmitter::printErrPanic() {
+  os << "if err != nil {\n";
+  os.indent();
+  os << "panic(err)\n";
+  os.unindent();
+  os << "}\n";
+}
+
+LogicalResult LattigoEmitter::printNewMethod(::mlir::Value result,
+                                             ::mlir::ValueRange operands,
+                                             std::string_view op, bool err) {
+  std::string errResult = err ? ", err" : "";
+  os << getName(result);
+  os << errResult << " := " << op << "(";
+  os << getCommaSeparatedNames(operands);
+  os << ")\n";
+  if (err) {
+    printErrPanic();
+  }
+  return success();
+}
+
+LogicalResult LattigoEmitter::printEvalInplaceMethod(
+    ::mlir::Value result, ::mlir::Value evaluator, ::mlir::Value operand,
+    ::mlir::Value operandInplace, std::string_view op, bool err) {
+  std::string errResult = err ? ", err := " : "";
+  os << errResult << getName(evaluator) << "." << op << "(" << getName(operand)
+     << ", " << getName(operandInplace) << ");\n";
+  if (err) {
+    printErrPanic();
+  }
+  // workaround
+  os << getName(result) << " := " << getName(operandInplace) << "\n";
+  return success();
+}
+
+LogicalResult LattigoEmitter::printEvalNewMethod(::mlir::ValueRange results,
+                                                 ::mlir::Value evaluator,
+                                                 ::mlir::ValueRange operands,
+                                                 std::string_view op,
+                                                 bool err) {
+  std::string errResult = err ? ", err" : "";
+  os << getCommaSeparatedNames(results);
+  os << errResult << " := " << getName(evaluator) << "." << op << "(";
+  os << getCommaSeparatedNames(operands);
+  os << ")\n";
+  if (err) {
+    printErrPanic();
+  }
+  return success();
+}
+
+LattigoEmitter::LattigoEmitter(raw_ostream &os,
+                               SelectVariableNames *variableNames)
+    : os(os), variableNames(variableNames) {}
+
+void registerToLattigoTranslation() {
+  TranslateFromMLIRRegistration reg(
+      "emit-lattigo",
+      "translate the lattigo dialect to GO code against the Lattigo API",
+      [](Operation *op, llvm::raw_ostream &output) {
+        return translateToLattigo(op, output);
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<arith::ArithDialect, func::FuncDialect,
+                        lattigo::LattigoDialect>();
+      });
+}
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -1,0 +1,109 @@
+#ifndef LIB_TARGET_LATTIGO_LATTIGOEMITTER_H_
+#define LIB_TARGET_LATTIGO_LATTIGOEMITTER_H_
+
+#include <string_view>
+
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
+#include "lib/Dialect/Lattigo/IR/LattigoOps.h"
+#include "lib/Utils/TargetUtils/TargetUtils.h"
+#include "llvm/include/llvm/Support/raw_ostream.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/ValueRange.h"             // from @llvm-project
+#include "mlir/include/mlir/Support/IndentedOstream.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+#include "mlir/include/mlir/Tools/mlir-translate/Translation.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+/// Translates the given operation to Lattigo
+::mlir::LogicalResult translateToLattigo(::mlir::Operation *op,
+                                         llvm::raw_ostream &os);
+
+class LattigoEmitter {
+ public:
+  LattigoEmitter(raw_ostream &os, SelectVariableNames *variableNames);
+
+  LogicalResult translate(::mlir::Operation &operation);
+
+ private:
+  /// Output stream to emit to.
+  raw_indented_ostream os;
+
+  /// Pre-populated analysis selecting unique variable names for all the SSA
+  /// values.
+  SelectVariableNames *variableNames;
+
+  // Functions for printing individual ops
+  LogicalResult printOperation(::mlir::ModuleOp op);
+  LogicalResult printOperation(::mlir::func::FuncOp op);
+  LogicalResult printOperation(::mlir::func::ReturnOp op);
+  LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  // Lattigo ops
+  LogicalResult printOperation(RLWENewEncryptorOp op);
+  LogicalResult printOperation(RLWENewDecryptorOp op);
+  LogicalResult printOperation(RLWENewKeyGeneratorOp op);
+  LogicalResult printOperation(RLWEGenKeyPairOp op);
+  LogicalResult printOperation(RLWEEncryptOp op);
+  LogicalResult printOperation(RLWEDecryptOp op);
+  LogicalResult printOperation(BGVNewParametersFromLiteralOp op);
+  LogicalResult printOperation(BGVNewEncoderOp op);
+  LogicalResult printOperation(BGVNewEvaluatorOp op);
+  LogicalResult printOperation(BGVNewPlaintextOp op);
+  LogicalResult printOperation(BGVEncodeOp op);
+  LogicalResult printOperation(BGVDecodeOp op);
+  LogicalResult printOperation(BGVAddOp op);
+  LogicalResult printOperation(BGVSubOp op);
+  LogicalResult printOperation(BGVMulOp op);
+
+  // Helpers for above
+  void printErrPanic();
+
+  LogicalResult printNewMethod(::mlir::Value result,
+                               ::mlir::ValueRange operands, std::string_view op,
+                               bool err);
+
+  LogicalResult printEvalInplaceMethod(::mlir::Value result,
+                                       ::mlir::Value evaluator,
+                                       ::mlir::Value operand,
+                                       ::mlir::Value operandInplace,
+                                       std::string_view op, bool err);
+
+  LogicalResult printEvalNewMethod(::mlir::ValueRange results,
+                                   ::mlir::Value evaluator,
+                                   ::mlir::ValueRange operands,
+                                   std::string_view op, bool err);
+
+  LogicalResult printEvalNewMethod(::mlir::Value result,
+                                   ::mlir::Value evaluator,
+                                   ::mlir::ValueRange operands,
+                                   std::string_view op, bool err) {
+    return printEvalNewMethod(::mlir::ValueRange(result), evaluator, operands,
+                              op, err);
+  }
+
+  std::string getName(::mlir::Value value) {
+    return variableNames->getNameForValue(value);
+  }
+
+  std::string getCommaSeparatedNames(::mlir::ValueRange values) {
+    return commaSeparatedValues(values,
+                                [&](Value value) { return getName(value); });
+  }
+};
+
+void registerToLattigoTranslation(void);
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TARGET_LATTIGO_LATTIGOEMITTER_H_

--- a/lib/Target/Lattigo/LattigoTemplates.h
+++ b/lib/Target/Lattigo/LattigoTemplates.h
@@ -1,0 +1,27 @@
+#ifndef LIB_TARGET_LATTIGO_LATTIGOTEMPLATES_H_
+#define LIB_TARGET_LATTIGO_LATTIGOTEMPLATES_H_
+
+#include <string_view>
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+// clang-format off
+constexpr std::string_view kModulePreludeTemplate = R"go(
+package main
+
+import (
+    "fmt"
+
+    "github.com/tuneinsight/lattigo/v6/core/rlwe"
+    "github.com/tuneinsight/lattigo/v6/schemes/bgv"
+)
+)go";
+// clang-format on
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TARGET_LATTIGO_LATTIGOTEMPLATES_H_

--- a/lib/Utils/TargetUtils/TargetUtils.h
+++ b/lib/Utils/TargetUtils/TargetUtils.h
@@ -2,6 +2,7 @@
 #define LIB_UTILS_TARGETUTILS_TARGETUTILS_H_
 
 #include <functional>
+#include <numeric>
 #include <string>
 
 #include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
@@ -20,6 +21,18 @@ namespace heir {
 // function.
 std::string commaSeparatedValues(
     ValueRange values, std::function<std::string(Value)> valueToString);
+
+// Return a comma-separated string containing the values in the given
+// ArrayRef, with each value being converted to a string by std::to_string
+template <typename T>
+std::string commaSeparated(ArrayRef<T> values) {
+  if (values.empty()) {
+    return std::string();
+  }
+  return std::accumulate(
+      std::next(values.begin()), values.end(), std::to_string(values[0]),
+      [&](const std::string& a, T b) { return a + ", " + std::to_string(b); });
+}
 
 // Return a comma-separated string containing the types in a given TypeRange,
 // or failure if the mapper fails to convert any of the types.

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -49,6 +49,7 @@ cc_binary(
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/LWE/Transforms",
         "@heir//lib/Dialect/LWE/Transforms:AddClientInterface",
+        "@heir//lib/Dialect/Lattigo/IR:Dialect",
         "@heir//lib/Dialect/LinAlg/Conversions/LinalgToTensorExt",
         "@heir//lib/Dialect/ModArith/Conversions/ModArithToArith",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
@@ -156,6 +157,7 @@ cc_binary(
     deps = [
         "@heir//lib/Source/AutoHog:AutoHogImporter",
         "@heir//lib/Target/Jaxite:JaxiteEmitter",
+        "@heir//lib/Target/Lattigo:LattigoEmitter",
         "@heir//lib/Target/Metadata:MetadataEmitter",
         "@heir//lib/Target/OpenFhePke:OpenFheRegistration",
         "@heir//lib/Target/TfheRust:TfheRustEmitter",
@@ -178,6 +180,7 @@ cc_binary(
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/Jaxite/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/Lattigo/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",

--- a/tools/heir-lsp.cpp
+++ b/tools/heir-lsp.cpp
@@ -4,6 +4,7 @@
 #include "lib/Dialect/Comb/IR/CombDialect.h"
 #include "lib/Dialect/Jaxite/IR/JaxiteDialect.h"
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
 #include "lib/Dialect/ModArith/IR/ModArithDialect.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
@@ -39,6 +40,7 @@ int main(int argc, char **argv) {
   registry.insert<cggi::CGGIDialect>();
   registry.insert<comb::CombDialect>();
   registry.insert<jaxite::JaxiteDialect>();
+  registry.insert<lattigo::LattigoDialect>();
   registry.insert<lwe::LWEDialect>();
   registry.insert<random::RandomDialect>();
   registry.insert<openfhe::OpenfheDialect>();

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -18,6 +18,7 @@
 #include "lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.h"
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/Passes.h"
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
 #include "lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.h"
 #include "lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h"
 #include "lib/Dialect/ModArith/IR/ModArithDialect.h"
@@ -118,6 +119,7 @@ int main(int argc, char **argv) {
   registry.insert<cggi::CGGIDialect>();
   registry.insert<comb::CombDialect>();
   registry.insert<jaxite::JaxiteDialect>();
+  registry.insert<lattigo::LattigoDialect>();
   registry.insert<lwe::LWEDialect>();
   registry.insert<random::RandomDialect>();
   registry.insert<openfhe::OpenfheDialect>();

--- a/tools/heir-translate.cpp
+++ b/tools/heir-translate.cpp
@@ -1,5 +1,6 @@
 #include "lib/Source/AutoHog/AutoHogImporter.h"
 #include "lib/Target/Jaxite/JaxiteEmitter.h"
+#include "lib/Target/Lattigo/LattigoEmitter.h"
 #include "lib/Target/Metadata/MetadataEmitter.h"
 #include "lib/Target/OpenFhePke/OpenFheTranslateRegistration.h"
 #include "lib/Target/TfheRust/TfheRustEmitter.h"
@@ -24,6 +25,9 @@ int main(int argc, char **argv) {
   mlir::heir::openfhe::registerTranslateOptions();
   mlir::heir::openfhe::registerToOpenFhePkeTranslation();
   mlir::heir::openfhe::registerToOpenFhePkeHeaderTranslation();
+
+  // Lattigo
+  mlir::heir::lattigo::registerToLattigoTranslation();
 
   // AutoHOG input
   mlir::heir::registerFromAutoHogTranslation();


### PR DESCRIPTION
Related to #323 

This is an initial support for [Lattigo](https://github.com/tuneinsight/lattigo/). The focus of this PR is to initiate the framework supporting concepts like encryptor/decryptor/evaluator. For arithmetic part only bgv.add/mul is supported, but I think others can be easily added in later PR.

Example IR now:

```mlir
#paramLiteral = #lattigo.bgv.parameters_literal<
    logN = 14,
    logQ = [56, 55, 55],
    logP = [55],
    plaintextModulus = 0x3ee0001
>

module {
    func.func @main() -> () {
        %param = lattigo.bgv.new_parameters_from_literal {paramsLiteral = #paramLiteral} : () -> !lattigo.bgv.parameter
        %encoder = lattigo.bgv.new_encoder %param : (!lattigo.bgv.parameter) -> !lattigo.bgv.encoder
        %kgen = lattigo.rlwe.new_key_generator %param : (!lattigo.bgv.parameter) -> !lattigo.rlwe.key_generator
        %sk, %pk = lattigo.rlwe.gen_key_pair %kgen : (!lattigo.rlwe.key_generator) -> (!lattigo.rlwe.secret_key, !lattigo.rlwe.public_key)
        %encryptor = lattigo.rlwe.new_encryptor %param, %pk : (!lattigo.bgv.parameter, !lattigo.rlwe.public_key) -> !lattigo.rlwe.encryptor
        %decryptor = lattigo.rlwe.new_decryptor %param, %sk : (!lattigo.bgv.parameter, !lattigo.rlwe.secret_key) -> !lattigo.rlwe.decryptor

        %evaluator = lattigo.bgv.new_evaluator %param : (!lattigo.bgv.parameter) -> !lattigo.bgv.evaluator

        %value1 = arith.constant 1 : i64
        %value2 = arith.constant 2 : i64

        %pt_raw1 = lattigo.bgv.new_plaintext %param : (!lattigo.bgv.parameter) -> !lattigo.rlwe.plaintext
        %pt_raw2 = lattigo.bgv.new_plaintext %param : (!lattigo.bgv.parameter) -> !lattigo.rlwe.plaintext

        %pt1 = lattigo.bgv.encode %encoder, %value1, %pt_raw1 : (!lattigo.bgv.encoder, i64, !lattigo.rlwe.plaintext) -> !lattigo.rlwe.plaintext
        %pt2 = lattigo.bgv.encode %encoder, %value2, %pt_raw2 : (!lattigo.bgv.encoder, i64, !lattigo.rlwe.plaintext) -> !lattigo.rlwe.plaintext
        %ct1 = lattigo.rlwe.encrypt %encryptor, %pt1 : (!lattigo.rlwe.encryptor, !lattigo.rlwe.plaintext) -> !lattigo.rlwe.ciphertext
        %ct2 = lattigo.rlwe.encrypt %encryptor, %pt2 : (!lattigo.rlwe.encryptor, !lattigo.rlwe.plaintext) -> !lattigo.rlwe.ciphertext

        %added = lattigo.bgv.add %evaluator, %ct1, %ct2 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
        %mul = lattigo.bgv.mul %evaluator, %added, %ct2 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext

        %dec = lattigo.rlwe.decrypt %decryptor, %mul : (!lattigo.rlwe.decryptor, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.plaintext

        %result = arith.constant 0 : i64

        %updated = lattigo.bgv.decode %encoder, %dec, %result : (!lattigo.bgv.encoder, !lattigo.rlwe.plaintext, i64) -> i64

        return
    }
}
```

With `heir-translate --emit-lattigo` we get

```go
package main

import (
	"fmt"

	"github.com/tuneinsight/lattigo/v6/core/rlwe"
	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
)

func main() {
	v0, err := bgv.NewParametersFromLiteral(bgv.ParametersLiteral{LogN: 14,
		LogQ:             []int{56, 55, 55},
		LogP:             []int{55},
		PlaintextModulus: 65929217,
	})
	if err != nil {
		panic(err)
	}
	v1 := bgv.NewEncoder(v0)
	v2 := rlwe.NewKeyGenerator(v0)
	v3, v4 := v2.GenKeyPairNew()
	v5 := rlwe.NewEncryptor(v0, v4)
	v6 := rlwe.NewDecryptor(v0, v3)
	v7 := bgv.NewEvaluator(v0, nil)
	v8 := []int64{1}
	v9 := []int64{2}
	v10 := bgv.NewPlaintext(v0, v0.MaxLevel())
	v11 := bgv.NewPlaintext(v0, v0.MaxLevel())
	v1.Encode(v8, v10)
	v12 := v10
	v1.Encode(v9, v11)
	v13 := v11
	v14, err := v5.EncryptNew(v12)
	if err != nil {
		panic(err)
	}
	v15, err := v5.EncryptNew(v13)
	if err != nil {
		panic(err)
	}
	v16, err := v7.AddNew(v14, v15)
	if err != nil {
		panic(err)
	}
	v17, err := v7.MulNew(v16, v15)
	if err != nil {
		panic(err)
	}
	v18 := v6.DecryptNew(v17)
	v19 := []int64{0}
	v1.Decode(v18, v19)
	v20 := v19

        // Println is manually added
	fmt.Println(v20)
}
```

It can compile and get the correct result.

### Discussion

In Lattigo, `encoder.Encode/Decode` update the operand in place, which has been expressed in the dialect op `lattigo.bgv.encode/decode` as one operand and one result, and the emitter will emit an `result = operand`. How should we express such in-place update.