### PR TITLE
cggi-to-tfhe-rs conversion pass: Adding arith support

### DIFF
--- a/lib/Dialect/Arith/Transforms/BUILD
+++ b/lib/Dialect/Arith/Transforms/BUILD
@@ -11,6 +11,8 @@ cc_library(
     deps = [
         ":QuarterWideInt",
         ":pass_inc_gen",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
     ],
 )
 
@@ -21,16 +23,13 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Utils:ConversionUtils",
-        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FuncTransforms",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:TensorDialect",
-        "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
-        "@llvm-project//mlir:VectorDialect",
     ],
 )
 

--- a/lib/Dialect/CGGI/Conversions/CGGIToTfheRust/CGGIToTfheRust.cpp
+++ b/lib/Dialect/CGGI/Conversions/CGGIToTfheRust/CGGIToTfheRust.cpp
@@ -12,10 +12,11 @@
 #include "lib/Dialect/TfheRust/IR/TfheRustTypes.h"
 #include "lib/Utils/ConversionUtils.h"
 #include "lib/Utils/Utils.h"
-#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
-#include "llvm/include/llvm/Support/Casting.h"           // from @llvm-project
-#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
-#include "llvm/include/llvm/Support/ErrorHandling.h"     // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/Casting.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/ErrorHandling.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
@@ -254,6 +255,25 @@ LogicalResult replaceBinaryGate(Operation *op, Value lhs, Value rhs,
   return success();
 }
 
+template <typename BinOp, typename TfheRustBinOp>
+struct ConvertCGGITRBinOp : public OpConversionPattern<BinOp> {
+  using OpConversionPattern<BinOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      BinOp op, typename BinOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op->getLoc(), rewriter);
+    FailureOr<Value> result = getContextualServerKey(op);
+    if (failed(result)) return result;
+
+    Value serverKey = result.value();
+
+    rewriter.replaceOp(op, b.create<TfheRustBinOp>(serverKey, adaptor.getLhs(),
+                                                   adaptor.getRhs()));
+    return success();
+  }
+};
+
 struct ConvertAndOp : public OpConversionPattern<cggi::AndOp> {
   ConvertAndOp(mlir::MLIRContext *context)
       : OpConversionPattern<cggi::AndOp>(context) {}
@@ -293,6 +313,52 @@ struct ConvertXorOp : public OpConversionPattern<cggi::XorOp> {
       ConversionPatternRewriter &rewriter) const override {
     return replaceBinaryGate(op.getOperation(), adaptor.getLhs(),
                              adaptor.getRhs(), rewriter, kXorLut);
+  }
+};
+
+struct ConvertShROp : public OpConversionPattern<cggi::ShiftRightOp> {
+  ConvertShROp(mlir::MLIRContext *context)
+      : OpConversionPattern<cggi::ShiftRightOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      cggi::ShiftRightOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    FailureOr<Value> result = getContextualServerKey(op);
+    if (failed(result)) return result;
+    Value serverKey = result.value();
+
+    auto subOp = b.create<tfhe_rust::ScalarRightShiftOp>(
+        serverKey, adaptor.getLhs(), adaptor.getShiftAmount());
+    rewriter.replaceOp(op, subOp);
+
+    return success();
+  }
+};
+
+struct ConvertCastOp : public OpConversionPattern<cggi::CastOp> {
+  ConvertCastOp(mlir::MLIRContext *context)
+      : OpConversionPattern<cggi::CastOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      cggi::CastOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    FailureOr<Value> result = getContextualServerKey(op);
+    if (failed(result)) return result;
+    Value serverKey = result.value();
+
+    auto outputType = getTypeConverter()->convertType(op.getResult().getType());
+
+    auto subOp =
+        b.create<tfhe_rust::CastOp>(outputType, serverKey, adaptor.getInput());
+    rewriter.replaceOp(op, subOp);
+
+    return success();
   }
 };
 
@@ -436,10 +502,13 @@ class CGGIToTfheRust : public impl::CGGIToTfheRustBase<CGGIToTfheRust> {
              (!containsDialects<lwe::LWEDialect, cggi::CGGIDialect>(op) ||
               hasServerKeyArg);
     });
