### PR TITLE
Openfhe: get plaintext modulus from LWE type

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -48,6 +48,19 @@ class Openfhe_BinaryOp<string mnemonic, list<Trait> traits = []>
 }
 
 def GenParamsOp : Openfhe_Op<"gen_params"> {
+  let description = [{
+    Generates the parameters for the OpenFHE scheme.
+
+    `mulDepth` is the depth of the multiplication circuit,
+    including the bootstrapping depth.
+
+    `plainMod` is the modulus of the plaintext space. If we
+    are using CKKS, this is 0.
+
+    `insecure` is a flag that determines whether the parameters
+    are generated securely or not. This is mainly used for
+    testing purposes.
+  }];
   let arguments = (ins
     I64Attr:$mulDepth,
     I64Attr:$plainMod,

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -105,10 +105,11 @@ class SecretToBGVTypeConverter : public TypeWithAttrTypeConverter {
     auto dimension = mgmtAttr.getDimension();
 
     auto *ctx = type.getContext();
+    // TODO(#661) : Calculate the appropriate values by analyzing the function
     auto plaintextRing = ::mlir::heir::polynomial::RingAttr::get(
         type.getContext(),
         mod_arith::ModArithType::get(
-            ctx, IntegerAttr::get(IntegerType::get(ctx, 64), 65537)),
+            ctx, IntegerAttr::get(IntegerType::get(ctx, 64), 4295294977)),
         ring.getPolynomialModulus());
 
     SmallVector<IntegerAttr, 6> moduliChain;

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -131,11 +131,11 @@ class SecretToCKKSTypeConverter : public TypeWithAttrTypeConverter {
 
     Type valueTy = type.getValueType();
 
+    // Note that slot number for CKKS is always half of the ring dimension.
+    // so ring_.getPolynomialModulus() is not useful here
+    // TODO(#1191): use packing information to get the correct slot number
     auto plaintextRing = ::mlir::heir::polynomial::RingAttr::get(
-        type.getContext(),
-        mod_arith::ModArithType::get(
-            ctx, IntegerAttr::get(IntegerType::get(ctx, 64), 65537)),
-        ring_.getPolynomialModulus());
+        type.getContext(), Float64Type::get(ctx), ring_.getPolynomialModulus());
 
     SmallVector<IntegerAttr, 6> moduliChain;
     for (auto modArithType :

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -684,7 +684,9 @@ LogicalResult OpenFhePkeEmitter::printOperation(GenParamsOp op) {
 
   os << "CCParamsT " << paramsName << ";\n";
   os << paramsName << ".SetMultiplicativeDepth(" << mulDepth << ");\n";
-  os << paramsName << ".SetPlaintextModulus(" << plainMod << ");\n";
+  if (plainMod != 0) {
+    os << paramsName << ".SetPlaintextModulus(" << plainMod << ");\n";
+  }
   if (op.getInsecure()) {
     os << paramsName << ".SetSecurityLevel(lbcrypto::HEStd_NotSet);\n";
     os << paramsName << ".SetRingDim(128);\n";

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -150,3 +150,13 @@ func.func @test_constant() -> tensor<2xf32> {
   %cst_2d = arith.constant dense<[[1.5, 2.5]]> : tensor<1x2xf64>
   return %splat : tensor<2xf32>
 }
+
+// -----
+
+// CHECK-LABEL: test_ckks_no_plaintext_modulus
+// CHECK-NOT: SetPlaintextModulus
+func.func @test_ckks_no_plaintext_modulus() -> !openfhe.crypto_context {
+  %0 = openfhe.gen_params  {insecure = false, mulDepth = 2 : i64, plainMod = 0 : i64} : () -> !openfhe.cc_params
+  %1 = openfhe.gen_context %0 {supportFHE = false} : (!openfhe.cc_params) -> !openfhe.crypto_context
+  return %1 : !openfhe.crypto_context
+}


### PR DESCRIPTION
Related to #1145, similar to #1189.

Also, newer version of OpenFHE does not allow `SetPlaintextModulus` for CKKS scheme, which could be checked at #1232 (`Delete .SetPlaintextModulus(). CKKS does not need it.`) and https://github.com/openfheorg/openfhe-development/blob/7b8346f4eac27121543e36c17237b919e03ec058/src/pke/include/scheme/ckksrns/gen-cryptocontext-ckksrns-params.h#L66-L68

For CKKS plaintext space, I just put a `f64` as the coefficient type.