### PR TITLE
BGV: Count Add/Keyswitch in one level for OpenFHE

### DIFF
--- a/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.cpp
+++ b/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.cpp
@@ -1,0 +1,159 @@
+#include "lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h"
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+LogicalResult CountAnalysis::visitOperation(
+    Operation *op, ArrayRef<const CountLattice *> operands,
+    ArrayRef<CountLattice *> results) {
+  auto propagate = [&](Value value, const CountState &state) {
+    auto *lattice = getLatticeElement(value);
+    ChangeResult changed = lattice->join(state);
+    propagateIfChanged(lattice, changed);
+  };
+
+  llvm::TypeSwitch<Operation &>(*op)
+      .Case<secret::GenericOp>([&](auto genericOp) {
+        Block *body = genericOp.getBody();
+        for (auto i = 0; i != body->getNumArguments(); ++i) {
+          auto blockArg = body->getArgument(i);
+          // one Vfresh
+          propagate(blockArg, CountState(1, 0));
+        }
+      })
+      .Case<arith::AddIOp, arith::SubIOp, arith::AddFOp, arith::SubFOp>(
+          [&](auto &op) {
+            // condition on result secretness
+            SmallVector<OpResult> secretResults;
+            getSecretResults(op, secretResults);
+            if (secretResults.empty()) {
+              return;
+            }
+
+            CountState zeroState(0, 0);
+            SmallVector<OpOperand *> secretOperands;
+            getSecretOperands(op, secretOperands);
+            for (auto *operand : secretOperands) {
+              auto countState =
+                  operands[operand->getOperandNumber()]->getValue();
+              zeroState = zeroState + countState;
+            }
+
+            for (auto result : secretResults) {
+              propagate(result, zeroState);
+            }
+          })
+      .Case<arith::MulIOp, arith::MulFOp>([&](auto &op) {
+        SmallVector<OpResult> secretResults;
+        getSecretResults(op, secretResults);
+        if (secretResults.empty()) {
+          return;
+        }
+
+        // now noise is Vmult
+        // TODO(#1168): we can actually do a more fine grained analysis here
+        // distinguishing ct-ct and ct-pt
+        propagate(op.getResult(), CountState(1, 0));
+      })
+      .Case<mgmt::RelinearizeOp, tensor_ext::RotateOp>([&](auto &op) {
+        SmallVector<OpOperand *> secretOperands;
+        getSecretOperands(op, secretOperands);
+        if (secretOperands.empty()) {
+          return;
+        }
+
+        auto state = operands[0]->getValue();
+        if (!state.isInitialized()) {
+          return;
+        }
+
+        propagate(op.getResult(), state.keySwitch());
+      })
+      // TODO(#1174): in BGV tensor::ExtractOp is assumed to be always
+      // mul+const
+      .Case<tensor::ExtractOp>([&](auto &op) {
+        SmallVector<OpResult> secretResults;
+        getSecretResults(op, secretResults);
+        if (secretResults.empty()) {
+          return;
+        }
+
+        // now noise is Vmult + one Vks
+        propagate(op.getResult(), CountState(1, 1));
+      })
+      .Case<mgmt::ModReduceOp>([&](auto modReduceOp) {
+        // implicitly ensure that the operand is secret
+
+        propagate(modReduceOp.getResult(), CountState(0, 0));
+      });
+  // should not propagate through mgmt::ModReduceOp
+  return success();
+}
+
+void annotateCount(Operation *top, DataFlowSolver *solver) {
+  auto getIntegerAttr = [&](int level) {
+    return IntegerAttr::get(IntegerType::get(top->getContext(), 64), level);
+  };
+
+  auto maxAddCount = 0;
+  auto maxKeySwitchCount = 0;
+
+  auto getCount = [&](Value value) {
+    auto state = solver->lookupState<CountLattice>(value)->getValue();
+    // update the max
+    maxAddCount = std::max(maxAddCount, state.getAddCount());
+    maxKeySwitchCount = std::max(maxKeySwitchCount, state.getKeySwitchCount());
+    return std::make_tuple(state.getAddCount(), state.getKeySwitchCount());
+  };
+
+  top->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {
+    for (auto i = 0; i != genericOp.getBody()->getNumArguments(); ++i) {
+      auto blockArg = genericOp.getBody()->getArgument(i);
+      auto [addCount, keySwitchCount] = getCount(blockArg);
+      if (addCount != 0) {
+        genericOp.setArgAttr(i, "addCount", getIntegerAttr(addCount));
+      }
+      if (keySwitchCount != 0) {
+        genericOp.setArgAttr(i, "keySwitchCount",
+                             getIntegerAttr(keySwitchCount));
+      }
+    }
+
+    genericOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (op->getNumResults() == 0) {
+        return;
+      }
+      auto [addCount, keySwitchCount] = getCount(op->getResult(0));
+      if (addCount != 0) {
+        op->setAttr("addCount", getIntegerAttr(addCount));
+      }
+      if (keySwitchCount != 0) {
+        op->setAttr("keySwitchCount", getIntegerAttr(keySwitchCount));
+      }
+    });
+
+    // annotate mgmt::OpenfheParamsAttr to func::FuncOp containing the genericOp
+    auto *funcOp = genericOp->getParentOp();
+    auto openfheParamAttr = mgmt::OpenfheParamsAttr::get(
+        funcOp->getContext(), maxAddCount, maxKeySwitchCount);
+    funcOp->setAttr(mgmt::MgmtDialect::kArgOpenfheParamsAttrName,
+                    openfheParamAttr);
+  });
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h
+++ b/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h
@@ -1,0 +1,123 @@
+#ifndef LIB_ANALYSIS_ADDANDKEYSWITCHCOUNTANALYSISANALYSIS_ADDANDKEYSWITCHCOUNTANALYSISANALYSIS_H_
+#define LIB_ANALYSIS_ADDANDKEYSWITCHCOUNTANALYSISANALYSIS_ADDANDKEYSWITCHCOUNTANALYSISANALYSIS_H_
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"        // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// This analysis should be used after --secret-with-mgmt-bgv
+// but before --secret-distribute-generic
+// where a whole secret::GenericOp is assumed
+//
+// this follows strictly the strategy of modulus switch
+// right before multiplication including the first.
+// namely FLEXIBLEAUTOEXT in OpenFHE
+//
+// OpenFHE only supports setting EvalAddCount/EvalKeySwitchCount
+// for BGV/BFV, so HEIR only supports BGV here
+//
+// For not include-the-first, the addCount for the L-th level
+// might be overestimated, as we can not distinguish between
+// Vmult and Vfresh
+
+class CountState {
+ public:
+  CountState() : initialized(false), addCount(0), keySwitchCount(0) {}
+  explicit CountState(int addCount, int keySwitchCount)
+      : initialized(true), addCount(addCount), keySwitchCount(keySwitchCount) {}
+  ~CountState() = default;
+
+  int getAddCount() const {
+    assert(isInitialized());
+    return addCount;
+  }
+
+  int getKeySwitchCount() const {
+    assert(isInitialized());
+    return keySwitchCount;
+  }
+
+  bool operator==(const CountState &rhs) const {
+    return initialized == rhs.initialized && addCount == rhs.addCount &&
+           keySwitchCount == rhs.keySwitchCount;
+  }
+
+  bool isInitialized() const { return initialized; }
+
+  CountState operator+(const CountState &rhs) const {
+    assert(isInitialized() && rhs.isInitialized());
+    return CountState{addCount + rhs.addCount,
+                      keySwitchCount + rhs.keySwitchCount};
+  }
+
+  CountState keySwitch() const {
+    assert(isInitialized());
+    return CountState{addCount, keySwitchCount + 1};
+  }
+
+  CountState max(const CountState &rhs) const {
+    assert(isInitialized() && rhs.isInitialized());
+    return CountState{std::max(addCount, rhs.addCount),
+                      std::max(keySwitchCount, rhs.keySwitchCount)};
+  }
+
+  static CountState join(const CountState &lhs, const CountState &rhs) {
+    if (!lhs.isInitialized()) return rhs;
+    if (!rhs.isInitialized()) return lhs;
+
+    return lhs.max(rhs);
+  }
+
+  void print(llvm::raw_ostream &os) const {
+    if (isInitialized()) {
+      os << "CountState(" << addCount << ", " << keySwitchCount << ")";
+    } else {
+      os << "CountState(uninitialized)";
+    }
+  }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const CountState &state) {
+    state.print(os);
+    return os;
+  }
+
+ private:
+  bool initialized;
+  int addCount;  // how many Vmult or Vfresh (before first multiplication)
+                 // encountered
+  int keySwitchCount;
+};
+
+class CountLattice : public dataflow::Lattice<CountState> {
+ public:
+  using Lattice::Lattice;
+};
+
+class CountAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<CountLattice>,
+      public SecretnessAnalysisDependent<CountAnalysis> {
+ public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+  friend class SecretnessAnalysisDependent<CountAnalysis>;
+
+  void setToEntryState(CountLattice *lattice) override {
+    propagateIfChanged(lattice, lattice->join(CountState()));
+  }
+
+  LogicalResult visitOperation(Operation *op,
+                               ArrayRef<const CountLattice *> operands,
+                               ArrayRef<CountLattice *> results) override;
+};
+
+void annotateCount(Operation *top, DataFlowSolver *solver);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_ANALYSIS_ADDANDKEYSWITCHCOUNTANALYSISANALYSIS_ADDANDKEYSWITCHCOUNTANALYSISANALYSIS_H_

