### PR TITLE
Lattigo: BGV: add relinearize/mod reduce/rotate

### DIFF
--- a/lib/Dialect/BGV/Conversions/BGVToLattigo/BGVToLattigo.cpp
+++ b/lib/Dialect/BGV/Conversions/BGVToLattigo/BGVToLattigo.cpp
@@ -33,6 +33,16 @@ using ConvertSubOp =
     ConvertRlweBinOp<lattigo::BGVEvaluatorType, SubOp, lattigo::BGVSubOp>;
 using ConvertMulOp =
     ConvertRlweBinOp<lattigo::BGVEvaluatorType, MulOp, lattigo::BGVMulOp>;
+using ConvertRelinOp =
+    ConvertRlweUnaryOp<lattigo::BGVEvaluatorType, RelinearizeOp,
+                       lattigo::BGVRelinearizeOp>;
+using ConvertModulusSwitchOp =
+    ConvertRlweUnaryOp<lattigo::BGVEvaluatorType, ModulusSwitchOp,
+                       lattigo::BGVRescaleOp>;
+
+// TODO(#1186): figure out generic rotating using BGVRotateColumns/RowsOp
+using ConvertRotateOp = ConvertRlweRotateOp<lattigo::BGVEvaluatorType, RotateOp,
+                                            lattigo::BGVRotateColumnsOp>;
 
 struct BGVToLattigo : public impl::BGVToLattigoBase<BGVToLattigo> {
   void runOnOperation() override {
@@ -60,8 +70,9 @@ struct BGVToLattigo : public impl::BGVToLattigoBase<BGVToLattigo> {
     });
 
     patterns.add<AddEvaluatorArg<bgv::BGVDialect, lattigo::BGVEvaluatorType>,
-                 ConvertAddOp, ConvertSubOp, ConvertMulOp>(typeConverter,
-                                                           context);
+                 ConvertAddOp, ConvertSubOp, ConvertMulOp, ConvertRelinOp,
+                 ConvertModulusSwitchOp, ConvertRotateOp>(typeConverter,
+                                                          context);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       return signalPassFailure();

--- a/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
@@ -76,9 +76,16 @@ def Lattigo_BGVNewEvaluatorOp : Lattigo_BGVOp<"new_evaluator"> {
   let summary = "Create a new evaluator in the Lattigo BGV dialect";
   let description = [{
     This operation creates a new evaluator for performing operations on ciphertexts in the Lattigo BGV dialect.
+
+    By default, the evaluator is created with the provided parameters and could execute
+    operations which does not relying on evaluation keys.
+
+    To support operations that require evaluation keys,
+    the optional evaluation key set should be provided.
   }];
   let arguments = (ins
-    Lattigo_BGVParameter:$params
+    Lattigo_BGVParameter:$params,
+    Optional<Lattigo_RLWEEvaluationKeySet>:$evaluationKeySet
   );
   let results = (outs Lattigo_BGVEvaluator:$evaluator);
 }
@@ -113,6 +120,55 @@ def Lattigo_BGVMulOp : Lattigo_BGVBinaryOp<"mul"> {
   let summary = "Multiply two ciphertexts in the Lattigo BGV dialect";
   let description = [{
     This operation multiplies two ciphertext values in the Lattigo BGV dialect.
+  }];
+}
+
+class Lattigo_BGVUnaryOp<string mnemonic> :
+        Lattigo_BGVOp<mnemonic> {
+  let arguments = (ins
+    Lattigo_BGVEvaluator:$evaluator,
+    Lattigo_RLWECiphertext:$input
+  );
+  let results = (outs Lattigo_RLWECiphertext:$output);
+}
+
+def Lattigo_BGVRelinearizeOp : Lattigo_BGVUnaryOp<"relinearize"> {
+  let summary = "Relinearize a ciphertext in the Lattigo BGV dialect";
+  let description = [{
+    This operation relinearizes a ciphertext value in the Lattigo BGV dialect.
+  }];
+}
+
+def Lattigo_BGVRescaleOp : Lattigo_BGVUnaryOp<"rescale"> {
+  let summary = "Rescale a ciphertext in the Lattigo BGV dialect";
+  let description = [{
+    This operation rescales a ciphertext value in the Lattigo BGV dialect.
+  }];
+}
+
+def Lattigo_BGVRotateColumnsOp : Lattigo_BGVOp<"rotate_columns"> {
+  let summary = "Rotate columns of a ciphertext in the Lattigo BGV dialect";
+  let description = [{
+    This operation rotates the columns of a ciphertext value in the Lattigo BGV dialect.
+
+    Lattigo exposes the SIMD slot of BGV as a N/2 x 2 matrix, where N/2 is the column.
+
+    offset is valid in (-N/2, N/2).
+  }];
+  let arguments = (ins
+    Lattigo_BGVEvaluator:$evaluator,
+    Lattigo_RLWECiphertext:$input,
+    Builtin_IntegerAttr:$offset
+  );
+  let results = (outs Lattigo_RLWECiphertext:$output);
+}
+
+def Lattigo_BGVRotateRowsOp : Lattigo_BGVUnaryOp<"rotate_rows"> {
+  let summary = "Rotate rows of a ciphertext in the Lattigo BGV dialect";
+  let description = [{
+    This operation swap the rows of a ciphertext value in the Lattigo BGV dialect.
+
+    Lattigo exposes the SIMD slot of BGV as a N/2 x 2 matrix, where 2 is the row.
   }];
 }
 

--- a/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
@@ -31,6 +31,45 @@ def Lattigo_RLWEGenKeyPairOp : Lattigo_RLWEOp<"gen_key_pair"> {
   );
 }
 
