### PR TITLE
Remove FPGA code from HL Emitter

### DIFF
--- a/lib/Target/TfheRustHL/TfheRustHLEmitter.h
+++ b/lib/Target/TfheRustHL/TfheRustHLEmitter.h
@@ -30,13 +30,11 @@ void registerToTfheRustHLTranslation();
 
 /// Translates the given operation to TfheRustHL.
 ::mlir::LogicalResult translateToTfheRustHL(::mlir::Operation *op,
-                                            llvm::raw_ostream &os,
-                                            bool belfortAPI);
+                                            llvm::raw_ostream &os);
 
 class TfheRustHLEmitter {
  public:
-  TfheRustHLEmitter(raw_ostream &os, SelectVariableNames *variableNames,
-                    bool belfortAPI);
+  TfheRustHLEmitter(raw_ostream &os, SelectVariableNames *variableNames);
 
   LogicalResult translate(::mlir::Operation &operation);
   bool containsVectorOperands(Operation *op);
@@ -48,9 +46,6 @@ class TfheRustHLEmitter {
   /// Pre-populated analysis selecting unique variable names for all the SSA
   /// values.
   SelectVariableNames *variableNames;
-
-  // Boolean to keep track if the Belfort API is used or not
-  bool belfortAPI;
 
   // Functions for printing individual ops
   LogicalResult printOperation(::mlir::ModuleOp op);

--- a/lib/Target/TfheRustHL/TfheRustHLTemplates.h
+++ b/lib/Target/TfheRustHL/TfheRustHLTemplates.h
@@ -14,14 +14,6 @@ use tfhe::prelude::*;
 use tfhe::ServerKey;
 )rust";
 
-constexpr std::string_view kFPGAModulePrelude = R"rust(
-use std::collections::BTreeMap;
-use tfhe::boolean::{engine::fpga::{BelfortBooleanServerKey, Gate}, prelude::*};
-
-use crate::server_key_enum::ServerKeyEnum;
-use crate::server_key_enum::ServerKeyTrait;
-)rust";
-
 }  // namespace tfhe_rust
 }  // namespace heir
 }  // namespace mlir


### PR DESCRIPTION
The lastest Belfort API does not need any specific code generated. 
The includes are done in the main function