### PR TITLE
ASM: suggest block name for secret.generic

### DIFF
--- a/lib/Dialect/Secret/IR/SecretOps.td
+++ b/lib/Dialect/Secret/IR/SecretOps.td
@@ -310,16 +310,6 @@ def Secret_GenericOp : Secret_Op<"generic", [
     // OpAsmOpInterface Methods
     //===------------------------------------------------------------------===//
 
-    // void getAsmResultNames(::mlir::OpAsmSetValueNameFn setNameFn) {
-    //   if (getNumResults() == 1) {
-    //     setNameFn(getResult(0), "computed");
-    //     return;
-    //   }
-    //   for (auto result : getResults()) {
-    //     setNameFn(result, "computed" + std::to_string(result.getResultNumber()));
-    //   }
-    // }
-
     void getAsmBlockArgumentNames(::mlir::Region &region,
                                   ::mlir::OpAsmSetValueNameFn setNameFn) {
       for (auto &block : region) {
@@ -329,13 +319,12 @@ def Secret_GenericOp : Secret_Op<"generic", [
       }
     }
 
-    // void getAsmBlockNames(::mlir::OpAsmSetBlockNameFn setNameFn) {
-    //   for (auto &block : getRegion().getBlocks()) {
-    //     setNameFn(&block, "body");
-    //   }
-    // }
-
-    // static ::llvm::StringRef getDefaultDialect() { return "secret"; }
+    void getAsmBlockNames(::mlir::OpAsmSetBlockNameFn setNameFn) {
+      // single block
+      for (auto &block : getRegion().getBlocks()) {
+        setNameFn(&block, "body");
+      }
+    }
   }];
 
   let hasCanonicalizer = 1;

--- a/tests/Dialect/LinAlg/Conversions/linalg_to_tensor_ext/float_vector_square_matrix_matmul_op.mlir
+++ b/tests/Dialect/LinAlg/Conversions/linalg_to_tensor_ext/float_vector_square_matrix_matmul_op.mlir
@@ -11,7 +11,7 @@
 // CHECK-SAME: 1.7{{0*}}e+01, 1.8{{0*}}e+01, 1.9{{0*}}e+01, 2.{{0*}}e+01
 // CHECK-SAME{LITERAL}: ]]>
 // CHECK:      %[[OUT:.*]] = secret.generic ins(%[[ARG]] : !secret.secret<tensor<1x4xf16>>)
-// CHECK:      ^bb0(%[[ARG_CONVERTED:.*]]: tensor<1x4xf16>):
+// CHECK:      ^body(%[[ARG_CONVERTED:.*]]: tensor<1x4xf16>):
 // CHECK:        %[[FOR_LOOP_OUT:.*]]:2 = affine.for %[[I:.*]] = 0 to 3 iter_args(%[[RUNNING_SUM:.*]] = %[[BIAS]], %[[ROTATED_VEC:.*]] = %[[ARG_CONVERTED]])
 // CHECK:        %[[SLICE:.*]] = tensor.extract_slice %[[DIAGONALIZED_MATRIX]][%[[I]], 0] [1, 4] [1, 1]
 // CHECK:        %[[MUL:.*]] = arith.mulf %[[ROTATED_VEC]], %[[SLICE]]
@@ -28,7 +28,7 @@ func.func @test_float_vector_square_matrix_linalg_to_arith(%vec : !secret.secret
   %matrix = arith.constant dense<[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0], [13.0, 14.0, 15.0, 16.0]]> : tensor<4x4xf16>
   %bias = arith.constant dense<[[17.0, 18.0, 19.0, 20.0]]> : tensor<1x4xf16>
   %out = secret.generic ins (%vec : !secret.secret<tensor<1x4xf16>>) {
-  ^bb0(%converted_vec: tensor<1x4xf16>):
+  ^body(%converted_vec: tensor<1x4xf16>):
     %0 = linalg.matmul ins(%converted_vec, %matrix : tensor<1x4xf16>, tensor<4x4xf16>) outs(%bias : tensor<1x4xf16>) -> tensor<1x4xf16>
     secret.yield %0 : tensor<1x4xf16>
   } -> !secret.secret<tensor<1x4xf16>>

--- a/tests/Dialect/LinAlg/Conversions/linalg_to_tensor_ext/integer_square_matrix_vector_matmul_op.mlir
+++ b/tests/Dialect/LinAlg/Conversions/linalg_to_tensor_ext/integer_square_matrix_vector_matmul_op.mlir
@@ -7,7 +7,7 @@
 // CHECK:      %[[BIAS:.*]] = arith.constant dense
 // CHECK-SAME{LITERAL}: <[[17], [18], [19], [20]]> : tensor<4x1xi16>
 // CHECK:      %[[OUT:.*]] = secret.generic ins(%[[ARG]] : !secret.secret<tensor<4x1xi16>>)
-// CHECK:      ^bb0(%[[ARG_CONVERTED:.*]]: tensor<4x1xi16>):
+// CHECK:      ^body(%[[ARG_CONVERTED:.*]]: tensor<4x1xi16>):
 // CHECK:        %[[FOR_LOOP_OUT:.*]]:2 = affine.for %[[I:.*]] = 0 to 3 iter_args(%[[RUNNING_SUM:.*]] = %[[BIAS]], %[[ROTATED_VEC:.*]] = %[[ARG_CONVERTED]])
 // CHECK:        %[[SLICE:.*]] = tensor.extract_slice %[[DIAGONALIZED_MATRIX]][0, %[[I]]] [4, 1] [1, 1]
 // CHECK:        %[[MUL:.*]] = arith.muli %[[ROTATED_VEC]], %[[SLICE]]
