### PR TITLE
SecretnessAnalysis: add interface method for dependent analysis

### DIFF
--- a/lib/Analysis/DimensionAnalysis/DimensionAnalysis.h
+++ b/lib/Analysis/DimensionAnalysis/DimensionAnalysis.h
@@ -1,6 +1,7 @@
 #ifndef LIB_ANALYSIS_DIMENSIONANALYSIS_DIMENSIONANALYSIS_H_
 #define LIB_ANALYSIS_DIMENSIONANALYSIS_DIMENSIONANALYSIS_H_
 
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"    // from @llvm-project
@@ -64,9 +65,11 @@ class DimensionLattice : public dataflow::Lattice<DimensionState> {
 };
 
 class DimensionAnalysis
-    : public dataflow::SparseForwardDataFlowAnalysis<DimensionLattice> {
+    : public dataflow::SparseForwardDataFlowAnalysis<DimensionLattice>,
+      public SecretnessAnalysisDependent<DimensionAnalysis> {
  public:
   using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  friend class SecretnessAnalysisDependent<DimensionAnalysis>;
 
   void setToEntryState(DimensionLattice *lattice) override {
     propagateIfChanged(lattice, lattice->join(DimensionState()));

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
@@ -28,16 +28,6 @@ LogicalResult LevelAnalysis::visitOperation(
     propagateIfChanged(lattice, changed);
   };
 
-  auto ensureSecretness = [&](Operation *op, Value value) -> bool {
-    // create dependency on SecretnessAnalysis
-    auto *lattice =
-        getOrCreateFor<SecretnessLattice>(getProgramPointAfter(op), value);
-    if (!lattice->getValue().isInitialized()) {
-      return false;
-    }
-    return lattice->getValue().getSecretness();
-  };
-
   llvm::TypeSwitch<Operation &>(*op)
       .Case<secret::GenericOp>([&](auto genericOp) {
         Block *body = genericOp.getBody();
@@ -56,30 +46,25 @@ LogicalResult LevelAnalysis::visitOperation(
         propagate(modReduceOp.getResult(), LevelState(level + 1));
       })
       .Default([&](auto &op) {
-        if (op.getNumResults() == 0) {
-          return;
-        }
-
         // condition on result secretness
-        auto secretness = ensureSecretness(&op, op.getResult(0));
-        if (!secretness) {
+        SmallVector<OpResult> secretResults;
+        getSecretResults(&op, secretResults);
+        if (secretResults.empty()) {
           return;
         }
 
         auto levelResult = 0;
-        for (const auto *operand : operands) {
-          auto secretness = ensureSecretness(&op, operand->getAnchor());
-          if (!secretness) {
-            continue;
-          }
-          // now operand is secret
-          if (!operand->getValue().isInitialized()) {
+        SmallVector<OpOperand *> secretOperands;
+        getSecretOperands(&op, secretOperands);
+        for (auto *operand : secretOperands) {
+          auto &levelState = getLatticeElement(operand->get())->getValue();
+          if (!levelState.isInitialized()) {
             return;
           }
-          levelResult = std::max(levelResult, operand->getValue().getLevel());
+          levelResult = std::max(levelResult, levelState.getLevel());
         }
 
-        for (auto result : op.getResults()) {
+        for (auto result : secretResults) {
           propagate(result, LevelState(levelResult));
         }
       });

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <optional>
 
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -68,9 +69,11 @@ class LevelLattice : public dataflow::Lattice<LevelState> {
 };
 
 class LevelAnalysis
-    : public dataflow::SparseForwardDataFlowAnalysis<LevelLattice> {
+    : public dataflow::SparseForwardDataFlowAnalysis<LevelLattice>,
+      public SecretnessAnalysisDependent<LevelAnalysis> {
  public:
   using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  friend class SecretnessAnalysisDependent<LevelAnalysis>;
 
   void setToEntryState(LevelLattice *lattice) override {
     propagateIfChanged(lattice, lattice->join(LevelState()));

--- a/lib/Analysis/MulResultAnalysis/MulResultAnalysis.h
+++ b/lib/Analysis/MulResultAnalysis/MulResultAnalysis.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <optional>
 
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"  // from @llvm-project
@@ -70,9 +71,11 @@ class MulResultLattice : public dataflow::Lattice<MulResultState> {
 };
 
 class MulResultAnalysis
-    : public dataflow::SparseForwardDataFlowAnalysis<MulResultLattice> {
+    : public dataflow::SparseForwardDataFlowAnalysis<MulResultLattice>,
+      public SecretnessAnalysisDependent<MulResultAnalysis> {
  public:
   using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  friend class SecretnessAnalysisDependent<MulResultAnalysis>;
 
   void setToEntryState(MulResultLattice *lattice) override {
     propagateIfChanged(lattice, lattice->join(MulResultState()));


### PR DESCRIPTION
This introduces a `SecretnessAnalysisDependent` interface class so that any `DataFlowAnalysis` depending on `SecretnessAnalysis` could more easily access the secretness of a given Value/OpOperand/OpResult.

In the future there would be more Analysis depending on SecretnessAnalysis so abstracting the common method for accessing SecretnessState is essential for readability and maintainability.