### PR TITLE
bgv-to-lattigo: lower client-interface and plain op

### DIFF
--- a/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
@@ -97,7 +97,7 @@ class Lattigo_BGVBinaryOp<string mnemonic> :
   let arguments = (ins
     Lattigo_BGVEvaluator:$evaluator,
     Lattigo_RLWECiphertext:$lhs,
-    Lattigo_RLWECiphertext:$rhs
+    Lattigo_RLWECiphertextOrPlaintext:$rhs
   );
   let results = (outs Lattigo_RLWECiphertext:$output);
 }

--- a/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
@@ -84,4 +84,6 @@ def Lattigo_RLWECiphertext : Lattigo_RLWEType<"Ciphertext", "ciphertext"> {
   let nameSuggestion = "ct";
 }
 
+def Lattigo_RLWECiphertextOrPlaintext : AnyTypeOf<[Lattigo_RLWECiphertext, Lattigo_RLWEPlaintext]>;
+
 #endif  // LIB_DIALECT_LATTIGO_IR_LATTIGORLWETYPES_TD_

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -60,6 +60,8 @@ RLWEPipelineBuilder mlirToRLWEPipelineBuilder(RLWEScheme scheme);
 
 RLWEPipelineBuilder mlirToOpenFheRLWEPipelineBuilder(RLWEScheme scheme);
 
