### PR TITLE
Attributes: stop including BuiltinAttributes

### DIFF
--- a/lib/Dialect/BGV/IR/BGVOps.td
+++ b/lib/Dialect/BGV/IR/BGVOps.td
@@ -10,6 +10,7 @@ include "lib/Dialect/LWE/IR/LWETypes.td"
 include "lib/Dialect/LWE/IR/LWETraits.td"
 include "lib/Dialect/Polynomial/IR/PolynomialAttributes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/BuiltinAttributes.td"
 
 class BGV_Op<string mnemonic, list<Trait> traits = []> :
         Op<BGV_Dialect, mnemonic, traits> {

--- a/lib/Dialect/CKKS/IR/CKKSOps.td
+++ b/lib/Dialect/CKKS/IR/CKKSOps.td
@@ -10,6 +10,7 @@ include "lib/Dialect/LWE/IR/LWETypes.td"
 include "lib/Dialect/LWE/IR/LWETraits.td"
 include "lib/Dialect/Polynomial/IR/PolynomialAttributes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/BuiltinAttributes.td"
 
 class CKKS_Op<string mnemonic, list<Trait> traits = []> :
         Op<CKKS_Dialect, mnemonic, traits> {

--- a/lib/Dialect/Mgmt/IR/MgmtAttributes.td
+++ b/lib/Dialect/Mgmt/IR/MgmtAttributes.td
@@ -2,7 +2,7 @@
 #define LIB_DIALECT_MGMT_IR_MGMTATTRIBUTES_TD_
 
 include "lib/Dialect/Mgmt/IR/MgmtDialect.td"
-include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/OpBase.td"
 
 class Mgmt_Attr<string name, string attrMnemonic, list<Trait> traits = []>
     : AttrDef<Mgmt_Dialect, name, traits> {

--- a/lib/Dialect/ModArith/IR/ModArithAttributes.td
+++ b/lib/Dialect/ModArith/IR/ModArithAttributes.td
@@ -3,8 +3,8 @@
 
 include "lib/Dialect/ModArith/IR/ModArithDialect.td"
 include "lib/Dialect/ModArith/IR/ModArithTypes.td"
-include "mlir/IR/BuiltinAttributes.td"
-
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/OpBase.td"
 
 class ModArith_Attr<string name, string attrMnemonic, list<Trait> traits = []>
   : AttrDef<ModArith_Dialect, name, traits> {

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
@@ -2,7 +2,8 @@
 #define LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALATTRIBUTES_TD_
 
 include "lib/Dialect/Polynomial/IR/PolynomialDialect.td"
-include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/OpBase.td"
 
 class Polynomial_Attr<string name, string attrMnemonic, list<Trait> traits = []>
     : AttrDef<Polynomial_Dialect, name, traits> {


### PR DESCRIPTION
Check https://heir.dev/docs/dialects/polynomial/ and other pages like `Mgmt` or `ModArith`. They also includes builtin attributes from MLIR.

The reason is that their `Attributes.td` includes `BuiltinAttributes.td` from MLIR. If we switch to `OpBase.td` then it is fine.

Including `BuiltinAttributes` for `Ops.td` is fine as the build process will filter out attribute definitions. 