### PR TITLE
Explicit target / file for add_heir_dialect_library

### DIFF
--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -1,6 +1,7 @@
 # BGV dialect
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -40,55 +41,22 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "BGVDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "BGVDialect.cpp.inc",
-        ),
-        (
-            [
-                "-gen-dialect-doc",
-            ],
-            "BGVDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "BGV",
+    kind = "dialect",
     td_file = "BGVDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "BGVOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "BGVOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "BGVOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "BGV",
+    kind = "op",
     td_file = "BGVOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
         "@heir//lib/Dialect/LWE/IR:td_files",
         "@heir//lib/Dialect/Polynomial/IR:td_files",

--- a/lib/Dialect/CGGI/IR/BUILD
+++ b/lib/Dialect/CGGI/IR/BUILD
@@ -1,4 +1,5 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -50,100 +51,45 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "CGGIDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "CGGIDialect.cpp.inc",
-        ),
-        (
-            ["-gen-dialect-doc"],
-            "CGGIDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "CGGI",
+    kind = "dialect",
     td_file = "CGGIDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
-    name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "CGGIOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "CGGIOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "CGGIOps.md",
-        ),
+add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "CGGI",
+    kind = "attribute",
+    td_file = "CGGIAttributes.td",
+    deps = [
+        ":td_files",
     ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+)
+
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "CGGI",
+    kind = "enum",
+    td_file = "CGGIEnums.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "CGGI",
+    kind = "op",
     td_file = "CGGIOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
         "@heir//lib/Dialect:td_files",
         "@heir//lib/Dialect/LWE/IR:td_files",
         "@heir//lib/Dialect/Polynomial/IR:td_files",
-    ],
-)
-
-gentbl_cc_library(
-    name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-attrdef-decls"],
-            "CGGIAttributes.h.inc",
-        ),
-        (
-            ["-gen-attrdef-defs"],
-            "CGGIAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "CGGIAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "CGGIAttributes.td",
-    deps = [
-        ":dialect_inc_gen",
-        ":enums_inc_gen",
-        ":td_files",
-    ],
-)
-
-gentbl_cc_library(
-    name = "enums_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-enum-decls"],
-            "CGGIEnums.h.inc",
-        ),
-        (
-            ["--gen-enum-defs"],
-            "CGGIEnums.cpp.inc",
-        ),
-        (
-            ["-gen-enum-doc"],
-            "CGGIEnums.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "CGGIEnums.td",
-    deps = [
-        ":td_files",
     ],
 )

--- a/lib/Dialect/CKKS/IR/BUILD
+++ b/lib/Dialect/CKKS/IR/BUILD
@@ -1,6 +1,7 @@
 # CKKS dialect
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -40,55 +41,22 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "CKKSDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "CKKSDialect.cpp.inc",
-        ),
-        (
-            [
-                "-gen-dialect-doc",
-            ],
-            "CKKSDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "CKKS",
+    kind = "dialect",
     td_file = "CKKSDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "CKKSOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "CKKSOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "CKKSOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "CKKS",
+    kind = "op",
     td_file = "CKKSOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
         "@heir//lib/Dialect/LWE/IR:td_files",
         "@heir//lib/Dialect/Polynomial/IR:td_files",

--- a/lib/Dialect/Jaxite/IR/BUILD
+++ b/lib/Dialect/Jaxite/IR/BUILD
@@ -1,6 +1,7 @@
 # Jaxite, an exit dialect to Jaxite API
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -40,90 +41,33 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "JaxiteDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "JaxiteDialect.cpp.inc",
-        ),
-        (
-            [
-                "-gen-dialect-doc",
-            ],
-            "JaxiteDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Jaxite",
+    kind = "dialect",
     td_file = "JaxiteDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "-typedefs-dialect=jaxite",
-            ],
-            "JaxiteTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "-typedefs-dialect=jaxite",
-            ],
-            "JaxiteTypes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-typedef-doc",
-                "-typedefs-dialect=jaxite",
-            ],
-            "JaxiteTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Jaxite",
+    kind = "type",
     td_file = "JaxiteTypes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "JaxiteOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "JaxiteOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "JaxiteOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Jaxite",