+RLWEPipelineBuilder mlirToLattigoRLWEPipelineBuilder(RLWEScheme scheme);
+
 void registerTosaToArithPipeline();
 
 }  // namespace mlir::heir

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -11,6 +11,7 @@ cc_library(
     hdrs = ["PipelineRegistration.h"],
     deps = [
         "@heir//lib/Dialect/BGV/Conversions/BGVToLWE",
+        "@heir//lib/Dialect/BGV/Conversions/BGVToLattigo",
         "@heir//lib/Dialect/LWE/Conversions/LWEToPolynomial",
         "@heir//lib/Dialect/LinAlg/Conversions/LinalgToTensorExt",
         "@heir//lib/Dialect/ModArith/Conversions/ModArithToArith",

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -55,6 +55,7 @@ class LattigoEmitter {
   LogicalResult printOperation(::mlir::func::ReturnOp op);
   LogicalResult printOperation(::mlir::func::CallOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  LogicalResult printOperation(::mlir::tensor::ExtractOp op);
   // Lattigo ops
   LogicalResult printOperation(RLWENewEncryptorOp op);
   LogicalResult printOperation(RLWENewDecryptorOp op);

--- a/lib/Utils/Utils.cpp
+++ b/lib/Utils/Utils.cpp
@@ -53,5 +53,15 @@ LogicalResult walkAndValidateValues(Operation *op, IsValidValueFn isValidValue,
   return res;
 }
 
+bool containsArgumentOfType(Operation *op, TypePredicate predicate) {
+  return llvm::any_of(op->getRegions(), [&](Region &region) {
+    return llvm::any_of(region.getBlocks(), [&](Block &block) {
+      return llvm::any_of(block.getArguments(), [&](BlockArgument arg) {
+        return predicate(arg.getType());
+      });
+    });
+  });
+}
+
 }  // namespace heir
 }  // namespace mlir

--- a/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-print-local-scope --bgv-to-lattigo %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --bgv-to-lwe --bgv-to-lattigo %s | FileCheck %s
 
 
 !Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -34,14 +34,14 @@
 
 module {
   // CHECK-LABEL: func compute
-  // CHECK-SAME: ([[v0:.*]] *bgv.Evaluator, [[v1:.*]] *rlwe.Ciphertext, [[v2:.*]] *rlwe.Ciphertext) (*rlwe.Ciphertext)
-  // CHECK: [[v3:ct.*]], [[err:.*]] := [[v0]].AddNew([[v1]], [[v2]])
-  // CHECK: [[v4:ct.*]], [[err:.*]] := [[v0]].MulNew([[v3]], [[v2]])
-  // CHECK: [[v5:ct.*]], [[err:.*]] := [[v0]].RelinearizeNew([[v4]])
-  // CHECK: [[err:.*]] := [[v0]].Rescale([[v5]], [[v5]])
-  // CHECK: [[v6:ct.*]] := [[v5]]
-  // CHECK: [[v7:ct.*]], [[err:.*]] := [[v0]].RotateColumnsNew([[v6]], 1)
-  // CHECK: return [[v7]]
+  // CHECK-SAME: ([[evaluator:.*]] *bgv.Evaluator, [[ct:.*]] *rlwe.Ciphertext, [[ct1:.*]] *rlwe.Ciphertext) (*rlwe.Ciphertext)
+  // CHECK: [[ct2:[^, ].*]], [[err:.*]] := [[evaluator]].AddNew([[ct]], [[ct1]])
+  // CHECK: [[ct3:[^, ].*]], [[err:.*]] := [[evaluator]].MulNew([[ct2]], [[ct1]])
+  // CHECK: [[ct4:[^, ].*]], [[err:.*]] := [[evaluator]].RelinearizeNew([[ct3]])
+  // CHECK: [[err:.*]] := [[evaluator]].Rescale([[ct4]], [[ct4]])
+  // CHECK: [[ct5:[^, ].*]] := [[ct4]]
+  // CHECK: [[ct6:[^, ].*]], [[err:.*]] := [[evaluator]].RotateColumnsNew([[ct5]], 1)
+  // CHECK: return [[ct6]]
   func.func @compute(%evaluator : !evaluator, %ct1 : !ct, %ct2 : !ct) -> (!ct) {
     %added = lattigo.bgv.add %evaluator, %ct1, %ct2 : (!evaluator, !ct, !ct) -> !ct
     %mul = lattigo.bgv.mul %evaluator, %added, %ct2 : (!evaluator, !ct, !ct) -> !ct
@@ -52,36 +52,39 @@ module {
   }
 
   // CHECK-LABEL: func test_basic_emitter
-  // CHECK: [[param:param.*]], [[err:.*]] := bgv.NewParametersFromLiteral
+  // CHECK: [[param:[^, ].*]], [[err:.*]] := bgv.NewParametersFromLiteral
   // CHECK: bgv.ParametersLiteral
   // CHECK: LogN
   // CHECK: LogQ
   // CHECK: LogP
   // CHECK: PlaintextModulus
-  // CHECK: [[encoder:encoder.*]] := bgv.NewEncoder([[param]])
-  // CHECK: [[kgen:kgen.*]] := rlwe.NewKeyGenerator([[param]])
-  // CHECK: [[sk:sk.*]], [[pk:.*]] := [[kgen]].GenKeyPairNew()
-  // CHECK: [[rk:rk.*]] := [[kgen]].GenRelinearizationKeyNew([[sk]])
-  // CHECK: [[gk5:gk.*]] := [[kgen]].GenGaloisKeyNew(5, [[sk]])
-  // CHECK: [[evalKeySet:ekset.*]] := rlwe.NewMemEvaluationKeySet([[rk]], [[gk5]])
-  // CHECK: [[enc:enc.*]] := rlwe.NewEncryptor([[param]], [[pk]])
-  // CHECK: [[dec:dec.*]] := rlwe.NewDecryptor([[param]], [[sk]])
-  // CHECK: [[eval:eval.*]] := bgv.NewEvaluator([[param]], [[evalKeySet]])
-  // CHECK: [[value1:v.*]] := []int64
-  // CHECK: [[value2:v.*]] := []int64
-  // CHECK: [[pt1:pt.*]] := bgv.NewPlaintext([[param]], [[param]].MaxLevel())
-  // CHECK: [[pt2:pt.*]] := bgv.NewPlaintext([[param]], [[param]].MaxLevel())
-  // CHECK: [[encoder]].Encode([[value1]], [[pt1]])
-  // CHECK: [[pt3:pt.*]] := [[pt1]]
-  // CHECK: [[encoder]].Encode([[value2]], [[pt2]])
-  // CHECK: [[pt4:pt.*]] := [[pt2]]
-  // CHECK: [[ct1:ct.*]], [[err:.*]] := [[enc]].EncryptNew([[pt3]])
-  // CHECK: [[ct2:ct.*]], [[err:.*]] := [[enc]].EncryptNew([[pt4]])
-  // CHECK: [[res:ct.*]] := compute([[eval]], [[ct1]], [[ct2]])
-  // CHECK: [[pt5:pt.*]] := [[dec]].DecryptNew([[res]])
-  // CHECK: [[value3:v.*]] := []int64
+  // CHECK: [[encoder:[^, ].*]] := bgv.NewEncoder([[param]])
+  // CHECK: [[kgen:[^, ].*]] := rlwe.NewKeyGenerator([[param]])
+  // CHECK: [[sk:[^, ].*]], [[pk:[^, ].*]] := [[kgen]].GenKeyPairNew()
+  // CHECK: [[rk:[^, ].*]] := [[kgen]].GenRelinearizationKeyNew([[sk]])
+  // CHECK: [[gk5:[^, ].*]] := [[kgen]].GenGaloisKeyNew(5, [[sk]])
+  // CHECK: [[evalKeySet:[^, ].*]] := rlwe.NewMemEvaluationKeySet([[rk]], [[gk5]])
+  // CHECK: [[enc:[^, ].*]] := rlwe.NewEncryptor([[param]], [[pk]])
+  // CHECK: [[dec:[^, ].*]] := rlwe.NewDecryptor([[param]], [[sk]])
+  // CHECK: [[eval:[^, ].*]] := bgv.NewEvaluator([[param]], [[evalKeySet]])
+  // CHECK: [[value1:[^, ].*]] := []int64
+  // CHECK: [[value2:[^, ].*]] := []int64
+  // CHECK: [[pt1:[^, ].*]] := bgv.NewPlaintext([[param]], [[param]].MaxLevel())
+  // CHECK: [[pt2:[^, ].*]] := bgv.NewPlaintext([[param]], [[param]].MaxLevel())
+  // CHECK: [[value1Packed:[^, ].*]][i] = int64([[value1]][i % len([[value1]])])
+  // CHECK: [[encoder]].Encode([[value1Packed]], [[pt1]])
+  // CHECK: [[pt3:[^, ].*]] := [[pt1]]
+  // CHECK: [[value2Packed:[^, ].*]][i] = int64([[value2]][i % len([[value2]])])
+  // CHECK: [[encoder]].Encode([[value2Packed]], [[pt2]])
+  // CHECK: [[pt4:[^, ].*]] := [[pt2]]
+  // CHECK: [[ct1:[^, ].*]], [[err:.*]] := [[enc]].EncryptNew([[pt3]])
+  // CHECK: [[ct2:[^, ].*]], [[err:.*]] := [[enc]].EncryptNew([[pt4]])
+  // CHECK: [[res:[^, ].*]] := compute([[eval]], [[ct1]], [[ct2]])
+  // CHECK: [[pt5:[^, ].*]] := [[dec]].DecryptNew([[res]])
+  // CHECK: [[value3:[^, ].*]] := []int64
   // CHECK: [[encoder]].Decode([[pt5]], [[value3]])
-  // CHECK: [[value4:v.*]] := [[value3]]
+  // CHECK: [[value3Converted:[^, ].*]][i] = int64([[value3]][i])
+  // CHECK: [[value4:[^, ].*]] := [[value3Converted]]
   func.func @test_basic_emitter() -> () {
     %param = lattigo.bgv.new_parameters_from_literal {paramsLiteral = #paramsLiteral} : () -> !params
     %encoder = lattigo.bgv.new_encoder %param : (!params) -> !encoder

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -8,15 +8,17 @@ package(default_applicable_licenses = ["@heir//:license"])
 heir_lattigo_lib(
     name = "binops",
     heir_opt_flags = [
-        "--secretize",
-        "--mlir-to-secret-arithmetic",
-        "--secret-insert-mgmt-bgv",
-        "--secret-distribute-generic",
-        "--secret-to-bgv=poly-mod-degree=4",
-        "--bgv-to-lattigo",
-        "--cse",
+        "--mlir-to-lattigo-bgv=entry-function=add ciphertext-degree=4",
     ],
     mlir_src = "binops.mlir",
+)
+
+heir_lattigo_lib(
+    name = "dot_product_8",
+    heir_opt_flags = [
+        "--mlir-to-lattigo-bgv=entry-function=dot_product ciphertext-degree=8",
+    ],
+    mlir_src = "dot_product_8.mlir",
 )
 
 # For Google-internal reasons we must separate the go_test rules from the macro
@@ -25,6 +27,16 @@ go_test(
     name = "binops_test",
     srcs = ["binops_test.go"],
     embed = [":binops"],
+    deps = [
+        "@lattigo//core/rlwe",
+        "@lattigo//schemes/bgv",
+    ],
+)
+
+go_test(
+    name = "dot_product_8_test",
+    srcs = ["dot_product_8_test.go"],
+    embed = [":dot_product_8"],
     deps = [
         "@lattigo//core/rlwe",
         "@lattigo//schemes/bgv",

--- a/tests/Examples/lattigo/binops.mlir
+++ b/tests/Examples/lattigo/binops.mlir
@@ -1,6 +1,6 @@
 // From https://github.com/google/heir/pull/1182
 
-func.func @add(%arg0: tensor<4xi16>, %arg1: tensor<4xi16>) -> tensor<4xi16> {
+func.func @add(%arg0: tensor<4xi16> {secret.secret}, %arg1: tensor<4xi16> {secret.secret}) -> tensor<4xi16> {
   %0 = arith.addi %arg0, %arg1 : tensor<4xi16>
   %1 = arith.muli %0, %arg1 : tensor<4xi16>
   %c1 = arith.constant 1 : index

--- a/tests/Examples/lattigo/dot_product_8.mlir
+++ b/tests/Examples/lattigo/dot_product_8.mlir
@@ -1,0 +1,12 @@
+func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16> {secret.secret}) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %arg2 = 0 to 8 iter_args(%iter = %c0_si16) -> (i16) {
+    %1 = tensor.extract %arg0[%arg2] : tensor<8xi16>
+    %2 = tensor.extract %arg1[%arg2] : tensor<8xi16>
+    %3 = arith.muli %1, %2 : i16
+    %4 = arith.addi %iter, %3 : i16
+    affine.yield %4 : i16
+  }
+  return %0 : i16
+}

--- a/tests/Examples/lattigo/dot_product_8_test.go
+++ b/tests/Examples/lattigo/dot_product_8_test.go
@@ -1,4 +1,4 @@
-package binops
+package dot_product_8
 
 import (
 	"testing"
@@ -29,27 +29,30 @@ func TestBinops(t *testing.T) {
 	enc := rlwe.NewEncryptor(params, sk)
 	dec := rlwe.NewDecryptor(params, sk)
 	relinKeys := kgen.GenRelinearizationKeyNew(sk)
-	galKey := kgen.GenGaloisKeyNew(5, sk)
-	evalKeys := rlwe.NewMemEvaluationKeySet(relinKeys, galKey)
+	// 5^7 % (2^14) = 12589
+	galKey12589 := kgen.GenGaloisKeyNew(12589, sk)
+	// 5^4 = 625
+	galKey625 := kgen.GenGaloisKeyNew(625, sk)
+	// 5^2 = 25
+	galKey25 := kgen.GenGaloisKeyNew(25, sk)
+	// 5^1 = 5
+	galKey5 := kgen.GenGaloisKeyNew(5, sk)
+	evalKeys := rlwe.NewMemEvaluationKeySet(relinKeys, galKey5, galKey25, galKey625, galKey12589)
 	evaluator := bgv.NewEvaluator(params, evalKeys /*scaleInvariant=*/, false)
 
 	// Vector of plaintext values
-	// 0, 1, 2, 3
-	arg0 := []int16{0, 1, 2, 3}
-	// 1, 2, 3, 4
-	arg1 := []int16{1, 2, 3, 4}
+	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8}
+	arg1 := []int16{2, 3, 4, 5, 6, 7, 8, 9}
 
-	expected := []int16{6, 15, 28, 1}
+	expected := int16(240)
 
-	ct0, ct1 := add__encrypt(evaluator, params, ecd, enc, arg0, arg1)
+	ct0, ct1 := dot_product__encrypt(evaluator, params, ecd, enc, arg0, arg1)
 
-	resultCt := add(evaluator, params, ecd, ct0, ct1)
+	resultCt := dot_product(evaluator, params, ecd, ct0, ct1)
 
-	result := add__decrypt(evaluator, params, ecd, dec, resultCt)
+	result := dot_product__decrypt(evaluator, params, ecd, dec, resultCt)
 
-	for i := range 4 {
-		if result[i] != expected[i] {
-			t.Errorf("Decryption error at index %d: %d != %d", i, result[i], expected[i])
-		}
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
 	}
 }

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -370,6 +370,13 @@ int main(int argc, char **argv) {
       mlirToOpenFheRLWEPipelineBuilder(mlir::heir::RLWEScheme::bgvScheme));
 
   PassPipelineRegistration<mlir::heir::MlirToRLWEPipelineOptions>(
+      "mlir-to-lattigo-bgv",
+      "Convert a func using standard MLIR dialects to FHE using BGV and "
+      "export "
+      "to Lattigo GO code.",
+      mlirToLattigoRLWEPipelineBuilder(mlir::heir::RLWEScheme::bgvScheme));
+
+  PassPipelineRegistration<mlir::heir::MlirToRLWEPipelineOptions>(
       "mlir-to-ckks",
       "Convert a func using standard MLIR dialects to FHE using "
       "CKKS.",


### PR DESCRIPTION
With this PR we can lower the dot_product_8 example with client interface. The emitter/tests has not been added as there are hacks in this pass that needs discussion.

`lwe-add-client-interface` will add helper function for encryption/decryption, and the function signature is `__encrypt(value, sk/pk)`. However, this is only for openfhe backend, as openfhe needs `CryptoContext` and `sk/pk` to encrypt/decrypt, and openfhe lowering will add its own CryptoContext arg.

For lattigo, things are different in that we have `evaluator/encryptor/decryptor/encoder/decoder` instead of one context, and all of them should be passed on-demand.

This brings the complicacy that a lot of predicating is needed to make sure things are added _in correct order_, otherwise the function signature is not stable.

Currently I add evaluator in a specified order with predicate, so we can have more predictable function signature.

With `--mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --secret-distribute-generic --secret-to-bgv="poly-mod-degree=8" --lwe-add-client-interface --bgv-to-lwe --bgv-to-lattigo` we can get the following IR (of course with some ASM trick locally #1219)

```mlir
  func.func @dot_product(%evaluator: !evaluator, %params: !params, %encoder: !encoder, %ct: !ct, %ct_0: !ct) -> !ct
  
  func.func @dot_product__encrypt(%evaluator: !evaluator, %params: !params, %encoder: !encoder, %encryptor: !encryptor, %arg0: tensor<8xi16>, %arg1: tensor<8xi16>, %skey: !skey) -> (!ct, !ct) {
    %pt = lattigo.bgv.new_plaintext %params : (!params) -> !pt
    %pt_0 = lattigo.bgv.encode %encoder, %arg0, %pt : (!encoder, tensor<8xi16>, !pt) -> !pt
    %ct = lattigo.rlwe.encrypt %encryptor, %pt_0 : (!encryptor, !pt) -> !ct
    %pt_1 = lattigo.bgv.new_plaintext %params : (!params) -> !pt
    %pt_2 = lattigo.bgv.encode %encoder, %arg1, %pt_1 : (!encoder, tensor<8xi16>, !pt) -> !pt
    %ct_3 = lattigo.rlwe.encrypt %encryptor, %pt_2 : (!encryptor, !pt) -> !ct
    return %ct, %ct_3 : !ct, !ct
  }

    func.func @dot_product__decrypt(%evaluator: !evaluator, %params: !params, %encoder: !encoder, %decryptor: !decryptor, %ct: !ct, %skey: !skey) -> i16 {
    %pt = lattigo.rlwe.decrypt %decryptor, %ct : (!decryptor, !ct) -> !pt
    %cst = arith.constant dense<0> : tensor<1xi16>
    %0 = lattigo.bgv.decode %encoder, %pt, %cst : (!encoder, !pt, tensor<1xi16>) -> tensor<1xi16>
    %c0 = arith.constant 0 : index
    %extracted = tensor.extract %0[%c0] : tensor<1xi16>
    return %extracted : i16
  }

```

### Discussion
* in `__encrypt/decrypt` the `skey` is not needed. This is produced by `lwe-add-client-interface` but not used by furthur backend pass, so should we either not produce it or detele it here. (involves some ordering/validity check of function signature update)
* This should be re-organized in similar style to #1196 as a `--lwe-to-lattigo`.
* `lwe.reinterpret_underlying_type` should be moved earlier (packing pipeline). Backend should not care about them (only care about ct types but not pt types). It used to work because we forward lwe type to openfhe dialect, but not this way for lattigo dialect. Similarly `bgv.extract` should be moved earlier, which I used `bgv-to-lwe` to handle it (#1174).
