### PR TITLE
openfhe: add bootstrap op

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -50,14 +50,16 @@ class Openfhe_BinaryOp<string mnemonic, list<Trait> traits = []>
 def GenParamsOp : Openfhe_Op<"gen_params"> {
   let arguments = (ins
     I64Attr:$mulDepth,
-    I64Attr:$plainMod
+    I64Attr:$plainMod,
+    BoolAttr:$insecure
   );
   let results = (outs Openfhe_CCParams:$params);
 }
 
 def GenContextOp : Openfhe_Op<"gen_context"> {
   let arguments = (ins
-    Openfhe_CCParams:$params
+    Openfhe_CCParams:$params,
+    BoolAttr:$supportFHE
   );
   let results = (outs Openfhe_CryptoContext:$context);
 }
@@ -74,6 +76,21 @@ def GenRotKeyOp : Openfhe_Op<"gen_rotkey"> {
     Openfhe_CryptoContext:$cryptoContext,
     Openfhe_PrivateKey:$privateKey,
     DenseI64ArrayAttr:$indices
+  );
+}
+
+def SetupBootstrapOp : Openfhe_Op<"setup_bootstrap"> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    Builtin_IntegerAttr:$levelBudgetEncode,
+    Builtin_IntegerAttr:$levelBudgetDecode
+  );
+}
+
+def GenBootstrapKeyOp : Openfhe_Op<"gen_bootstrapkey"> {
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    Openfhe_PrivateKey:$privateKey
   );
 }
 
@@ -207,5 +224,7 @@ def KeySwitchOp : Openfhe_Op<"key_switch", [
   );
   let results = (outs NewLWECiphertext:$output);
 }
+
+def BootstrapOp : Openfhe_UnaryTypeSwitchOp<"bootstrap"> { let summary = "OpenFHE bootstrap operation of a ciphertext. (For CKKS)"; }
 
 #endif  // LIB_DIALECT_OPENFHE_IR_OPENFHEOPS_TD_

--- a/lib/Dialect/Openfhe/Transforms/Passes.td
+++ b/lib/Dialect/Openfhe/Transforms/Passes.td
@@ -19,8 +19,14 @@ def ConfigureCryptoContext : Pass<"openfhe-configure-crypto-context"> {
   let options = [
     Option<"entryFunction", "entry-function", "std::string",
            /*default=*/"", "Default entry function "
-           "name of entry function.">
-
+           "name of entry function.">,
+    Option<"levelBudgetEncode", "level-budget-encode", "int",
+           /*default=*/"3", "Level budget for CKKS bootstrap encode (s2c) phase">,
+    Option<"levelBudgetDecode", "level-budget-decode", "int",
+           /*default=*/"3", "Level budget for CKKS bootstrap decode (c2s) phase">,
+    Option<"insecure", "insecure", "bool",
+           /*default=*/"false", "Whether to use insecure parameter for faster evaluation"
+           "(should only be used in test) (defaults to false)">
   ];
 }
 

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -67,12 +67,14 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(AddOp op);
   LogicalResult printOperation(AddPlainOp op);
   LogicalResult printOperation(AutomorphOp op);
+  LogicalResult printOperation(BootstrapOp op);
   LogicalResult printOperation(DecryptOp op);
   LogicalResult printOperation(EncryptOp op);
   LogicalResult printOperation(GenParamsOp op);
   LogicalResult printOperation(GenContextOp op);
   LogicalResult printOperation(GenMulKeyOp op);
   LogicalResult printOperation(GenRotKeyOp op);
+  LogicalResult printOperation(GenBootstrapKeyOp op);
   LogicalResult printOperation(KeySwitchOp op);
   LogicalResult printOperation(LevelReduceOp op);
   LogicalResult printOperation(MakePackedPlaintextOp op);
@@ -85,6 +87,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(NegateOp op);
   LogicalResult printOperation(RelinOp op);
   LogicalResult printOperation(RotOp op);
+  LogicalResult printOperation(SetupBootstrapOp op);
   LogicalResult printOperation(SquareOp op);
   LogicalResult printOperation(SubOp op);
 

--- a/tests/Dialect/Openfhe/IR/ops.mlir
+++ b/tests/Dialect/Openfhe/IR/ops.mlir
@@ -25,6 +25,7 @@
 #ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
 
 !pk = !openfhe.public_key
+!sk = !openfhe.private_key
 !ek = !openfhe.eval_key
 !cc = !openfhe.crypto_context
 !ct = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
