### PR TITLE
Arith-To-Mod-Arith Conversion pass extension to Memref

### DIFF
--- a/lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.cpp
+++ b/lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.cpp
@@ -8,11 +8,10 @@
 #include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Utils/ConversionUtils/ConversionUtils.h"
-#include "llvm/include/llvm/Support/Casting.h"           // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypeInterfaces.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
@@ -32,7 +31,7 @@ static mod_arith::ModArithType convertArithType(Type type) {
   auto modulus = (1L << (modulusBitSize - 1L));
   auto newType = mlir::IntegerType::get(type.getContext(), modulusBitSize + 1);
 
-  return mod_arith::ModArithType::get(newType.getContext(),
+  return mod_arith::ModArithType::get(type.getContext(),
                                       mlir::IntegerAttr::get(newType, modulus));
 }
 
@@ -41,6 +40,21 @@ static Type convertArithLikeType(ShapedType type) {
     return type.cloneWith(type.getShape(), convertArithType(arithType));
   }
   return type;
+}
+
+static Value buildLoadOps(OpBuilder &builder, Type resultTypes,
+                          ValueRange inputs, Location loc) {
+  assert(inputs.size() == 1);
+  auto loadOp = inputs[0].getDefiningOp<memref::LoadOp>();
+
+  if (!loadOp) return {};
+
+  auto *globaMemReflOp = loadOp.getMemRef().getDefiningOp();
+
+  if (!globaMemReflOp) return {};
+
+  return builder.create<mod_arith::EncapsulateOp>(
+      loc, convertArithType(loadOp.getType()), loadOp.getResult());
 }
 
 class ArithToModArithTypeConverter : public TypeConverter {
@@ -52,6 +66,7 @@ class ArithToModArithTypeConverter : public TypeConverter {
     });
     addConversion(
         [](ShapedType type) -> Type { return convertArithLikeType(type); });
+    addTargetMaterialization(buildLoadOps);
   }
 };
 
