### PR TITLE
Add first e2e lattigo test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     rev: "v1.5.4"
     hooks:
       - id: remove-tabs
+        exclude: ".*[.]go"
 
 # Github workflow actionlint
 -   repo: https://github.com/Mateusz-Grzelinski/actionlint-py
@@ -63,5 +64,11 @@ repos:
     additional_dependencies:
     - mdformat-gfm
     - mdformat-frontmatter
+
+# golang hooks
+- repo: https://github.com/dnephin/pre-commit-golang
+  rev: "v0.5.1"
+  hooks:
+    - id: go-fmt
 
 exclude: patches/.*\.patch$

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,6 +52,85 @@ python_register_toolchains(
 load("@python3_10//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
+# Download the Go rules.
+http_archive(
+    name = "io_bazel_rules_go",
+    integrity = "sha256-M6zErg9wUC20uJPJ/B3Xqb+ZjCPn/yxFF3QdQEmpdvg=",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
+    ],
+)
+
+# Download Gazelle.
+http_archive(
+    name = "bazel_gazelle",
+    integrity = "sha256-12v3pg/YsFBEQJDfooN6Tq+YKeEWVhjuNdzspcvfWNU=",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+# Load macros and repository rules.
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+# Declare Go direct dependencies.
+go_repository(
+    name = "lattigo",
+    importpath = "github.com/tuneinsight/lattigo/v6",
+    sum = "h1:CyO07L4b+Dwi28eXcrQVZNqbfPT99ntzsoSsTX9syzI=",
+    version = "v6.1.0",
+)
+
+# Testing library for lattigo
+go_repository(
+    name = "com_github_stretchr_testify",
+    importpath = "github.com/stretchr/testify",
+    sum = "h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=",
+    version = "v1.10.0",
+)
+
+# Bigfloat for lattigo
+go_repository(
+    name = "com_github_altree_bigfloat",
+    importpath = "github.com/ALTree/bigfloat",
+    sum = "h1:DG4UyTVIujioxwJc8Zj8Nabz1L1wTgQ/xNBSQDfdP3I=",
+    version = "v0.0.0-20220102081255-38c8b72a9924",
+)
+
+# Bigfloat for lattigo
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    importpath = "github.com/davecgh/go-spew",
+    sum = "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=",
+    version = "v1.1.1",
+)
+
+go_repository(
+    name = "in_gopkg_yaml_v3",
+    importpath = "gopkg.in/yaml.v3",
+    sum = "h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=",
+    version = "v3.0.0-20200313102051-9f266ea9e77c",
+)
+
+go_repository(
+    name = "org_golang_x_exp",
+    build_file_generation = "on",
+    importpath = "golang.org/x/exp",
+    sum = "h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=",
+    version = "v0.0.0-20250106191152-7588d65b2ba8",
+)
+
+# Declare indirect dependencies and register toolchains.
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.23.1")
+
+gazelle_dependencies()
+
 ## ortools needs to be loaded earlier so later rules can get access to its
 ## patch files.
 git_repository(

--- a/lib/Target/Lattigo/LattigoTemplates.h
+++ b/lib/Target/Lattigo/LattigoTemplates.h
@@ -12,8 +12,6 @@ constexpr std::string_view kModulePreludeTemplate = R"go(
 package main
 
 import (
-    "fmt"
-
     "github.com/tuneinsight/lattigo/v6/core/rlwe"
     "github.com/tuneinsight/lattigo/v6/schemes/bgv"
 )

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -1,0 +1,20 @@
+# See README.md for setup required to run these tests
+
+load("@heir//tests/Examples/lattigo:test.bzl", "lattigo_end_to_end_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+lattigo_end_to_end_test(
+    name = "binops_test",
+    heir_opt_flags = [
+        "--secretize",
+        "--mlir-to-secret-arithmetic",
+        "--secret-insert-mgmt-bgv",
+        "--secret-distribute-generic",
+        "--secret-to-bgv=poly-mod-degree=4",
+        "--bgv-to-lattigo",
+        "--cse",
+    ],
+    mlir_src = "binops.mlir",
+    test_src = "binops_test.go",
+)

--- a/tests/Examples/lattigo/README.md
+++ b/tests/Examples/lattigo/README.md
@@ -1,0 +1,8 @@
+# End to end lattigo codegen tests
+
+These tests exercise Lattigo codegen for the
+[Lattigo](https://github.com/tuneinsight/lattigo) backend library, including
+compiling the generated golang source and running the resulting binary.
+
+Lattigo is added as a bazel project-level dependency (unlike the `tfhe-rs`
+end-to-end tests) and built from source.

--- a/tests/Examples/lattigo/binops.mlir
+++ b/tests/Examples/lattigo/binops.mlir
@@ -1,0 +1,9 @@
+// From https://github.com/google/heir/pull/1182
+
+func.func @add(%arg0: tensor<4xi16>, %arg1: tensor<4xi16>) -> tensor<4xi16> {
+  %0 = arith.addi %arg0, %arg1 : tensor<4xi16>
+  %1 = arith.muli %0, %arg1 : tensor<4xi16>
+  %c1 = arith.constant 1 : index
+  %2 = tensor_ext.rotate %1, %c1 : tensor<4xi16>, index
+  return %2 : tensor<4xi16>
+}

--- a/tests/Examples/lattigo/binops_test.go
+++ b/tests/Examples/lattigo/binops_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tuneinsight/lattigo/v6/core/rlwe"
+	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
+)
+
+func TestBinops(t *testing.T) {
+	var err error
+	var params bgv.Parameters
+
+	// 128-bit secure parameters enabling depth-7 circuits.
+	// LogN:14, LogQP: 431.
+	if params, err = bgv.NewParametersFromLiteral(
+		bgv.ParametersLiteral{
+			LogN:             14,                                    // log2(ring degree)
+			LogQ:             []int{55, 45, 45, 45, 45, 45, 45, 45}, // log2(primes Q) (ciphertext modulus)
+			LogP:             []int{61},                             // log2(primes P) (auxiliary modulus)
+			PlaintextModulus: 0x10001,                               // log2(scale)
+		}); err != nil {
+		panic(err)
+	}
+
+	kgen := rlwe.NewKeyGenerator(params)
+	sk := kgen.GenSecretKeyNew()
+	ecd := bgv.NewEncoder(params)
+	enc := rlwe.NewEncryptor(params, sk)
+	dec := rlwe.NewDecryptor(params, sk)
+	relin_keys := kgen.GenRelinearizationKeyNew(sk)
+	galKey := kgen.GenGaloisKeyNew(5, sk)
+	evalKeys := rlwe.NewMemEvaluationKeySet(relin_keys, galKey)
+	evaluator := bgv.NewEvaluator(params, evalKeys /*scaleInvariant=*/, false)
+
+	T := params.MaxSlots()
+	// Vector of plaintext values
+	// 0, 1, 2, 3
+	arg0 := make([]uint64, T)
+	// 1, 2, 3, 4
+	arg1 := make([]uint64, T)
+
+	expected := make([]uint64, T)
+	result := make([]uint64, T)
+
+	// Hack until we have packing system: replicate values cycling every 4
+	data_size := 4
+	for i := range arg0 {
+		arg0[i] = uint64(i % data_size)
+		arg1[i] = (uint64(i%data_size) + 1)
+		expected[i] = (arg0[i] + arg1[i]) * arg1[i]
+	}
+
+	// Rotate by 1
+	tmp := expected[0]
+	for i := range T - 1 {
+		expected[i] = expected[i+1]
+	}
+	expected[T-1] = tmp
+
+	// Allocates a plaintext at the max level.
+	// Default rlwe.MetaData:
+	// - IsBatched = true (slots encoding)
+	// - Scale = params.DefaultScale()
+	pt0 := bgv.NewPlaintext(params, params.MaxLevel())
+	pt1 := bgv.NewPlaintext(params, params.MaxLevel())
+
+	// Encodes the vector of plaintext values
+	if err = ecd.Encode(arg0, pt0); err != nil {
+		panic(err)
+	}
+	if err = ecd.Encode(arg1, pt1); err != nil {
+		panic(err)
+	}
+
+	// Encrypts the vector of plaintext values
+	var ct0 *rlwe.Ciphertext
+	var ct1 *rlwe.Ciphertext
+	if ct0, err = enc.EncryptNew(pt0); err != nil {
+		panic(err)
+	}
+	if ct1, err = enc.EncryptNew(pt1); err != nil {
+		panic(err)
+	}
+
+	result_ct := add(evaluator, ct0, ct1)
+	result_encoded := dec.DecryptNew(result_ct)
+	err = ecd.Decode(result_encoded, result)
+	if err != nil {
+		panic(err)
+	}
+
+	for i := range 4 {
+		if result[i] != expected[i] {
+			t.Errorf("Decryption error at index %d: %d != %d", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/test.bzl
+++ b/tests/Examples/lattigo/test.bzl
@@ -1,0 +1,67 @@
+"""A macro providing an end-to-end test for Lattigo codegen."""
+
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+def lattigo_end_to_end_test(name, mlir_src, test_src, heir_opt_flags = [], heir_translate_flags = [], data = [], tags = [], deps = [], **kwargs):
+    """A rule for running generating Lattigo and running a test on it.
+
+    Args:
+      name: The name of the go_test target and the generated .go file basename.
+      mlir_src: The source mlir file to run through heir-translate
+      test_src: The Go test harness source file.
+      heir_opt_flags: Flags to pass to heir-opt before heir-translate
+      heir_translate_flags: Flags to pass to heir-translate
+      data: Data dependencies to be passed to go_test
+      tags: Tags to pass to go_test
+      deps: Deps to pass to go_test and go_library
+      **kwargs: Keyword arguments to pass to go_library and go_test.
+    """
+    go_codegen_target = name + ".heir_translate_go"
+    go_lib_target_name = "%s_go_lib" % name
+    generated_go_filename = "%s_lib.inc.go" % name
+    heir_opt_name = "%s_heir_opt" % name
+    generated_heir_opt_name = "%s_heir_opt.mlir" % name
+    heir_translate_flags = heir_translate_flags + ["--emit-lattigo"]
+
+    if heir_opt_flags:
+        heir_opt(
+            name = heir_opt_name,
+            src = mlir_src,
+            pass_flags = heir_opt_flags,
+            generated_filename = generated_heir_opt_name,
+        )
+    else:
+        generated_heir_opt_name = mlir_src
+
+    heir_translate(
+        name = go_codegen_target,
+        src = generated_heir_opt_name,
+        pass_flags = heir_translate_flags,
+        generated_filename = generated_go_filename,
+    )
+    go_library(
+        name = go_lib_target_name,
+        srcs = [":" + generated_go_filename],
+        deps = deps + [
+            "@lattigo//:lattigo",
+            "@lattigo//core/rlwe",
+            "@lattigo//schemes/bgv",
+        ],
+        tags = tags,
+        **kwargs
+    )
+    go_test(
+        name = name,
+        srcs = [test_src, generated_go_filename],
+        deps = deps + [
+            ":" + go_lib_target_name,
+            "@lattigo//:lattigo",
+            "@lattigo//core/rlwe",
+            "@lattigo//schemes/bgv",
+        ],
+        tags = tags,
+        data = data,
+        **kwargs
+    )


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/323

This PR adds rules_go, lattigo, and lattigo's dependencies to the workspace, and sets up an analogous e2e testing framework as to OpenFHE. Also adds a simple test (albeit with some complicated setup) that runs heir-opt + heir-translate on @ZenithalHourlyRate's example lattigo test from https://github.com/google/heir/pull/1182