### PR TITLE
fix crash in RotateAndReduce

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
+++ b/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
@@ -46,7 +46,7 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
                << "Trying to replace rotations ending in " << *op << "\n");
     auto b = ImplicitLocOpBuilder(op->getLoc(), op);
     auto tensor = reduction.getTensor();
-    Operation *finalOp;
+    Operation *finalOp = nullptr;
     auto tensorShape =
         mlir::cast<RankedTensorType>(tensor.getType()).getShape();
     for (int64_t shiftSize = tensorShape[0] / 2; shiftSize > 0;
@@ -70,7 +70,7 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
     for (auto value : reduction.getSavedValues()) {
       finalOp = b.create<ArithOp>(finalOp->getResult(0), value);
     }
-    op->replaceAllUsesWith(finalOp);
+    if (finalOp) op->replaceAllUsesWith(finalOp);
     LLVM_DEBUG(llvm::dbgs() << "Post-replacement: " << *parentOp << "\n");
   }
 

--- a/tests/Dialect/TensorExt/Transforms/rotate_and_reduce.mlir
+++ b/tests/Dialect/TensorExt/Transforms/rotate_and_reduce.mlir
@@ -910,3 +910,10 @@ func.func @test_dot_product_regression(%arg0: !secret.secret<tensor<8xi16>>, %ar
   } -> !secret.secret<i16>
   return %0 : !secret.secret<i16>
 }
+
+// Another crash regression test, this time for tensors of size 1
+// CHECK-LABEL: @test_size_one_regression
+func.func @test_size_one_regression(%arg0: tensor<1xi16>, %arg1: tensor<1xi16>) -> tensor<1xi16> {
+  %0 = arith.addi %arg0, %arg1 : tensor<1xi16>
+  return %0 : tensor<1xi16>
+}


### PR DESCRIPTION
Fixes #870 

`--rotate-and-reduce`  crashed for tensors of size one due to a bug in `tryReplaceOperations`, which effectively did the following (simplified snippet):
```C++
// finalOp pointer is created
Operation *finalOp;
...
// for loop that would set finalOp, but is skipped when size is 1
for (int64_t shiftSize = tensorShape[0] / 2; shiftSize > 0;
         shiftSize /= 2) {
      auto rotatedTensor = b.create<tensor_ext::RotateOp>(
          tensor, b.create<arith::ConstantOp>(b.getIndexAttr(shiftSize)));
      auto addOp = b.create<ArithOp>(tensor, rotatedTensor);
      finalOp = addOp;
      tensor = addOp->getResult(0);
  }
...
// crashes with a surprisingly cryptic message 
op->replaceAllUsesWith(finalOp);
```

The fix is pretty simple: explicitly initialize finalOp as nullptr and only do the replace at the end if finalOp isn't null.