@@ -66,10 +81,32 @@ struct ConvertConstant : public OpConversionPattern<mlir::arith::ConstantOp> {
       ConversionPatternRewriter &rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
+    if (isa<IndexType>(op.getValue().getType())) {
+      return failure();
+    }
+
     auto result = b.create<mod_arith::ConstantOp>(mod_arith::ModArithAttr::get(
         convertArithType(op.getType()),
         cast<IntegerAttr>(op.getValue()).getValue().getSExtValue()));
 
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct ConvertExt : public OpConversionPattern<mlir::arith::ExtSIOp> {
+  ConvertExt(mlir::MLIRContext *context)
+      : OpConversionPattern<mlir::arith::ExtSIOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ::mlir::arith::ExtSIOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+    auto result = b.create<mod_arith::ModSwitchOp>(
+        op.getLoc(), convertArithType(op.getType()), adaptor.getIn());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -109,12 +146,34 @@ void ArithToModArith::runOnOperation() {
   target.addLegalDialect<mod_arith::ModArithDialect>();
   target.addIllegalDialect<mlir::arith::ArithDialect>();
 
+  target.addDynamicallyLegalOp<mlir::arith::ConstantOp>(
+      [](mlir::arith::ConstantOp op) {
+        return isa<IndexType>(op.getValue().getType());
+      });
+
+  target.addDynamicallyLegalOp<memref::LoadOp>([&](Operation *op) {
+    return cast<memref::LoadOp>(op).getMemRef().getDefiningOp();
+  });
+
+  target.addDynamicallyLegalOp<
+      memref::AllocOp, memref::DeallocOp, memref::StoreOp, memref::SubViewOp,
+      memref::CopyOp, tensor::FromElementsOp, tensor::ExtractOp>(
+      [&](Operation *op) {
+        return typeConverter.isLegal(op->getOperandTypes()) &&
+               typeConverter.isLegal(op->getResultTypes());
+      });
+
   RewritePatternSet patterns(context);
   patterns
-      .add<ConvertConstant, ConvertBinOp<mlir::arith::AddIOp, mod_arith::AddOp>,
+      .add<ConvertConstant, ConvertExt,
+           ConvertBinOp<mlir::arith::AddIOp, mod_arith::AddOp>,
            ConvertBinOp<mlir::arith::SubIOp, mod_arith::SubOp>,
-           ConvertBinOp<mlir::arith::MulIOp, mod_arith::MulOp>>(typeConverter,
-                                                                context);
+           ConvertBinOp<mlir::arith::MulIOp, mod_arith::MulOp>,
+           ConvertAny<memref::LoadOp>, ConvertAny<memref::AllocOp>,
+           ConvertAny<memref::DeallocOp>, ConvertAny<memref::StoreOp>,
+           ConvertAny<memref::SubViewOp>, ConvertAny<memref::CopyOp>,
+           ConvertAny<tensor::FromElementsOp>, ConvertAny<tensor::ExtractOp> >(
+          typeConverter, context);
 
   addStructuralConversionPatterns(typeConverter, patterns, target);
 

--- a/lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.cpp
+++ b/lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.cpp
@@ -16,6 +16,7 @@
 #include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
 #include "llvm/include/llvm/Support/Casting.h"           // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
 #include "mlir/include/mlir/Analysis/SliceAnalysis.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
@@ -30,6 +31,8 @@
 #include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
 #include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+#define DEBUG_TYPE "cggi-to-tfhe-rust-bool"
 
 namespace mlir::heir {
 

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -101,14 +101,6 @@ LogicalResult verifySameWidth(OpType op, ModArithType modArithType,
   return success();
 }
 
-LogicalResult EncapsulateOp::verify() {
-  auto modArithType = getResultModArithType(*this);
-  auto integerType = getOperandIntegerType(*this);
-  auto result = verifySameWidth(*this, modArithType, integerType);
-  if (result.failed()) return result;
-  return verifyModArithType(*this, getResultModArithType(*this));
-}
-
 LogicalResult ExtractOp::verify() {
   auto modArithType = getOperandModArithType(*this);
   auto integerType = getResultIntegerType(*this);

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -24,9 +24,6 @@ def ModArith_EncapsulateOp : ModArith_Op<"encapsulate", [Pure, ElementwiseMappab
   let description = [{
     `mod_arith.encapsulate` converts the integer to be of mod_arith type.
 
-    It is required that the bitwidth of the input integer type is the same
-    as that of the storage type of the output mod_arith type.
-
     Examples:
     ```
     mod_arith.encapsulate %c0 : i32 -> mod_arith.int<65537 : i32>
@@ -38,7 +35,6 @@ def ModArith_EncapsulateOp : ModArith_Op<"encapsulate", [Pure, ElementwiseMappab
     SignlessIntegerLike:$input
   );
   let results = (outs ModArithLike:$output);
-  let hasVerifier = 1;
   let assemblyFormat = "operands attr-dict `:` type($input) `->` type($output)";
 }
 
@@ -66,6 +62,25 @@ def ModArith_ExtractOp : ModArith_Op<"extract", [Pure, ElementwiseMappable]> {
   let results = (outs SignlessIntegerLike:$output);
   let hasVerifier = 1;
   let assemblyFormat = "operands attr-dict `:` type($input) `->` type($output)";
+}
+
+def ModArith_ModSwitchOp : ModArith_Op<"mod_switch", [Pure, SameOperandsAndResultShape]> {
+  let summary = "change the modulus of a mod_arith";
+
+  let description = [{
+    "mod_switch" operation to change the modulus of a mod_arith type to a
+    bigger space.
+
+    Examples:
+    ```
+    `mod_arith.mod_switch %c0 : mod_arith.int<65537 : i32> to mod_arith.int<65539 : i32>`
+    ```
+  }];
+
+  let arguments = (ins ModArith_ModArithType:$input);
+  let results = (outs ModArith_ModArithType:$output);
+
+  let assemblyFormat = "$input attr-dict `:` type($input) `to` type($output)";
 }
 
 def ModArith_ConstantOp : Op<ModArith_Dialect, "constant",

--- a/lib/Dialect/ModArith/IR/ModArithTypes.td
+++ b/lib/Dialect/ModArith/IR/ModArithTypes.td
@@ -5,14 +5,15 @@ include "lib/Dialect/ModArith/IR/ModArithDialect.td"
 
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/AttrTypeBase.td"
 
-class ModArith_Type<string name, string typeMnemonic>
-    : TypeDef<ModArith_Dialect, name> {
+class ModArith_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<ModArith_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
 }
 
-def ModArith_ModArithType : ModArith_Type<"ModArith", "int"> {
+def ModArith_ModArithType : ModArith_Type<"ModArith", "int", [MemRefElementTypeInterface]> {
   let summary = "Integer type with modular arithmetic";
   let description = [{
     `mod_arith.int<p>` represents an element of the ring of integers modulo $p$.

--- a/tests/Dialect/Arith/Conversions/ArithToModArith/arith-to-mod-arith.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToModArith/arith-to-mod-arith.mlir
@@ -53,3 +53,26 @@ func.func @test_lower_mul_vec(%lhs : tensor<4xi32>, %rhs : tensor<4xi32>) -> ten
   %res = arith.muli %lhs, %rhs : tensor<4xi32>
   return %res : tensor<4xi32>
 }
+
+// CHECK-LABEL: @test_memref_global
+// CHECK-SAME: (%[[ARG:.*]]: memref<1x1x!Z2147483648_i33_>) -> memref<1x1x!Z2147483648_i33_> {
+module attributes {tf_saved_model.semantics} {
+  memref.global "private" constant @__constant_16xi32_0 : memref<16xi32> = dense<[-729, 1954, 610, 0, 241, -471, -35, -867, 571, 581, 4260, 3943, 591, 0, -889, -5103]> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_16x1xi8 : memref<16x1xi8> = dense<[[-9], [-54], [57], [71], [104], [115], [98], [99], [64], [-26], [127], [25], [-82], [68], [95], [86]]> {alignment = 64 : i64}
+  func.func @test_memref_global(%arg0: memref<1x1xi32>) -> memref<1x1xi32> {
+    %c429_i32 = arith.constant 429 : i32
+    %c0 = arith.constant 0 : index
+    %0 = memref.get_global @__constant_16x1xi8 : memref<16x1xi8>
+    %3 = memref.get_global @__constant_16xi32_0 : memref<16xi32>
+    %21 = memref.load %3[%c0] : memref<16xi32>
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1xi32>
+    %22 = memref.load %0[%c0, %c0] : memref<16x1xi8>
+    %24 = memref.load %arg0[%c0, %c0] : memref<1x1xi32>
+  // CHECK: %[[ENC:.*]] = mod_arith.mod_switch %{{.*}}: !Z128_i9_ to !Z2147483648_i33_
+    %a24 = arith.extsi %22 : i8 to i32
+    %25 = arith.muli %24, %a24 : i32
+    %26 = arith.addi %21, %25 : i32
+    memref.store %26, %alloc[%c0, %c0] : memref<1x1xi32>
+    return %alloc : memref<1x1xi32>
+  }
+}

--- a/tests/Dialect/ModArith/IR/invalid-ops.mlir
+++ b/tests/Dialect/ModArith/IR/invalid-ops.mlir
@@ -2,13 +2,6 @@
 
 !Zp = !mod_arith.int<255 : i8>
 
-// CHECK-NOT: @test_bad_mod
-func.func @test_bad_mod(%lhs : i8) -> !Zp {
-  // expected-error@+1 {{underlying type's bitwidth must be 1 bit larger than the modulus bitwidth, but got 8 while modulus requires width 8.}}
-  %m = mod_arith.encapsulate %lhs : i8 -> !Zp
-  return %m : !Zp
-}
-
 // -----
 
 !Zp = !mod_arith.int<255 : i32>

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -68,5 +68,8 @@ func.func @test_arith_syntax() {
   %subifge = mod_arith.subifge %zero, %cmod : i10
   %subifge_vec = mod_arith.subifge %c_vec, %cmod_vec : tensor<4xi10>
 
+  // CHECK: mod_arith.mod_switch
+  %mod_switch = mod_arith.mod_switch %e6: !Zp to !mod_arith.int<31 : i10>
+
   return
 }

--- a/tests/Transforms/tosa_to_boolean_tfhe/BUILD
+++ b/tests/Transforms/tosa_to_boolean_tfhe/BUILD
@@ -17,6 +17,11 @@ glob_lit_tests(
             "notap",
             "manual",
         ],
+        "hello_world_clean.mlir": [
+            "nofastbuild",
+            "notap",
+            "manual",
+        ],
     },
     test_file_exts = ["mlir"],
 )

--- a/tests/Transforms/tosa_to_boolean_tfhe/hello_world_clean.mlir
+++ b/tests/Transforms/tosa_to_boolean_tfhe/hello_world_clean.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt --tosa-to-boolean-tfhe=abc-fast=true %s | FileCheck %s
+
+// CHECK-LABEL: module
+module attributes {tf_saved_model.semantics} {
+
+  func.func @main(%arg0: tensor<1x1xi8> {iree.identifier = "serving_default_dense_input:0", tf_saved_model.index_path = ["dense_input"]}) -> (tensor<1x1xi32> {iree.identifier = "StatefulPartitionedCall:0", tf_saved_model.index_path = ["dense_2"]}) attributes {tf_saved_model.exported_names = ["serving_default"]} {
+    %0 = "tosa.const"() {value = dense<429> : tensor<1xi32>} : () -> tensor<1xi32>
+    %1 = "tosa.const"() {value = dense<[[-39, 59, 39, 21, 28, -32, -34, -35, 15, 27, -59, -41, 18, -35, -7, 127]]> : tensor<1x16xi8>} : () -> tensor<1x16xi8>
+    %2 = "tosa.const"() {value = dense<[-729, 1954, 610, 0, 241, -471, -35, -867, 571, 581, 4260, 3943, 591, 0, -889, -5103]> : tensor<16xi32>} : () -> tensor<16xi32>
+    %3 = "tosa.const"() {value = dense<"0xF41AED091921F424E021EFBCF7F5FA1903DCD20206F9F402FFFAEFF1EFD327E1FB27DDEBDBE4051A17FC241215EF1EE410FE14DA1CF8F3F1EFE2F309E3E9EDE3E415070B041B1AFEEB01DE21E60BEC03230A22241E2703E60324FFC011F8FCF1110CF5E0F30717E5E8EDFADCE823FB07DDFBFD0014261117E7F111EA0226040425211D0ADB1DDC2001FAE3370BF11A16EF1CE703E01602032118092ED9E5140BEA1AFCD81300C4D8ECD9FE0D1920D8D6E21FE9D7CAE2DDC613E7043E000114C7DBE71515F506D61ADC0922FE080213EF191EE209FDF314DDDA20D90FE3F9F7EEE924E629000716E21E0D23D3DDF714FA0822262109080F0BE012F47FDC58E526"> : tensor<16x16xi8>} : () -> tensor<16x16xi8>
+    %4 = "tosa.const"() {value = dense<[0, 0, -5438, -5515, -1352, -1500, -4152, -84, 3396, 0, 1981, -5581, 0, -6964, 3407, -7217]> : tensor<16xi32>} : () -> tensor<16xi32>
+    %5 = "tosa.const"() {value = dense<[[-9], [-54], [57], [71], [104], [115], [98], [99], [64], [-26], [127], [25], [-82], [68], [95], [86]]> : tensor<16x1xi8>} : () -> tensor<16x1xi8>
+    %6 = "tosa.fully_connected"(%arg0, %5, %4) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>} : (tensor<1x1xi8>, tensor<16x1xi8>, tensor<16xi32>) -> tensor<1x16xi32>
+    %9 = "tosa.fully_connected"(%6, %3, %2) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>} : (tensor<1x16xi32>, tensor<16x16xi8>, tensor<16xi32>) -> tensor<1x16xi32>
+    %12 = "tosa.fully_connected"(%9, %1, %0) {quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>} : (tensor<1x16xi32>, tensor<1x16xi8>, tensor<1xi32>) -> tensor<1x1xi32>
+    // CHECK: return
+    return %12 : tensor<1x1xi32>
+  }
+}


### PR DESCRIPTION
Follow-up of #1125 

Arith-To-Mod-Arith Extension to Memref
- Extension of the mod_arith dialect with a new operation + tests: ModSwitching
- Parsing of new operations: ExtSI
- Adding parsing for memref objects:

1. If it is a memref global object: do not transform to mod_arith and include an encapsulate operation. 
2. Other cases (orginates from a function argument), do not encapsulate. 

Now, this addition of the encapsulate operation is done in the parsing of the 'calculation' operations (I.e., add, extsi, ...). Have doubts about it how future proof this is. 
An alternative would be to mark memref.loadOp to be illegal if they come from an GetGlobalOp and don't have a successor encapsulate operations. 

Remove the verifier of the encapsulate op