### PR TITLE
add_heir_dialect_library build macro for bazel

### DIFF
--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -1,4 +1,5 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -20,6 +21,7 @@ cc_library(
     deps = [
         ":attributes_inc_gen",
         ":dialect_inc_gen",
+        ":enums_inc_gen",
         ":ops_inc_gen",
         ":types_inc_gen",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
@@ -67,125 +69,36 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "LWEDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "LWEDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "LWEDialect.td",
-    deps = [
-        ":td_files",
-    ],
+add_heir_dialect_library(
+    dialect = "LWE",
+    kind = "dialect",
 )
 
-gentbl_cc_library(
-    name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-            ],
-            "LWEAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-            ],
-            "LWEAttributes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-enum-decls",
-            ],
-            "LWEEnums.h.inc",
-        ),
-        (
-            [
-                "-gen-enum-defs",
-            ],
-            "LWEEnums.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "LWEAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+add_heir_dialect_library(
+    dialect = "LWE",
+    kind = "attribute",
+)
+
+add_heir_dialect_library(
+    dialect = "LWE",
+    kind = "enum",
     td_file = "LWEAttributes.td",
-    deps = [
-        ":dialect_inc_gen",
-        ":td_files",
-    ],
 )
 
-gentbl_cc_library(
-    name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "-typedefs-dialect=lwe",
-            ],
-            "LWETypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "-typedefs-dialect=lwe",
-            ],
-            "LWETypes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-typedef-doc",
-                "-typedefs-dialect=lwe",
-            ],
-            "LWETypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "LWETypes.td",
+add_heir_dialect_library(
+    dialect = "LWE",
+    kind = "type",
     deps = [
         ":attributes_inc_gen",
-        ":dialect_inc_gen",
-        ":td_files",
+        ":enums_inc_gen",
         "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )
 
-gentbl_cc_library(
-    name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "LWEOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "LWEOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "LWEOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "LWEOps.td",
+add_heir_dialect_library(
+    dialect = "LWE",
+    kind = "op",
     deps = [
-        ":dialect_inc_gen",
-        ":td_files",
         ":types_inc_gen",
         "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],

--- a/lib/Dialect/LWE/IR/LWEDialect.td
+++ b/lib/Dialect/LWE/IR/LWEDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_LWE_IR_LWEDIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def LWE_Dialect : Dialect {
   let name = "lwe";

--- a/lib/Dialect/Openfhe/IR/BUILD
+++ b/lib/Dialect/Openfhe/IR/BUILD
@@ -1,4 +1,5 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -40,84 +41,20 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "OpenfheDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "OpenfheDialect.cpp.inc",
-        ),
-        (
-            [
-                "-gen-dialect-doc",
-            ],
-            "OpenfheDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "OpenfheDialect.td",
-    deps = [
-        ":td_files",
-    ],
+add_heir_dialect_library(
+    dialect = "Openfhe",
+    kind = "dialect",
 )
 
-gentbl_cc_library(
-    name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-            ],
-            "OpenfheTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-            ],
-            "OpenfheTypes.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "OpenfheTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "OpenfheTypes.td",
-    deps = [
-        ":dialect_inc_gen",
-        ":td_files",
-    ],
+add_heir_dialect_library(
+    dialect = "Openfhe",
+    kind = "type",
 )
 
-gentbl_cc_library(
-    name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "OpenfheOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "OpenfheOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "OpenfheOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "OpenfheOps.td",
+add_heir_dialect_library(
+    dialect = "Openfhe",
+    kind = "op",
     deps = [
-        ":dialect_inc_gen",
-        ":td_files",
         ":types_inc_gen",
         "@heir//lib/Dialect/LWE/IR:td_files",
     ],

--- a/lib/Dialect/dialect.bzl
+++ b/lib/Dialect/dialect.bzl
@@ -1,0 +1,98 @@
+"""Macros to streamline the generation of HEIR dialect tablegen-generated
+files."""
+
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+def add_heir_dialect_library(
+        dialect = None,
+        kind = None,
+        td_file = None,
+        deps = []):
+    """Generates a .inc library for a HEIR dialect.
+
+    Args:
+        dialect: The name of the dialect.
+        kind: The kind of tablegen file to generate.
+        td_file: The .td file to use for tablegen.
+        deps: The dependencies of the generated target.
+    """
+    if dialect == None:
+        fail("dialect must be provided to add_heir_dialect_library.")
+
+    _target_name_prefix = None
+    _target_name_suffix = "_inc_gen"
+
+    _tblgen_command_prefix = "-gen-"
+    _tblgen_command_infix = None
+    _tblgen_command_suffix_decls = "-decls"
+    _tblgen_command_suffix_defs = "-defs"
+    _tblgen_command_suffix_doc = "-doc"
+
+    _file_name_prefix = dialect
+    _file_name_infix = None
+
+    _dep_includes_dialect = True
+
+    if kind == "dialect":
+        _target_name_prefix = "dialect"
+        _tblgen_command_infix = "dialect"
+        _file_name_infix = "Dialect"
+        _dep_includes_dialect = False
+    elif kind == "attribute":
+        _target_name_prefix = "attributes"
+        _tblgen_command_infix = "attrdef"
+        _file_name_infix = "Attributes"
+    elif kind == "enum":
+        _target_name_prefix = "enums"
+        _tblgen_command_infix = "enum"
+        _file_name_infix = "Enums"
+    elif kind == "type":
+        _target_name_prefix = "types"
+        _tblgen_command_infix = "typedef"
+        _file_name_infix = "Types"
+    elif kind == "op":
+        _target_name_prefix = "ops"
+        _tblgen_command_infix = "op"
+        _file_name_infix = "Ops"
+    else:
+        fail("kind must be provided to add_heir_dialect_library.")
+
+    _td_file = td_file
+    if _td_file == None:
+        _td_file = _file_name_prefix + _file_name_infix + ".td"
+
+    _target_name = _target_name_prefix + _target_name_suffix
+
+    _header_inc_file = _file_name_prefix + _file_name_infix + ".h.inc"
+    _cpp_inc_file = _file_name_prefix + _file_name_infix + ".cpp.inc"
+    _doc_inc_file = _file_name_prefix + _file_name_infix + ".md"
+
+    _tblgen_command_decls = [_tblgen_command_prefix + _tblgen_command_infix + _tblgen_command_suffix_decls]
+    _tblgen_command_defs = [_tblgen_command_prefix + _tblgen_command_infix + _tblgen_command_suffix_defs]
+    _tblgen_command_doc = [_tblgen_command_prefix + _tblgen_command_infix + _tblgen_command_suffix_doc]
+
+    _deps = [":td_files"]
+    if _dep_includes_dialect:
+        _deps.append(":dialect_inc_gen")
+    _deps = _deps + deps
+
+    gentbl_cc_library(
+        name = _target_name,
+        tbl_outs = [
+            (
+                _tblgen_command_decls,
+                _header_inc_file,
+            ),
+            (
+                _tblgen_command_defs,
+                _cpp_inc_file,
+            ),
+            (
+                _tblgen_command_doc,
+                _doc_inc_file,
+            ),
+        ],
+        tblgen = "@llvm-project//mlir:mlir-tblgen",
+        td_file = _td_file,
+        deps = _deps,
+    )


### PR DESCRIPTION
Related to #1045, similar to #1055 and see also #1235 where the verbose `gentbl_cc_library` is error-prone.

This PR demos the usability of such macro for LWE/Openfhe dialect. If such change is favored, further PR will update other BUILD file and the template generator.