### PR TITLE
doc: correctly generate Enum doc

### DIFF
--- a/lib/Dialect/CGGI/IR/BUILD
+++ b/lib/Dialect/CGGI/IR/BUILD
@@ -137,7 +137,7 @@ gentbl_cc_library(
             "CGGIEnums.cpp.inc",
         ),
         (
-            ["-gen-attrdef-doc"],
+            ["-gen-enum-doc"],
             "CGGIEnums.md",
         ),
     ],

--- a/lib/Dialect/Comb/IR/BUILD
+++ b/lib/Dialect/Comb/IR/BUILD
@@ -155,6 +155,10 @@ gentbl_cc_library(
             ],
             "CombEnums.cpp.inc",
         ),
+        (
+            ["-gen-enum-doc"],
+            "CombEnums.md",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "Comb.td",

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -121,6 +121,10 @@ gentbl_cc_library(
             ["-gen-attrdef-doc"],
             "LWEAttributes.md",
         ),
+        (
+            ["-gen-enum-doc"],
+            "LWEEnums.md",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "LWEAttributes.td",

--- a/lib/Dialect/Random/IR/BUILD
+++ b/lib/Dialect/Random/IR/BUILD
@@ -60,6 +60,10 @@ gentbl_cc_library(
             ["--gen-enum-defs"],
             "RandomEnums.cpp.inc",
         ),
+        (
+            ["-gen-enum-doc"],
+            "RandomEnums.md",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "RandomEnums.td",

--- a/lib/Dialect/TfheRustBool/IR/BUILD
+++ b/lib/Dialect/TfheRustBool/IR/BUILD
@@ -177,7 +177,7 @@ gentbl_cc_library(
             "TfheRustBoolEnums.cpp.inc",
         ),
         (
-            ["-gen-attrdef-doc"],
+            ["-gen-enum-doc"],
             "TfheRustBoolEnums.md",
         ),
     ],


### PR DESCRIPTION
Check https://heir.dev/docs/dialects/cggi/#cggi-additional-definitions, where builtin attributes are in the doc.

Also, Enum attrs are missing.

Turned out documentations for Enum are incorrectly generated (used `-gen-attrdef-doc` instead of `-gen-enum-doc`), so this PR fixes them.