### PR TITLE
[Arith]: Quarter Wide Int Conversion Pass

### DIFF
--- a/lib/Dialect/Arith/Transforms/BUILD
+++ b/lib/Dialect/Arith/Transforms/BUILD
@@ -1,0 +1,40 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":QuarterWideInt",
+        ":pass_inc_gen",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "QuarterWideInt",
+    srcs = ["QuarterWideInt.cpp"],
+    hdrs = ["QuarterWideInt.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Utils:ConversionUtils",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:FuncTransforms",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    header_filename = "Passes.h.inc",
+    pass_name = "Arith",
+    td_file = "Passes.td",
+)

--- a/lib/Dialect/Arith/Transforms/Passes.h
+++ b/lib/Dialect/Arith/Transforms/Passes.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_ARITH_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_ARITH_TRANSFORMS_PASSES_H_
+
+#include "lib/Dialect/Arith/Transforms/QuarterWideInt.h"
+
+namespace mlir {
+namespace heir {
+namespace arith {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Arith/Transforms/Passes.h.inc"
+
+}  // namespace arith
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ARITH_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/Arith/Transforms/Passes.td
+++ b/lib/Dialect/Arith/Transforms/Passes.td
@@ -1,0 +1,26 @@
+#ifndef LIB_DIALECT_ARITH_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_ARITH_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def QuarterWideInt : Pass<"arith-quarter-wide-int"> {
+
+  let summary = "Convert high precision arithmetic operations to a sequence of lower precision operations";
+  let description = [{
+    This pass converts high precision arithmetic operations, i.e. operations on 32 bit integer,
+    into a sequence of lower precision operations, i.e 8b operations.
+    Currently, the pass splits the 32b integer into four 8b integers, using the tensor dialect.
+    These smaller integers are stored in an 16b integer, so that we don't lose the carry information.
+
+    Based on the `arith-emulate-wide-int` pass from the MLIR arith dialect.
+
+    General assumption: the first element in the tensor is also the LSB element.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::vector::VectorDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_ARITH_TRANSFORMS_PASSES_TD_

--- a/lib/Dialect/Arith/Transforms/QuarterWideInt.cpp
+++ b/lib/Dialect/Arith/Transforms/QuarterWideInt.cpp
@@ -1,0 +1,489 @@
+#include "lib/Dialect/Arith/Transforms/QuarterWideInt.h"
+
+#include <optional>
+
+#include "lib/Utils/ConversionUtils.h"
+#include "llvm/include/llvm/ADT/APInt.h"                // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/FormatVariadic.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Vector/IR/VectorOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/TypeUtilities.h"         // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"         // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith {
+
+#define GEN_PASS_DEF_QUARTERWIDEINT
+#include "lib/Dialect/Arith/Transforms/Passes.h.inc"
+
+static constexpr unsigned maxIntWidth = 16;
+
+class QuarterWideTypeConverter : public TypeConverter {
+ public:
+  QuarterWideTypeConverter(MLIRContext *ctx) {
+    // Allow unknown types.
+    addConversion([](Type ty) -> std::optional<Type> { return ty; });
+
+    // Scalar case.
+    addConversion([](IntegerType ty) -> std::optional<Type> {
+      unsigned width = ty.getWidth();
+      if (width <= maxIntWidth) return ty;
+
+      // i2N --> tensor<4xiN>
+      if (width == 2 * maxIntWidth)
+        return RankedTensorType::get(
+            4, IntegerType::get(ty.getContext(), maxIntWidth));
+
+      return std::nullopt;
+    });
+
+    // tensor case.
+    addConversion([](ShapedType ty) -> std::optional<Type> {
+      auto intTy = dyn_cast<IntegerType>(ty.getElementType());
+      if (!intTy) return ty;
+
+      unsigned width = intTy.getWidth();
+      if (width <= maxIntWidth) return ty;
+
+      // tensor<...xi2N> --> tensor<...x4xiN>
+      if (width == 2 * maxIntWidth) {
+        auto newShape = to_vector(ty.getShape());
+        newShape.push_back(4);
+        return RankedTensorType::get(
+            newShape, IntegerType::get(ty.getContext(), maxIntWidth));
+      }
+      return std::nullopt;
+    });
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Common Helper Functions
+//===----------------------------------------------------------------------===//
+
+/// Returns the number divided into four chunks of N/2 bits from `value`, where
+/// N = `newBitWidth/2`. Treats `value` as a 2*N bits-wide integer. The bottom
+/// bits are returned in the first pair element, while the top bits in the
+/// fourth one.
+static std::tuple<APInt, APInt, APInt, APInt> getQuarters(
+    const APInt &value, unsigned newBitWidth) {
+  auto acutalBitWidth = newBitWidth >> 1;
+
+  APInt low = value.extractBits(acutalBitWidth, 0);
+  APInt midLow = value.extractBits(acutalBitWidth, acutalBitWidth);
+  APInt midHigh = value.extractBits(acutalBitWidth, 2 * acutalBitWidth);
+  APInt high = value.extractBits(acutalBitWidth, 3 * acutalBitWidth);
+  return {std::move(low), std::move(midLow), std::move(midHigh),
+          std::move(high)};
+}
+
+/// Returns the type with the last (innermost) dimension reduced to x1.
+/// Scalarizes 1D tensor inputs to match how we extract/insert tensor values,
+/// e.g.:
+///   - tensor<3x2xi16> --> tensor<3x1xi16>
+///   - tensor<2xi16>   --> i16
+static Type reduceInnermostDim(RankedTensorType type) {
+  if (type.getShape().size() == 1) return type.getElementType();
+
+  auto newShape = to_vector(type.getShape());
+  newShape.back() = 1;
+  return RankedTensorType::get(newShape, type.getElementType());
+}
+
+/// Extracts the `input` tensor slice with elements at the last dimension offset
+/// by `lastOffset`. Returns a value of tensor type with the last dimension
+/// reduced to x1 or fully scalarized, e.g.:
+///   - tensor<2xi16>   --> i16
+static Value extractLastDimSlice(ConversionPatternRewriter &rewriter,
+                                 Location loc, Value input,
+                                 int64_t lastOffset) {
+  ArrayRef<int64_t> shape = cast<RankedTensorType>(input.getType()).getShape();
+  assert(lastOffset < shape.back() && "Offset out of bounds");
+
+  // Create valueRange
+  auto intAttr = rewriter.getIntegerAttr(rewriter.getIndexType(), lastOffset);
+  auto constantOp = rewriter.create<mlir::arith::ConstantOp>(loc, intAttr);
+  ValueRange valueRange(constantOp.getResult());
+
+  // Scalarize the result in case of 1D tensors.
+  if (shape.size() == 1)
+    return rewriter.create<tensor::ExtractOp>(loc, input, valueRange);
+
+  SmallVector<OpFoldResult> offsets(shape.size(), rewriter.getIndexAttr(0));
+  offsets.back() = rewriter.getIndexAttr(lastOffset);
+  SmallVector<OpFoldResult> sizes(shape.size());
+  sizes.back() = rewriter.getIndexAttr(1);
+  SmallVector<OpFoldResult> strides(shape.size(), rewriter.getIndexAttr(1));
+
+  return rewriter.create<tensor::ExtractSliceOp>(loc, input, offsets, sizes,
+                                                 strides);
+}
+
+/// Extracts four tensor slices from the `input` whose type is `tensor<...x4T>`,
+/// with the first element at offset 0, second element at offset 1 and so on.
+static std::tuple<Value, Value, Value, Value> extractLastDimHalves(
+    ConversionPatternRewriter &rewriter, Location loc, Value input) {
+  return {extractLastDimSlice(rewriter, loc, input, 0),
+          extractLastDimSlice(rewriter, loc, input, 1),
+          extractLastDimSlice(rewriter, loc, input, 2),
+          extractLastDimSlice(rewriter, loc, input, 3)};
+}
+
+/// Inserts the `source` tensor slice into the `dest` tensor at offset
+/// `lastOffset` in the last dimension. `source` can be a scalar when `dest` is
+/// a 1D tensor.
+static Value insertLastDimSlice(ConversionPatternRewriter &rewriter,
+                                Location loc, Value source, Value dest,
+                                int64_t lastOffset) {
+  ArrayRef<int64_t> shape = cast<RankedTensorType>(dest.getType()).getShape();
+  assert(lastOffset < shape.back() && "Offset out of bounds");
+
+  // Handle scalar source.
+  if (isa<IntegerType>(source.getType())) {
+    auto intAttr = rewriter.getIntegerAttr(rewriter.getIndexType(), lastOffset);
+    auto constantOp = rewriter.create<mlir::arith::ConstantOp>(loc, intAttr);
+    ValueRange valueRange(constantOp.getResult());
+
+    return rewriter.create<tensor::InsertOp>(loc, source, dest, valueRange);
+  }
+
+  SmallVector<OpFoldResult> offsets(shape.size(), rewriter.getIndexAttr(0));
+  offsets.back() = rewriter.getIndexAttr(lastOffset);
+  SmallVector<OpFoldResult> sizes(shape.size());
+  sizes.back() = rewriter.getIndexAttr(1);
+  SmallVector<OpFoldResult> strides(shape.size(), rewriter.getIndexAttr(1));
+
+  return rewriter.create<tensor::InsertSliceOp>(loc, source, dest, offsets,
+                                                sizes, strides);
+}
+
+static Value createScalarOrSplatConstant(OpBuilder &builder, Location loc,
+                                         Type type, int64_t value) {
+  unsigned elementBitWidth = 0;
+  if (auto intTy = dyn_cast<IntegerType>(type))
+    elementBitWidth = intTy.getWidth();
+  else
+    elementBitWidth = cast<ShapedType>(type).getElementTypeBitWidth();
+
+  auto apValue = APInt(elementBitWidth, value);
+
+  TypedAttr attr;
+  if (isa<IntegerType>(type)) {
+    attr = builder.getIntegerAttr(type, apValue);
+  } else {
+    auto vecTy = cast<ShapedType>(type);
+    attr = SplatElementsAttr::get(vecTy, apValue);
+  }
+
+  return builder.create<mlir::arith::ConstantOp>(loc, attr);
+}
+
+/// Constructs a new tensor of type `resultType` by creating a series of
+/// insertions of `resultComponents`, each at the next offset of the last tensor
+/// dimension.
+/// When all `resultComponents` are scalars, the result type is `tensor<NxT>`;
+/// when `resultComponents` are `tensor<...x1xT>`s, the result type is
+/// `tensor<...xNxT>`, where `N` is the number of `resultComponents`.
+static Value constructResultTensor(ConversionPatternRewriter &rewriter,
+                                   Location loc, RankedTensorType resultType,
+                                   ValueRange resultComponents) {
+  Value resultVec = createScalarOrSplatConstant(rewriter, loc, resultType, 0);
+  for (auto [i, component] : llvm::enumerate(resultComponents))
+    resultVec = insertLastDimSlice(rewriter, loc, component, resultVec, i);
+
+  return resultVec;
+}
+
+struct ConvertAddI final : OpConversionPattern<mlir::arith::AddIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::arith::AddIOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    ImplicitLocOpBuilder b(loc, rewriter);
+
+    auto newTy =
+        getTypeConverter()->convertType<RankedTensorType>(op.getType());
+    if (!newTy)
+      return rewriter.notifyMatchFailure(
+          loc, llvm::formatv("unsupported type: {0}", op.getType()));
+
+    Type elemTy = reduceInnermostDim(newTy);
+
+    auto [lhsElem0, lhsElem1, lhsElem2, lhsElem3] =
+        extractLastDimHalves(rewriter, loc, adaptor.getLhs());
+    auto [rhsElem0, rhsElem1, rhsElem2, rhsElem3] =
+        extractLastDimHalves(rewriter, loc, adaptor.getRhs());
+
+    // Actual type of the underlying elements; we use half the width.
+    auto realTy = IntegerType::get(op.getContext(), maxIntWidth >> 1);
+    // Create Constant
+    auto intAttr = rewriter.getIntegerAttr(elemTy, maxIntWidth >> 1);
+    auto constantOp = b.create<mlir::arith::ConstantOp>(intAttr);
+
+    auto lowSum0 = b.create<mlir::arith::AddIOp>(lhsElem0, rhsElem0);
+    auto lowSum1 = b.create<mlir::arith::AddIOp>(lhsElem1, rhsElem1);
+    auto lowSum2 = b.create<mlir::arith::AddIOp>(lhsElem2, rhsElem2);
+    auto lowSum3 = b.create<mlir::arith::AddIOp>(lhsElem3, rhsElem3);
+
+    auto output0Lsb = b.create<mlir::arith::TruncIOp>(realTy, lowSum0);
+    auto output0LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output0Lsb);
+
+    auto output1Lsb = b.create<mlir::arith::TruncIOp>(realTy, lowSum1);
+    auto output1LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output1Lsb);
+
+    auto output2Lsb = b.create<mlir::arith::TruncIOp>(realTy, lowSum2);
+    auto output2LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output2Lsb);
+
+    auto output3Lsb = b.create<mlir::arith::TruncIOp>(realTy, lowSum3);
+    auto output3LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output3Lsb);
+
+    // Now all the outputs are 16b elements, wants presentation of 4x8b
+    auto carry0 =
+        b.create<mlir::arith::ShRUIOp>(lowSum0, constantOp.getResult());
+    auto carry1 =
+        b.create<mlir::arith::ShRUIOp>(lowSum1, constantOp.getResult());
+    auto carry2 =
+        b.create<mlir::arith::ShRUIOp>(lowSum2, constantOp.getResult());
+
+    auto high1 = b.create<mlir::arith::AddIOp>(output1LsbHigh, carry0);
+    auto high2 = b.create<mlir::arith::AddIOp>(output2LsbHigh, carry1);
+    auto high3 = b.create<mlir::arith::AddIOp>(output3LsbHigh, carry2);
+
+    Value resultVec = constructResultTensor(
+        rewriter, loc, newTy, {output0LsbHigh, high1, high2, high3});
+    rewriter.replaceOp(op, resultVec);
+    return success();
+  }
+};
+
+// Implemented using the Karatsuba algorithm
+// https://en.wikipedia.org/wiki/Karatsuba_algorithm#Algorithm
+struct ConvertMulI final : OpConversionPattern<mlir::arith::MulIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::arith::MulIOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    ImplicitLocOpBuilder b(loc, rewriter);
+
+    auto newTy =
+        getTypeConverter()->convertType<RankedTensorType>(op.getType());
+    if (!newTy)
+      return rewriter.notifyMatchFailure(
+          loc, llvm::formatv("unsupported type: {0}", op.getType()));
+
+    auto elemTy = reduceInnermostDim(newTy);
+    // Actual type of the underlying elements; we use half the width.
+    auto realTy = IntegerType::get(op.getContext(), maxIntWidth >> 1);
+
+    // Create Constant
+    auto intAttr = rewriter.getIntegerAttr(elemTy, maxIntWidth >> 1);
+    auto constantOp = b.create<mlir::arith::ConstantOp>(intAttr);
+
+    auto [lhsElem0, lhsElem1, lhsElem2, lhsElem3] =
+        extractLastDimHalves(rewriter, loc, adaptor.getLhs());
+    auto [rhsElem0, rhsElem1, rhsElem2, rhsElem3] =
+        extractLastDimHalves(rewriter, loc, adaptor.getRhs());
+
+    // TODO: Implement the real Karatsuba algorithm for 4x4 multiplication.
+    // First part of Karatsuba algorithm
+    auto z00 = b.create<mlir::arith::MulIOp>(lhsElem0, rhsElem0);
+    auto z02 = b.create<mlir::arith::MulIOp>(lhsElem1, rhsElem1);
+    auto z01_p1 = b.create<mlir::arith::AddIOp>(lhsElem0, lhsElem1);
+    auto z01_p2 = b.create<mlir::arith::AddIOp>(rhsElem0, rhsElem1);
+    auto z01_m = b.create<mlir::arith::MulIOp>(z01_p1, z01_p2);
+    auto z01_s = b.create<mlir::arith::SubIOp>(z01_m, z00);
+    auto z01 = b.create<mlir::arith::SubIOp>(z01_s, z02);
+
+    // Second part I of Karatsuba algorithm
+    auto z1a0 = b.create<mlir::arith::MulIOp>(lhsElem0, rhsElem2);
+    auto z1a2 = b.create<mlir::arith::MulIOp>(lhsElem1, rhsElem3);
+    auto z1a1_p1 = b.create<mlir::arith::AddIOp>(lhsElem0, lhsElem1);
+    auto z1a1_p2 = b.create<mlir::arith::AddIOp>(rhsElem2, rhsElem3);
+    auto z1a1_m = b.create<mlir::arith::MulIOp>(z1a1_p1, z1a1_p2);
+    auto z1a1_s = b.create<mlir::arith::SubIOp>(z1a1_m, z1a0);
+    auto z1a1 = b.create<mlir::arith::SubIOp>(z1a1_s, z1a2);
+
+    // Second part II of Karatsuba algorithm
+    auto z1b0 = b.create<mlir::arith::MulIOp>(lhsElem2, rhsElem0);
+    auto z1b2 = b.create<mlir::arith::MulIOp>(lhsElem3, rhsElem1);
+    auto z1b1_p1 = b.create<mlir::arith::AddIOp>(lhsElem2, lhsElem3);
+    auto z1b1_p2 = b.create<mlir::arith::AddIOp>(rhsElem0, rhsElem1);
+    auto z1b1_m = b.create<mlir::arith::MulIOp>(z1b1_p1, z1b1_p2);
+    auto z1b1_s = b.create<mlir::arith::SubIOp>(z1b1_m, z1b0);
+    auto z1b1 = b.create<mlir::arith::SubIOp>(z1b1_s, z1b2);
+
+    auto out2Kara = b.create<mlir::arith::AddIOp>(z1a0, z1b0);
+    auto out2Carry = b.create<mlir::arith::AddIOp>(out2Kara, z02);
+    auto out3Carry = b.create<mlir::arith::AddIOp>(z1a1, z1b1);
+
+    // Output are now all 16b elements, wants presentation of 4x8b
+    auto output0Lsb = b.create<mlir::arith::TruncIOp>(realTy, z00);
+    auto output0LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output0Lsb);
+    auto output0Msb =
+        b.create<mlir::arith::ShRUIOp>(z00, constantOp.getResult());
+
+    auto output1Lsb = b.create<mlir::arith::TruncIOp>(realTy, z01);
+    auto output1LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output1Lsb);
+    auto output1Msb =
+        b.create<mlir::arith::ShRUIOp>(z01, constantOp.getResult());
+
+    auto output2Lsb = b.create<mlir::arith::TruncIOp>(realTy, out2Carry);
+    auto output2LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output2Lsb);
+    auto output2Msb =
+        b.create<mlir::arith::ShRUIOp>(out2Carry, constantOp.getResult());
+
+    auto output3Lsb = b.create<mlir::arith::TruncIOp>(realTy, out3Carry);
+    auto output3LsbHigh = b.create<mlir::arith::ExtUIOp>(elemTy, output3Lsb);
+
+    auto output1 = b.create<mlir::arith::AddIOp>(output1LsbHigh, output0Msb);
+    auto output2 = b.create<mlir::arith::AddIOp>(output2LsbHigh, output1Msb);
+    auto output3 = b.create<mlir::arith::AddIOp>(output3LsbHigh, output2Msb);
+
+    Value resultVec = constructResultTensor(
+        rewriter, loc, newTy, {output0LsbHigh, output1, output2, output3});
+    rewriter.replaceOp(op, resultVec);
+    return success();
+  }
+};
+
+struct ConvertArithConstant final
+    : OpConversionPattern<mlir::arith::ConstantOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::arith::ConstantOp op, OpAdaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type oldType = op.getType();
+    auto newType = getTypeConverter()->convertType<RankedTensorType>(oldType);
+
+    if (!newType)
+      return rewriter.notifyMatchFailure(
+          op, llvm::formatv("unsupported type: {0}", op.getType()));
+
+    unsigned newBitWidth = newType.getElementTypeBitWidth();
+    Attribute oldValue = op.getValueAttr();
+
+    if (auto intAttr = dyn_cast<IntegerAttr>(oldValue)) {
+      auto [low, midLow, midHigh, high] =
+          getQuarters(intAttr.getValue(), newBitWidth);
+      auto newAttr =
+          DenseElementsAttr::get(newType, {low, midLow, midHigh, high});
+      rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(op, newAttr);
+      return success();
+    }
+
+    if (auto splatAttr = dyn_cast<SplatElementsAttr>(oldValue)) {
+      auto [low, midLow, midHigh, high] =
+          getQuarters(splatAttr.getSplatValue<APInt>(), newBitWidth);
+      int64_t numSplatElems = splatAttr.getNumElements();
+      SmallVector<APInt> values;
+      values.reserve(numSplatElems * 4);
+      for (int64_t i = 0; i < numSplatElems; ++i) {
+        values.push_back(low);
+        values.push_back(midLow);
+        values.push_back(midHigh);
+        values.push_back(high);
+      }
+
+      auto attr = DenseElementsAttr::get(newType, values);
+      rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(op, attr);
+      return success();
+    }
+
+    if (auto elemsAttr = dyn_cast<DenseElementsAttr>(oldValue)) {
+      int64_t numElems = elemsAttr.getNumElements();
+      SmallVector<APInt> values;
+      values.reserve(numElems * 4);
+      for (const APInt &origVal : elemsAttr.getValues<APInt>()) {
+        auto [low, midLow, midHigh, high] = getQuarters(origVal, newBitWidth);
+        values.push_back(std::move(low));
+        values.push_back(std::move(midLow));
+        values.push_back(std::move(midHigh));
+        values.push_back(std::move(high));
+      }
+
+      auto attr = DenseElementsAttr::get(newType, values);
+      rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(op, attr);
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(op.getLoc(),
+                                       "unhandled constant attribute");
+  }
+};
+
+struct ConvertExtUI final : OpConversionPattern<mlir::arith::ExtUIOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mlir::arith::ExtUIOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+
+    auto newTy =
+        getTypeConverter()->convertType<RankedTensorType>(op.getType());
+
+    if (!newTy)
+      return rewriter.notifyMatchFailure(
+          loc, llvm::formatv("unsupported type: {0}", op.getType()));
+
+    Value resultVec = constructResultTensor(rewriter, loc, newTy, {op.getIn()});
+    rewriter.replaceOp(op, resultVec);
+    rewriter.replaceOp(op, resultVec);
+    return success();
+  }
+};
+
+struct QuarterWideInt : impl::QuarterWideIntBase<QuarterWideInt> {
+  using QuarterWideIntBase::QuarterWideIntBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    Operation *op = getOperation();
+    RewritePatternSet patterns(context);
+    QuarterWideTypeConverter typeConverter(context);
+
+    ConversionTarget target(*context);
+    target.addDynamicallyLegalOp<func::FuncOp>([&typeConverter](Operation *op) {
+      return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
+    });
+    auto opLegalCallback = [&typeConverter](Operation *op) {
+      return typeConverter.isLegal(op);
+    };
+
+    target.addDynamicallyLegalOp<func::CallOp, func::ReturnOp>(opLegalCallback);
+    target.addDynamicallyLegalDialect<mlir::arith::ArithDialect,
+                                      tensor::TensorDialect>(opLegalCallback);
+
+    addStructuralConversionPatterns(typeConverter, patterns, target);
+
+    patterns.add<ConvertAddI, ConvertMulI, ConvertExtUI, ConvertArithConstant>(
+        typeConverter, context);
+
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      signalPassFailure();
+
+    // Remove the uncessary tensor ops between each converted arith operation.
+    OpPassManager pipeline("builtin.module");
+    pipeline.addPass(createCSEPass());
+    (void)runPipeline(pipeline, getOperation());
+  }
+};
+
+}  // namespace arith
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Arith/Transforms/QuarterWideInt.h
+++ b/lib/Dialect/Arith/Transforms/QuarterWideInt.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_ARITH_TRANSFORMS_QUARTERWIDEINT_H_
+#define LIB_DIALECT_ARITH_TRANSFORMS_QUARTERWIDEINT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace arith {
+
+#define GEN_PASS_DECL_QUARTERWIDEINT
+#include "lib/Dialect/Arith/Transforms/Passes.h.inc"
+
+}  // namespace arith
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ARITH_TRANSFORMS_QUARTERWIDEINT_H_