--- a/lib/Analysis/AddAndKeySwitchCountAnalysis/BUILD
+++ b/lib/Analysis/AddAndKeySwitchCountAnalysis/BUILD
@@ -1,0 +1,20 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "AddAndKeySwitchCountAnalysis",
+    srcs = ["AddAndKeySwitchCountAnalysis.cpp"],
+    hdrs = ["AddAndKeySwitchCountAnalysis.h"],
+    deps = [
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/lib/Dialect/Mgmt/IR/MgmtAttributes.td
+++ b/lib/Dialect/Mgmt/IR/MgmtAttributes.td
@@ -41,5 +41,33 @@ def Mgmt_MgmtAttr : Mgmt_Attr<"Mgmt", "mgmt"> {
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
+def Mgmt_OpenfheParamsAttr : Mgmt_Attr<"OpenfheParams", "openfhe_params"> {
+  let summary = "Container attribute for some OpenFHE-specific parameters";
+  let description = [{
+    This attribute is used to store some OpenFHE-specific parameters.
+
+    The attribute is a struct with the following fields:
+      - `evalAddCount` : param for OpenFHE SetEvalAddCount
+      - `keySwitchCount` : param for OpenFHE SetKeySwitchCount
+
+    When this attribute presents, the lowering of openfhe pass
+    will use these parameters to set the corresponding OpenFHE
+    parameters.
+
+    It should be populated by --secret-with-mgmt-bgv before
+    going through the secret-to-bgv bgv-to-openfhe pass.
+
+    Example:
+    ```
+    #openfhe_params = #mgmt.openfhe_params<evalAddCount = 1, keySwitchCount = 1>
+    ```
+  }];
+
+  let parameters = (ins
+    "int": $evalAddCount,
+    "int": $keySwitchCount
+  );
+  let assemblyFormat = "`<` struct(params) `>`";
+}
 
 #endif  // LIB_DIALECT_MGMT_IR_MGMTATTRIBUTES_TD_

--- a/lib/Dialect/Mgmt/IR/MgmtDialect.td
+++ b/lib/Dialect/Mgmt/IR/MgmtDialect.td
@@ -19,6 +19,10 @@ def Mgmt_Dialect : Dialect {
     /// Name of the attribute holding MgmtAttr
     constexpr const static ::llvm::StringLiteral
         kArgMgmtAttrName = "mgmt.mgmt";
+
+    /// Name of the attribute holding OpenfheParamsAttr
+    constexpr const static ::llvm::StringLiteral
+        kArgOpenfheParamsAttrName = "mgmt.openfhe_params";
   }];
 
 

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -75,7 +75,9 @@ def GenParamsOp : Openfhe_Op<"gen_params"> {
   let arguments = (ins
     I64Attr:$mulDepth,
     I64Attr:$plainMod,
-    BoolAttr:$insecure
+    BoolAttr:$insecure,
+    I64Attr:$evalAddCount,
+    I64Attr:$keySwitchCount
   );
   let results = (outs Openfhe_CCParams:$params);
 }

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -26,6 +26,7 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheTypes.h"
@@ -98,9 +99,21 @@ LogicalResult generateGenFunc(func::FuncOp op, const std::string &genFuncName,
     }
   }
 