+def Lattigo_RLWEGenRelinearizationKeyOp : Lattigo_RLWEOp<"gen_relinearization_key"> {
+  let summary = "Generates a new RLWE relinearization key";
+  let description = [{
+    This operation generates a new RLWE relinearization key
+  }];
+  let arguments = (ins
+    Lattigo_RLWEKeyGenerator:$keyGenerator,
+    Lattigo_RLWESecretKey:$secretKey
+  );
+  let results = (outs Lattigo_RLWERelinearizationKey:$relinearizationKey);
+}
+
+def Lattigo_RLWEGenGaloisKeyOp : Lattigo_RLWEOp<"gen_galois_key"> {
+  let summary = "Generates a new RLWE Galois key";
+  let description = [{
+    This operation generates a new RLWE Galois key
+
+    galoisElement: Enabling the automorphism X -> X^{galoisElement}.
+  }];
+  let arguments = (ins
+    Lattigo_RLWEKeyGenerator:$keyGenerator,
+    Lattigo_RLWESecretKey:$secretKey,
+    Builtin_IntegerAttr:$galoisElement
+  );
+  let results = (outs Lattigo_RLWEGaloisKey:$galoisKey);
+}
+
+def Lattigo_RLWENewEvaluationKeySetOp : Lattigo_RLWEOp<"new_evaluation_key_set"> {
+  let summary = "Generates a new RLWE evaluation key set";
+  let description = [{
+    This operation generates a new RLWE evaluation key set
+  }];
+  let arguments = (ins
+    Lattigo_RLWERelinearizationKey:$relinearizationKey,
+    Variadic<Lattigo_RLWEGaloisKey>:$galoisKeys
+  );
+  let results = (outs Lattigo_RLWEEvaluationKeySet:$evaluationKeySet);
+}
+
 def Lattigo_RLWENewEncryptorOp : Lattigo_RLWEOp<"new_encryptor"> {
   let summary = "Creates a new RLWE encryptor";
   let description = [{

--- a/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
@@ -28,6 +28,28 @@ def Lattigo_RLWEPublicKey : Lattigo_RLWEType<"PublicKey", "public_key"> {
   }];
 }
 
+def Lattigo_RLWERelinearizationKey : Lattigo_RLWEType<"RelinearizationKey", "relinearization_key"> {
+  let description = [{
+    This type represents the relinearization key for the RLWE encryption scheme.
+  }];
+}
+
+def Lattigo_RLWEGaloisKey : Lattigo_RLWEType<"GaloisKey", "galois_key"> {
+  let description = [{
+    This type represents the Galois key for the RLWE encryption scheme.
+
+    galoisElement: Enabling the automorphism X -> X^{galoisElement}.
+  }];
+  let parameters = (ins Builtin_IntegerAttr:$galoisElement);
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+def Lattigo_RLWEEvaluationKeySet : Lattigo_RLWEType<"EvaluationKeySet", "evaluation_key_set"> {
+  let description = [{
+    This type represents the evaluation key set for the RLWE encryption scheme.
+  }];
+}
+
 def Lattigo_RLWEEncryptor : Lattigo_RLWEType<"Encryptor", "encryptor"> {
   let description = [{
     This type represents the encryptor for the RLWE encryption scheme.

--- a/lib/Dialect/Lattigo/IR/LattigoTypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoTypes.td
@@ -6,6 +6,7 @@ include "LattigoAttributes.td"
 
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributes.td"
 
 // A base class for all types in this dialect
 class Lattigo_Type<string name, string typeMnemonic>

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -53,6 +53,9 @@ class LattigoEmitter {
   LogicalResult printOperation(RLWENewDecryptorOp op);
   LogicalResult printOperation(RLWENewKeyGeneratorOp op);
   LogicalResult printOperation(RLWEGenKeyPairOp op);
+  LogicalResult printOperation(RLWEGenRelinearizationKeyOp op);
+  LogicalResult printOperation(RLWEGenGaloisKeyOp op);
+  LogicalResult printOperation(RLWENewEvaluationKeySetOp op);
   LogicalResult printOperation(RLWEEncryptOp op);
   LogicalResult printOperation(RLWEDecryptOp op);
   LogicalResult printOperation(BGVNewParametersFromLiteralOp op);
@@ -64,9 +67,13 @@ class LattigoEmitter {
   LogicalResult printOperation(BGVAddOp op);
   LogicalResult printOperation(BGVSubOp op);
   LogicalResult printOperation(BGVMulOp op);
+  LogicalResult printOperation(BGVRelinearizeOp op);
+  LogicalResult printOperation(BGVRescaleOp op);
+  LogicalResult printOperation(BGVRotateColumnsOp op);
+  LogicalResult printOperation(BGVRotateRowsOp op);
 
   // Helpers for above
-  void printErrPanic();
+  void printErrPanic(std::string_view errName);
 
   LogicalResult printNewMethod(::mlir::Value result,
                                ::mlir::ValueRange operands, std::string_view op,
@@ -94,6 +101,11 @@ class LattigoEmitter {
   // helper on name and type
   std::string getName(::mlir::Value value) {
     return variableNames->getNameForValue(value);
+  }
+
+  std::string getErrName() {
+    static int errCount = 0;
+    return "err" + std::to_string(errCount++);
   }
 
   std::string getCommaSeparatedNames(::mlir::ValueRange values) {

--- a/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
@@ -5,10 +5,15 @@
 #my_poly = #polynomial.int_polynomial<1 + x**1024>
 // cmod is 64153 * 2521
 #ring1 = #polynomial.ring<coefficientType=!mod_arith.int<161729713:i32>, polynomialModulus=#my_poly>
+#ring2 = #polynomial.ring<coefficientType=!mod_arith.int<64153:i32>, polynomialModulus=#my_poly>
 
 #params1 = #lwe.rlwe_params<dimension=2, ring=#ring1>
+#params2 = #lwe.rlwe_params<dimension=3, ring=#ring1>
+#params3 = #lwe.rlwe_params<dimension=2, ring=#ring2>
 
 !ct = !lwe.rlwe_ciphertext<encoding=#encoding, rlwe_params=#params1, underlying_type=i3>
+!ct1 = !lwe.rlwe_ciphertext<encoding=#encoding, rlwe_params=#params2, underlying_type=i3>
+!ct2 = !lwe.rlwe_ciphertext<encoding=#encoding, rlwe_params=#params3, underlying_type=i3>
 
 // CHECK: module
 module {
@@ -24,6 +29,16 @@ module {
   func.func @test_ops(%x : !ct, %y : !ct) {
     // CHECK: %[[v1:.*]] = lattigo.bgv.add [[C]], %[[x:.*]], %[[y:.*]]: ([[S]], [[T]], [[T]]) -> [[T]]
     %add = bgv.add %x, %y  : !ct
+    // CHECK: %[[mul:.*]] = lattigo.bgv.mul [[C]], %[[x]], %[[y]]: ([[S]], [[T]], [[T]]) -> [[T]]
+    %mul = bgv.mul %x, %y  : (!ct, !ct) -> !ct1
+    // CHECK: %[[relin:.*]] = lattigo.bgv.relinearize [[C]], %[[mul]] : ([[S]], [[T]]) -> [[T]]
+    %relin = bgv.relinearize %mul  {
+      from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>
+    }: !ct1 -> !ct
+    // CHECK: %[[rescale:.*]] = lattigo.bgv.rescale [[C]], %[[relin]] : ([[S]], [[T]]) -> [[T]]
+    %rescale = bgv.modulus_switch %relin {to_ring = #ring2} : !ct -> !ct2
+    // CHECK: %[[rot:.*]] = lattigo.bgv.rotate_columns [[C]], %[[rescale]] {offset = 1 : i64} : ([[S]], [[T]]) -> [[T]]
+    %rot = bgv.rotate %rescale { offset = 1 } : !ct2
     return
   }
 }

--- a/tests/Dialect/Lattigo/IR/ops.mlir
+++ b/tests/Dialect/Lattigo/IR/ops.mlir
@@ -4,6 +4,10 @@
 
 !pk = !lattigo.rlwe.public_key
 !sk = !lattigo.rlwe.secret_key
+!rk = !lattigo.rlwe.relinearization_key
+!gk5 = !lattigo.rlwe.galois_key<galoisElement = 5>
+!eval_key_set = !lattigo.rlwe.evaluation_key_set
+
 !ct = !lattigo.rlwe.ciphertext
 !pt = !lattigo.rlwe.plaintext
 
@@ -62,6 +66,27 @@ module {
     return
   }
 
+  // CHECK-LABEL: func @test_rlwe_gen_relinearization_key
+  func.func @test_rlwe_gen_relinearization_key(%key_generator: !key_generator, %sk: !sk) {
+    // CHECK: %[[v1:.*]] = lattigo.rlwe.gen_relinearization_key
+    %rk = lattigo.rlwe.gen_relinearization_key %key_generator, %sk : (!key_generator, !sk) -> !rk
+    return
+  }
+
+  // CHECK-LABEL: func @test_rlwe_gen_galois_key
+  func.func @test_rlwe_gen_galois_key(%key_generator: !key_generator, %sk: !sk) {
+    // CHECK: %[[v1:.*]] = lattigo.rlwe.gen_galois_key
+    %gk = lattigo.rlwe.gen_galois_key %key_generator, %sk {galoisElement = 5} : (!key_generator, !sk) -> !gk5
+    return
+  }
+
+  // CHECK-LABEL: func @test_rlwe_new_evaluation_key_set
+  func.func @test_rlwe_new_evaluation_key_set(%rk : !rk, %gk5 : !gk5) {
+    // CHECK: %[[v1:.*]] = lattigo.rlwe.new_evaluation_key_set
+    %eval_key_set = lattigo.rlwe.new_evaluation_key_set %rk, %gk5 : (!rk, !gk5) -> !eval_key_set
+    return
+  }
+
   // CHECK-LABEL: func @test_rlwe_new_encryptor
   func.func @test_rlwe_new_encryptor(%params: !params, %pk: !pk) {
     // CHECK: %[[v1:.*]] = lattigo.rlwe.new_encryptor
@@ -76,10 +101,17 @@ module {
     return
   }
 
-  // CHECK-LABEL: func @test_bgv_new_evaluator
-  func.func @test_bgv_new_evaluator(%params: !params) {
+  // CHECK-LABEL: func @test_bgv_new_evaluator_no_key_set
+  func.func @test_bgv_new_evaluator_no_key_set(%params: !params) {
     // CHECK: %[[v1:.*]] = lattigo.bgv.new_evaluator
     %evaluator = lattigo.bgv.new_evaluator %params : (!params) -> !evaluator
+    return
+  }
+
+  // CHECK-LABEL: func @test_bgv_new_evaluator
+  func.func @test_bgv_new_evaluator(%params: !params, %eval_key_set: !eval_key_set) {
+    // CHECK: %[[v1:.*]] = lattigo.bgv.new_evaluator
+    %evaluator = lattigo.bgv.new_evaluator %params, %eval_key_set : (!params, !eval_key_set) -> !evaluator
     return
   }
 
@@ -136,6 +168,34 @@ module {
   func.func @test_bgv_decode(%encoder: !encoder, %value : !value, %pt: !pt) {
     // CHECK: %[[v1:.*]] = lattigo.bgv.decode
     %decoded = lattigo.bgv.decode %encoder, %pt, %value : (!encoder, !pt, !value) -> !value
+    return
+  }
+
+  // CHECK-LABEL: func @test_bgv_relinearize
+  func.func @test_bgv_relinearize(%evaluator: !evaluator, %ct: !ct) {
+    // CHECK: %[[v1:.*]] = lattigo.bgv.relinearize
+    %output = lattigo.bgv.relinearize %evaluator, %ct : (!evaluator, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_bgv_rescale
+  func.func @test_bgv_rescale(%evaluator: !evaluator, %ct: !ct) {
+    // CHECK: %[[v1:.*]] = lattigo.bgv.rescale
+    %output = lattigo.bgv.rescale %evaluator, %ct : (!evaluator, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_bgv_rotate_columns
+  func.func @test_bgv_rotate_columns(%evaluator: !evaluator, %ct: !ct) {
+    // CHECK: %[[v1:.*]] = lattigo.bgv.rotate_columns
+    %output = lattigo.bgv.rotate_columns %evaluator, %ct {offset = 1} : (!evaluator, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_bgv_rotate_rows
+  func.func @test_bgv_rotate_rows(%evaluator: !evaluator, %ct: !ct) {
+    // CHECK: %[[v1:.*]] = lattigo.bgv.rotate_rows
+    %output = lattigo.bgv.rotate_rows %evaluator, %ct : (!evaluator, !ct) -> !ct
     return
   }
 }


### PR DESCRIPTION
This introduces the keyswitching/modulus switching ability thus we are able to do relinearize/rotate.

Check `tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir` for detail usage of them. It runs and get a correct result.

Also, the following input can be used with current `secret-insert-mgmt-bgv` to get a correct management

```mlir
func.func @add(%arg0: tensor<4xi16>, %arg1: tensor<4xi16>) -> tensor<4xi16> {
  %0 = arith.addi %arg0, %arg1 : tensor<4xi16>
  %1 = arith.muli %0, %arg1 : tensor<4xi16>
  %c1 = arith.constant 1 : index
  %2 = tensor_ext.rotate %1, %c1 : tensor<4xi16>, index
  return %2 : tensor<4xi16>
}
```

With `--secretize --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --secret-distribute-generic --secret-to-bgv=poly-mod-degree=4 --bgv-to-lattigo --cse` we get

```mlir
  func.func @add(%arg0: !lattigo.bgv.evaluator, %arg1: !lattigo.rlwe.ciphertext, %arg2: !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext {
    %0 = lattigo.bgv.add %arg0, %arg1, %arg2 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
    %1 = lattigo.bgv.mul %arg0, %0, %arg2 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
    %2 = lattigo.bgv.relinearize %arg0, %1 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
    %3 = lattigo.bgv.rotate_columns %arg0, %2 {offset = 1 : index} : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
    %4 = lattigo.bgv.rescale %arg0, %3 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
    return %4 : !lattigo.rlwe.ciphertext
  }
```

It can correctly translate to GO code and runs with correct result with a main function.

Note that `--lwe-add-client-interface` still does not work as I do not have a lowering for that. Thus we do not have `--mlir-to-lattigo-bgv` for now. Will do so in future PR.

### Discussion

* Rotation for BGV in lattigo is exposed as `RotateColumns` and `RotateRows`. If we want to get a correct rotation for any index (currently only works for index 1), we have to compute the correct way to use these API.
* GaloisKey are generated using the `x -> x^i` (called `galEl`), instead of `index`. As we can see in the code, I generated the GaloisKey for galEl 5 but then for rotation I used the index 1. If not generating with correct galois key, we get the following

```
panic: cannot apply Automorphism: GaloisKey[5] is nil: key for galEl 5 = 5^{1} key is missing
```
