### PR TITLE
Add decorator to Python frontend

### DIFF
--- a/heir_py/BUILD
+++ b/heir_py/BUILD
@@ -6,6 +6,21 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+DATA_DEPS = [
+    "@cereal//:headers",
+    "@heir//tools:heir-opt",
+    "@heir//tools:heir-translate",
+    "@openfhe//:headers",
+    "@openfhe//:binfhe",
+    # copybara: openfhe_binfhe_headers
+    "@openfhe//:core",
+    # copybara: openfhe_core_headers
+    "@openfhe//:pke",
+    # copybara: openfhe_pke_headers
+    # copybara: python_runtime_headers
+    "@rapidjson//:headers",
+]
+
 # a single-source build dependency that gives the whole (non-test) source tree;
 # note we chose the style of putting all test rules below, because glob does
 # not recurse into subdirectories with BUILD files in them.
@@ -17,20 +32,7 @@ py_library(
             "**/*_test.py",
         ],
     ),
-    data = [
-        "@cereal//:headers",
-        "@heir//tools:heir-opt",
-        "@heir//tools:heir-translate",
-        "@openfhe//:headers",
-        "@openfhe//:binfhe",
-        # copybara: openfhe_binfhe_headers
-        "@openfhe//:core",
-        # copybara: openfhe_core_headers
-        "@openfhe//:pke",
-        # copybara: openfhe_pke_headers
-        # copybara: python_runtime_headers
-        "@rapidjson//:headers",
-    ],
+    data = DATA_DEPS,
     deps = [
         "@heir_py_pip_deps_numba//:pkg",
         "@heir_py_pip_deps_pybind11//:pkg",
@@ -41,6 +43,15 @@ py_library(
 heir_py_test(
     name = "pipeline_test",
     srcs = ["pipeline_test.py"],
+    tags = [
+        # copybara: manual
+        "notap",
+    ],
+)
+
+heir_py_test(
+    name = "e2e_test",
+    srcs = ["e2e_test.py"],
     tags = [
         # copybara: manual
         "notap",

--- a/heir_py/__init__.py
+++ b/heir_py/__init__.py
@@ -1,0 +1,3 @@
+from decorator import compile
+
+__all__ = ["compile"]

--- a/heir_py/decorator.py
+++ b/heir_py/decorator.py
@@ -1,0 +1,144 @@
+"""The decorator entry point for the frontend."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from heir_py import heir_config as _heir_config
+from heir_py import openfhe_config
+from heir_py.pipeline import CompilationResult, run_compiler
+
+
+class CompilationResultInterface(ABC):
+
+  @abstractmethod
+  def setup(self):
+    """Configure the initial cryptosystem and this wrapper interface."""
+    ...
+
+  @abstractmethod
+  def decrypt_result(self, result, **kwargs):
+    ...
+
+  @abstractmethod
+  def __getattr__(self, key):
+    """Invoke a function with a dynamically-generated name:
+
+    - encrypt_{arg_name}
+    - {func_name}
+    """
+    ...
+
+  @abstractmethod
+  def __call__(self, *args, **kwargs):
+    """Run the compiled function end to end.
+
+    Includes crypto parameter setup, encryption of function arguments,
+    and decryption of the result.
+    """
+    ...
+
+
+class OpenfheClientInterface(CompilationResultInterface):
+
+  def __init__(self, compilation_result: CompilationResult):
+    self.compilation_result = compilation_result
+
+  def setup(self):
+    # TODO(#1119): Rethink the server/client split
+    self.crypto_context = self.compilation_result.setup_funcs[
+        "generate_crypto_context"
+    ]()
+    self.keypair = self.crypto_context.KeyGen()
+    # Really, "configure" is just setting up non-public key material, and
+    # all public parameter configuration is done on
+    # generate_crypto_context.
+    self.compilation_result.setup_funcs["configure_crypto_context"](
+        self.crypto_context, self.keypair.secretKey
+    )
+
+  def decrypt_result(self, result, *, crypto_context=None, secret_key=None):
+    return self.compilation_result.result_dec_func(
+        crypto_context or self.crypto_context,
+        result,
+        secret_key or self.keypair.secretKey,
+    )
+
+  def __getattr__(self, key):
+    if key.startswith("encrypt_"):
+      arg_name = key[len("encrypt_") :]
+      fn = self.compilation_result.arg_enc_funcs[arg_name]
+
+      def wrapper(arg, *, crypto_context=None, public_key=None):
+        return fn(
+            crypto_context or self.crypto_context,
+            arg,
+            public_key or self.keypair.publicKey,
+        )
+
+      return wrapper
+
+    if key == self.compilation_result.func_name:
+      fn = self.compilation_result.main_func
+
+      def wrapper(*args, crypto_context=None):
+        return fn(crypto_context or self.crypto_context, *args)
+
+      return wrapper
+
+    try:
+      getattr(self.compilation_result.module, key)
+    except AttributeError:
+      raise AttributeError(f"Attribute {key} not found")
+
+  def __call__(self, *args, **kwargs):
+    self.setup()
+    arg_names = list(self.compilation_result.arg_names)
+    num_args = len(arg_names)
+
+    if len(args) != num_args:
+      raise ValueError(
+          f"Expected {num_args} arguments, got {len(args)}. "
+          f"Expected args: {arg_names}"
+      )
+
+    args_encrypted = [
+        getattr(self, f"encrypt_{arg_name}")(arg)
+        for arg_name, arg in zip(arg_names, args)
+    ]
+    result_encrypted = getattr(self, self.compilation_result.func_name)(
+        *args_encrypted
+    )
+    return self.decrypt_result(result_encrypted)
+
+
+def compile(
+    backend: str = "openfhe",
+    backend_config: Optional[openfhe_config.OpenFHEConfig] = None,
+    heir_config: Optional[_heir_config.HEIRConfig] = None,
+):
+  """Compile a function to its private equivalent in FHE.
+
+  Args:
+      backend: a string indicating the backend to use. Options: 'openfhe'
+        (default).
+      backend_config: a config object to control system-specific paths for the
+        backend in question.
+      heir_config: a config object to control paths to the tools in the HEIR
+        compilation toolchain.
+
+  Returns:
+    The decorator to apply to the given function.
+  """
+
+  def decorator(func):
+    compilation_result = run_compiler(
+        func,
+        openfhe_config=backend_config or openfhe_config.from_os_env(),
+        heir_config=heir_config or _heir_config.from_os_env(),
+    )
+    if backend == "openfhe":
+      return OpenfheClientInterface(compilation_result)
+    else:
+      raise ValueError(f"Unknown backend: {backend}")
+
+  return decorator

--- a/heir_py/e2e_test.py
+++ b/heir_py/e2e_test.py
@@ -1,0 +1,27 @@
+from heir_py import compile
+
+from absl.testing import absltest  # fmt: skip
+
+
+class EndToEndTest(absltest.TestCase):
+
+  def test_simple_arithmetic(self):
+    @compile(backend="openfhe")
+    def foo(a, b):
+      return a * a - b * b
+
+    # Test the e2e path
+    self.assertEqual(-15, foo(7, 8))
+
+    # Also test the manual way with crypto_context and keys threaded in
+    # automatically
+    foo.setup()
+    enc_a = foo.encrypt_a(7)
+    enc_b = foo.encrypt_b(8)
+    result_enc = foo.foo(enc_a, enc_b)
+    result = foo.decrypt_result(result_enc)
+    self.assertEqual(-15, result)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/heir_py/heir_config.py
+++ b/heir_py/heir_config.py
@@ -37,13 +37,16 @@ def from_os_env() -> HEIRConfig:
   """
   which_heir_opt = shutil.which("heir-opt")
   which_heir_translate = shutil.which("heir-translate")
+  resolved_heir_opt_path = os.environ.get(
+      "HEIR_OPT_PATH",
+      which_heir_opt or DEVELOPMENT_HEIR_CONFIG.heir_opt_path,
+  )
+  resolved_heir_translate_path = os.environ.get(
+      "HEIR_TRANSLATE_PATH",
+      which_heir_translate or DEVELOPMENT_HEIR_CONFIG.heir_translate_path,
+  )
+
   return HEIRConfig(
-      heir_opt_path=os.environ.get(
-          "HEIR_OPT_PATH",
-          which_heir_opt or DEVELOPMENT_HEIR_CONFIG.heir_opt_path,
-      ),
-      heir_translate_path=os.environ.get(
-          "HEIR_TRANSLATE_PATH",
-          which_heir_translate or DEVELOPMENT_HEIR_CONFIG.heir_translate_path,
-      ),
+      heir_opt_path=resolved_heir_opt_path,
+      heir_translate_path=resolved_heir_translate_path,
   )

--- a/heir_py/openfhe_config.py
+++ b/heir_py/openfhe_config.py
@@ -94,8 +94,9 @@ def from_os_env(debug=False) -> OpenFHEConfig:
       print(f"Warning: include directory {include_dir} does not exist")
 
   return OpenFHEConfig(
-      include_dirs=include_dirs,
-      lib_dir=lib_dir,
-      link_libs=link_libs,
+      include_dirs=include_dirs
+      or DEFAULT_INSTALLED_OPENFHE_CONFIG.include_dirs,
+      lib_dir=lib_dir or DEFAULT_INSTALLED_OPENFHE_CONFIG.lib_dir,
+      link_libs=link_libs or DEFAULT_INSTALLED_OPENFHE_CONFIG.link_libs,
       include_type=os.environ.get("OPENFHE_INCLUDE_TYPE", "install-relative"),
   )

--- a/heir_py/pipeline_test.py
+++ b/heir_py/pipeline_test.py
@@ -15,7 +15,7 @@ class PipelineTest(absltest.TestCase):
         foo,
         openfhe_config=openfhe_config.from_os_env(),
         heir_config=heir_config.from_os_env(),
-    )
+    ).module
 
     cc = heir_foo.foo__generate_crypto_context()
     kp = cc.KeyGen()


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/1105

This PR adds a decorator layer for the Python frontend.

For example, (from `e2e_test.py`)

```python
@compile(backend="openfhe")
def foo(a, b):
    return a * a - b * b

# Test the e2e path
self.assertEqual(-15, foo(7, 8))

# Also test the manual way with crypto_context and keys threaded in
# automatically
foo.setup()
enc_a = foo.encrypt_a(7)
enc_b = foo.encrypt_b(8)
result_enc = foo.foo(enc_a, enc_b)
result = foo.decrypt_result(result_enc)
self.assertEqual(-15, result)
```

Note the crypto context and private/public keys can also be accessed as member variables of `foo`, though which subset of variables are present would be backend-dependent. Also the allowed kwargs on the various functions would also be backend-dependent, as some backends may take the parameters/key args in different combinations.