-    target.addDynamicallyLegalOp<memref::AllocOp, memref::DeallocOp,
-                                 memref::StoreOp, memref::LoadOp,
-                                 memref::SubViewOp, memref::CopyOp,
-                                 tensor::FromElementsOp, tensor::ExtractOp>(
+
+    target.addLegalOp<mlir::arith::ConstantOp>();
+
+    target.addDynamicallyLegalOp<
+        memref::AllocOp, memref::DeallocOp, memref::StoreOp, memref::LoadOp,
+        memref::SubViewOp, memref::CopyOp, affine::AffineLoadOp,
+        affine::AffineStoreOp, tensor::FromElementsOp, tensor::ExtractOp>(
         [&](Operation *op) {
           return typeConverter.isLegal(op->getOperandTypes()) &&
                  typeConverter.isLegal(op->getResultTypes());
@@ -447,14 +516,19 @@ class CGGIToTfheRust : public impl::CGGIToTfheRustBase<CGGIToTfheRust> {
 
     // FIXME: still need to update callers to insert the new server key arg, if
     // needed and possible.
-    patterns
-        .add<AddServerKeyArg, ConvertAndOp, ConvertEncodeOp, ConvertLut2Op,
-             ConvertLut3Op, ConvertNotOp, ConvertOrOp, ConvertTrivialEncryptOp,
-             ConvertXorOp, ConvertAny<memref::AllocOp>,
-             ConvertAny<memref::DeallocOp>, ConvertAny<memref::StoreOp>,
-             ConvertAny<memref::LoadOp>, ConvertAny<memref::SubViewOp>,
-             ConvertAny<memref::CopyOp>, ConvertAny<tensor::FromElementsOp>,
-             ConvertAny<tensor::ExtractOp>>(typeConverter, context);
+    patterns.add<
+        AddServerKeyArg, ConvertEncodeOp, ConvertLut2Op, ConvertLut3Op,
+        ConvertNotOp, ConvertTrivialEncryptOp, ConvertTrivialOp,
+        ConvertCGGITRBinOp<cggi::AddOp, tfhe_rust::AddOp>,
+        ConvertCGGITRBinOp<cggi::MulOp, tfhe_rust::MulOp>,
+        ConvertCGGITRBinOp<cggi::SubOp, tfhe_rust::SubOp>, ConvertAndOp,
+        ConvertOrOp, ConvertXorOp, ConvertCastOp, ConvertShROp,
+        ConvertAny<memref::AllocOp>, ConvertAny<memref::DeallocOp>,
+        ConvertAny<memref::StoreOp>, ConvertAny<memref::LoadOp>,
+        ConvertAny<memref::SubViewOp>, ConvertAny<memref::CopyOp>,
+        ConvertAny<tensor::FromElementsOp>, ConvertAny<tensor::ExtractOp>,
+        ConvertAny<affine::AffineLoadOp>, ConvertAny<affine::AffineStoreOp>>(
+        typeConverter, context);
 
     if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
       return signalPassFailure();

--- a/lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.cpp
+++ b/lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.cpp
@@ -118,7 +118,7 @@ struct AddBoolServerKeyArg : public OpConversionPattern<func::FuncOp> {
 };
 
 template <typename BinOp, typename TfheRustBoolBinOp>
-struct ConvertCGGIBinOp : public OpConversionPattern<BinOp> {
+struct ConvertCGGITRBBinOp : public OpConversionPattern<BinOp> {
   using OpConversionPattern<BinOp>::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
@@ -135,15 +135,6 @@ struct ConvertCGGIBinOp : public OpConversionPattern<BinOp> {
     return success();
   }
 };
-
-using ConvertBoolAndOp = ConvertCGGIBinOp<cggi::AndOp, tfhe_rust_bool::AndOp>;
-using ConvertBoolNandOp =
-    ConvertCGGIBinOp<cggi::NandOp, tfhe_rust_bool::NandOp>;
-using ConvertBoolOrOp = ConvertCGGIBinOp<cggi::OrOp, tfhe_rust_bool::OrOp>;
-using ConvertBoolNorOp = ConvertCGGIBinOp<cggi::NorOp, tfhe_rust_bool::NorOp>;
-using ConvertBoolXorOp = ConvertCGGIBinOp<cggi::XorOp, tfhe_rust_bool::XorOp>;
-using ConvertBoolXNorOp =
-    ConvertCGGIBinOp<cggi::XNorOp, tfhe_rust_bool::XnorOp>;
 
 struct ConvertBoolNotOp : public OpConversionPattern<cggi::NotOp> {
   ConvertBoolNotOp(mlir::MLIRContext *context)
@@ -291,9 +282,14 @@ class CGGIToTfheRustBool
 
     // FIXME: still need to update callers to insert the new server key arg, if
     // needed and possible.
-    patterns.add<AddBoolServerKeyArg, ConvertBoolAndOp, ConvertBoolEncodeOp,
-                 ConvertBoolOrOp, ConvertBoolTrivialEncryptOp, ConvertBoolXorOp,
-                 ConvertBoolNorOp, ConvertBoolXNorOp, ConvertBoolNandOp,
+    patterns.add<AddBoolServerKeyArg,
+                 ConvertCGGITRBBinOp<cggi::AndOp, tfhe_rust_bool::AndOp>,
+                 ConvertCGGITRBBinOp<cggi::NandOp, tfhe_rust_bool::NandOp>,
+                 ConvertCGGITRBBinOp<cggi::OrOp, tfhe_rust_bool::OrOp>,
+                 ConvertCGGITRBBinOp<cggi::NorOp, tfhe_rust_bool::NorOp>,
+                 ConvertCGGITRBBinOp<cggi::XorOp, tfhe_rust_bool::XorOp>,
+                 ConvertCGGITRBBinOp<cggi::XNorOp, tfhe_rust_bool::XnorOp>,
+                 ConvertBoolEncodeOp, ConvertBoolTrivialEncryptOp,
                  ConvertBoolNotOp, ConvertPackedOp, ConvertAny<memref::AllocOp>,
                  ConvertAny<memref::DeallocOp>, ConvertAny<memref::StoreOp>,
                  ConvertAny<memref::LoadOp>, ConvertAny<memref::SubViewOp>,

--- a/lib/Dialect/CGGI/IR/CGGIOps.td
+++ b/lib/Dialect/CGGI/IR/CGGIOps.td
@@ -311,7 +311,7 @@ def CGGI_ShiftLeftOp : CGGI_Op<"shl", [
   let summary = "Arithmetic shift to left of a ciphertext by an integer. Note this operations to mirror the TFHE-rs implmementation.";
 }
 
-// FIXME: Two options:
+// Two options:
 // 1. Allow arith.constant and use an encryption op to bring it to the ciphertext space.
 // 2. Use a trivial op where the constant is embedded in the ciphertext.
 def CGGI_CreateTrivialOp : CGGI_Op<"create_trivial", [Pure]> {

--- a/lib/Dialect/TfheRust/IR/TfheRustOps.td
+++ b/lib/Dialect/TfheRust/IR/TfheRustOps.td
@@ -30,7 +30,7 @@ class TfheRust_BinaryOp<string mnemonic>
   let results = (outs TfheRust_CiphertextType:$output);
 }
 
-def CreateTrivialOp : TfheRust_Op<"create_trivial", [Pure]> {
+def TfheRust_CreateTrivialOp : TfheRust_Op<"create_trivial", [Pure]> {
   let arguments = (ins TfheRust_ServerKey:$serverKey, AnyInteger:$value);
   let results = (outs TfheRust_CiphertextType:$output);
   let hasCanonicalizer = 1;
@@ -42,7 +42,7 @@ def TfheRust_SubOp : TfheRust_BinaryOp<"sub"> { let summary = "Arithmetic sub of
 def TfheRust_MulOp : TfheRust_BinaryOp<"mul"> { let summary = "Arithmetic mul of two tfhe ciphertexts."; }
 
 
-def ScalarLeftShiftOp : TfheRust_Op<"scalar_left_shift", [
+def TfheRust_ScalarLeftShiftOp : TfheRust_Op<"scalar_left_shift", [
     Pure,
     AllTypesMatch<["ciphertext", "output"]>
 ]> {
@@ -54,7 +54,7 @@ def ScalarLeftShiftOp : TfheRust_Op<"scalar_left_shift", [
   let results = (outs TfheRust_CiphertextType:$output);
 }
 
-def ScalarRightShiftOp : TfheRust_Op<"scalar_right_shift", [
+def TfheRust_ScalarRightShiftOp : TfheRust_Op<"scalar_right_shift", [
     Pure,
     AllTypesMatch<["ciphertext", "output"]>
 ]> {
@@ -66,7 +66,7 @@ def ScalarRightShiftOp : TfheRust_Op<"scalar_right_shift", [
   let results = (outs TfheRust_CiphertextType:$output);
 }
 
-def ApplyLookupTableOp : TfheRust_Op<"apply_lookup_table", [
+def TfheRust_ApplyLookupTableOp : TfheRust_Op<"apply_lookup_table", [
     Pure,
     AllTypesMatch<["input", "output"]>
 ]> {
@@ -78,7 +78,7 @@ def ApplyLookupTableOp : TfheRust_Op<"apply_lookup_table", [
   let results = (outs TfheRust_CiphertextType:$output);
 }
 
-def GenerateLookupTableOp : TfheRust_Op<"generate_lookup_table", [Pure]> {
+def TfheRust_GenerateLookupTableOp : TfheRust_Op<"generate_lookup_table", [Pure]> {
   let arguments = (
     ins TfheRust_ServerKey:$serverKey,
     // TODO(#246): Generalize to support integer-valued lookup tables; for now
@@ -89,5 +89,16 @@ def GenerateLookupTableOp : TfheRust_Op<"generate_lookup_table", [Pure]> {
   let results = (outs TfheRust_LookupTable:$lookupTable);
   let hasCanonicalizer = 1;
 }
+
+def TfheRust_CastOp : TfheRust_Op<"cast", [
+    Pure,
+]> {
+  let arguments = (ins
+    TfheRust_ServerKey:$serverKey,
+    TfheRust_CiphertextType:$ciphertext
+  );
+  let results = (outs TfheRust_CiphertextType:$output);
+}
+
 
 #endif  // LIB_DIALECT_TFHERUST_IR_TFHERUSTOPS_TD_

--- a/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/arith.mlir
+++ b/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/arith.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt --cggi-to-tfhe-rust %s | FileCheck %s
+
+#encoding = #lwe.unspecified_bit_field_encoding<cleartext_bitwidth = 32>
+!ct_ty = !lwe.lwe_ciphertext<encoding = #encoding>
+
+// CHECK-LABEL: @test_affine
+// CHECK-SAME: (%[[ARG0:.*]]: !tfhe_rust.server_key, %[[ARG1:.*]]: memref<1x1x!tfhe_rust.eui32>) -> [[T:.*]] {
+func.func @test_affine(%arg0: memref<1x1x!ct_ty>) -> memref<1x1x!ct_ty> {
+  // CHECK: return %[[OUT:.*]] : [[T]]
+  %0 = cggi.create_trivial  {value = 429 : i32} : () -> !ct_ty
+  %1 = cggi.create_trivial  {value = 33 : i32} : () -> !ct_ty
+  %2 = affine.load %arg0[0, 0] : memref<1x1x!ct_ty>
+  %c0 = arith.constant 0 : index
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ct_ty>
+  %3 = cggi.mul %2, %1 : !ct_ty
+  %4 = cggi.add %3, %0 : !ct_ty
+  affine.store %4, %alloc[0, 0] : memref<1x1x!ct_ty>
+  return %alloc : memref<1x1x!ct_ty>
+}


### PR DESCRIPTION
Follow Up of  [#1248](https://github.com/google/heir/pull/1248)
First conversion pass to lower the (TOSA orginated) Arith dialect to CGGI to TFHE-rs