@@ -24,7 +24,7 @@ func.func @test_integer_square_matrix_vector_linalg_to_arith(%vec : !secret.secr
   %matrix = arith.constant dense<[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]> : tensor<4x4xi16>
   %bias = arith.constant dense<[[17], [18], [19], [20]]> : tensor<4x1xi16>
   %out = secret.generic ins (%vec : !secret.secret<tensor<4x1xi16>>) {
-  ^bb0(%converted_vec: tensor<4x1xi16>):
+  ^body(%converted_vec: tensor<4x1xi16>):
     %0 = linalg.matmul ins(%matrix, %converted_vec : tensor<4x4xi16>, tensor<4x1xi16>) outs(%bias : tensor<4x1xi16>) -> tensor<4x1xi16>
     secret.yield %0 : tensor<4x1xi16>
   } -> !secret.secret<tensor<4x1xi16>>

--- a/tests/Dialect/LinAlg/Conversions/linalg_to_tensor_ext/integer_vector_square_matrix_matmul_op.mlir
+++ b/tests/Dialect/LinAlg/Conversions/linalg_to_tensor_ext/integer_vector_square_matrix_matmul_op.mlir
@@ -7,7 +7,7 @@
 // CHECK:      %[[BIAS:.*]] = arith.constant dense
 // CHECK-SAME{LITERAL}: <[[17, 18, 19, 20]]> : tensor<1x4xi16>
 // CHECK:      %[[OUT:.*]] = secret.generic ins(%[[ARG]] : !secret.secret<tensor<1x4xi16>>)
-// CHECK:      ^bb0(%[[ARG_CONVERTED:.*]]: tensor<1x4xi16>):
+// CHECK:      ^body(%[[ARG_CONVERTED:.*]]: tensor<1x4xi16>):
 // CHECK:        %[[FOR_LOOP_OUT:.*]]:2 = affine.for %[[I:.*]] = 0 to 3 iter_args(%[[RUNNING_SUM:.*]] = %[[BIAS]], %[[ROTATED_VEC:.*]] = %[[ARG_CONVERTED]])
 // CHECK:        %[[SLICE:.*]] = tensor.extract_slice %[[DIAGONALIZED_MATRIX]][%[[I]], 0] [1, 4] [1, 1]
 // CHECK:        %[[MUL:.*]] = arith.muli %[[ROTATED_VEC]], %[[SLICE]]
@@ -24,7 +24,7 @@ func.func @test_integer_vector_square_matrix_linalg_to_arith(%vec : !secret.secr
   %matrix = arith.constant dense<[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]> : tensor<4x4xi16>
   %bias = arith.constant dense<[[17, 18, 19, 20]]> : tensor<1x4xi16>
   %out = secret.generic ins (%vec : !secret.secret<tensor<1x4xi16>>) {
-  ^bb0(%converted_vec: tensor<1x4xi16>):
+  ^body(%converted_vec: tensor<1x4xi16>):
     %0 = linalg.matmul ins(%converted_vec, %matrix : tensor<1x4xi16>, tensor<4x4xi16>) outs(%bias : tensor<1x4xi16>) -> tensor<1x4xi16>
     secret.yield %0 : tensor<1x4xi16>
   } -> !secret.secret<tensor<1x4xi16>>

--- a/tests/Dialect/Secret/Transforms/extract_generic_body.mlir
+++ b/tests/Dialect/Secret/Transforms/extract_generic_body.mlir
@@ -5,7 +5,7 @@
 // CHECK-SAME:  ) {
 // CHECK-NEXT:    secret.conceal %[[ARG]]
 // CHECK-NEXT:    secret.generic
-// CHECK-NEXT:      ^bb0(%[[SARG:.*]]: i32)
+// CHECK-NEXT:      ^body(%[[SARG:.*]]: i32)
 // CHECK-NEXT:      %[[V0:.*]] = func.call [[F0:.*]](%[[SARG]]) : (i32) -> i32
 // CHECK-NEXT:      secret.yield %[[V0]]
 // CHECK:         return
@@ -14,7 +14,7 @@ module {
   func.func @test_add(%value : i32) {
     %Y = secret.conceal %value : i32 -> !secret.secret<i32>
     %Z = secret.generic ins(%Y : !secret.secret<i32>) {
-      ^bb0(%y: i32) :
+      ^body(%y: i32) :
         %c7_i32_0 = arith.constant 7 : i32
         %d = arith.addi %c7_i32_0, %y: i32
         secret.yield %d : i32
@@ -30,11 +30,11 @@ module {
 // CHECK-SAME:  ) {
 // CHECK-NEXT:    secret.conceal %[[ARG]]
 // CHECK-NEXT:    secret.generic
-// CHECK-NEXT:      ^bb0(%[[SARG:.*]]: i32)
+// CHECK-NEXT:      ^body(%[[SARG:.*]]: i32)
 // CHECK-NEXT:      %[[V0:.*]] = func.call [[F1:.*]](%[[SARG]]) : (i32) -> i32
 // CHECK-NEXT:      secret.yield %[[V0]]
 // CHECK:    secret.generic
-// CHECK-NEXT:      ^bb0(%[[SARG1:.*]]: i32)
+// CHECK-NEXT:      ^body(%[[SARG1:.*]]: i32)
 // CHECK-NEXT:      %[[V1:.*]] = func.call [[F2:.*]](%[[SARG1]]) : (i32) -> i32
 // CHECK-NEXT:      secret.yield %[[V1]]
 // CHECK:         return
@@ -43,13 +43,13 @@ module {
   func.func @test_multiple(%value : i32) {
     %Y = secret.conceal %value : i32 -> !secret.secret<i32>
     %Z = secret.generic ins(%Y : !secret.secret<i32>) {
-      ^bb0(%y: i32) :
+      ^body(%y: i32) :
         %c7_i32_0 = arith.constant 7 : i32
         %d = arith.addi %c7_i32_0, %y: i32
         secret.yield %d : i32
       } -> (!secret.secret<i32>)
     %A = secret.generic ins(%Z : !secret.secret<i32>) {
-      ^bb0(%y: i32) :
+      ^body(%y: i32) :
         %c12_i32_0 = arith.constant 12 : i32
         %d = arith.addi %c12_i32_0, %y: i32
         secret.yield %d : i32
@@ -75,7 +75,7 @@ module {
 // CHECK-SAME:  ) {
 // CHECK-NEXT:    secret.conceal %[[ARG]]
 // CHECK-NEXT:    secret.generic
-// CHECK-NEXT:      ^bb0(%[[SARG:.*]]: memref<1xi32>)
+// CHECK-NEXT:      ^body(%[[SARG:.*]]: memref<1xi32>)
 // CHECK-NEXT:      %[[V0:.*]] = func.call [[F1:.*]](%[[SARG]]) : (memref<1xi32>) -> memref<1xi32>
 // CHECK-NEXT:      secret.yield %[[V0]]
 // CHECK:         return
@@ -84,7 +84,7 @@ module {
   func.func @test_region(%value : memref<1xi32>) {
     %Y = secret.conceal %value : memref<1xi32> -> !secret.secret<memref<1xi32>>
     %Z = secret.generic ins(%Y : !secret.secret<memref<1xi32>>) {
-      ^bb0(%y: memref<1xi32>) :
+      ^body(%y: memref<1xi32>) :
         %c7_i32_0 = arith.constant 7 : i32
         affine.for %i = 0 to 1 {
           %0 = affine.load %y[%i] : memref<1xi32>

--- a/tests/Dialect/Secret/Transforms/merge_adjacent_generics.mlir
+++ b/tests/Dialect/Secret/Transforms/merge_adjacent_generics.mlir
@@ -7,18 +7,18 @@ func.func @test_chained_input_output(%value : !ty) -> !ty {
   // CHECK: %[[c1:.*]] = arith.constant 1
   %c1 = arith.constant 1 : i32
   // CHECK:      secret.generic ins(%[[value]]
-  // CHECK-NEXT: ^bb{{[0-9]}}(%[[clear_value:.*]]: i32):
+  // CHECK-NEXT: ^body(%[[clear_value:.*]]: i32):
   // CHECK-NEXT:   %[[res:.*]] = arith.addi %[[clear_value]], %[[c1]]
   // CHECK-NEXT:   %[[res2:.*]] = arith.addi %[[res]], %[[c1]]
   // CHECK-NEXT:   secret.yield %[[res2:.*]]
   // CHECK-NOT:   secret.generic
   %0 = secret.generic ins(%value : !ty) {
-    ^bb0(%x: i32) :
+    ^body(%x: i32) :
       %res = arith.addi %x, %c1: i32
       secret.yield %res : i32
     } -> (!ty)
   %1 = secret.generic ins(%0 : !ty) {
-    ^bb0(%x: i32) :
+    ^body(%x: i32) :
       %res = arith.addi %x, %c1: i32
       secret.yield %res : i32
     } -> (!ty)
@@ -32,18 +32,18 @@ func.func @test_chained_input_output(%value : !ty) -> !ty {
 !ty = !secret.secret<i32>
 func.func @test_shared_input(%v1: !ty, %v2: !ty, %v3: !ty) -> !ty {
   // CHECK:      secret.generic ins(%[[v1]], %[[v2]], %[[v3]]
-  // CHECK-NEXT: ^bb{{[0-9]}}(%[[cv1:.*]]: i32, %[[cv2:.*]]: i32, %[[cv3:.*]]: i32
+  // CHECK-NEXT: ^body(%[[cv1:.*]]: i32, %[[cv2:.*]]: i32, %[[cv3:.*]]: i32
   // CHECK-NEXT:   %[[r1:.*]] = arith.addi %[[cv1]], %[[cv2]]
   // CHECK-NEXT:   %[[r2:.*]] = arith.addi %[[cv2]], %[[cv3]]
   // CHECK-NEXT:   secret.yield %[[r1]], %[[r2]]
   // CHECK-NOT:  secret.generic
   %0 = secret.generic ins(%v1, %v2 : !ty, !ty) {
-    ^bb0(%clear1: i32, %clear2: i32) :
+    ^body(%clear1: i32, %clear2: i32) :
       %res = arith.addi %clear1, %clear2: i32
       secret.yield %res : i32
     } -> (!ty)
   %1 = secret.generic ins(%v2, %v3 : !ty, !ty) {
-    ^bb0(%clear2: i32, %clear3: i32) :
+    ^body(%clear2: i32, %clear3: i32) :
       %res = arith.addi %clear2, %clear3: i32
       secret.yield %res : i32
     } -> (!ty)
@@ -59,18 +59,18 @@ func.func @test_unshared_input(%v1: !ty, %v2: !ty, %v3: !ty) -> !ty {
   // CHECK: %[[c1:.*]] = arith.constant 1
   %c1 = arith.constant 1 : i32
   // CHECK:      secret.generic ins(%[[v1]], %[[v2]], %[[v3]]
-  // CHECK-NEXT: ^bb{{[0-9]}}(%[[cv1:.*]]: i32, %[[cv2:.*]]: i32, %[[cv3:.*]]: i32
+  // CHECK-NEXT: ^body(%[[cv1:.*]]: i32, %[[cv2:.*]]: i32, %[[cv3:.*]]: i32
   // CHECK-NEXT:   %[[r1:.*]] = arith.addi %[[cv1]], %[[c1]]
   // CHECK-NEXT:   %[[r2:.*]] = arith.addi %[[cv2]], %[[cv3]]
   // CHECK-NEXT:   secret.yield %[[r1]], %[[r2]]
   // CHECK-NOT:  secret.generic
   %0 = secret.generic ins(%v1 : !ty) {
-    ^bb0(%clear1: i32) :
+    ^body(%clear1: i32) :
       %res = arith.addi %clear1, %c1: i32
       secret.yield %res : i32
     } -> (!ty)
   %1 = secret.generic ins(%v2, %v3 : !ty, !ty) {
-    ^bb0(%clear2: i32, %clear3: i32) :
+    ^body(%clear2: i32, %clear3: i32) :
       %res = arith.addi %clear2, %clear3: i32
       secret.yield %res : i32
     } -> (!ty)

--- a/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_flags.mlir
+++ b/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_flags.mlir
@@ -8,7 +8,7 @@ func.func @test_affine_for(
     %data: !secret.secret<memref<10xi32>>) -> !secret.secret<memref<10xi32>> {
   // CHECK:       affine.for
   // CHECK:       secret.generic
-  // CHECK-NEXT:    bb
+  // CHECK-NEXT:    ^body
   // CHECK-NEXT:    affine.load
   // CHECK-NEXT:    arith.addi
   // CHECK-NEXT:    affine.store
@@ -17,7 +17,7 @@ func.func @test_affine_for(
   // CHECK: return %[[data]]
   secret.generic
     ins(%value, %data : !secret.secret<i32>, !secret.secret<memref<10xi32>>) {
-    ^bb0(%clear_value: i32, %clear_data : memref<10xi32>):
+    ^body(%clear_value: i32, %clear_data : memref<10xi32>):
       affine.for %i = 0 to 10 {
         %2 = affine.load %clear_data[%i] : memref<10xi32>
         %3 = arith.addi %2, %clear_value : i32
@@ -36,14 +36,14 @@ func.func @test_affine_for_split_end(
     %data: !secret.secret<memref<10xi32>>) -> !secret.secret<memref<10xi32>> {
   secret.generic
     ins(%value, %data : !secret.secret<i32>, !secret.secret<memref<10xi32>>) {
-    ^bb0(%clear_value: i32, %clear_data : memref<10xi32>):
+    ^body(%clear_value: i32, %clear_data : memref<10xi32>):
       // CHECK:    arith.constant
       // CHECK:    arith.constant
       %c7 = arith.constant 7 : i32
       %c0 = arith.constant 0 : index
 
       // CHECK:       secret.generic
-      // CHECK-NEXT:    bb
+      // CHECK-NEXT:    ^body
       // CHECK-NEXT:    memref.load
       // CHECK-NEXT:    arith.addi
       // CHECK-NEXT:    memref.store
@@ -54,7 +54,7 @@ func.func @test_affine_for_split_end(
 
       // CHECK:       affine.for
       // CHECK:       secret.generic
-      // CHECK-NEXT:    bb
+      // CHECK-NEXT:    ^body
       // CHECK-NEXT:    affine.load
       // CHECK-NEXT:    arith.addi
       // CHECK-NEXT:    arith.addi
@@ -81,14 +81,14 @@ func.func @test_affine_for_split_middle(
     %data: !secret.secret<memref<10xi32>>) -> !secret.secret<memref<10xi32>> {
   secret.generic
     ins(%value, %data : !secret.secret<i32>, !secret.secret<memref<10xi32>>) {
-    ^bb0(%clear_value: i32, %clear_data : memref<10xi32>):
+    ^body(%clear_value: i32, %clear_data : memref<10xi32>):
       // CHECK:    arith.constant
       // CHECK:    arith.constant
       %c7 = arith.constant 7 : i32
       %c0 = arith.constant 0 : index
 
       // CHECK:       secret.generic
-      // CHECK-NEXT:    bb
+      // CHECK-NEXT:    ^body
       // CHECK-NEXT:    memref.load
       // CHECK-NEXT:    arith.addi
       // CHECK-NEXT:    memref.store
@@ -99,7 +99,7 @@ func.func @test_affine_for_split_middle(
 
       // CHECK:       affine.for
       // CHECK:       secret.generic
-      // CHECK-NEXT:    bb
+      // CHECK-NEXT:    ^body
       // CHECK-NEXT:    affine.load
       // CHECK-NEXT:    arith.addi
       // CHECK-NEXT:    arith.addi
@@ -113,7 +113,7 @@ func.func @test_affine_for_split_middle(
       }
 
       // CHECK:       secret.generic
-      // CHECK-NEXT:    bb
+      // CHECK-NEXT:    ^body
       // CHECK-NEXT:    memref.load
       // CHECK-NEXT:    arith.addi
       // CHECK-NEXT:    memref.store
@@ -132,7 +132,7 @@ func.func @test_affine_for_split_middle(
 // CHECK-SAME: %[[data:.*]]: !secret.secret<memref<10xi8>>
 func.func @affine_for_yielding_memref(%arg0: !secret.secret<memref<10xi8>>) -> !secret.secret<memref<10xi8>> {
   %0 = secret.generic ins(%arg0 : !secret.secret<memref<10xi8>>) {
-  ^bb0(%arg1: memref<10xi8>):
+  ^body(%arg1: memref<10xi8>):
     // CHECK:       secret.generic
     // CHECK-NEXT:    memref.alloc
     // CHECK-NEXT:    secret.yield
@@ -140,7 +140,7 @@ func.func @affine_for_yielding_memref(%arg0: !secret.secret<memref<10xi8>>) -> !
 
     // CHECK:       affine.for
     // CHECK:       secret.generic
-    // CHECK-NEXT:    bb
+    // CHECK-NEXT:    ^body
     // CHECK-NEXT:    affine.load
     // CHECK-NEXT:    affine.store
     // CHECK-NEXT:    secret.yield
@@ -157,7 +157,7 @@ func.func @affine_for_yielding_memref(%arg0: !secret.secret<memref<10xi8>>) -> !
 // CHECK-SAME: %[[data:.*]]: !secret.secret<memref<1x80xi8>>
 func.func @affine_for_hello_world_reproducer(%arg0: !secret.secret<memref<1x80xi8>>) -> !secret.secret<memref<1x80xi8>> {
   %0 = secret.generic ins(%arg0 : !secret.secret<memref<1x80xi8>>) {
-  ^bb0(%arg1: memref<1x80xi8>):
+  ^body(%arg1: memref<1x80xi8>):
     // CHECK:    arith.constant
     %c-128_i8 = arith.constant -128 : i8
 
@@ -169,7 +169,7 @@ func.func @affine_for_hello_world_reproducer(%arg0: !secret.secret<memref<1x80xi
     // CHECK:       affine.for
     // CHECK-NEXT:    affine.for
     // CHECK-NEXT:      secret.generic
-    // CHECK-NEXT:      bb
+    // CHECK-NEXT:      ^body
     // CHECK-NEXT:      affine.load
     // CHECK-NEXT:      arith.addi
     // CHECK-NEXT:      affine.store

--- a/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_loops.mlir
+++ b/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_loops.mlir
@@ -89,7 +89,7 @@ func.func @simple_sum_secret_bound(%arg0: tensor<32xi16> { secret.secret }, %arg
     %c0_i16 = arith.constant 0 : i16
     %c1 = arith.constant 1 : index
     // CHECK: secret.generic ins(%[[data]], %[[arg1]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>)
-    // CHECK-NEXT: ^bb0(%[[DATA:.*]]: tensor<32xi16>, %[[ARG1:.*]]: index):
+    // CHECK-NEXT: ^body(%[[DATA:.*]]: tensor<32xi16>, %[[ARG1:.*]]: index):
     // CHECK-NEXT:   %[[sum:.*]] = scf.for
     // CHECK-SAME: to %[[ARG1]]
     %1 = scf.for %arg4 = %c0 to %arg1 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {

--- a/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_regions.mlir
+++ b/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_regions.mlir
@@ -17,7 +17,7 @@ func.func @test_separator(
   %c0_i32 = arith.constant 0 : i32
   %0 = secret.generic
     ins(%value : !secret.secret<i32>) {
-    ^bb0(%clear_value: i32):
+    ^body(%clear_value: i32):
       %alloc_0 = memref.alloc() : memref<10xi32>
       affine.for %i = 0 to 10 {
         affine.store %c0_i32, %alloc_0[%i] : memref<10xi32>
@@ -33,7 +33,7 @@ func.func @test_separator(
 func.func @test_operand_defined_in_region(
     %value: !secret.secret<memref<10xi32>>) -> !secret.secret<memref<10xi32>> {
   // CHECK: %[[data:.*]] = secret.generic
-  // CHECK-NEXT: ^bb0
+  // CHECK-NEXT: ^body
   // CHECK-NEXT: memref.alloc
   // CHECK:       affine.for
   // CHECK-NEXT:    affine.load
@@ -43,7 +43,7 @@ func.func @test_operand_defined_in_region(
   // CHECK: return %[[data]]
   %0 = secret.generic
     ins(%value : !secret.secret<memref<10xi32>>) {
-    ^bb0(%clear_value: memref<10xi32>):
+    ^body(%clear_value: memref<10xi32>):
       %alloc_0 = memref.alloc() : memref<10xi32>
       affine.for %i = 0 to 10 {
         %1 = affine.load %clear_value[%i] : memref<10xi32>

--- a/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_hello_world.mlir
+++ b/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_hello_world.mlir
@@ -11,7 +11,7 @@ module attributes {tf_saved_model.semantics} {
   func.func @main(%arg0: !secret.secret<memref<1x1xi8>> {iree.identifier = "serving_default_dense_input:0", tf_saved_model.index_path = ["dense_input"]}) -> (!secret.secret<memref<1x1xi8>> {iree.identifier = "StatefulPartitionedCall:0", tf_saved_model.index_path = ["dense_2"]}) attributes {tf_saved_model.exported_names = ["serving_default"]} {
     // CHECK-NOT: secret.generic
     %0 = secret.generic ins(%arg0 : !secret.secret<memref<1x1xi8>>) {
-    ^bb0(%arg1: memref<1x1xi8>):
+    ^body(%arg1: memref<1x1xi8>):
       %c-128_i32 = arith.constant -128 : i32
       %c0_i32 = arith.constant 0 : i32
       %c1073741824_i64 = arith.constant 1073741824 : i64
@@ -48,7 +48,7 @@ module attributes {tf_saved_model.semantics} {
             // CHECK: affine.load
           %7 = affine.load %1[%arg3, %arg2] : memref<16x1xi8>
             // CHECK: secret.generic
-            // CHECK-NEXT: bb
+            // CHECK-NEXT: ^body
             // CHECK-NEXT: affine.store
             // CHECK-NEXT: secret.yield
           affine.store %7, %alloc[%arg2, %arg3] : memref<1x16xi8>
@@ -83,7 +83,7 @@ module attributes {tf_saved_model.semantics} {
             %8 = affine.load %alloc[%arg4, %arg3] : memref<1x16xi8>
             %9 = affine.load %alloc_1[%arg2, %arg3] : memref<1x16xi32>
             // CHECK: secret.generic
-            // CHECK-NEXT:   bb
+            // CHECK-NEXT:   ^body
             // CHECK-NEXT: arith.extsi
             // CHECK-NEXT: arith.subi
             // CHECK-NEXT: arith.extsi
@@ -96,7 +96,7 @@ module attributes {tf_saved_model.semantics} {
             %14 = arith.muli %12, %13 : i32
             %15 = arith.addi %9, %14 : i32
             // CHECK: secret.generic
-            // CHECK-NEXT:   bb
+            // CHECK-NEXT:   ^body
             // CHECK-NEXT: affine.store
             // CHECK-NEXT: secret.yield
             affine.store %15, %alloc_1[%arg2, %arg3] : memref<1x16xi32>

--- a/tests/Dialect/TOSA/Conversions/tosa_to_secret_arith/tosa_sigmoid_to_arith.mlir
+++ b/tests/Dialect/TOSA/Conversions/tosa_to_secret_arith/tosa_sigmoid_to_arith.mlir
@@ -5,7 +5,7 @@
 // CHECK-DAG:   %[[COEFF_1:.*]] = arith.constant dense<1.97{{0*}}e-01> : tensor<1x16xf32>
 // CHECK-DAG:   %[[COEFF_3:.*]] = arith.constant dense<-4.{{0*}}e-03> : tensor<1x16xf32>
 // CHECK:       %[[RET:.*]] = secret.generic ins(%[[ARG]] : !secret.secret<tensor<1x16xf32>>)
-// CHECK-NEXT:  ^bb0(%[[CONVERTED_ARG:.*]]: tensor<1x16xf32>):
+// CHECK-NEXT:  ^body(%[[CONVERTED_ARG:.*]]: tensor<1x16xf32>):
 // CHECK:         %[[COEFF_MUL_DEGREE_1:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[COEFF_1]]
 // CHECK:         %[[DEGREE_2:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[CONVERTED_ARG]]
 // CHECK:         %[[DEGREE_3:.*]] = arith.mulf %[[DEGREE_2]], %[[CONVERTED_ARG]]
@@ -17,7 +17,7 @@
 module {
 func.func @test_tosa_sigmoid_to_secret_arith(%vec : !secret.secret<tensor<1x16xf32>>) -> !secret.secret<tensor<1x16xf32>> {
   %out = secret.generic ins (%vec : !secret.secret<tensor<1x16xf32>>) {
-  ^bb0(%converted_vec: tensor<1x16xf32>):
+  ^body(%converted_vec: tensor<1x16xf32>):
     %0 = tosa.sigmoid %converted_vec : (tensor<1x16xf32>) -> tensor<1x16xf32>
     secret.yield %0 : tensor<1x16xf32>
   } -> !secret.secret<tensor<1x16xf32>>

--- a/tests/Dialect/TensorExt/Transforms/simd_pack.mlir
+++ b/tests/Dialect/TensorExt/Transforms/simd_pack.mlir
@@ -6,7 +6,7 @@ module  {
   // CHECK-SAME{LITERAL}: !secret.secret<tensor<1024xi16, #tensor_ext.simd_packing<in = [16], padding = [0], out = [1024]>>>
   func.func @main(%arg0: tensor<16xi16>, %arg1: tensor<16xi16>) -> tensor<16xi16> {
     // CHECK-NEXT: secret.generic ins(%[[arg0:.*]], %[[arg1:.*]] : !secret.secret<[[ty:.*]]>, !secret.secret<[[ty]]>)
-    // CHECK-NEXT:  ^bb0(%[[arg0_0:.*]]: [[ty]], %[[arg1_0:.*]]: [[ty]]):
+    // CHECK-NEXT:  ^body(%[[arg0_0:.*]]: [[ty]], %[[arg1_0:.*]]: [[ty]]):
     // CHECK-NEXT:    %[[add:.*]] = arith.addi %[[arg0_0]], %[[arg1_0]] : [[ty]]
     // CHECK-NEXT:    secret.yield %[[add]] : [[ty]]
     %0 = arith.addi %arg0, %arg1 : tensor<16xi16>
@@ -26,7 +26,7 @@ module  {
     // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
     // CHECK-DAG: %[[c20:.*]] = arith.constant 20 : index
     // CHECK: secret.generic ins(%[[arg0]] : !secret.secret<[[ty:.*]]>)
-    // CHECK-NEXT:  ^bb0(%[[arg0_0:.*]]: [[ty]]):
+    // CHECK-NEXT:  ^body(%[[arg0_0:.*]]: [[ty]]):
     // CHECK-NEXT:    %[[extract1:.*]] = tensor.extract %[[arg0_0]][%[[c1]], %[[c976]]] : [[ty]]
     // CHECK-NEXT:    %[[extracted:.*]] = tensor.insert %[[extract1]] into %[[arg0_0]][%[[c0]], %[[c20]]] : [[ty]]
     // CHECK-NEXT:    secret.yield %[[extracted]]

--- a/tests/Transforms/annotate_secretness/annotate_secretness.mlir
+++ b/tests/Transforms/annotate_secretness/annotate_secretness.mlir
@@ -14,8 +14,8 @@ func.func @annotated_secretness(%s: i32 {secret.secret}, %p: i32) {
 // CHECK-SAME: ([[S:%.*]]: [[ST:.*]], [[P:%.*]]: [[PT:.*]])
 func.func @typed_secretness(%s: !secret.secret<i32>, %p: i32) {
     %0 = secret.generic ins(%s , %p : !secret.secret<i32>, i32) {
-    //CHECK: ^bb0([[SS:%.*]]: [[PT]], [[PP:%.*]]: [[PT]]):
-    ^bb0(%ss: i32, %pp: i32):
+    //CHECK: ^body([[SS:%.*]]: [[PT]], [[PP:%.*]]: [[PT]]):
+    ^body(%ss: i32, %pp: i32):
         //CHECK-NEXT: arith.addi  [[PP]], [[PP]] {secretness = false} : [[PT]]
         %0 = arith.addi %pp, %pp : i32
         //CHECK-NEXT: arith.addi  [[SS]], [[PP]] {secretness = true} : [[PT]]

--- a/tests/Transforms/data_oblivious/convert_secret_for_to_static_for/secret_dependent_for_loops.mlir
+++ b/tests/Transforms/data_oblivious/convert_secret_for_to_static_for/secret_dependent_for_loops.mlir
@@ -4,7 +4,7 @@
 func.func @for_loop_with_data_dependent_upper_bound(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
     // CHECK-NEXT: %[[C0_I16:.*]] = arith.constant 0 : i16
     // CHECK-NEXT: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[ARG1:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
-    // CHECK-NEXT:  ^bb0(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
+    // CHECK-NEXT:  ^body(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
     // CHECK-NEXT:   %[[FOR:.*]] = affine.for %[[IV:.*]] = 0 to 42 iter_args(%[[ACC:.*]] = %[[C0_I16]]) -> (i16) {
     // CHECK-NEXT:   %[[COND:.*]] = arith.cmpi slt, %[[IV]], %[[ARG3]] : index
     // CHECK-NEXT:    %[[IF:.*]] = scf.if %[[COND]] -> (i16) {
@@ -23,7 +23,7 @@ func.func @for_loop_with_data_dependent_upper_bound(%arg0: !secret.secret<tensor
     %c0_i16 = arith.constant 0 : i16
     %c1 = arith.constant 1 : index
     %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
-    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+    ^body(%arg2: tensor<32xi16>, %arg3: index):
       %1 = scf.for %arg4 = %c0 to %arg3 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {
         %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
         %2 = arith.addi %extracted, %arg5 : i16
@@ -38,7 +38,7 @@ func.func @for_loop_with_data_dependent_upper_bound(%arg0: !secret.secret<tensor
 func.func @for_loop_with_data_dependent_lower_bound(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
     // CHECK-NEXT: %[[C0_I16:.*]] = arith.constant 0 : i16
     // CHECK-NEXT: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[ARG1:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
-    // CHECK-NEXT:  ^bb0(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
+    // CHECK-NEXT:  ^body(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
     // CHECK-NEXT:   %[[FOR:.*]] = affine.for %[[IV:.*]] = 0 to 32 iter_args(%[[ACC:.*]] = %[[C0_I16]]) -> (i16) {
     // CHECK-NEXT:   %[[COND:.*]] = arith.cmpi sge, %[[IV]], %[[ARG3]] : index
     // CHECK-NEXT:    %[[IF:.*]] = scf.if %[[COND]] -> (i16) {
@@ -57,7 +57,7 @@ func.func @for_loop_with_data_dependent_lower_bound(%arg0: !secret.secret<tensor
     %c0_i16 = arith.constant 0 : i16
     %c1 = arith.constant 1 : index
     %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
-    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+    ^body(%arg2: tensor<32xi16>, %arg3: index):
       %1 = scf.for %arg4 = %arg3 to %c32 step %c1 iter_args(%arg5 = %c0_i16) -> (i16) {
         %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
         %2 = arith.addi %extracted, %arg5 : i16
@@ -72,7 +72,7 @@ func.func @for_loop_with_data_dependent_lower_bound(%arg0: !secret.secret<tensor
 func.func @for_loop_with_data_dependent_upper_and_lower_bounds(%arg0: !secret.secret<tensor<32xi16>>, %lower: !secret.secret<index>, %upper: !secret.secret<index>) -> !secret.secret<i16> {
     // CHECK-NEXT: %[[C0_I16:.*]] = arith.constant 0 : i16
     // CHECK-NEXT: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[LOWER:.*]], %[[UPPER:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>, !secret.secret<index>) {
-    // CHECK-NEXT:  ^bb0(%[[ARG3:.*]]: tensor<32xi16>, %[[ARG4:.*]]: index, %[[ARG5:.*]]: index):
+    // CHECK-NEXT:  ^body(%[[ARG3:.*]]: tensor<32xi16>, %[[ARG4:.*]]: index, %[[ARG5:.*]]: index):
     // CHECK-NEXT:   %[[FOR:.*]] = affine.for %[[IV:.*]] = 0 to 42 iter_args(%[[ACC:.*]] = %[[C0_I16]]) -> (i16) {
     // CHECK-NEXT:   %[[CMPIL:.*]] = arith.cmpi sge, %[[IV]], %[[ARG4]] : index
     // CHECK-NEXT:   %[[CMPIU:.*]] = arith.cmpi slt, %[[IV]], %[[ARG5]] : index
@@ -92,7 +92,7 @@ func.func @for_loop_with_data_dependent_upper_and_lower_bounds(%arg0: !secret.se
     %c0_i16 = arith.constant 0 : i16
     %c1 = arith.constant 1 : index
     %0 = secret.generic ins(%arg0, %lower, %upper : !secret.secret<tensor<32xi16>>, !secret.secret<index>,  !secret.secret<index>) {
-    ^bb0(%arg3: tensor<32xi16>, %arg4: index, %arg5: index):
+    ^body(%arg3: tensor<32xi16>, %arg4: index, %arg5: index):
       %1 = scf.for %arg6 = %arg4 to %arg5 step %c1 iter_args(%arg7 = %c0_i16) -> (i16) {
         %extracted = tensor.extract %arg3[%arg6] : tensor<32xi16>
         %2 = arith.addi %extracted, %arg7 : i16
@@ -107,7 +107,7 @@ func.func @for_loop_with_data_dependent_upper_and_lower_bounds(%arg0: !secret.se
 func.func @for_loop_with_data_dependent_upper_bound_multiple_iter_args(%arg0: !secret.secret<tensor<32xi16>>, %arg1: !secret.secret<index>) -> !secret.secret<i16> {
     // CHECK: %[[C0_I16:.*]] = arith.constant 0 : i16
     // CHECK: %[[RESULT:.*]] = secret.generic ins(%[[ARG0:.*]], %[[ARG1:.*]] : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
-    // CHECK:  ^bb0(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
+    // CHECK:  ^body(%[[ARG2:.*]]: tensor<32xi16>, %[[ARG3:.*]]: index):
     // CHECK:   %[[FOR:.*]]:2 = affine.for %[[I:.*]] = 0 to 42 iter_args(%[[ARG5:.*]] = %[[C0_I16]], %[[ARG6:.*]] = %[[C0_I16]]) -> (i16, i16) {
     // CHECK:      %[[CMPIU:.*]] = arith.cmpi slt, %[[I]], %[[ARG3]] : index
     // CHECK:      %[[IF:.*]]:2 = scf.if %[[CMPIU]] -> (i16, i16) {
@@ -128,7 +128,7 @@ func.func @for_loop_with_data_dependent_upper_bound_multiple_iter_args(%arg0: !s
     %c0_i16 = arith.constant 0 : i16
     %c1 = arith.constant 1 : index
     %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32xi16>>, !secret.secret<index>) {
-    ^bb0(%arg2: tensor<32xi16>, %arg3: index):
+    ^body(%arg2: tensor<32xi16>, %arg3: index):
       %1, %2 = scf.for %arg4 = %c0 to %arg3 step %c1 iter_args(%arg5 = %c0_i16, %arg6 = %c0_i16) -> (i16, i16) {
         %extracted = tensor.extract %arg2[%arg4] : tensor<32xi16>
         %3 = arith.addi %extracted, %arg5 : i16
@@ -145,7 +145,7 @@ func.func @for_loop_with_data_dependent_upper_bound_multiple_iter_args(%arg0: !s
 func.func @partial_sum_with_secret_threshold(%secretInput :!secret.secret<tensor<16xi16>>, %secretIndex: !secret.secret<index>, %secretThreshold: !secret.secret<i16>) -> (!secret.secret<i16>, !secret.secret<i16>) {
   // CHECK: %[[C0:.*]] = arith.constant 0 : i16
   // CHECK: %[[RESULT:.*]]:2 = secret.generic ins(%[[SECRET_INPUT:.*]], %[[SECRET_INDEX:.*]], %[[SECRET_THRESHOLD:.*]] : !secret.secret<tensor<16xi16>>, !secret.secret<index>, !secret.secret<i16>) {
-  // CHECK:  ^bb0(%[[INPUT:.*]]: tensor<16xi16>, %[[INDEX:.*]]: index, %[[THRESHOLD:.*]]: i16):
+  // CHECK:  ^body(%[[INPUT:.*]]: tensor<16xi16>, %[[INDEX:.*]]: index, %[[THRESHOLD:.*]]: i16):
   // CHECK:   %[[FOR:.*]]:2 = affine.for %[[I:.*]] = 0 to 16 iter_args(%[[ARG1:.*]] = %[[C0]], %[[ARG2:.*]] = %[[C0]]) -> (i16, i16) {
   // CHECK:     %[[CMPI:.*]] = arith.cmpi slt, %[[I]], %[[INDEX]] : index
   // CHECK:     %[[IF:.*]]:2 = scf.if %[[CMPI]] -> (i16, i16) {
@@ -172,7 +172,7 @@ func.func @partial_sum_with_secret_threshold(%secretInput :!secret.secret<tensor
   %step = arith.constant 1 : index
   %c0 = arith.constant 0 : i16
   %0, %1 = secret.generic ins(%secretInput, %secretIndex, %secretThreshold : !secret.secret<tensor<16xi16>>, !secret.secret<index>, !secret.secret<i16>) {
-  ^bb0(%input: tensor<16xi16>, %index: index, %threshold: i16):
+  ^body(%input: tensor<16xi16>, %index: index, %threshold: i16):
       %2, %3 = scf.for %i = %start to %index step %step iter_args(%arg1 = %c0, %arg2 = %c0) -> (i16, i16) {
           %cond = arith.cmpi slt, %arg1, %threshold : i16
           %extracted = tensor.extract %input[%i] : tensor<16xi16>

--- a/tests/Transforms/data_oblivious/convert_secret_while_to_static_for/secret_dependent_while_loop.mlir
+++ b/tests/Transforms/data_oblivious/convert_secret_while_to_static_for/secret_dependent_while_loop.mlir
@@ -4,13 +4,13 @@
 func.func @basic_while_loop_with_secret_condition(%input: !secret.secret<i16>) -> !secret.secret<i16> {
   // CHECK-NOT: scf.while
   // CHECK: %[[RESULT:.*]] = secret.generic ins(%[[SECRET_INPUT:.*]]: !secret.secret<i16>)
-  // CHECK-NEXT: ^bb0(%[[INPUT:.*]]: i16):
+  // CHECK-NEXT: ^body(%[[INPUT:.*]]: i16):
   // CHECK: %[[FOR:.*]] = affine.for %[[I:.*]] = 0 to 16 iter_args(%[[ARG:.*]] = %[[INPUT]]) -> (i16)
   // CHECK-NEXT: arith.cmpi
   %c100 = arith.constant 100 : i16
   %c20 = arith.constant 20 : i16
   %0 = secret.generic ins(%input : !secret.secret<i16>) {
-  ^bb0(%arg1: i16):
+  ^body(%arg1: i16):
     %1 = scf.while (%arg2 = %arg1) : (i16) -> i16 {
       %3 = arith.cmpi sgt, %arg2, %c100 : i16
       scf.condition(%3) %arg2 : i16
@@ -28,13 +28,13 @@ func.func @basic_while_loop_with_secret_condition(%input: !secret.secret<i16>) -
 func.func @while_loop_with_joint_secret_condition(%input: !secret.secret<i16>) -> !secret.secret<i16> {
   // CHECK-NOT: scf.while
   // CHECK: %[[RESULT:.*]] = secret.generic ins(%[[SECRET_INPUT:.*]]: !secret.secret<i16>)
-  // CHECK-NEXT: ^bb0(%[[INPUT:.*]]: i16):
+  // CHECK-NEXT: ^body(%[[INPUT:.*]]: i16):
   // CHECK: %[[FOR:.*]] = affine.for %[[I:.*]] = 0 to 16 iter_args(%[[ARG:.*]] = %[[INPUT]]) -> (i16)
   // CHECK: arith.andi
   %c100 = arith.constant 100 : i16
   %c20 = arith.constant 20 : i16
   %0 = secret.generic ins(%input : !secret.secret<i16>) {
-  ^bb0(%arg1: i16):
+  ^body(%arg1: i16):
     %1 = scf.while (%arg2 = %arg1) : (i16) -> i16 {
       %3 = arith.cmpi slt, %arg2, %c100 : i16
       %4 = arith.cmpi sgt, %arg2, %c20 : i16

--- a/tests/Transforms/heir_simd_vectorizer/box_blur_64x64.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/box_blur_64x64.mlir
@@ -10,7 +10,7 @@ module  {
   // CHECK-DAG:    %[[c63:.*]] = arith.constant 63 : index
   // CHECK-DAG:    %[[c65:.*]] = arith.constant 65 : index
   // CHECK-NEXT:   %[[v0:.*]] = secret.generic ins(%[[arg0]] : !secret.secret<tensor<4096xi16>>) {
-  // CHECK-NEXT:   ^bb0(%[[arg1:.*]]: tensor<4096xi16>):
+  // CHECK-NEXT:   ^body(%[[arg1:.*]]: tensor<4096xi16>):
   // CHECK-NEXT:     %[[v1:.*]] = tensor_ext.rotate %[[arg1]], %[[c3968]]
   // CHECK-NEXT:     %[[v2:.*]] = tensor_ext.rotate %[[arg1]], %[[c4032]]
   // CHECK-NEXT:     %[[v3:.*]] = arith.addi %[[v1]], %[[v2]]

--- a/tests/Transforms/heir_simd_vectorizer/roberts_cross_4x4.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/roberts_cross_4x4.mlir
@@ -9,7 +9,7 @@ module{
   // CHECK-DAG:  %[[c15:.*]] = arith.constant 15 : index
   // CHECK-DAG:  %[[c11:.*]] = arith.constant 11 : index
   // CHECK-NEXT: secret.generic ins(%[[arg0]] : !secret.secret<tensor<16xi16>>) {
-  // CHECK-NEXT:  ^bb0(%[[arg1:.*]]: tensor<16xi16>):
+  // CHECK-NEXT:  ^body(%[[arg1:.*]]: tensor<16xi16>):
   // CHECK-NEXT:    %[[v1:.*]] = tensor_ext.rotate %[[arg1]], %[[c11]]
   // CHECK-NEXT:    %[[v2:.*]] = arith.subi %[[v1]], %[[arg1]]
   // CHECK-NEXT:    %[[v3:.*]] = tensor_ext.rotate %[[arg1]], %[[c15]]

--- a/tests/Transforms/heir_simd_vectorizer/roberts_cross_64x64.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/roberts_cross_64x64.mlir
@@ -10,7 +10,7 @@ module{
   // CHECK-NEXT: %[[cMinusRow:.*]] = arith.constant 4032 : index
   // CHECK-NEXT: %[[cMinusRowMinusOne:.*]] = arith.constant 4031 : index
   // CHECK-NEXT: secret.generic ins(%[[arg0]] : !secret.secret<tensor<4096xi16>>) {
-  // CHECK-NEXT:  ^bb0(%[[arg1:.*]]: tensor<4096xi16>):
+  // CHECK-NEXT:  ^body(%[[arg1:.*]]: tensor<4096xi16>):
   // CHECK-NEXT:    %[[v1:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusRowMinusOne]]
   // CHECK-NEXT:    %[[v2:.*]] = arith.subi %[[v1]], %[[arg1]]
   // CHECK-NEXT:    %[[v3:.*]] = tensor_ext.rotate %[[arg1]], %[[cMinusRow]]

--- a/tests/Transforms/operation_balancer/balance_sigmoid.mlir
+++ b/tests/Transforms/operation_balancer/balance_sigmoid.mlir
@@ -7,7 +7,7 @@
 // CHECK-DAG: %[[COEFF_0:.*]] = arith.constant dense<5.{{0*}}e-01> : tensor<1x16xf32>
 
 // CHECK:     %[[RET:.*]] = secret.generic ins(%[[ARG0]] : !secret.secret<tensor<1x16xf32>>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG:.*]]: tensor<1x16xf32>):
+// CHECK:     ^body(%[[CONVERTED_ARG:.*]]: tensor<1x16xf32>):
 // CHECK:       %[[COEFF_MUL_DEGREE_1:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[COEFF_1]]
 
 // CHECK:       %[[DEGREE_2:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[CONVERTED_ARG]]

--- a/tests/Transforms/operation_balancer/complex_balance_secret_add_mult_tree.mlir
+++ b/tests/Transforms/operation_balancer/complex_balance_secret_add_mult_tree.mlir
@@ -6,7 +6,7 @@
 // CHECK:     func.func @complex_balance_secret_add_mult_tree(%[[ARG0:.*]]: !secret.secret<i16>, %[[ARG1:.*]]: !secret.secret<i16>, %[[ARG2:.*]]: !secret.secret<i16>, %[[ARG3:.*]]: !secret.secret<i16>, %[[ARG4:.*]]: !secret.secret<i16>, %[[ARG5:.*]]: !secret.secret<i16>, %[[ARG6:.*]]: !secret.secret<i16>)
 
 // CHECK:     %[[RET:.*]] = secret.generic ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]], %[[ARG5]], %[[ARG6]] : !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16, %[[CONVERTED_ARG4:.*]]: i16, %[[CONVERTED_ARG5:.*]]: i16, %[[CONVERTED_ARG6:.*]]: i16):
+// CHECK:     ^body(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16, %[[CONVERTED_ARG4:.*]]: i16, %[[CONVERTED_ARG5:.*]]: i16, %[[CONVERTED_ARG6:.*]]: i16):
 
 // CHECK-DAG: %[[ADD_ONE:.*]] = arith.addi %[[CONVERTED_ARG0]], %[[CONVERTED_ARG1]]
 // CHECK-DAG: %[[ADD_TWO:.*]] = arith.addi %[[CONVERTED_ARG2]], %[[CONVERTED_ARG3]]

--- a/tests/Transforms/operation_balancer/complex_balance_secret_add_tree.mlir
+++ b/tests/Transforms/operation_balancer/complex_balance_secret_add_tree.mlir
@@ -6,7 +6,7 @@
 // CHECK:     func.func @complex_balance_secret_add_tree(%[[ARG0:.*]]: !secret.secret<i16>, %[[ARG1:.*]]: !secret.secret<i16>, %[[ARG2:.*]]: !secret.secret<i16>, %[[ARG3:.*]]: !secret.secret<i16>, %[[ARG4:.*]]: !secret.secret<i16>, %[[ARG5:.*]]: !secret.secret<i16>, %[[ARG6:.*]]: !secret.secret<i16>)
 
 // CHECK:     %[[RET:.*]]:3 = secret.generic ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]], %[[ARG5]], %[[ARG6]] : !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16, %[[CONVERTED_ARG4:.*]]: i16, %[[CONVERTED_ARG5:.*]]: i16, %[[CONVERTED_ARG6:.*]]: i16):
+// CHECK:     ^body(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16, %[[CONVERTED_ARG4:.*]]: i16, %[[CONVERTED_ARG5:.*]]: i16, %[[CONVERTED_ARG6:.*]]: i16):
 
 // CHECK-DAG: %[[ADD_ONE:.*]] = arith.addi %[[CONVERTED_ARG0]], %[[CONVERTED_ARG1]]
 // CHECK-DAG: %[[ADD_TWO:.*]] = arith.addi %[[CONVERTED_ARG2]], %[[CONVERTED_ARG3]]

--- a/tests/Transforms/operation_balancer/complex_balance_secret_mult_tree.mlir
+++ b/tests/Transforms/operation_balancer/complex_balance_secret_mult_tree.mlir
@@ -6,7 +6,7 @@
 // CHECK:     func.func @complex_balance_secret_mult_tree(%[[ARG0:.*]]: !secret.secret<i16>, %[[ARG1:.*]]: !secret.secret<i16>, %[[ARG2:.*]]: !secret.secret<i16>, %[[ARG3:.*]]: !secret.secret<i16>, %[[ARG4:.*]]: !secret.secret<i16>, %[[ARG5:.*]]: !secret.secret<i16>, %[[ARG6:.*]]: !secret.secret<i16>)
 
 // CHECK:     %[[RET:.*]]:3 = secret.generic ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]], %[[ARG5]], %[[ARG6]] : !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16, %[[CONVERTED_ARG4:.*]]: i16, %[[CONVERTED_ARG5:.*]]: i16, %[[CONVERTED_ARG6:.*]]: i16):
+// CHECK:     ^body(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16, %[[CONVERTED_ARG4:.*]]: i16, %[[CONVERTED_ARG5:.*]]: i16, %[[CONVERTED_ARG6:.*]]: i16):
 
 // CHECK-DAG: %[[MULT_ONE:.*]] = arith.muli %[[CONVERTED_ARG0]], %[[CONVERTED_ARG1]]
 // CHECK-DAG: %[[MULT_TWO:.*]] = arith.muli %[[CONVERTED_ARG2]], %[[CONVERTED_ARG3]]

--- a/tests/Transforms/operation_balancer/simple_balance_secret_add_float_tree.mlir
+++ b/tests/Transforms/operation_balancer/simple_balance_secret_add_float_tree.mlir
@@ -2,7 +2,7 @@
 
 // CHECK:     func.func @simple_balance_secret_add_float_tree(%[[ARG0:.*]]: !secret.secret<f32>, %[[ARG1:.*]]: !secret.secret<f32>, %[[ARG2:.*]]: !secret.secret<f32>, %[[ARG3:.*]]: !secret.secret<f32>)
 // CHECK:     %[[RET:.*]] = secret.generic ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] : !secret.secret<f32>, !secret.secret<f32>, !secret.secret<f32>, !secret.secret<f32>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG0:.*]]: f32, %[[CONVERTED_ARG1:.*]]: f32, %[[CONVERTED_ARG2:.*]]: f32, %[[CONVERTED_ARG3:.*]]: f32):
+// CHECK:     ^body(%[[CONVERTED_ARG0:.*]]: f32, %[[CONVERTED_ARG1:.*]]: f32, %[[CONVERTED_ARG2:.*]]: f32, %[[CONVERTED_ARG3:.*]]: f32):
 // CHECK-DAG: %[[ADD_ONE:.*]] = arith.addf %[[CONVERTED_ARG0]], %[[CONVERTED_ARG1]]
 // CHECK-DAG: %[[ADD_TWO:.*]] = arith.addf %[[CONVERTED_ARG2]], %[[CONVERTED_ARG3]]
 // CHECK:     %[[ADD_THREE:.*]] = arith.addf %[[ADD_ONE]], %[[ADD_TWO]]

--- a/tests/Transforms/operation_balancer/simple_balance_secret_add_tree.mlir
+++ b/tests/Transforms/operation_balancer/simple_balance_secret_add_tree.mlir
@@ -2,7 +2,7 @@
 
 // CHECK:     func.func @simple_balance_secret_add_tree(%[[ARG0:.*]]: !secret.secret<i16>, %[[ARG1:.*]]: !secret.secret<i16>, %[[ARG2:.*]]: !secret.secret<i16>, %[[ARG3:.*]]: !secret.secret<i16>)
 // CHECK:     %[[RET:.*]] = secret.generic ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] : !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16):
+// CHECK:     ^body(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16):
 // CHECK-DAG: %[[ADD_ONE:.*]] = arith.addi %[[CONVERTED_ARG0]], %[[CONVERTED_ARG1]]
 // CHECK-DAG: %[[ADD_TWO:.*]] = arith.addi %[[CONVERTED_ARG2]], %[[CONVERTED_ARG3]]
 // CHECK:     %[[ADD_THREE:.*]] = arith.addi %[[ADD_ONE]], %[[ADD_TWO]]

--- a/tests/Transforms/operation_balancer/simple_balance_secret_mult_tree.mlir
+++ b/tests/Transforms/operation_balancer/simple_balance_secret_mult_tree.mlir
@@ -2,7 +2,7 @@
 
 // CHECK:     func.func @simple_balance_secret_mult_tree(%[[ARG0:.*]]: !secret.secret<i16>, %[[ARG1:.*]]: !secret.secret<i16>, %[[ARG2:.*]]: !secret.secret<i16>, %[[ARG3:.*]]: !secret.secret<i16>)
 // CHECK:     %[[RET:.*]] = secret.generic ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] : !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>, !secret.secret<i16>)
-// CHECK:     ^bb0(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16):
+// CHECK:     ^body(%[[CONVERTED_ARG0:.*]]: i16, %[[CONVERTED_ARG1:.*]]: i16, %[[CONVERTED_ARG2:.*]]: i16, %[[CONVERTED_ARG3:.*]]: i16):
 // CHECK-DAG: %[[MUL_ONE:.*]] = arith.muli %[[CONVERTED_ARG0]], %[[CONVERTED_ARG1]]
 // CHECK-DAG: %[[MUL_TWO:.*]] = arith.muli %[[CONVERTED_ARG2]], %[[CONVERTED_ARG3]]
 // CHECK:     %[[MUL_THREE:.*]] = arith.muli %[[MUL_ONE]], %[[MUL_TWO]]

--- a/tests/Transforms/yosys_optimizer/unroll_factor.mlir
+++ b/tests/Transforms/yosys_optimizer/unroll_factor.mlir
@@ -42,11 +42,11 @@ func.func @basic_example(%arg0: !in_ty) -> (!out_ty) {
 //   CHECK-DAG: %[[false:.*]] = arith.constant false
 //
 //   CHECK: secret.generic
-//   CHECK-NEXT:  ^bb
+//   CHECK-NEXT:  ^body
 //     CHECK-NEXT: memref.load
 //     CHECK-NEXT: secret.yield
 //   CHECK: secret.generic
-//   CHECK-NEXT:  ^bb
+//   CHECK-NEXT:  ^body
 //     CHECK-NEXT: memref.load
 //     CHECK-NEXT: secret.yield
 //   CHECK-NEXT: }
@@ -55,7 +55,7 @@ func.func @basic_example(%arg0: !in_ty) -> (!out_ty) {
 //
 //                The main computation
 //   CHECK-NEXT:  secret.generic
-//   CHECK-NEXT:  ^bb{{.*}}(%[[arg2:.*]]: memref<8xi1>, %[[arg3:.*]]: memref<8xi1>):
+//   CHECK-NEXT:  ^body{{.*}}(%[[arg2:.*]]: memref<8xi1>, %[[arg3:.*]]: memref<8xi1>):
 //                  Note bit 7 is never loaded because it is shifted out
 //   CHECK-DAG:    %[[arg2bit0:.*]] = memref.load %[[arg2]][%[[c0]]] : memref<8xi1>
 //   CHECK-DAG:    %[[arg2bit1:.*]] = memref.load %[[arg2]][%[[c1]]] : memref<8xi1>
@@ -104,12 +104,12 @@ func.func @basic_example(%arg0: !in_ty) -> (!out_ty) {
 //   CHECK-NEXT:  secret.cast
 //   CHECK-NEXT:  secret.cast
 //   CHECK-NEXT:  secret.generic
-//   CHECK-NEXT:  ^bb
+//   CHECK-NEXT:  ^body
 //   CHECK-NEXT:    memref.store
 //   CHECK-NEXT:    secret.yield
 //   CHECK-NEXT:  }
 //   CHECK-NEXT:  secret.generic
-//   CHECK-NEXT:  ^bb
+//   CHECK-NEXT:  ^body
 //   CHECK-NEXT:    memref.store
 //   CHECK-NEXT:    secret.yield
 //   CHECK-NEXT:  }


### PR DESCRIPTION
An older version of #1224 is merged in https://github.com/google/heir/commit/5a4742601da66868bf3fad0cd700aaff61693fb9, where the change to `getAsmBlockNames` is not merged.