@@ -148,6 +149,24 @@ module {
   func.func @test_level_reduce(%cc : !cc, %pt : !pt, %pk3 : !pk) {
     %ct = openfhe.encrypt %cc, %pt, %pk3 : (!cc, !pt, !pk) -> !ct
     %out = openfhe.level_reduce %cc, %ct: (!cc, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_bootstrap
+  func.func @test_bootstrap(%cc : !cc, %ct : !ct) {
+    %out = openfhe.bootstrap %cc, %ct: (!cc, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_gen_bootstrap_key
+  func.func @test_gen_bootstrap_key(%cc : !cc, %sk : !sk) {
+    openfhe.gen_bootstrapkey %cc, %sk: (!cc, !sk) -> ()
+    return
+  }
+
+  // CHECK-LABEL: func @test_setup_bootstrap
+  func.func @test_setup_bootstrap(%cc : !cc) {
+    openfhe.setup_bootstrap %cc {levelBudgetEncode = 3, levelBudgetDecode = 3}: (!cc) -> ()
     return
   }
 }

--- a/tests/Dialect/Openfhe/Transforms/configure_crypto_context_bootstrap.mlir
+++ b/tests/Dialect/Openfhe/Transforms/configure_crypto_context_bootstrap.mlir
@@ -1,0 +1,29 @@
+// RUN: heir-opt --openfhe-configure-crypto-context=entry-function=bootstrap %s | FileCheck %s
+
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #full_crt_packing_encoding>
+#ring_rns_L0_1_x32_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**32>>
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x32_, encryption_type = lsb>
+!ct_L0_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+
+
+func.func @bootstrap(%arg0: !openfhe.crypto_context, %arg1: !ct_L0_) -> !ct_L0_ {
+  %0 = openfhe.bootstrap %arg0, %arg1 : (!openfhe.crypto_context, !ct_L0_) -> !ct_L0_
+  return %0 : !ct_L0_
+}
+
+// CHECK: @bootstrap
+// CHECK: @bootstrap__generate_crypto_context
+// CHECK: mulDepth = 20
+// CHECK: openfhe.gen_context %{{.*}} {supportFHE = true}
+
+// CHECK: @bootstrap__configure_crypto_context
+// CHECK: openfhe.gen_mulkey
+// CHECK: openfhe.setup_bootstrap %{{.*}} {levelBudgetDecode = 3 : index, levelBudgetEncode = 3 : index}
+// CHECK: openfhe.gen_bootstrapkey

--- a/tests/Examples/openfhe/BUILD
+++ b/tests/Examples/openfhe/BUILD
@@ -95,3 +95,18 @@ openfhe_end_to_end_test(
     tags = ["notap"],
     test_src = "halevi_shoup_matmul_test.cpp",
 )
+
+openfhe_end_to_end_test(
+    name = "simple_ckks_bootstrapping_test",
+    generated_lib_header = "simple_ckks_bootstrapping_lib.h",
+    heir_opt_flags = [
+        "--openfhe-configure-crypto-context=entry-function=simple_ckks_bootstrapping insecure=true",
+    ],
+    heir_translate_flags = [
+        "--openfhe-scheme=ckks",
+        "--openfhe-include-type=source-relative",
+    ],
+    mlir_src = "simple_ckks_bootstrapping.mlir",
+    tags = ["notap"],
+    test_src = "simple_ckks_bootstrapping_test.cpp",
+)

--- a/tests/Examples/openfhe/simple_ckks_bootstrapping.mlir
+++ b/tests/Examples/openfhe/simple_ckks_bootstrapping.mlir
@@ -1,0 +1,35 @@
+!Z1005037682689_i64_ = !mod_arith.int<1005037682689 : i64>
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 1024>
+#key = #lwe.key<>
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+#modulus_chain_L5_C2_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 2>
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+!rns_L2_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_, !Z1005037682689_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #inverse_canonical_encoding>
+#ring_rns_L0_1_x32_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**32>>
+#ring_rns_L1_1_x32_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**32>>
+#ring_rns_L2_1_x32_ = #polynomial.ring<coefficientType = !rns_L2_, polynomialModulus = <1 + x**32>>
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x32_, encryption_type = lsb>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x32_, encryption_type = lsb>
+#ciphertext_space_L2_ = #lwe.ciphertext_space<ring = #ring_rns_L2_1_x32_, encryption_type = lsb>
+
+!ct_L0_ = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<8xf64>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<8xf64>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!ct_L2_ = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<8xf64>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L2_, key = #key, modulus_chain = #modulus_chain_L5_C2_>
+
+module {
+  func.func @simple_ckks_bootstrapping(%cc: !openfhe.crypto_context, %ct: !ct_L2_) -> !ct_L2_ {
+    // in FLEXIBLEAUTOEXT mode, openfhe won't execute those mod_reduce
+    // added here just for type conversion
+    %0 = openfhe.mod_reduce %cc, %ct : (!openfhe.crypto_context, !ct_L2_) -> !ct_L1_
+    %1 = openfhe.mod_reduce %cc, %0 : (!openfhe.crypto_context, !ct_L1_) -> !ct_L0_
+    %2 = openfhe.bootstrap %cc, %1 : (!openfhe.crypto_context, !ct_L0_) -> !ct_L2_
+    return %2 : !ct_L2_
+  }
+}

--- a/tests/Examples/openfhe/simple_ckks_bootstrapping_test.cpp
+++ b/tests/Examples/openfhe/simple_ckks_bootstrapping_test.cpp
@@ -1,0 +1,66 @@
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/simple_ckks_bootstrapping_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(SimpleCKKSBootstrappingTest, RunTest) {
+  // WARNING: This test used insecure parameter for faster testing.
+  // If you were to use this test as a starter point, please change the
+  // insecure flag in BUILD to false.
+  auto cryptoContext = simple_ckks_bootstrapping__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  cryptoContext = simple_ckks_bootstrapping__configure_crypto_context(
+      cryptoContext, keyPair.secretKey);
+
+  // in accordance with simple_ckks_bootstrapping.mlir function arguments
+  uint32_t levelsAvailableAfterBootstrap = 2;
+
+  // 3 for levelBudgetEncode
+  // 14 for approxModDepth
+  // 3 for levelBudgetDecode
+  // extra +1 for FLEXIBLEAUTOEXT
+  auto depth = levelsAvailableAfterBootstrap + 3 + 14 + 3 + 1;
+
+  std::vector<double> x = {0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0};
+  size_t encodedLength = x.size();
+
+  // We start with a depleted ciphertext that has used up all of its levels.
+  lbcrypto::Plaintext ptxt =
+      cryptoContext->MakeCKKSPackedPlaintext(x, 1, depth - 1);
+
+  auto levelBeforeBootstrapping = depth - ptxt->GetLevel();
+
+  EXPECT_EQ(levelBeforeBootstrapping, 1);
+
+  ptxt->SetLength(encodedLength);
+
+  Ciphertext<lbcrypto::DCRTPoly> encrypted =
+      cryptoContext->Encrypt(keyPair.publicKey, ptxt);
+
+  auto out = simple_ckks_bootstrapping(cryptoContext, encrypted);
+
+  auto levelAfterBootstrapping =
+      depth - out->GetLevel() - (out->GetNoiseScaleDeg() - 1);
+
+  EXPECT_EQ(levelAfterBootstrapping, levelsAvailableAfterBootstrap);
+
+  lbcrypto::Plaintext result;
+  cryptoContext->Decrypt(keyPair.secretKey, out, &result);
+  result->SetLength(encodedLength);
+
+  for (size_t i = 0; i < encodedLength; i++) {
+    EXPECT_NEAR(x[i], result->GetCKKSPackedValue()[i].real(), 0.01);
+  }
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
This follows the setup step in [simple-ckks-bootstrapping example in OpenFHE](https://github.com/openfheorg/openfhe-development/blob/main/src/pke/examples/simple-ckks-bootstrapping.cpp).

With input

```mlir
  func.func @func(%arg0: !openfhe.crypto_context, %arg1: !rlwe_ct_L0_) -> !rlwe_ct_L0_ {
    %0 = openfhe.bootstrap %arg0, %arg1 : (!openfhe.crypto_context, !rlwe_ct_L0_) -> !rlwe_ct_L0_
    return %0 : !rlwe_ct_L0_
  }
```

with `--openfhe-configure-crypto-context` we get
```mlir
  func.func @func__generate_crypto_context() -> !openfhe.crypto_context {
    %0 = openfhe.gen_params  {mulDepth = 20 : i64, plainMod = 4295294977 : i64} : () -> !openfhe.cc_params
    %1 = openfhe.gen_context %0 {supportFHE = true} : (!openfhe.cc_params) -> !openfhe.crypto_context
    return %1 : !openfhe.crypto_context
  }
  func.func @func__configure_crypto_context(%arg0: !openfhe.crypto_context, %arg1: !openfhe.private_key) -> !openfhe.crypto_context {
    openfhe.gen_mulkey %arg0, %arg1 : (!openfhe.crypto_context, !openfhe.private_key) -> ()
    openfhe.setup_bootstrap %arg0 {levelBudgetDecode = 3 : index, levelBudgetEncode = 3 : index} : (!openfhe.crypto_context) -> ()
    openfhe.gen_bootstrap_key %arg0, %arg1 : (!openfhe.crypto_context, !openfhe.private_key) -> ()
    return %arg0 : !openfhe.crypto_context
  }
```

Then the translated code can run with a main function similar to `simple-ckks-bootstrap`.

To make it run faster, the following setup step is needed
```
  v3.SetSecurityLevel(HEStd_NotSet);
  v3.SetRingDim(1 << 12);
```

Link the generated code against an OpenFHE with multi-thread support and fast math backend (HEIR internal one is single-thread, slow math backend). It could run within 3 second (96 core machine). Link against HEIR internal one would require about 2 minutes to run.

### Discussion

* mulDepth is now interwined with bootstrap, hence all the RNS instantiation need to change. and #1176 way could not handle this. I think that would need introducing a `mgmt.bootstrap` op and implement a bootstrap management pass  (possibly related to #289, #1166).
* Currently, the `bootstrapDepth` (level consumed by bootstrap) is hard-encoded with value taken from openfhe. This depth will affect logN selection hence slot num, which is needed by the `EvalBootstrapKeyGen`. Now I acquire this time in runtime (by the emitter) from `cryptoContext` instead of putting it in `openfhe.gen_bootstrap_key` op.