+    kind = "op",
     td_file = "JaxiteOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        ":types_inc_gen",
         "@heir//lib/Dialect/LWE/IR:td_files",
     ],
 )

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -72,36 +72,52 @@ td_library(
 )
 
 add_heir_dialect_library(
+    name = "dialect_inc_gen",
     dialect = "LWE",
     kind = "dialect",
-)
-
-add_heir_dialect_library(
-    dialect = "LWE",
-    kind = "attribute",
-)
-
-add_heir_dialect_library(
-    dialect = "LWE",
-    kind = "enum",
-    td_file = "LWEAttributes.td",
-)
-
-add_heir_dialect_library(
-    dialect = "LWE",
-    kind = "type",
+    td_file = "LWEDialect.td",
     deps = [
-        ":attributes_inc_gen",
-        ":enums_inc_gen",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
+        ":td_files",
     ],
 )
 
 add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "LWE",
+    kind = "attribute",
+    td_file = "LWEAttributes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "LWE",
+    kind = "enum",
+    td_file = "LWEAttributes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "types_inc_gen",
+    dialect = "LWE",
+    kind = "type",
+    td_file = "LWETypes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
     dialect = "LWE",
     kind = "op",
+    td_file = "LWEOps.td",
     deps = [
-        ":types_inc_gen",
+        ":td_files",
         "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )

--- a/lib/Dialect/Lattigo/IR/BUILD
+++ b/lib/Dialect/Lattigo/IR/BUILD
@@ -1,6 +1,7 @@
 # Lattigo dialect implementation
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -108,107 +109,42 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "LattigoDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "LattigoDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Lattigo",
+    kind = "dialect",
     td_file = "LattigoDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-            ],
-            "LattigoAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-            ],
-            "LattigoAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "LattigoAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Lattigo",
+    kind = "attribute",
     td_file = "LattigoAttributes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-            ],
-            "LattigoTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-            ],
-            "LattigoTypes.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "LattigoTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Lattigo",
+    kind = "type",
     td_file = "LattigoTypes.td",
     deps = [
-        ":attributes_inc_gen",
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "LattigoOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "LattigoOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "LattigoOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Lattigo",
+    kind = "op",
     td_file = "LattigoOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        ":types_inc_gen",
     ],
 )

--- a/lib/Dialect/Lattigo/IR/LattigoDialect.td
+++ b/lib/Dialect/Lattigo/IR/LattigoDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_LATTIGO_IR_LATTIGODIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def Lattigo_Dialect : Dialect {
   let name = "lattigo";

--- a/lib/Dialect/Mgmt/IR/BUILD
+++ b/lib/Dialect/Mgmt/IR/BUILD
@@ -1,6 +1,7 @@
 # Mgmt dialect implementation
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -62,79 +63,32 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "MgmtDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "MgmtDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Mgmt",
+    kind = "dialect",
     td_file = "MgmtDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-                "-attrdefs-dialect=mgmt",
-            ],
-            "MgmtAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-                "-attrdefs-dialect=mgmt",
-            ],
-            "MgmtAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "MgmtAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Mgmt",
+    kind = "attribute",
     td_file = "MgmtAttributes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "MgmtOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "MgmtOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "MgmtOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Mgmt",
+    kind = "op",
     td_file = "MgmtOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )

--- a/lib/Dialect/Mgmt/IR/MgmtDialect.td
+++ b/lib/Dialect/Mgmt/IR/MgmtDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_MGMT_IR_MGMTDIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def Mgmt_Dialect : Dialect {
   let name = "mgmt";

--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -1,6 +1,7 @@
 # ModArith dialect
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -50,104 +51,42 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "ModArithDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "ModArithDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "ModArith",
+    kind = "dialect",
     td_file = "ModArithDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-                "-attrdefs-dialect=mod_arith",
-            ],
-            "ModArithAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-                "-attrdefs-dialect=mod_arith",
-            ],
-            "ModArithAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "ModArithAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "ModArith",
+    kind = "attribute",
     td_file = "ModArithAttributes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-typedef-decls"],