--- a/lib/Dialect/ModArith/Transforms/BUILD
+++ b/lib/Dialect/ModArith/Transforms/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -29,25 +29,8 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=ModArith",
-            ],
-            "Passes.h.inc",
-        ),
-        (
-            ["-gen-pass-doc"],
-            "ModArithPasses.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "Passes",
     td_file = "Passes.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
 )

--- a/tests/Dialect/Arith/Conversions/ArithToModArith/arith-to-mod-arith.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToModArith/arith-to-mod-arith.mlir
@@ -71,7 +71,7 @@ module attributes {tf_saved_model.semantics} {
     %22 = memref.load %0[%c0, %c0] : memref<16x1xi8>
     %24 = memref.load %arg0[%c0, %c0] : memref<1x1xi32>
   // CHECK: %[[ENC:.*]] = mod_arith.mod_switch %{{.*}}: !Z128_i9_ to !Z2147483648_i33_
-    %a24 = arith.extsi %22 : i8 to i32
+    %a24 = arith.extui %22 : i8 to i32
     %25 = arith.muli %24, %a24 : i32
     %26 = arith.addi %21, %25 : i32
     %27 = arith.addi %26, %c33 : i32

--- a/tests/Dialect/Arith/Transforms/BUILD
+++ b/tests/Dialect/Arith/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Arith/Transforms/quarter_wide.mlir
+++ b/tests/Dialect/Arith/Transforms/quarter_wide.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --arith-quarter-wide-int  %s | FileCheck %s
+
+// CHECK-LABEL: func @test_simple_split
+// CHECK-COUNT-9: arith.muli
+// CHECK-COUNT-7: arith.addi
+// CHECK-COUNT-3: arith.shrui
+// CHECK-COUNT-3: arith.addi
+func.func @test_simple_split(%arg0: i32, %arg1: i32) -> i32 {
+  %1 = arith.constant 522067228: i32 // Hex 1f1e1d1c
+  %2 = arith.constant 31 : i8
+  %3 = arith.extui %2 : i8 to i32
+  %4 = arith.muli %1, %arg1 : i32
+  %5 = arith.addi %arg0, %3 : i32
+  return %4 : i32
+}

--- a/tests/Dialect/Arith/Transforms/runner/BUILD
+++ b/tests/Dialect/Arith/Transforms/runner/BUILD
@@ -1,0 +1,20 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = [
+        "@//tests/Dialect/Arith/Transforms/runner:quarter_to_llvm.c",
+        "@heir//tests:test_utilities",
+        "@llvm-project//clang:clang",
+        "@llvm-project//llvm:llc",
+        "@llvm-project//mlir:mlir-translate",
+    ],
+    default_tags = [
+        "manual",
+        "notap",
+    ],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Arith/Transforms/runner/lower_split.mlir
+++ b/tests/Dialect/Arith/Transforms/runner/lower_split.mlir
@@ -1,0 +1,17 @@
+
+// RUN: heir-opt --arith-quarter-wide-int -convert-tensor-to-scalars -convert-to-llvm %s | mlir-translate --mlir-to-llvmir | llc -filetype=obj > %t
+// RUN: clang -c quarter_to_llvm.c
+// RUN: clang quarter_to_llvm.o %t -o a.out
+// RUN: ./a.out | FileCheck %s
+
+// 1f1e1d1c * fb + 9f
+// 1e82868a74 + 9f
+// CHECK: 82 86 8b 13
+func.func @test_lowera_quarter_mul(%arg0: i32) -> i32{
+  %c1 = arith.constant 522067228: i32 // Hex 1f1e1d1c
+  %c2 = arith.constant 159 : i8
+  %3 = arith.extui %c2 : i8 to i32
+  %4 = arith.muli %c1, %arg0 : i32
+  %5 = arith.addi %4, %3 : i32
+  return %5 : i32
+}

--- a/tests/Dialect/Arith/Transforms/runner/quarter_to_llvm.c
+++ b/tests/Dialect/Arith/Transforms/runner/quarter_to_llvm.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+
+// This is the function we want to call from LLVM
+void test_lowera_quarter_mul(uint16_t *res, uint16_t i0, uint16_t i1,
+                             uint16_t i2, uint16_t i3);
+
+int main(int argc, char *argv[]) {
+  uint16_t c[4] = {0};
+
+  test_lowera_quarter_mul(c, 251, 0, 0, 0);
+
+  printf("%x %x %x %x", c[3], c[2], c[1], c[0]);
+
+  return 0;
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -33,6 +33,8 @@ cc_binary(
     includes = ["include"],
     deps = [
         "@heir//lib/Dialect/Arith/Conversions/ArithToModArith",
+        "@heir//lib/Dialect/Arith/Transforms",
+        "@heir//lib/Dialect/Arith/Transforms:QuarterWideInt",
         "@heir//lib/Dialect/BGV/Conversions/BGVToLWE",
         "@heir//lib/Dialect/BGV/Conversions/BGVToLattigo",
         "@heir//lib/Dialect/BGV/IR:Dialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.h"
+#include "lib/Dialect/Arith/Transforms/Passes.h"
 #include "lib/Dialect/BGV/Conversions/BGVToLWE/BGVToLWE.h"
 #include "lib/Dialect/BGV/Conversions/BGVToLattigo/BGVToLattigo.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
@@ -71,6 +72,7 @@
 #include "mlir/include/mlir/Conversion/ArithToLLVM/ArithToLLVM.h"  // from @llvm-project
 #include "mlir/include/mlir/Conversion/ComplexToLLVM/ComplexToLLVM.h"  // from @llvm-project
 #include "mlir/include/mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"  // from @llvm-project
+#include "mlir/include/mlir/Conversion/ConvertToLLVM/ToLLVMPass.h"  // from @llvm-project
 #include "mlir/include/mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"  // from @llvm-project
 #include "mlir/include/mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"  // from @llvm-project
 #include "mlir/include/mlir/Conversion/IndexToLLVM/IndexToLLVM.h"  // from @llvm-project
@@ -202,6 +204,9 @@ int main(int argc, char **argv) {
   registerPass([]() -> std::unique_ptr<Pass> {
     return createReconcileUnrealizedCastsPass();
   });
+  registerPass(
+
+      []() -> std::unique_ptr<Pass> { return createConvertToLLVMPass(); });
 
   // Bufferization and external models
   bufferization::registerBufferizationPasses();
@@ -213,8 +218,10 @@ int main(int argc, char **argv) {
   mlir::linalg::registerBufferizableOpInterfaceExternalModels(registry);
   scf::registerBufferizableOpInterfaceExternalModels(registry);
   tensor::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::arith::registerConvertArithToLLVMInterface(registry);
 
   // Custom passes in HEIR
+  heir::arith::registerArithPasses();
   cggi::registerCGGIPasses();
   lwe::registerLWEPasses();
   mgmt::registerMgmtPasses();


### PR DESCRIPTION
Conversion pass to lower 32b arith operations to tensor 4x8b operations. 
Currently Supported operations: 

- Additon
- 32b Multiplication
- 64 Multiplicatation
- arith.constant
- arith.ExtSi

Do I need to write more tests? 