### PR TITLE
[poly][mod_arith] Update `fastNTT` to emit mod_arith ops

### DIFF
--- a/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -337,9 +337,9 @@ void ModArithToArith::runOnOperation() {
   addStructuralConversionPatterns(typeConverter, patterns, target);
 
   target.addDynamicallyLegalOp<
-      tensor::EmptyOp, tensor::ExtractOp, tensor::InsertOp, affine::AffineForOp,
-      affine::AffineYieldOp, linalg::GenericOp, linalg::YieldOp,
-      tensor::ExtractSliceOp, tensor::InsertSliceOp>(
+      tensor::EmptyOp, tensor::ExtractOp, tensor::InsertOp, tensor::CastOp,
+      affine::AffineForOp, affine::AffineYieldOp, linalg::GenericOp,
+      linalg::YieldOp, tensor::ExtractSliceOp, tensor::InsertSliceOp>(
       [&](auto op) { return typeConverter.isLegal(op); });
 
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {

--- a/lib/Dialect/Polynomial/IR/BUILD
+++ b/lib/Dialect/Polynomial/IR/BUILD
@@ -152,6 +152,7 @@ gentbl_cc_library(
         ":dialect_inc_gen",
         ":td_files",
         ":types_inc_gen",
+        "@heir//lib/Dialect/ModArith/IR:td_files",
     ],
 )
 

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.td
@@ -1,6 +1,7 @@
 #ifndef LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALOPS_TD_
 #define LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALOPS_TD_
 
+include "lib/Dialect/ModArith/IR/ModArithTypes.td"
 include "lib/Dialect/Polynomial/IR/PolynomialAttributes.td"
 include "lib/Dialect/Polynomial/IR/PolynomialDialect.td"
 include "lib/Dialect/Polynomial/IR/PolynomialTypes.td"
@@ -309,7 +310,7 @@ def Polynomial_NTTOp : Polynomial_Op<"ntt", [Pure]> {
     Polynomial_PolynomialType:$input,
     OptionalAttr<Polynomial_PrimitiveRootAttr>:$root
   );
-  let results = (outs RankedTensorOf<[AnyInteger]>:$output);
+  let results = (outs RankedTensorOf<[ModArith_ModArithType]>:$output);
   let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` type($output)";
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
@@ -330,7 +331,7 @@ def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure]> {
     The choice of primitive root may be optionally specified.
   }];
   let arguments = (
-    ins RankedTensorOf<[AnyInteger]>:$input,
+    ins RankedTensorOf<[ModArith_ModArithType]>:$input,
     OptionalAttr<Polynomial_PrimitiveRootAttr>:$root
   );
   let results = (outs Polynomial_PolynomialType:$output);

--- a/lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.cpp
+++ b/lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.cpp
@@ -51,8 +51,8 @@ struct ConvertAnyElementwiseMappableOpOnRankedTensors : public RewritePattern {
     auto ip = rewriter.saveInsertionPoint();
 
     // Create an empty tensor as initial value of the iter_args
-    Value target =
-        rewriter.create<tensor::EmptyOp>(op->getLoc(), shape, elementType);
+    Value target = rewriter.create<tensor::EmptyOp>(
+        op->getLoc(), shape, elementType, resultType.getEncoding());
 
     llvm::SmallVector<Value, 1> indices;
 

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_intt.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_intt.mlir
@@ -4,7 +4,8 @@
 // https://doi.org/10.1109/ACCESS.2023.3294446
 
 #cycl = #polynomial.int_polynomial<1 + x**4>
-#ring = #polynomial.ring<coefficientType=!mod_arith.int<7681:i32>, polynomialModulus=#cycl>
+!coeff_ty = !mod_arith.int<7681:i32>
+#ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl>
 #root = #polynomial.primitive_root<value=1925:i32, degree=8:i32>
 !poly_ty = !polynomial.polynomial<ring=#ring>
 
@@ -16,12 +17,14 @@
 // CHECK-DAG: #[[ADD_DIV_MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1 floordiv 2)>
 // CHECK-DAG: #[[ROOT_MAP:.*]] = affine_map<(d0, d1) -> ((d0 * 2 + 1) * d1)>
 
-// CHECK:     func.func @lower_intt() -> [[MOD_ARITH_OUTPUT_TYPE:.*]] {
+// CHECK:     func.func @lower_intt() -> [[MOD_TYPE:.*]] {
 // CHECK:      %[[COEFFS:.*]] = arith.constant dense<[1, 2, 3, 4]> : [[INPUT_TYPE:.*]]
-// CHECK:      %[[CAST:.*]] = tensor.cast %[[COEFFS]] : [[INPUT_TYPE]] to [[OUTPUT_TYPE:.*]]
-// CHECK-DAG:  %[[INITIAL_VALUE:.*]] = arith.extui %[[CAST]] : [[OUTPUT_TYPE]] to [[INTER_TYPE:.*]]
-// CHECK-DAG:  %[[CMOD:.*]] = arith.constant 7681 : [[ELEM_TYPE:i64]]
-// CHECK-DAG:  %[[ROOTS:.*]] = arith.constant dense<[1, 1213, 4298, 5756]> : [[INTER_TYPE]]
+// CHECK:      %[[COEFFS_ENC:.*]] = mod_arith.encapsulate %[[COEFFS]] : [[INPUT_TYPE]] -> [[RING_MOD_TYPE:.*]]
+// CHECK:      %[[COEFFS_CAST:.*]] = tensor.cast %[[COEFFS_ENC]] : [[RING_MOD_TYPE]] to [[MOD_TYPE:.*]]
+
+// CHECK-DAG:  %[[INITIAL_VALUE:.*]] = mod_arith.reduce %[[COEFFS_CAST]] : [[MOD_TYPE]]
+// CHECK-DAG:  %[[ROOTS:.*]] = arith.constant dense<[1, 1213, 4298, 5756]> : [[INT_TYPE:.*]]
+// CHECK-DAG:  %[[ROOTS_ENC:.*]] = mod_arith.encapsulate %[[ROOTS]] : [[INT_TYPE]] -> [[MOD_TYPE]]
 
 // CHECK-DAG:    %[[ZERO:.*]] = arith.constant 0 : index
 // CHECK-DAG:    %[[ONE:.*]] = arith.constant 1 : index
@@ -29,58 +32,56 @@
 // CHECK-DAG:    %[[N:.*]] = arith.constant 4 : index
 
 // CHECK:        %[[RES:.]]:3 = affine.for %[[_:.*]] = 0 to 2
-// CHECK-SAME:     iter_args(%[[TARGET:.*]] = %[[INITIAL_VALUE]], %[[BATCH_SIZE:.*]] = %[[N]], %[[ROOT_EXP:.*]] = %[[ONE]]) -> ([[INTER_TYPE]], index, index) {
+// CHECK-SAME:     iter_args(%[[TARGET:.*]] = %[[INITIAL_VALUE]], %[[BATCH_SIZE:.*]] = %[[N]], %[[ROOT_EXP:.*]] = %[[ONE]]) -> ([[MOD_TYPE]], index, index) {
 // CHECK:          %[[INNER_RES:.]] = affine.for %[[INDEX:.*]] = #[[ID_MAP]](%[[ZERO]]) to #[[DIV_MAP]](%[[N]], %[[BATCH_SIZE]])
-// CHECK-SAME:       iter_args(%[[INNER_TARGET:.*]] = %[[TARGET]]) -> ([[INTER_TYPE]]) {
+// CHECK-SAME:       iter_args(%[[INNER_TARGET:.*]] = %[[TARGET]]) -> ([[MOD_TYPE]]) {
 // CHECK:            %[[INDEX_K:.*]] = affine.apply #[[MUL_MAP]](%[[BATCH_SIZE]], %[[INDEX]])
 // CHECK:            %[[ARITH_RES:.*]] = affine.for %[[INDEX_J:.*]] = #[[ID_MAP]](%[[ZERO]]) to #[[C_DIV_MAP]](%[[BATCH_SIZE]])
-// CHECK-SAME:         iter_args(%[[ARITH_TARGET:.*]] = %[[INNER_TARGET]]) -> ([[INTER_TYPE]]) {
+// CHECK-SAME:         iter_args(%[[ARITH_TARGET:.*]] = %[[INNER_TARGET]]) -> ([[MOD_TYPE]]) {
+
 // CHECK:              %[[INDEX_A:.*]] = affine.apply #[[ADD_MAP]](%[[INDEX_J]], %[[INDEX_K]])
-// CHECK:              %[[A:.*]] = tensor.extract %[[ARITH_TARGET]][%[[INDEX_A]]] : [[INTER_TYPE]]
+// CHECK:              %[[A:.*]] = tensor.extract %[[ARITH_TARGET]][%[[INDEX_A]]] : [[MOD_TYPE]]
+
 // CHECK:              %[[INDEX_B:.*]] = affine.apply #[[ADD_DIV_MAP]](%[[INDEX_A]], %[[BATCH_SIZE]])
-// CHECK:              %[[B:.*]] = tensor.extract %[[ARITH_TARGET]][%[[INDEX_B]]] : [[INTER_TYPE]]
+// CHECK:              %[[B:.*]] = tensor.extract %[[ARITH_TARGET]][%[[INDEX_B]]] : [[MOD_TYPE]]
+
 // CHECK:              %[[ROOT_INDEX:.*]] = affine.apply #[[ROOT_MAP]](%[[INDEX_J]], %[[ROOT_EXP]])
-// CHECK:              %[[ROOT:.*]] = tensor.extract %[[ROOTS]][%[[ROOT_INDEX]]] : [[INTER_TYPE]]
+// CHECK:              %[[ROOT:.*]] = tensor.extract %[[ROOTS_ENC]][%[[ROOT_INDEX]]] : [[MOD_TYPE]]
 
-// CHECK:              %[[APLUSB:.*]] = arith.addi %[[A]], %[[B]] : [[ELEM_TYPE]]
-// CHECK:              %[[GSPLUS:.*]] = arith.remui %[[APLUSB]], %[[CMOD]] : [[ELEM_TYPE]]
+// CHECK:              %[[GSPLUS:.*]] = mod_arith.add %[[A]], %[[B]] : [[coeff_ty:.*]]
+// CHECK:              %[[AMINUSB:.*]] = mod_arith.sub %[[A]], %[[B]] : [[coeff_ty]]
+// CHECK:              %[[GSMINUS:.*]] = mod_arith.mul %[[AMINUSB]], %[[ROOT]] : [[coeff_ty]]
 
-// CHECK:              %[[AMINUSB:.*]] = arith.subi %[[A]], %[[B]] : [[ELEM_TYPE]]
-// CHECK:              %[[AMINUSB_SHIFT:.*]] = arith.addi %[[AMINUSB]], %[[CMOD]] : [[ELEM_TYPE]]
-// CHECK:              %[[AMINUSB_MOD:.*]] = arith.remui %[[AMINUSB_SHIFT]], %[[CMOD]] : [[ELEM_TYPE]]
+// CHECK:              %[[INSERT_PLUS:.*]] = tensor.insert %[[GSPLUS]] into %[[ARITH_TARGET]][%[[INDEX_A]]] : [[MOD_TYPE]]
+// CHECK:              %[[INSERT_MINUS:.*]] = tensor.insert %[[GSMINUS]] into %[[INSERT_PLUS]][%[[INDEX_B]]] : [[MOD_TYPE]]
+// CHECK:              affine.yield %[[INSERT_MINUS]] : [[MOD_TYPE]]
 
-// CHECK:              %[[ROOTS_MUL:.*]] = arith.muli %[[AMINUSB_MOD]], %[[ROOT]] : [[ELEM_TYPE]]
-// CHECK:              %[[GSMINUS:.*]] = arith.remui %[[ROOTS_MUL]], %[[CMOD]] : [[ELEM_TYPE]]
-
-// CHECK:              %[[INSERT_PLUS:.*]] = tensor.insert %[[GSPLUS]] into %[[ARITH_TARGET]][%[[INDEX_A]]] : [[INTER_TYPE]]
-// CHECK:              %[[INSERT_MINUS:.*]] = tensor.insert %[[GSMINUS]] into %[[INSERT_PLUS]][%[[INDEX_B]]] : [[INTER_TYPE]]
-// CHECK:              affine.yield %[[INSERT_MINUS]] : [[INTER_TYPE]]
-
-// CHECK:            affine.yield %[[ARITH_RES]] : [[INTER_TYPE]]
+// CHECK:            affine.yield %[[ARITH_RES]] : [[MOD_TYPE]]
 
 // CHECK:          %[[NEXT_BATCH_SIZE:.*]] = arith.divui %[[BATCH_SIZE]], %[[TWO]] : index
 // CHECK:          %[[NEXT_ROOT_EXP:.*]] = arith.muli %[[ROOT_EXP]], %[[TWO]] : index
-// CHECK:          affine.yield %[[INNER_RES]], %[[NEXT_BATCH_SIZE]], %[[NEXT_ROOT_EXP]] : [[INTER_TYPE]], index, index
+// CHECK:          affine.yield %[[INNER_RES]], %[[NEXT_BATCH_SIZE]], %[[NEXT_ROOT_EXP]] : [[MOD_TYPE]], index, index
 
-// CHECK:       %[[N_INV_VEC:.*]] = arith.constant dense<5761> : [[INTER_TYPE]]
-// CHECK:       %[[CMOD_VEC:.*]] = arith.constant dense<7681> : [[INTER_TYPE]]
-// CHECK:       %[[RES_MUL:.*]] = arith.muli %[[RES]]#0, %[[N_INV_VEC]] : [[INTER_TYPE]]
-// CHECK:       %[[RES_MOD:.*]] = arith.remui %[[RES_MUL]], %[[CMOD_VEC]] : [[INTER_TYPE]]
-// CHECK:       %[[RES_TRUNC:.*]] = arith.trunci %[[RES_MOD]] : [[INTER_TYPE]] to [[OUTPUT_TYPE]]
+// CHECK:       %[[N_INV_VEC:.*]] = arith.constant dense<5761> : [[INT_TYPE]]
+// CHECK:       %[[N_INV_VEC_ENC:.*]] = mod_arith.encapsulate %[[N_INV_VEC]] : [[INT_TYPE]] -> [[MOD_TYPE]]
+
+// CHECK:       %[[RES_INTT:.*]] = mod_arith.mul %[[RES]]#0, %[[N_INV_VEC_ENC]] : [[MOD_TYPE]]
 
 // CHECK:      %[[REVERSE_BIT_ORDER_COEFFS:.*]] = arith.constant dense<[0, 2, 1, 3]> : tensor<4xindex>
-// CHECK:      %[[OUTPUT_VEC:.*]] = arith.constant dense<0> : [[OUTPUT_TYPE]]
+// CHECK:      %[[OUTPUT_VEC:.*]] = arith.constant dense<0> : [[INT_TYPE]]
+// CHECK:      %[[OUTPUT_ENC:.*]] = mod_arith.encapsulate %[[OUTPUT_VEC]] : [[INT_TYPE]] -> [[MOD_TYPE]]
 // CHECK:      %[[ORDERED_OUTPUT:.*]] = linalg.generic {indexing_maps = [#[[ID_MAP]], #[[ID_MAP]]], iterator_types = ["parallel"]}
-// CHECK-SAME:   ins(%[[REVERSE_BIT_ORDER_COEFFS]] : tensor<4xindex>) outs(%[[OUTPUT_VEC]] : [[OUTPUT_TYPE]]) {
-// CHECK:       ^bb0(%[[REV_INDEX:.*]]: index, %[[OUT:.*]]: i32):
-// CHECK:         %[[EXTRACTED:.*]] = tensor.extract %[[RES_TRUNC]][%[[REV_INDEX]]] : [[OUTPUT_TYPE]]
-// CHECK:         linalg.yield %[[EXTRACTED]] : i32
-// CHECK:       } -> [[OUTPUT_TYPE]]
-// CHECK:       %[[CONVERTED_OUTPUT:.*]] = mod_arith.encapsulate %[[ORDERED_OUTPUT]] : [[OUTPUT_TYPE]] -> [[MOD_ARITH_OUTPUT_TYPE:.*]]
-// CHECK:       return %[[CONVERTED_OUTPUT]] : [[MOD_ARITH_OUTPUT_TYPE]]
+// CHECK-SAME:   ins(%[[REVERSE_BIT_ORDER_COEFFS]] : tensor<4xindex>) outs(%[[OUTPUT_ENC]] : [[MOD_TYPE]]) {
+// CHECK:       ^bb0(%[[REV_INDEX:.*]]: index, %[[OUT:.*]]: [[coeff_ty:!Z7681_i32_]]):
+// CHECK:         %[[EXTRACTED:.*]] = tensor.extract %[[RES_INTT]][%[[REV_INDEX]]] : [[MOD_TYPE]]
+// CHECK:         linalg.yield %[[EXTRACTED]] : [[coeff_ty]]
+// CHECK:       } -> [[MOD_TYPE]]
+
+// CHECK:       return %[[ORDERED_OUTPUT]] : [[MOD_TYPE]]
 
 func.func @lower_intt() -> !poly_ty {
-  %ntt_coeffs = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32, #ring>
-  %ret = polynomial.intt %ntt_coeffs {root=#root} : tensor<4xi32, #ring> -> !poly_ty
+  %coeffsRaw = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32, #ring>
+  %coeffs = mod_arith.encapsulate %coeffsRaw : tensor<4xi32, #ring> -> tensor<4x!coeff_ty, #ring>
+  %ret = polynomial.intt %coeffs {root=#root} : tensor<4x!coeff_ty, #ring> -> !poly_ty
   return %ret : !poly_ty
 }

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_intt_runner.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_intt_runner.mlir
@@ -15,9 +15,10 @@ func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interf
 !poly_ty = !polynomial.polynomial<ring=#ring>
 
 func.func @test_poly_ntt() {
-  %coeffs = arith.constant dense<[1467,2807,3471,7621]> : tensor<4xi32>
-  %ntt_coeffs = tensor.cast %coeffs : tensor<4xi32> to tensor<4xi32, #ring>
-  %0 = polynomial.intt %ntt_coeffs {root=#root} : tensor<4xi32, #ring> -> !poly_ty
+  %coeffsRaw = arith.constant dense<[1467,2807,3471,7621]> : tensor<4xi32>
+  %coeffs = tensor.cast %coeffsRaw : tensor<4xi32> to tensor <4xi32, #ring>
+  %coeffs_enc = mod_arith.encapsulate %coeffs : tensor<4xi32, #ring> -> tensor<4x!coeff_ty, #ring>
+  %0 = polynomial.intt %coeffs_enc {root=#root} : tensor<4x!coeff_ty, #ring> -> !poly_ty
 
   %1 = polynomial.to_tensor %0 : !poly_ty -> tensor<4x!coeff_ty>
   %2 = mod_arith.extract %1 : tensor<4x!coeff_ty> -> tensor<4xi32>

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_ntt_runner.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_ntt_runner.mlir
@@ -18,11 +18,12 @@ func.func @test_poly_ntt() {
   %coeffsRaw = arith.constant dense<[1,2,3,4]> : tensor<4xi32>
   %coeffs = mod_arith.encapsulate %coeffsRaw : tensor<4xi32> -> tensor<4x!coeff_ty>
   %poly = polynomial.from_tensor %coeffs : tensor<4x!coeff_ty> -> !poly_ty
-  %0 = polynomial.ntt %poly {root=#root} : !poly_ty -> tensor<4xi32, #ring>
+  %res = polynomial.ntt %poly {root=#root} : !poly_ty -> tensor<4x!coeff_ty, #ring>
 
-  %1 = tensor.cast %0 : tensor<4xi32, #ring> to tensor<4xi32>
-  %2 = bufferization.to_memref %1 : tensor<4xi32> to memref<4xi32>
-  %U = memref.cast %2 : memref<4xi32> to memref<*xi32>
+  %extract = mod_arith.extract %res : tensor<4x!coeff_ty, #ring> -> tensor<4xi32, #ring>
+  %0 = tensor.cast %extract : tensor<4xi32, #ring> to tensor<4xi32>
+  %1 = bufferization.to_memref %0 : tensor<4xi32> to memref<4xi32>
+  %U = memref.cast %1 : memref<4xi32> to memref<*xi32>
   func.call @printMemrefI32(%U) : (memref<*xi32>) -> ()
   return
 }

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/lower_ntt_perf_runner.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/lower_ntt_perf_runner.mlir
@@ -19,14 +19,14 @@ func.func @test_poly_ntt() {
   %insert_rand1 = tensor.insert_slice %rand_coeffs into %insert_rand0[65280] [256] [1] : tensor<256xi32> into tensor<65536xi32>
   %rand1_enc = mod_arith.encapsulate %insert_rand1 : tensor<65536xi32> -> tensor<65536x!coeff_ty>
   %poly = polynomial.from_tensor %rand1_enc : tensor<65536x!coeff_ty> -> !poly_ty
-  %0 = polynomial.ntt %poly {root=#root} : !poly_ty -> tensor<65536xi32, #ring>
+  %0 = polynomial.ntt %poly {root=#root} : !poly_ty -> tensor<65536x!coeff_ty, #ring>
 
   // Insert casts so that intt(ntt()) does not get folded away during polynomial
   // canonicalization
-  %cast = tensor.cast %0 : tensor<65536xi32, #ring> to tensor<65536xi32>
-  %cast_back = tensor.cast %cast : tensor<65536xi32> to tensor<65536xi32, #ring>
+  %cast = tensor.cast %0 : tensor<65536x!coeff_ty, #ring> to tensor<65536x!coeff_ty>
+  %cast_back = tensor.cast %cast : tensor<65536x!coeff_ty> to tensor<65536x!coeff_ty, #ring>
 
-  %1 = polynomial.intt %cast_back {root=#root} : tensor<65536xi32, #ring> -> !poly_ty
+  %1 = polynomial.intt %cast_back {root=#root} : tensor<65536x!coeff_ty, #ring> -> !poly_ty
 
   %2 = polynomial.to_tensor %1 : !poly_ty -> tensor<65536x!coeff_ty>
   %ext2 = mod_arith.extract %2 : tensor<65536x!coeff_ty> -> tensor<65536xi32>

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/ntt_benchmark.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/ntt_benchmark.mlir
@@ -16,11 +16,13 @@ func.func @input_generation() -> !poly_ty attributes { llvm.emit_c_interface } {
 }
 
 func.func @ntt(%arg0 : !poly_ty) -> tensor<65536xi32, #ring> attributes { llvm.emit_c_interface } {
-  %0 = polynomial.ntt %arg0 {root=#root} : !poly_ty -> tensor<65536xi32, #ring>
-  return %0 : tensor<65536xi32, #ring>
+  %0 = polynomial.ntt %arg0 {root=#root} : !poly_ty -> tensor<65536x!coeff_ty, #ring>
+  %1 = mod_arith.extract %0 : tensor<65536x!coeff_ty, #ring> -> tensor<65536xi32, #ring>
+  return %1 : tensor<65536xi32, #ring>
 }
 
 func.func @intt(%arg0 : tensor<65536xi32, #ring>) -> !poly_ty attributes { llvm.emit_c_interface } {
-  %0 = polynomial.intt %arg0 {root=#root} : tensor<65536xi32, #ring> -> !poly_ty
-  return %0 :!poly_ty
+  %0 = mod_arith.encapsulate %arg0 : tensor<65536xi32, #ring> -> tensor<65536x!coeff_ty, #ring>
+  %1 = polynomial.intt %0 {root=#root} : tensor<65536x!coeff_ty, #ring> -> !poly_ty
+  return %1 :!poly_ty
 }

--- a/tests/Dialect/Polynomial/IR/mod_arith_coefficients.mlir
+++ b/tests/Dialect/Polynomial/IR/mod_arith_coefficients.mlir
@@ -100,17 +100,17 @@ module {
   }
 
   func.func @test_ntt(%0 : !ntt_poly_ty) {
-    %1 = polynomial.ntt %0 {root=#polynomial.primitive_root<value=31:i32, degree=8:index>} : !ntt_poly_ty -> tensor<8xi32, #ntt_ring>
+    %1 = polynomial.ntt %0 {root=#polynomial.primitive_root<value=31:i32, degree=8:index>} : !ntt_poly_ty -> tensor<8x!coeff_ty2, #ntt_ring>
     return
   }
 
   func.func @test_ntt_with_overflowing_root(%0 : !ntt_poly_ty_2) {
-    %1 = polynomial.ntt %0 {root=#ntt_ring_2_root} : !ntt_poly_ty_2 -> tensor<65536xi32, #ntt_ring_2>
+    %1 = polynomial.ntt %0 {root=#ntt_ring_2_root} : !ntt_poly_ty_2 -> tensor<65536x!coeff_ty3, #ntt_ring_2>
     return
   }
 
-  func.func @test_intt(%0 : tensor<8xi32, #ntt_ring>) {
-    %1 = polynomial.intt %0 {root=#polynomial.primitive_root<value=31:i32, degree=8:index>} : tensor<8xi32, #ntt_ring> -> !ntt_poly_ty
+  func.func @test_intt(%0 : tensor<8x!coeff_ty2, #ntt_ring>) {
+    %1 = polynomial.intt %0 {root=#polynomial.primitive_root<value=31:i32, degree=8:index>} : tensor<8x!coeff_ty2, #ntt_ring> -> !ntt_poly_ty
     return
   }
 }


### PR DESCRIPTION
```- update computeReverseBitOrder to work on mod_arith type
- update butterfly operations to use mod_arith ops
- restrict the types of the ntt/intt ops to only allow the ModArith attr
  and add verification of the operations

- updates testcases lower_ntt.mlir and lower_intt.mlir to check for new
  emitted ops and the types of operand/results
- updates testcases lower_ntt_runner.mlir and lower_intt_runner.mlir to
  use the newly required types
- updates ntt_benchmakr.mlir and lower_ntt_perf_runner.mlir to use newly
required types
- updates canonicalization.mlir and mod_arith_coefficients.mlir to use
newly required types

- let tensor.cast be a legal op in the mod-arith-to-arith pass to stop a
failure to resolve materialization error
review comments:

- fix ElementwiseToAffine losing embedding info by passing it down to
the empty tensor create op
```

Resolves #1113 