+  // get evalAddCount/KeySwitchCount from func attribute, if present
+  int64_t evalAddCount = 0;
+  int64_t keySwitchCount = 0;
+  if (auto openfheParamsAttr = op->getAttrOfType<mgmt::OpenfheParamsAttr>(
+          mgmt::MgmtDialect::kArgOpenfheParamsAttrName)) {
+    evalAddCount = openfheParamsAttr.getEvalAddCount();
+    keySwitchCount = openfheParamsAttr.getKeySwitchCount();
+    // remove the attribute after reading
+    op->removeAttr(mgmt::MgmtDialect::kArgOpenfheParamsAttrName);
+  }
+
   Type openfheParamsType = openfhe::CCParamsType::get(builder.getContext());
   Value ccParams = builder.create<openfhe::GenParamsOp>(
-      openfheParamsType, mulDepth, plainMod, insecure);
+      openfheParamsType, mulDepth, plainMod, insecure, evalAddCount,
+      keySwitchCount);
   Value cryptoContext = builder.create<openfhe::GenContextOp>(
       openfheContextType, ccParams,
       BoolAttr::get(builder.getContext(), hasBootstrapOp));

--- a/lib/Target/Lattigo/BUILD
+++ b/lib/Target/Lattigo/BUILD
@@ -15,6 +15,7 @@ cc_library(
     deps = [
         "@heir//lib/Analysis/SelectVariableNames",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Utils:TargetUtils",
         "@llvm-project//llvm:Support",

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -7,6 +7,7 @@
 #include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
 #include "lib/Dialect/Lattigo/IR/LattigoOps.h"
 #include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/RNS/IR/RNSDialect.h"
 #include "lib/Target/Lattigo/LattigoTemplates.h"
 #include "lib/Utils/TargetUtils.h"
@@ -564,7 +565,8 @@ void registerToLattigoTranslation() {
       },
       [](DialectRegistry &registry) {
         registry.insert<rns::RNSDialect, arith::ArithDialect, func::FuncDialect,
-                        tensor::TensorDialect, lattigo::LattigoDialect>();
+                        tensor::TensorDialect, lattigo::LattigoDialect,
+                        mgmt::MgmtDialect>();
       });
 }
 

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -737,6 +737,8 @@ LogicalResult OpenFhePkeEmitter::printOperation(GenParamsOp op) {
   auto paramsName = variableNames->getNameForValue(op.getResult());
   int64_t mulDepth = op.getMulDepthAttr().getValue().getSExtValue();
   int64_t plainMod = op.getPlainModAttr().getValue().getSExtValue();
+  int64_t evalAddCount = op.getEvalAddCountAttr().getValue().getSExtValue();
+  int64_t keySwitchCount = op.getKeySwitchCountAttr().getValue().getSExtValue();
 
   os << "CCParamsT " << paramsName << ";\n";
   os << paramsName << ".SetMultiplicativeDepth(" << mulDepth << ");\n";
@@ -746,6 +748,12 @@ LogicalResult OpenFhePkeEmitter::printOperation(GenParamsOp op) {
   if (op.getInsecure()) {
     os << paramsName << ".SetSecurityLevel(lbcrypto::HEStd_NotSet);\n";
     os << paramsName << ".SetRingDim(128);\n";
+  }
+  if (evalAddCount != 0) {
+    os << paramsName << ".SetEvalAddCount(" << evalAddCount << ");\n";
+  }
+  if (keySwitchCount != 0) {
+    os << paramsName << ".SetKeySwitchCount(" << keySwitchCount << ");\n";
   }
   return success();
 }

--- a/lib/Transforms/SecretInsertMgmt/BUILD
+++ b/lib/Transforms/SecretInsertMgmt/BUILD
@@ -17,6 +17,7 @@ cc_library(
     deps = [
         ":SecretInsertMgmtPatterns",
         ":pass_inc_gen",
+        "@heir//lib/Analysis/AddAndKeySwitchCountAnalysis",
         "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/MulResultAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
@@ -1,5 +1,6 @@
 #include <utility>
 
+#include "lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/MulResultAnalysis/MulResultAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
@@ -87,6 +88,15 @@ struct SecretInsertMgmtBGV
     pipeline.addPass(createCSEPass());
     pipeline.addPass(mgmt::createAnnotateMgmt());
     (void)runPipeline(pipeline, getOperation());
+
+    // calculate addCount/keySwitchCount
+    solver.load<CountAnalysis>();
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+    annotateCount(getOperation(), &solver);
   }
 };
 

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -174,7 +174,7 @@ module attributes {scheme.bgv} {
 // CHECK-NOT: SetPlaintextModulus
 module attributes {scheme.ckks} {
   func.func @test_ckks_no_plaintext_modulus() -> !openfhe.crypto_context {
-    %0 = openfhe.gen_params  {insecure = false, mulDepth = 2 : i64, plainMod = 0 : i64} : () -> !openfhe.cc_params
+    %0 = openfhe.gen_params  {insecure = false, mulDepth = 2 : i64, plainMod = 0 : i64, evalAddCount = 0 : i64, keySwitchCount = 0 : i64} : () -> !openfhe.cc_params
     %1 = openfhe.gen_context %0 {supportFHE = false} : (!openfhe.cc_params) -> !openfhe.crypto_context
     return %1 : !openfhe.crypto_context
   }

--- a/tests/Transforms/secret_insert_mgmt/eval_add_count.mlir
+++ b/tests/Transforms/secret_insert_mgmt/eval_add_count.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv %s | FileCheck %s
+
+// CHECK: mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>
+func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16> {secret.secret}) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %arg2 = 0 to 8 iter_args(%iter = %c0_si16) -> (i16) {
+    %1 = tensor.extract %arg0[%arg2] : tensor<8xi16>
+    %2 = tensor.extract %arg1[%arg2] : tensor<8xi16>
+    %3 = arith.muli %1, %2 : i16
+    %4 = arith.addi %iter, %3 : i16
+    affine.yield %4 : i16
+  }
+  return %0 : i16
+}


### PR DESCRIPTION
Part of #1168.

This is a baseline of parameter selection for BGV. While concrete param (like moduli) is still selected by the OpenFHE library, the information of the circuit needed by the OpenFHE is now provided by the compiler.

Note that providing `EvalAddCount/KeySwitchCount` is crucial under the [Application-Aware security model](https://ia.cr/2024/203), where the compiler/library should reject circuit whose parameter can not be generated, or generate larger parameters. Cite

> In the case of the attack in [11] the proper OpenFHE use of
BGV/BFV for this scenario would require the user to supply
the number of additions before generating the parameters
using SETEVALADDCOUNT, or an equivalent multiplicative
depth using SETMULTIPLICATIVEDEPTH. One can check
that, when this is done correctly, a larger parameter set is
generated by OpenFHE than the one used for the attack.

When further optimization on parameter selection is landed, this can be kept as a comparable baseline for evaluation purpose. For end-user, they could then select different param generation mechanism based on their needs.

### Example

For the `dot_product_8.mlir`, we get the following counting result.

```mlir
module {
  func.func @func(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) -> !secret.secret<i16> attributes {mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>} {
    %c1 = arith.constant 1 : index
    %c2 = arith.constant 2 : index
    %c4 = arith.constant 4 : index
    %c7 = arith.constant 7 : index
    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<8xi16>>, !secret.secret<tensor<8xi16>>) attrs = {arg0 = {addCount = 1 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>}, arg1 = {addCount = 1 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>}} {
    ^bb0(%input0: tensor<8xi16>, %input1: tensor<8xi16>):
      %1 = arith.muli %input0, %input1 {addCount = 1 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2, dimension = 3>} : tensor<8xi16>
      %2 = mgmt.relinearize %1 {addCount = 1 : i64, keySwitchCount = 1 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %3 = tensor_ext.rotate %2, %c4 {addCount = 1 : i64, keySwitchCount = 2 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
      %4 = arith.addi %2, %3 {addCount = 2 : i64, keySwitchCount = 3 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %5 = tensor_ext.rotate %4, %c2 {addCount = 2 : i64, keySwitchCount = 4 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
      %6 = arith.addi %4, %5 {addCount = 4 : i64, keySwitchCount = 7 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %7 = tensor_ext.rotate %6, %c1 {addCount = 4 : i64, keySwitchCount = 8 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
      %8 = arith.addi %6, %7 {addCount = 8 : i64, keySwitchCount = 15 : i64, mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %9 = mgmt.modreduce %8 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
      %extracted = tensor.extract %9[%c7] {addCount = 1 : i64, keySwitchCount = 1 : i64, mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
      %10 = mgmt.modreduce %extracted {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16
      secret.yield %10 : i16
    } -> !secret.secret<i16>
    return %0 : !secret.secret<i16>
  }
}
```

A very counter-intuitive result is that instead of `KeySwitchCount` being 4 (1 mul-relin + 3 rotate), it is 15 as it has been accumulated via additions. Detailed definition of KeySwitchCount could be found in [KPZ21, section 4](https://ia.cr/2021/204). Though I want to ask for review of relevent people whether I understand them correctly.

As a result, the generated param becomes

```
Element Parameters: ILDCRTParams [m=32768 n=16384 q=748300257136160271476183612726042708089465225445377 ru=0 bigq=0 bigru=0]
  m_params:
    0: ILParams [m=32768 n=16384 q=140737488486401 ru=3152167261 bigq=0 bigru=0]
    1: ILParams [m=32768 n=16384 q=9007199255560193 ru=523433461118 bigq=0 bigru=0]
    2: ILParams [m=32768 n=16384 q=9007199255658497 ru=785944929279 bigq=0 bigru=0]
    3: ILParams [m=32768 n=16384 q=65537 ru=9 bigq=0 bigru=0]
```

where the moduli chain has `[47, 53, 53, 16]` bits for each level and 169 bits in total.

When they are not specified, the generated param is

```
Element Parameters: ILDCRTParams [m=32768 n=16384 q=187075064281998384050658167829053521773423705948161 ru=0 bigq=0 bigru=0]
  m_params:
    0: ILParams [m=32768 n=16384 q=140737488486401 ru=3152167261 bigq=0 bigru=0]
    1: ILParams [m=32768 n=16384 q=4503599627763713 ru=51902047037 bigq=0 bigru=0]
    2: ILParams [m=32768 n=16384 q=4503599627796481 ru=38602712989 bigq=0 bigru=0]
    3: ILParams [m=32768 n=16384 q=65537 ru=9 bigq=0 bigru=0]
  m_originalModulus: 0
```

With moduli chain having `[47, 52, 52, 16]` bits and 167 bits in total.