### PR TITLE
Fix default option for elementwise-to-affine

### DIFF
--- a/tests/Dialect/Polynomial/Transforms/elementwise_to_affine.mlir
+++ b/tests/Dialect/Polynomial/Transforms/elementwise_to_affine.mlir
@@ -39,13 +39,13 @@
 
 // THE FOLLOWING SHOULD CONVERT NOTHING (EXCEPT "ARITH" OPS FOR SOME, BUT THERE ARE NONE IN THE TESTS)
 
-// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-ops=list={} %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine{convert-ops=""} %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine=convert-dialects=list={} %s \
+// RUN: heir-opt --mlir-print-local-scope --convert-elementwise-to-affine{convert-dialects=""} %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
-// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-ops=list={} convert-dialects=list={}' %s \
+// RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine{convert-ops="" convert-dialects=""}' %s \
 // RUN: | FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK_NOTADD --check-prefix=CHECK_NOTMUL %s
 
 // RUN: heir-opt --mlir-print-local-scope '--convert-elementwise-to-affine=convert-dialects=arith' %s \


### PR DESCRIPTION
Cf. https://github.com/google/heir/commit/ccba176a7f2b29f226f9e032ec56fd86ba8fee64#diff-6f8c01b4d228f97d2a800c5b5deca07240dd1203a0063e775b6a9f8e49cc9b9c for the change that introduced this, due to a failure caused by upstream changes.

https://github.com/llvm/llvm-project/pull/118877#issuecomment-2552273446 for the suggested correct form.