-            "ModArithTypes.h.inc",
-        ),
-        (
-            ["-gen-typedef-defs"],
-            "ModArithTypes.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "ModArithTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "ModArith",
+    kind = "type",
     td_file = "ModArithTypes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "ModArithOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "ModArithOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "ModArithOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "ModArith",
+    kind = "op",
     td_file = "ModArithOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )

--- a/lib/Dialect/ModArith/IR/ModArithDialect.td
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_MODARITH_IR_MODARITHDIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def ModArith_Dialect : Dialect {
   let name = "mod_arith";

--- a/lib/Dialect/Openfhe/IR/BUILD
+++ b/lib/Dialect/Openfhe/IR/BUILD
@@ -45,20 +45,32 @@ td_library(
 )
 
 add_heir_dialect_library(
+    name = "dialect_inc_gen",
     dialect = "Openfhe",
     kind = "dialect",
+    td_file = "OpenfheDialect.td",
+    deps = [
+        ":td_files",
+    ],
 )
 
 add_heir_dialect_library(
+    name = "types_inc_gen",
     dialect = "Openfhe",
     kind = "type",
+    td_file = "OpenfheTypes.td",
+    deps = [
+        ":td_files",
+    ],
 )
 
 add_heir_dialect_library(
+    name = "ops_inc_gen",
     dialect = "Openfhe",
     kind = "op",
+    td_file = "OpenfheOps.td",
     deps = [
-        ":types_inc_gen",
+        ":td_files",
         "@heir//lib/Dialect/LWE/IR:td_files",
     ],
 )

--- a/lib/Dialect/Polynomial/IR/BUILD
+++ b/lib/Dialect/Polynomial/IR/BUILD
@@ -1,3 +1,4 @@
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(
@@ -43,115 +44,43 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "PolynomialDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "PolynomialDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Polynomial",
+    kind = "dialect",
     td_file = "PolynomialDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-                "-attrdefs-dialect=polynomial",
-            ],
-            "PolynomialAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-                "-attrdefs-dialect=polynomial",
-            ],
-            "PolynomialAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "PolynomialAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Polynomial",
+    kind = "attribute",
     td_file = "PolynomialAttributes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "-typedefs-dialect=polynomial",
-            ],
-            "PolynomialTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "-typedefs-dialect=polynomial",
-            ],
-            "PolynomialTypes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-typedef-doc",
-                "-typedefs-dialect=polynomial",
-            ],
-            "PolynomialTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Polynomial",
+    kind = "type",
     td_file = "PolynomialTypes.td",
     deps = [
-        ":attributes_inc_gen",
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "PolynomialOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "PolynomialOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "PolynomialOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Polynomial",
+    kind = "op",
     td_file = "PolynomialOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        ":types_inc_gen",
         "@heir//lib/Dialect/ModArith/IR:td_files",
     ],
 )

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -1,6 +1,7 @@
 # RNS dialect implementation
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -90,101 +91,40 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "RNSDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "RNSDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "RNS",
+    kind = "dialect",
     td_file = "RNSDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-            ],
-            "RNSTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-            ],
-            "RNSTypes.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "RNSTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "RNS",
+    kind = "type",
     td_file = "RNSTypes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "RNSOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "RNSOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "RNSOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "RNS",
+    kind = "op",
     td_file = "RNSOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        ":types_inc_gen",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "type_interfaces_inc_gen",
-    tbl_outs = [
-        (
-            ["--gen-type-interface-decls"],
-            "RNSTypeInterfaces.h.inc",
-        ),
-        (
-            ["--gen-type-interface-defs"],
-            "RNSTypeInterfaces.cpp.inc",
-        ),
-        (
-            ["-gen-type-interface-docs"],
-            "RNSTypeInterfaces.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "RNS",
+    kind = "type_interface",
     td_file = "RNSTypeInterfaces.td",
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",

--- a/lib/Dialect/RNS/IR/RNSDialect.td
+++ b/lib/Dialect/RNS/IR/RNSDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_RNS_IR_RNSDIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def RNS_Dialect : Dialect {
   let name = "rns";

--- a/lib/Dialect/Random/IR/BUILD
+++ b/lib/Dialect/Random/IR/BUILD
@@ -1,6 +1,7 @@
 # Random dialect
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -49,100 +50,42 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "enums_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-enum-decls"],
-            "RandomEnums.h.inc",
-        ),
-        (
-            ["--gen-enum-defs"],
-            "RandomEnums.cpp.inc",
-        ),
-        (
-            ["-gen-enum-doc"],
-            "RandomEnums.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "RandomEnums.td",
-    deps = [
-        ":td_files",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
-    ],
-)
-
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "RandomDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "RandomDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Random",
+    kind = "dialect",
     td_file = "RandomDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
-    name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "RandomOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "RandomOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "RandomOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "RandomOps.td",
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "Random",
+    kind = "enum",
+    td_file = "RandomEnums.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-typedef-decls"],
-            "RandomTypes.h.inc",
-        ),
-        (
-            ["--gen-typedef-defs"],
-            "RandomTypes.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "RandomTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Random",
+    kind = "type",
     td_file = "RandomTypes.td",
     deps = [
-        ":dialect_inc_gen",
-        ":enums_inc_gen",
         ":td_files",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "Random",
+    kind = "op",
+    td_file = "RandomOps.td",
+    deps = [
+        ":td_files",
     ],
 )

--- a/lib/Dialect/Random/IR/RandomDialect.td
+++ b/lib/Dialect/Random/IR/RandomDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_RANDOM_IR_RANDOMDIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def Random_Dialect : Dialect {
   let name = "random";

--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -1,4 +1,5 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -97,74 +98,32 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "SecretDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "SecretDialect.cpp.inc",
-        ),
-        (
-            ["-gen-dialect-doc"],
-            "SecretDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Secret",
+    kind = "dialect",
     td_file = "SecretDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-typedef-decls"],
-            "SecretTypes.h.inc",
-        ),
-        (
-            ["-gen-typedef-defs"],
-            "SecretTypes.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "SecretTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Secret",
+    kind = "type",
     td_file = "SecretTypes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "SecretOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "SecretOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "SecretOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "Secret",
+    kind = "op",
     td_file = "SecretOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        ":types_inc_gen",
     ],
 )

