### PR TITLE
Arith-to-cggi-quart pass lowering to TFHE-rs HL emitter

### DIFF
--- a/docs/content/en/docs/pipelines.md
+++ b/docs/content/en/docs/pipelines.md
@@ -97,8 +97,7 @@ Example input:
 func.func @test_apply_lookup_table(%sks : !sks, %lut: !lut, %input : !eui3) -> !eui3 {
   %v1 = tfhe_rust.apply_lookup_table %sks, %input, %lut : (!sks, !eui3, !lut) -> !eui3
   %v2 = tfhe_rust.add %sks, %input, %v1 : (!sks, !eui3, !eui3) -> !eui3
-  %c1 = arith.constant 1 : i8
-  %v3 = tfhe_rust.scalar_left_shift %sks, %v2, %c1 : (!sks, !eui3, i8) -> !eui3
+  %v3 = tfhe_rust.scalar_left_shift %sks, %v2 {shiftAmount = 1 : index} : (!sks, !eui3) -> !eui3
   %v4 = tfhe_rust.apply_lookup_table %sks, %v3, %lut : (!sks, !eui3, !lut) -> !eui3
   return %v4 : !eui3
 }

--- a/lib/Dialect/Arith/Conversions/ArithToCGGI/ArithToCGGI.cpp
+++ b/lib/Dialect/Arith/Conversions/ArithToCGGI/ArithToCGGI.cpp
@@ -137,12 +137,10 @@ struct ConvertShRUIOp : public OpConversionPattern<mlir::arith::ShRUIOp> {
                              .getSExtValue();
 
       auto inputValue =
-          mlir::IntegerAttr::get(rewriter.getI8Type(), (int8_t)shiftAmount);
-      auto cteOp = rewriter.create<mlir::arith::ConstantOp>(
-          op.getLoc(), rewriter.getI8Type(), inputValue);
+          mlir::IntegerAttr::get(rewriter.getIndexType(), (int8_t)shiftAmount);
 
-      auto shiftOp =
-          b.create<cggi::ShiftRightOp>(outputType, adaptor.getLhs(), cteOp);
+      auto shiftOp = b.create<cggi::ScalarShiftRightOp>(
+          outputType, adaptor.getLhs(), inputValue);
       rewriter.replaceOp(op, shiftOp);
 
       return success();
@@ -155,14 +153,12 @@ struct ConvertShRUIOp : public OpConversionPattern<mlir::arith::ShRUIOp> {
     auto shiftAmount =
         cast<IntegerAttr>(cteShiftSizeOp.getValue()).getValue().getSExtValue();
 
-    auto inputValue = mlir::IntegerAttr::get(rewriter.getI8Type(), shiftAmount);
-    auto cteOp = rewriter.create<mlir::arith::ConstantOp>(
-        op.getLoc(), rewriter.getI8Type(), inputValue);
+    auto inputValue =
+        mlir::IntegerAttr::get(rewriter.getIndexType(), shiftAmount);
 
-    auto shiftOp =
-        b.create<cggi::ShiftRightOp>(outputType, adaptor.getLhs(), cteOp);
+    auto shiftOp = b.create<cggi::ScalarShiftRightOp>(
+        outputType, adaptor.getLhs(), inputValue);
     rewriter.replaceOp(op, shiftOp);
-    rewriter.replaceOp(op.getLhs().getDefiningOp(), cteOp);
 
     return success();
   }
@@ -182,10 +178,7 @@ struct ArithToCGGI : public impl::ArithToCGGIBase<ArithToCGGI> {
     target.addDynamicallyLegalOp<mlir::arith::ConstantOp>(
         [](mlir::arith::ConstantOp op) {
           // Allow use of constant if it is used to denote the size of a shift
-          bool usedByShift = llvm::any_of(op->getUsers(), [&](Operation *user) {
-            return isa<cggi::ShiftRightOp>(user);
-          });
-          return (isa<IndexType>(op.getValue().getType()) || (usedByShift));
+          return (isa<IndexType>(op.getValue().getType()));
         });
 
     target.addDynamicallyLegalOp<

--- a/lib/Dialect/CGGI/IR/CGGIOps.td
+++ b/lib/Dialect/CGGI/IR/CGGIOps.td
@@ -295,18 +295,18 @@ def CGGI_SubOp : CGGI_Op<"sub", [
 }
 
 
-def CGGI_ShiftRightOp : CGGI_Op<"shr", [
+def CGGI_ScalarShiftRightOp : CGGI_Op<"sshr", [
     Pure,
 ]> {
-  let arguments = (ins LWECiphertextLike:$lhs, AnyI8:$shiftAmount);
+  let arguments = (ins LWECiphertextLike:$lhs, IndexAttr:$shiftAmount);
   let results = (outs LWECiphertextLike:$output);
   let summary = "Arithmetic shift to the right of a ciphertext by an integer. Note this operations to mirror the TFHE-rs implmementation.";
 }
 
-def CGGI_ShiftLeftOp : CGGI_Op<"shl", [
+def CGGI_ScalarShiftLeftOp : CGGI_Op<"sshl", [
     Pure
 ]> {
-  let arguments = (ins LWECiphertextLike:$lhs, AnyI8:$shiftAmount);
+  let arguments = (ins LWECiphertextLike:$lhs, IndexAttr:$shiftAmount);
   let results = (outs LWECiphertextLike:$output);
   let summary = "Arithmetic shift to left of a ciphertext by an integer. Note this operations to mirror the TFHE-rs implmementation.";
 }

--- a/lib/Dialect/TfheRust/IR/TfheRustOps.td
+++ b/lib/Dialect/TfheRust/IR/TfheRustOps.td
@@ -24,15 +24,15 @@ class TfheRust_BinaryOp<string mnemonic>
 ]> {
   let arguments = (ins
     TfheRust_ServerKey:$serverKey,
-    TfheRust_CiphertextType:$lhs,
-    TfheRust_CiphertextType:$rhs
+    TfheRust_CiphertextLikeType:$lhs,
+    TfheRust_CiphertextLikeType:$rhs
   );
-  let results = (outs TfheRust_CiphertextType:$output);
+  let results = (outs TfheRust_CiphertextLikeType:$output);
 }
 
 def TfheRust_CreateTrivialOp : TfheRust_Op<"create_trivial", [Pure]> {
   let arguments = (ins TfheRust_ServerKey:$serverKey, AnyInteger:$value);
-  let results = (outs TfheRust_CiphertextType:$output);
+  let results = (outs TfheRust_CiphertextLikeType:$output);
   let hasCanonicalizer = 1;
 }
 
@@ -49,7 +49,7 @@ def TfheRust_ScalarLeftShiftOp : TfheRust_Op<"scalar_left_shift", [
   let arguments = (ins
     TfheRust_ServerKey:$serverKey,
     TfheRust_CiphertextType:$ciphertext,
-    AnyI8:$shiftAmount
+    IndexAttr:$shiftAmount
   );
   let results = (outs TfheRust_CiphertextType:$output);
 }
@@ -61,7 +61,7 @@ def TfheRust_ScalarRightShiftOp : TfheRust_Op<"scalar_right_shift", [
   let arguments = (ins
     TfheRust_ServerKey:$serverKey,
     TfheRust_CiphertextType:$ciphertext,
-    AnyI8:$shiftAmount
+    IndexAttr:$shiftAmount
   );
   let results = (outs TfheRust_CiphertextType:$output);
 }

--- a/lib/Dialect/TfheRust/IR/TfheRustTypes.td
+++ b/lib/Dialect/TfheRust/IR/TfheRustTypes.td
@@ -65,6 +65,7 @@ def TfheRust_CiphertextType :
     TfheRust_EncryptedInt256,
   ]>;
 
+def TfheRust_CiphertextLikeType : TypeOrContainer<TfheRust_CiphertextType, "tfhe-ciphertext-like">;
 
 def TfheRust_ServerKey : TfheRust_Type<"ServerKey", "server_key", [PassByReference]> {
   let summary = "The short int server key required to perform homomorphic operations.";

--- a/lib/Target/TfheRustHL/TfheRustHLEmitter.cpp
+++ b/lib/Target/TfheRustHL/TfheRustHLEmitter.cpp
@@ -561,8 +561,12 @@ LogicalResult TfheRustHLEmitter::printOperation(SubOp op) {
 }
 
 LogicalResult TfheRustHLEmitter::printOperation(ScalarRightShiftOp op) {
-  return printBinaryOp(op.getResult(), op.getCiphertext(), op.getShiftAmount(),
-                       ">>");
+  emitAssignPrefix(op.getResult());
+
+  os << checkOrigin(op.getCiphertext())
+     << variableNames->getNameForValue(op.getCiphertext()) << " >> "
+     << op.getShiftAmount() << "u8;\n";
+  return success();
 }
 
 LogicalResult TfheRustHLEmitter::printOperation(CastOp op) {

--- a/tests/Dialect/Arith/Conversions/ArithToCGGI/arith-to-cggi.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToCGGI/arith-to-cggi.mlir
@@ -66,6 +66,8 @@ func.func @test_affine(%arg0: memref<1x1xi32>) -> memref<1x1xi32> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1xi32>
   %25 = arith.muli %0, %c33_i8 : i32
   %26 = arith.addi %c429_i32, %25 : i32
+  %c2 = arith.constant 2 : i32
+  %27 = arith.shrui %26, %c2 : i32
   affine.store %26, %alloc[0, 0] : memref<1x1xi32>
   return %alloc : memref<1x1xi32>
 }

--- a/tests/Dialect/Arith/Conversions/ArithToCGGIQuart/quarter_wide.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToCGGIQuart/quarter_wide.mlir
@@ -1,10 +1,10 @@
 // RUN: heir-opt --arith-to-cggi-quart  %s | FileCheck %s
 
 // CHECK: return %[[RET:.*]] tensor<4x!lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>>
-func.func @test_simple_split2(%arg0: i32, %arg1: i16) -> i32 {
-  %2 = arith.constant 31 : i16
-  %5 = arith.addi %arg1, %2 : i16
-  %6 = arith.extui %5 : i16 to i32
-  %7 = arith.addi %arg0, %6 : i32
-  return %6 : i32
+func.func @test_simple_split2(%arg0: i32, %arg1: i32) -> i32 {
+  %2 = arith.constant 31 : i8
+  %1 = arith.extui %2 : i8 to i32
+  %5 = arith.addi %arg1, %1 : i32
+  %7 = arith.muli %arg0, %5 : i32
+  return %7 : i32
 }

--- a/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/arith.mlir
+++ b/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/arith.mlir
@@ -14,6 +14,7 @@ func.func @test_affine(%arg0: memref<1x1x!ct_ty>) -> memref<1x1x!ct_ty> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ct_ty>
   %3 = cggi.mul %2, %1 : !ct_ty
   %4 = cggi.add %3, %0 : !ct_ty
-  affine.store %4, %alloc[0, 0] : memref<1x1x!ct_ty>
+  %5 = cggi.sshr %4 {shiftAmount = 2 : index} : (!ct_ty) -> !ct_ty
+  affine.store %5, %alloc[0, 0] : memref<1x1x!ct_ty>
   return %alloc : memref<1x1x!ct_ty>
 }

--- a/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/binary_gates.mlir
+++ b/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/binary_gates.mlir
@@ -7,9 +7,7 @@
 // CHECK-SAME: %[[sks:.*]]: [[sks_ty:!tfhe_rust.server_key]], %[[arg1:.*]]: [[ct_ty:!tfhe_rust.eui3]], %[[arg2:.*]]: [[ct_ty]]
 func.func @binary_gates(%arg1: !ct_ty, %arg2: !ct_ty) -> (!ct_ty) {
   // CHECK: %[[v0:.*]] = tfhe_rust.generate_lookup_table %[[sks]] {truthTable = 8 : ui4}
-  // CHECK: %[[shiftAmount:.*]] = arith.constant 1 : i8
-
-  // CHECK: %[[v1:.*]] = tfhe_rust.scalar_left_shift %[[sks]], %[[arg2]], %[[shiftAmount]]
+  // CHECK: %[[v1:.*]] = tfhe_rust.scalar_left_shift %[[sks]], %[[arg2]] {shiftAmount = 1 : index}
   // CHECK: %[[v2:.*]] = tfhe_rust.add %[[sks]], %[[v1]], %[[arg1]]
   // CHECK: %[[v3:.*]] = tfhe_rust.apply_lookup_table %[[sks]], %[[v2]], %[[v0]]
   %0 = cggi.and %arg1, %arg2 : !ct_ty
@@ -25,7 +23,7 @@ func.func @binary_gates(%arg1: !ct_ty, %arg2: !ct_ty) -> (!ct_ty) {
   %2 = cggi.not %1 : !ct_ty
 
   // CHECK: %[[v8:.*]] = tfhe_rust.generate_lookup_table %[[sks]] {truthTable = 6 : ui4}
-  // CHECK: %[[v9:.*]] = tfhe_rust.scalar_left_shift %[[sks]], %[[v3]], %[[shiftAmount]]
+  // CHECK: %[[v9:.*]] = tfhe_rust.scalar_left_shift %[[sks]], %[[v3]] {shiftAmount = 1 : index}
   // CHECK: %[[v10:.*]] = tfhe_rust.add %[[sks]], %[[v9]], %[[v7]]
   // CHECK: %[[v11:.*]] = tfhe_rust.apply_lookup_table %[[sks]], %[[v10]], %[[v8]]
   %3 = cggi.xor %2, %0 : !ct_ty

--- a/tests/Dialect/TfheRust/Emitters/emit_levelled_ops.mlir
+++ b/tests/Dialect/TfheRust/Emitters/emit_levelled_ops.mlir
@@ -14,11 +14,10 @@
 // CHECK:  temp_nodes[
 // CHECK-NEXT: }
 func.func @test_levelled_op(%sks : !sks, %lut: !lut, %input1 : !eui3, %input2 : !eui3) -> !eui3 {
-  %c1 = arith.constant 1 : i8
   %v0 = tfhe_rust.apply_lookup_table %sks, %input1, %lut : (!sks, !eui3, !lut) -> !eui3
   %v1 = tfhe_rust.apply_lookup_table %sks, %input2, %lut : (!sks, !eui3, !lut) -> !eui3
   %v2 = tfhe_rust.add %sks, %v0, %v1 : (!sks, !eui3, !eui3) -> !eui3
-  %v3 = tfhe_rust.scalar_left_shift %sks, %v2, %c1 : (!sks, !eui3, i8) -> !eui3
+  %v3 = tfhe_rust.scalar_left_shift %sks, %v2 {shiftAmount = 1 : index} : (!sks, !eui3) -> !eui3
   %v4 = tfhe_rust.apply_lookup_table %sks, %v3, %lut : (!sks, !eui3, !lut) -> !eui3
   return %v4 : !eui3
 }
@@ -44,7 +43,7 @@ func.func @test_levelled_op_break(%sks : !sks, %lut: !lut, %input1 : !eui3, %inp
   %v1 = tfhe_rust.apply_lookup_table %sks, %input2, %lut : (!sks, !eui3, !lut) -> !eui3
   %v2 = tfhe_rust.add %sks, %v0, %v1 : (!sks, !eui3, !eui3) -> !eui3
   %c1 = arith.constant 1 : i8
-  %v3 = tfhe_rust.scalar_left_shift %sks, %v2, %c1 : (!sks, !eui3, i8) -> !eui3
+  %v3 = tfhe_rust.scalar_left_shift %sks, %v2 {shiftAmount = 1 : index} : (!sks, !eui3) -> !eui3
   %v4 = tfhe_rust.apply_lookup_table %sks, %v3, %lut : (!sks, !eui3, !lut) -> !eui3
   return %v4 : !eui3
 }

--- a/tests/Dialect/TfheRust/Emitters/emit_tfhe_rust.mlir
+++ b/tests/Dialect/TfheRust/Emitters/emit_tfhe_rust.mlir
@@ -38,16 +38,14 @@ func.func @test_apply_lookup_table(%sks : !sks, %lut: !lut, %input : !eui3) -> !
 // CHECK-NEXT: ) -> Ciphertext {
 // CHECK:   let [[v1:.*]] = [[sks]].apply_lookup_table(&[[input]], &[[lut]]);
 // CHECK:   let [[v2:.*]] = [[sks]].unchecked_add(&[[input]], &[[v1]]);
-// CHECK:   let [[c1:.*]] = 1;
-// CHECK:   let [[v3:.*]] = [[sks]].scalar_left_shift(&[[v2]], [[c1]] as u8);
+// CHECK:   let [[v3:.*]] = [[sks]].scalar_left_shift(&[[v2]], [[c1:.*]] as u8);
 // CHECK:   let [[v4:.*]] = [[sks]].apply_lookup_table(&[[v3]], &[[lut]]);
 // CHECK-NEXT:   [[v4]]
 // CHECK-NEXT: }
 func.func @test_apply_lookup_table2(%sks : !sks, %lut: !lut, %input : !eui3) -> !eui3 {
   %v1 = tfhe_rust.apply_lookup_table %sks, %input, %lut : (!sks, !eui3, !lut) -> !eui3
   %v2 = tfhe_rust.add %sks, %input, %v1 : (!sks, !eui3, !eui3) -> !eui3
-  %c1 = arith.constant 1 : i8
-  %v3 = tfhe_rust.scalar_left_shift %sks, %v2, %c1 : (!sks, !eui3, i8) -> !eui3
+  %v3 = tfhe_rust.scalar_left_shift %sks, %v2 {shiftAmount = 1 : index} : (!sks, !eui3) -> !eui3
   %v4 = tfhe_rust.apply_lookup_table %sks, %v3, %lut : (!sks, !eui3, !lut) -> !eui3
   return %v4 : !eui3
 }

--- a/tests/Dialect/TfheRust/IR/ops.mlir
+++ b/tests/Dialect/TfheRust/IR/ops.mlir
@@ -38,8 +38,7 @@ module {
     %e1 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
     %e2 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
 
-    %shiftAmount = arith.constant 1 : i8
-    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2, %shiftAmount : (!sks, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2 {shiftAmount = 1 : index} : (!sks, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %eCombined =  tfhe_rust.add %sks, %e1, %e2Shifted : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
 
     %out = tfhe_rust.apply_lookup_table %sks, %eCombined, %lut : (!sks, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3

--- a/tests/Dialect/TfheRust/Transforms/canonicalize.mlir
+++ b/tests/Dialect/TfheRust/Transforms/canonicalize.mlir
@@ -6,14 +6,11 @@ module {
   // CHECK-LABEL: func @test_move_create_trivial
   func.func @test_move_create_trivial(%sks : !sks, %lut: !tfhe_rust.lookup_table) -> !tfhe_rust.eui3 {
     // CHECK: arith.constant
-    // CHECK-NEXT: arith.constant
     // CHECK-NEXT: tfhe_rust.create_trivial
     // CHECK-NEXT: tfhe_rust.create_trivial
     %0 = arith.constant 1 : i3
-    %1 = arith.constant 2 : i3
     %e2 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
-    %shiftAmount = arith.constant 1 : i8
-    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2, %shiftAmount : (!sks, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2 {shiftAmount = 1 : index} : (!sks, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %e1 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
     %eCombined =  tfhe_rust.add %sks, %e1, %e2Shifted : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %out = tfhe_rust.apply_lookup_table %sks, %eCombined, %lut : (!sks, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
@@ -23,19 +20,16 @@ module {
   // CHECK-LABEL: func @test_move_out_of_loop
   func.func @test_move_out_of_loop(%sks : !sks, %lut: !tfhe_rust.lookup_table) -> memref<10x!tfhe_rust.eui3> {
     // CHECK: arith.constant
-    // CHECK-NEXT: arith.constant
     // CHECK-NEXT: tfhe_rust.create_trivial
     // CHECK-NEXT: tfhe_rust.create_trivial
     // CHECK-NEXT: memref.alloc
     // CHECK-NEXT: affine.for
     %0 = arith.constant 1 : i3
-    %1 = arith.constant 2 : i3
     %memref = memref.alloca() : memref<10x!tfhe_rust.eui3>
 
     affine.for %i = 0 to 10 {
       %e2 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
-      %shiftAmount = arith.constant 1 : i8
-      %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2, %shiftAmount : (!sks, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+      %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2 {shiftAmount = 1 : index} : (!sks, !tfhe_rust.eui3) -> !tfhe_rust.eui3
       %e1 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
       %eCombined =  tfhe_rust.add %sks, %e1, %e2Shifted : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
       %out = tfhe_rust.apply_lookup_table %sks, %eCombined, %lut : (!sks, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3

--- a/tests/Examples/tfhe_rust/test_simple_lut.mlir
+++ b/tests/Examples/tfhe_rust/test_simple_lut.mlir
@@ -11,8 +11,7 @@
 // CHECK: 1
 func.func @fn_under_test(%sks : !sks, %a: !eui3, %b: !eui3) -> !eui3 {
   %lut = tfhe_rust.generate_lookup_table %sks {truthTable = 7 : ui8} : (!sks) -> !lut
-  %c1 = arith.constant 1 : i8
-  %0 = tfhe_rust.scalar_left_shift %sks, %a, %c1 : (!sks, !eui3, i8) -> !eui3
+  %0 = tfhe_rust.scalar_left_shift %sks, %a {shiftAmount = 1 : index} : (!sks, !eui3) -> !eui3
   %1 = tfhe_rust.add %sks, %0, %b : (!sks, !eui3, !eui3) -> !eui3
   %2 = tfhe_rust.apply_lookup_table %sks, %1, %lut : (!sks, !eui3, !lut) -> !eui3
   return %2 : !eui3

--- a/tests/Transforms/forward_store_to_load/forward_add_one.mlir
+++ b/tests/Transforms/forward_store_to_load/forward_add_one.mlir
@@ -32,8 +32,8 @@ module {
     %2 = tfhe_rust.create_trivial %arg0, %false : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
     %3 = tfhe_rust.create_trivial %arg0, %0 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
     %4 = tfhe_rust.generate_lookup_table %arg0 {truthTable = 8 : ui8} : (!tfhe_rust.server_key) -> !tfhe_rust.lookup_table
-    %5 = tfhe_rust.scalar_left_shift %arg0, %2, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %6 = tfhe_rust.scalar_left_shift %arg0, %3, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %5 = tfhe_rust.scalar_left_shift %arg0, %2 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %6 = tfhe_rust.scalar_left_shift %arg0, %3 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %7 = tfhe_rust.add %arg0, %5, %6 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %8 = tfhe_rust.add %arg0, %7, %1 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %9 = tfhe_rust.apply_lookup_table %arg0, %8, %4 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
@@ -41,8 +41,8 @@ module {
     %11 = memref.load %arg1[%c1] : memref<8x!tfhe_rust.eui3>
     %12 = tfhe_rust.create_trivial %arg0, %10 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
     %13 = tfhe_rust.generate_lookup_table %arg0 {truthTable = 150 : ui8} : (!tfhe_rust.server_key) -> !tfhe_rust.lookup_table
-    %14 = tfhe_rust.scalar_left_shift %arg0, %12, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %15 = tfhe_rust.scalar_left_shift %arg0, %11, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %14 = tfhe_rust.scalar_left_shift %arg0, %12 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %15 = tfhe_rust.scalar_left_shift %arg0, %11 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %16 = tfhe_rust.add %arg0, %14, %15 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %17 = tfhe_rust.add %arg0, %16, %9 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %18 = tfhe_rust.apply_lookup_table %arg0, %17, %13 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
@@ -52,32 +52,32 @@ module {
     %22 = memref.load %arg1[%c2] : memref<8x!tfhe_rust.eui3>
     %23 = tfhe_rust.create_trivial %arg0, %21 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
     %24 = tfhe_rust.generate_lookup_table %arg0 {truthTable = 43 : ui8} : (!tfhe_rust.server_key) -> !tfhe_rust.lookup_table
-    %25 = tfhe_rust.scalar_left_shift %arg0, %23, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %26 = tfhe_rust.scalar_left_shift %arg0, %22, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %25 = tfhe_rust.scalar_left_shift %arg0, %23 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %26 = tfhe_rust.scalar_left_shift %arg0, %22 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %27 = tfhe_rust.add %arg0, %25, %26 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %28 = tfhe_rust.add %arg0, %27, %20 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %29 = tfhe_rust.apply_lookup_table %arg0, %28, %24 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
     %30 = memref.load %alloc[%c3] : memref<8xi1>
     %31 = memref.load %arg1[%c3] : memref<8x!tfhe_rust.eui3>
     %32 = tfhe_rust.create_trivial %arg0, %30 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
-    %33 = tfhe_rust.scalar_left_shift %arg0, %32, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %34 = tfhe_rust.scalar_left_shift %arg0, %31, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %33 = tfhe_rust.scalar_left_shift %arg0, %32 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %34 = tfhe_rust.scalar_left_shift %arg0, %31 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %35 = tfhe_rust.add %arg0, %33, %34 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %36 = tfhe_rust.add %arg0, %35, %29 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %37 = tfhe_rust.apply_lookup_table %arg0, %36, %24 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
     %38 = memref.load %alloc[%c4] : memref<8xi1>
     %39 = memref.load %arg1[%c4] : memref<8x!tfhe_rust.eui3>
     %40 = tfhe_rust.create_trivial %arg0, %38 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
-    %41 = tfhe_rust.scalar_left_shift %arg0, %40, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %42 = tfhe_rust.scalar_left_shift %arg0, %39, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %41 = tfhe_rust.scalar_left_shift %arg0, %40 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %42 = tfhe_rust.scalar_left_shift %arg0, %39 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %43 = tfhe_rust.add %arg0, %41, %42 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %44 = tfhe_rust.add %arg0, %43, %37 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %45 = tfhe_rust.apply_lookup_table %arg0, %44, %24 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
     %46 = memref.load %alloc[%c5] : memref<8xi1>
     %47 = memref.load %arg1[%c5] : memref<8x!tfhe_rust.eui3>
     %48 = tfhe_rust.create_trivial %arg0, %46 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
-    %49 = tfhe_rust.scalar_left_shift %arg0, %48, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %50 = tfhe_rust.scalar_left_shift %arg0, %47, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %49 = tfhe_rust.scalar_left_shift %arg0, %48 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %50 = tfhe_rust.scalar_left_shift %arg0, %47 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %51 = tfhe_rust.add %arg0, %49, %50 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %52 = tfhe_rust.add %arg0, %51, %45 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %53 = tfhe_rust.apply_lookup_table %arg0, %52, %24 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
@@ -85,8 +85,8 @@ module {
     %55 = memref.load %arg1[%c6] : memref<8x!tfhe_rust.eui3>
     %56 = tfhe_rust.create_trivial %arg0, %54 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
     %57 = tfhe_rust.generate_lookup_table %arg0 {truthTable = 105 : ui8} : (!tfhe_rust.server_key) -> !tfhe_rust.lookup_table
-    %58 = tfhe_rust.scalar_left_shift %arg0, %56, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %59 = tfhe_rust.scalar_left_shift %arg0, %55, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %58 = tfhe_rust.scalar_left_shift %arg0, %56 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %59 = tfhe_rust.scalar_left_shift %arg0, %55 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %60 = tfhe_rust.add %arg0, %58, %59 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %61 = tfhe_rust.add %arg0, %60, %53 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %62 = tfhe_rust.apply_lookup_table %arg0, %61, %57 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3
@@ -94,8 +94,8 @@ module {
     %64 = memref.load %alloc[%c7] : memref<8xi1>
     %65 = memref.load %arg1[%c7] : memref<8x!tfhe_rust.eui3>
     %66 = tfhe_rust.create_trivial %arg0, %64 : (!tfhe_rust.server_key, i1) -> !tfhe_rust.eui3
-    %67 = tfhe_rust.scalar_left_shift %arg0, %66, %c2_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
-    %68 = tfhe_rust.scalar_left_shift %arg0, %65, %c1_i8 : (!tfhe_rust.server_key, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %67 = tfhe_rust.scalar_left_shift %arg0, %66 {shiftAmount = 2 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
+    %68 = tfhe_rust.scalar_left_shift %arg0, %65 {shiftAmount = 1 : index} : (!tfhe_rust.server_key, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %69 = tfhe_rust.add %arg0, %67, %68 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %70 = tfhe_rust.add %arg0, %69, %63 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %71 = tfhe_rust.apply_lookup_table %arg0, %70, %57 : (!tfhe_rust.server_key, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3

--- a/tests/Transforms/loop_unroll/full_loop_unroll.mlir
+++ b/tests/Transforms/loop_unroll/full_loop_unroll.mlir
@@ -11,8 +11,7 @@ func.func @test_move_out_of_loop(%sks : !sks, %lut: !tfhe_rust.lookup_table) -> 
 
   affine.for %i = 0 to 10 {
     %e2 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
-    %shiftAmount = arith.constant 1 : i8
-    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2, %shiftAmount : (!sks, !tfhe_rust.eui3, i8) -> !tfhe_rust.eui3
+    %e2Shifted = tfhe_rust.scalar_left_shift %sks, %e2 {shiftAmount = 1 : index} : (!sks, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %e1 = tfhe_rust.create_trivial %sks, %0 : (!sks, i3) -> !tfhe_rust.eui3
     %eCombined =  tfhe_rust.add %sks, %e1, %e2Shifted : (!sks, !tfhe_rust.eui3, !tfhe_rust.eui3) -> !tfhe_rust.eui3
     %out = tfhe_rust.apply_lookup_table %sks, %eCombined, %lut : (!sks, !tfhe_rust.eui3, !tfhe_rust.lookup_table) -> !tfhe_rust.eui3


### PR DESCRIPTION
Follow up of #1265 
- Change the Scalar Right Shift ops definition of CGGI and TFHE-rs to use an index attr to define the shift amount
- Extended some TFHE-rs ops to allow vectors as operands
- Further integration of the arith-to-cggi-quart pass lowering to TFHE-rs HL emitter