--- a/lib/Dialect/TensorExt/IR/BUILD
+++ b/lib/Dialect/TensorExt/IR/BUILD
@@ -1,5 +1,6 @@
 # TensorExt dialect implementation
 
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(
@@ -72,76 +73,33 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "TensorExtDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "TensorExtDialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TensorExt",
+    kind = "dialect",
     td_file = "TensorExtDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-attrdef-decls"],
-            "TensorExtAttributes.h.inc",
-        ),
-        (
-            ["-gen-attrdef-defs"],
-            "TensorExtAttributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "TensorExtAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TensorExt",
+    kind = "attribute",
     td_file = "TensorExtAttributes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "TensorExtOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "TensorExtOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "TensorExtOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TensorExt",
+    kind = "op",
     td_file = "TensorExtOps.td",
     deps = [
-        ":attributes_inc_gen",
-        ":dialect_inc_gen",
         ":td_files",
-        "@heir//lib/Dialect/Polynomial/IR:td_files",
     ],
 )
 

--- a/lib/Dialect/TensorExt/IR/TensorExtDialect.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtDialect.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_TENSOREXT_IR_TENSOREXTDIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def TensorExt_Dialect : Dialect {
   let name = "tensor_ext";

--- a/lib/Dialect/TfheRust/IR/BUILD
+++ b/lib/Dialect/TfheRust/IR/BUILD
@@ -1,4 +1,5 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -60,89 +61,32 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "TfheRustDialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "TfheRustDialect.cpp.inc",
-        ),
-        (
-            [
-                "-gen-dialect-doc",
-            ],
-            "TfheRustDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TfheRust",
+    kind = "dialect",
     td_file = "TfheRustDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "-typedefs-dialect=tfhe_rust",
-            ],
-            "TfheRustTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "-typedefs-dialect=tfhe_rust",
-            ],
-            "TfheRustTypes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-typedef-doc",
-                "-typedefs-dialect=tfhe_rust",
-            ],
-            "TfheRustTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TfheRust",
+    kind = "type",
     td_file = "TfheRustTypes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "TfheRustOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "TfheRustOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "TfheRustOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TfheRust",
+    kind = "op",
     td_file = "TfheRustOps.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        ":types_inc_gen",
     ],
 )

--- a/lib/Dialect/TfheRustBool/IR/BUILD
+++ b/lib/Dialect/TfheRustBool/IR/BUILD
@@ -1,4 +1,5 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -48,143 +49,54 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-dialect-decls"],
-            "TfheRustBoolDialect.h.inc",
-        ),
-        (
-            ["-gen-dialect-defs"],
-            "TfheRustBoolDialect.cpp.inc",
-        ),
-        (
-            ["-gen-dialect-doc"],
-            "TfheRustBoolDialect.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TfheRustBool",
+    kind = "dialect",
     td_file = "TfheRustBoolDialect.td",
     deps = [
         ":td_files",
     ],
 )
 
-gentbl_cc_library(
-    name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-                "-typedefs-dialect=tfhe_rust_bool",
-            ],
-            "TfheRustBoolTypes.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-                "-typedefs-dialect=tfhe_rust_bool",
-            ],
-            "TfheRustBoolTypes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-typedef-doc",
-                "-typedefs-dialect=tfhe_rust_bool",
-            ],
-            "TfheRustBoolTypes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "TfheRustBoolTypes.td",
-    deps = [
-        ":dialect_inc_gen",
-        ":td_files",
-    ],
-)
-
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-                "-typedefs-dialect=tfhe_rust_bool",
-            ],
-            "TfheRustBoolAttributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-                "-typedefs-dialect=tfhe_rust_bool",
-            ],
-            "TfheRustBoolAttributes.cpp.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-doc",
-                "-typedefs-dialect=tfhe_rust_bool",
-            ],
-            "TfheRustBoolAttributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TfheRustBool",
+    kind = "attribute",
     td_file = "TfheRustBoolAttributes.td",
     deps = [
-        ":dialect_inc_gen",
-        ":enums_inc_gen",
         ":td_files",
         "@heir//lib/Dialect/CGGI/IR:td_files",
     ],
 )
 
-gentbl_cc_library(
-    name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "TfheRustBoolOps.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "TfheRustBoolOps.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "TfheRustBoolOps.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "TfheRustBoolOps.td",
-    deps = [
-        ":attributes_inc_gen",
-        ":dialect_inc_gen",
-        ":td_files",
-        ":types_inc_gen",
-    ],
-)
-
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "enums_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-enum-decls"],
-            "TfheRustBoolEnums.h.inc",
-        ),
-        (
-            ["--gen-enum-defs"],
-            "TfheRustBoolEnums.cpp.inc",
-        ),
-        (
-            ["-gen-enum-doc"],
-            "TfheRustBoolEnums.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "TfheRustBool",
+    kind = "enum",
     td_file = "TfheRustBoolEnums.td",
     deps = [
         ":td_files",
         "@heir//lib/Dialect/CGGI/IR:td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "types_inc_gen",
+    dialect = "TfheRustBool",
+    kind = "type",
+    td_file = "TfheRustBoolTypes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "TfheRustBool",
+    kind = "op",
+    td_file = "TfheRustBoolOps.td",
+    deps = [
+        ":td_files",
     ],
 )

--- a/lib/Dialect/dialect.bzl
+++ b/lib/Dialect/dialect.bzl
@@ -18,11 +18,12 @@ def add_heir_dialect_library(
         td_file: The .td file to use for tablegen.
         deps: The dependencies of the generated target.
     """
+    if name == None:
+        fail("name must be provided to add_heir_dialect_library.")
     if dialect == None:
         fail("dialect must be provided to add_heir_dialect_library.")
-
-    _target_name_prefix = None
-    _target_name_suffix = "_inc_gen"
+    if td_file == None:
+        fail("td_file must be provided to add_heir_dialect_library.")
 
     _tblgen_command_prefix = "-gen-"
     _tblgen_command_infix = None
@@ -33,37 +34,27 @@ def add_heir_dialect_library(
     _file_name_prefix = dialect
     _file_name_infix = None
 
-    _dep_includes_dialect = True
-
     if kind == "dialect":
-        _target_name_prefix = "dialect"
         _tblgen_command_infix = "dialect"
         _file_name_infix = "Dialect"
-        _dep_includes_dialect = False
     elif kind == "attribute":
-        _target_name_prefix = "attributes"
         _tblgen_command_infix = "attrdef"
         _file_name_infix = "Attributes"
     elif kind == "enum":
-        _target_name_prefix = "enums"
         _tblgen_command_infix = "enum"
         _file_name_infix = "Enums"
     elif kind == "type":
-        _target_name_prefix = "types"
         _tblgen_command_infix = "typedef"
         _file_name_infix = "Types"
     elif kind == "op":
-        _target_name_prefix = "ops"
         _tblgen_command_infix = "op"
         _file_name_infix = "Ops"
+    elif kind == "type_interface":
+        _tblgen_command_infix = "type-interface"
+        _tblgen_command_suffix_doc = "-docs"
+        _file_name_infix = "TypeInterfaces"
     else:
         fail("kind must be provided to add_heir_dialect_library.")
-
-    _td_file = td_file
-    if _td_file == None:
-        _td_file = _file_name_prefix + _file_name_infix + ".td"
-
-    _target_name = _target_name_prefix + _target_name_suffix
 
     _header_inc_file = _file_name_prefix + _file_name_infix + ".h.inc"
     _cpp_inc_file = _file_name_prefix + _file_name_infix + ".cpp.inc"
@@ -73,18 +64,8 @@ def add_heir_dialect_library(
     _tblgen_command_defs = [_tblgen_command_prefix + _tblgen_command_infix + _tblgen_command_suffix_defs]
     _tblgen_command_doc = [_tblgen_command_prefix + _tblgen_command_infix + _tblgen_command_suffix_doc]
 
-    _deps = [":td_files"]
-    if _dep_includes_dialect:
-        _deps.append(":dialect_inc_gen")
-    _deps = _deps + deps
-
-    # Allow override by user, part of standard bazel conventions and to help it
-    # work properly with internal tooling.
-    if name:
-        _target_name = name
-
     gentbl_cc_library(
-        name = _target_name,
+        name = name,
         tbl_outs = [
             (
                 _tblgen_command_decls,
@@ -100,6 +81,6 @@ def add_heir_dialect_library(
             ),
         ],
         tblgen = "@llvm-project//mlir:mlir-tblgen",
-        td_file = _td_file,
-        deps = _deps,
+        td_file = td_file,
+        deps = deps,
     )

--- a/scripts/templates/Dialect/lib/BUILD.jinja
+++ b/scripts/templates/Dialect/lib/BUILD.jinja
@@ -1,6 +1,7 @@
 # {{ dialect_name }} dialect implementation
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -146,23 +147,11 @@ td_library(
     ],
 )
 
-gentbl_cc_library(
+
+add_heir_dialect_library(
     name = "dialect_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-dialect-decls",
-            ],
-            "{{ dialect_name }}Dialect.h.inc",
-        ),
-        (
-            [
-                "-gen-dialect-defs",
-            ],
-            "{{ dialect_name }}Dialect.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "{{ dialect_name }}",
+    kind = "dialect",
     td_file = "{{ dialect_name }}Dialect.td",
     deps = [
         ":td_files",
@@ -170,93 +159,37 @@ gentbl_cc_library(
 )
 
 {% if enable_attributes %}
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "attributes_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-attrdef-decls",
-            ],
-            "{{ dialect_name }}Attributes.h.inc",
-        ),
-        (
-            [
-                "-gen-attrdef-defs",
-            ],
-            "{{ dialect_name }}Attributes.cpp.inc",
-        ),
-        (
-            ["-gen-attrdef-doc"],
-            "{{ dialect_name }}Attributes.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "{{ dialect_name }}",
+    kind = "attribute",
     td_file = "{{ dialect_name }}Attributes.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 {% endif %}
 
 {% if enable_types %}
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "types_inc_gen",
-    tbl_outs = [
-        (
-            [
-                "-gen-typedef-decls",
-            ],
-            "{{ dialect_name }}Types.h.inc",
-        ),
-        (
-            [
-                "-gen-typedef-defs",
-            ],
-            "{{ dialect_name }}Types.cpp.inc",
-        ),
-        (
-            ["-gen-typedef-doc"],
-            "{{ dialect_name }}Types.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "{{ dialect_name }}",
+    kind = "type",
     td_file = "{{ dialect_name }}Types.td",
     deps = [
-        {% if enable_attributes %}
-        ":attributes_inc_gen",
-        {% endif %}
-        ":dialect_inc_gen",
         ":td_files",
     ],
 )
 {% endif %}
 
 {% if enable_ops %}
-gentbl_cc_library(
+add_heir_dialect_library(
     name = "ops_inc_gen",
-    tbl_outs = [
-        (
-            ["-gen-op-decls"],
-            "{{ dialect_name }}Ops.h.inc",
-        ),
-        (
-            ["-gen-op-defs"],
-            "{{ dialect_name }}Ops.cpp.inc",
-        ),
-        (
-            ["-gen-op-doc"],
-            "{{ dialect_name }}Ops.md",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    dialect = "{{ dialect_name }}",
+    kind = "op",
     td_file = "{{ dialect_name }}Ops.td",
     deps = [
-        ":dialect_inc_gen",
         ":td_files",
-        {% if enable_types %}
-        ":types_inc_gen",
-        {% endif %}
     ],
 )
 {% endif %}

--- a/scripts/templates/Dialect/lib/Dialect.td.jinja
+++ b/scripts/templates/Dialect/lib/Dialect.td.jinja
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_{{ dialect_name | upper }}_IR_{{ dialect_name | upper }}DIALECT_TD_
 
 include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
 
 def {{ dialect_name }}_Dialect : Dialect {
   let name = "{{ dialect_namespace }}";


### PR DESCRIPTION
Fixes #1242.

Also migrated almost all `IR/BUILD` in `lib/Dialect` except `Comb` and those canonicalization td for TensorExt/Polynomial.