### PR TITLE
Common configure-crypto-context for relin/rotate

### DIFF
--- a/lib/Dialect/BUILD
+++ b/lib/Dialect/BUILD
@@ -13,6 +13,7 @@ cc_library(
     hdrs = ["HEIRInterfaces.h"],
     deps = [
         ":interfaces_inc_gen",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
     ],
 )

--- a/lib/Dialect/HEIRInterfaces.cpp
+++ b/lib/Dialect/HEIRInterfaces.cpp
@@ -6,5 +6,32 @@
 namespace mlir {
 namespace heir {
 #include "lib/Dialect/HEIRInterfaces.cpp.inc"
+
+// Helper function to find all the relin basis in the function
+SmallVector<int32_t> findAllRelinBasis(func::FuncOp op) {
+  std::set<int32_t> distinctRelinBasis;
+  op.walk([&](RelinearizeOpInterface relinOp) {
+    for (auto basis : relinOp.getFromBasis()) {
+      distinctRelinBasis.insert(basis);
+    }
+    return WalkResult::advance();
+  });
+  SmallVector<int32_t> relinBasis(distinctRelinBasis.begin(),
+                                  distinctRelinBasis.end());
+  return relinBasis;
 }
+
+// Helper function to find all the rotation indices in the function
+SmallVector<int64_t> findAllRotIndices(func::FuncOp op) {
+  std::set<int64_t> distinctRotIndices;
+  op.walk([&](RotateOpInterface rotOp) {
+    distinctRotIndices.insert(rotOp.getRotationOffset());
+    return WalkResult::advance();
+  });
+  SmallVector<int64_t> rotIndicesResult(distinctRotIndices.begin(),
+                                        distinctRotIndices.end());
+  return rotIndicesResult;
+}
+
+}  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/HEIRInterfaces.h
+++ b/lib/Dialect/HEIRInterfaces.h
@@ -1,6 +1,7 @@
 #ifndef LIB_DIALECT_HEIRINTERFACES_H_
 #define LIB_DIALECT_HEIRINTERFACES_H_
 
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
@@ -10,6 +11,11 @@ namespace mlir {
 namespace heir {
 // Pull in HEIR interfaces
 #include "lib/Dialect/HEIRInterfaces.h.inc"
+
+SmallVector<int32_t> findAllRelinBasis(func::FuncOp op);
+
+SmallVector<int64_t> findAllRotIndices(func::FuncOp op);
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/lib/Dialect/HEIRInterfaces.td
+++ b/lib/Dialect/HEIRInterfaces.td
@@ -12,3 +12,29 @@ def LUTOpInterface : OpInterface<"LUTOpInterface"> {
     >,
   ];
 }
+
+def RelinearizeOpInterface : OpInterface<"RelinearizeOpInterface"> {
+  let description = [{
+    This Operation Interface exposes common methods for relinearize operations.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Gets the key basis of the input ciphertext.",
+      "SmallVector<int32_t>", "getFromBasis"
+    >,
+  ];
+}
+
+def RotateOpInterface : OpInterface<"RotateOpInterface"> {
+  let description = [{
+    This Operation Interface exposes common methods for rotate operations.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Gets the rotation offset of the input ciphertext.",
+      "int64_t", "getRotationOffset"
+    >,
+  ];
+}

--- a/lib/Dialect/Openfhe/IR/BUILD
+++ b/lib/Dialect/Openfhe/IR/BUILD
@@ -20,6 +20,7 @@ cc_library(
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":types_inc_gen",
+        "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Utils/Tablegen:AsmInterfaces",
         "@llvm-project//llvm:Support",
@@ -37,6 +38,7 @@ td_library(
     ],
     includes = ["../../../.."],
     deps = [
+        "@heir//lib/Dialect:td_files",
         "@heir//lib/Utils/Tablegen:td_files",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",

--- a/lib/Dialect/Openfhe/IR/OpenfheDialect.cpp
+++ b/lib/Dialect/Openfhe/IR/OpenfheDialect.cpp
@@ -26,6 +26,17 @@ void OpenfheDialect::initialize() {
       >();
 }
 
+SmallVector<int32_t> RelinOp::getFromBasis() {
+  SmallVector<int32_t> fromBasis;
+  auto dimension = getCiphertext().getType().getCiphertextSpace().getSize();
+  for (int i = 0; i < dimension; i++) {
+    fromBasis.push_back(i);
+  }
+  return fromBasis;
+}
+
+int64_t RotOp::getRotationOffset() { return getIndex().getInt(); }
+
 }  // namespace openfhe
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.h
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.h
@@ -1,6 +1,7 @@
 #ifndef LIB_DIALECT_OPENFHE_IR_OPENFHEOPS_H_
 #define LIB_DIALECT_OPENFHE_IR_OPENFHEOPS_H_
 
+#include "lib/Dialect/HEIRInterfaces.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheTypes.h"

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -4,6 +4,7 @@
 include "OpenfheDialect.td"
 include "OpenfheTypes.td"
 
+include "lib/Dialect/HEIRInterfaces.td"
 include "lib/Dialect/LWE/IR/LWETypes.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/CommonTypeConstraints.td"
@@ -207,14 +208,19 @@ def MulConstOp : Openfhe_Op<"mul_const",[
 
 def NegateOp : Openfhe_UnaryOp<"negate"> { let summary = "OpenFHE negate operation of a ciphertext."; }
 def SquareOp : Openfhe_UnaryOp<"square"> { let summary = "OpenFHE square operation of a ciphertext."; }
-def RelinOp : Openfhe_UnaryTypeSwitchOp<"relin"> { let summary = "OpenFHE relinearize operation of a ciphertext."; }
+def RelinOp : Openfhe_UnaryTypeSwitchOp<"relin", [
+  DeclareOpInterfaceMethods<RelinearizeOpInterface>
+]> {
+  let summary = "OpenFHE relinearize operation of a ciphertext.";
+}
 
 def ModReduceOp : Openfhe_UnaryTypeSwitchOp<"mod_reduce"> { let summary = "OpenFHE mod_reduce operation of a ciphertext. (used only for BGV/CKKS)"; }
 def LevelReduceOp : Openfhe_UnaryTypeSwitchOp<"level_reduce"> { let summary = "OpenFHE level_reduce operation of a ciphertext."; }
 
 def RotOp : Openfhe_Op<"rot",[
   Pure,
-  AllTypesMatch<["ciphertext", "output"]>
+  AllTypesMatch<["ciphertext", "output"]>,
+  DeclareOpInterfaceMethods<RotateOpInterface>
 ]> {
   let arguments = (ins
     Openfhe_CryptoContext:$cryptoContext,

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -36,27 +36,8 @@ namespace openfhe {
 
 // Helper function to check if the function has RelinOp
 bool hasRelinOp(func::FuncOp op) {
-  bool result = false;
-  op.walk<WalkOrder::PreOrder>([&](Operation *op) {
-    if (isa<openfhe::RelinOp>(op)) {
-      result = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return result;
-}
-
-// Helper function to find all the rotation indices in the function
-SmallVector<int64_t> findAllRotIndices(func::FuncOp op) {
-  std::set<int64_t> distinctRotIndices;
-  op.walk([&](openfhe::RotOp rotOp) {
-    distinctRotIndices.insert(rotOp.getIndex().getInt());
-    return WalkResult::advance();
-  });
-  SmallVector<int64_t> rotIndicesResult(distinctRotIndices.begin(),
-                                        distinctRotIndices.end());
-  return rotIndicesResult;
+  auto res = findAllRelinBasis(op);
+  return !res.empty();
 }
 
 // Helper function to check if the function has BootstrapOp


### PR DESCRIPTION
This PR deals with the relin/rotation setup, which has been in `--openfhe-configure-crypto-context`.

For now, we add `lwe.relinearize_degree` and `lwe.rotation_indices` attribute on the main function, and expect further backend specific lowering to use them to configure their context.

The exact definition of the lwe attribute should be discussed.

### Example

`--bgv-to-lwe --lwe-configure-crypto-context=entry-function=dot_product`:

```mlir
func.func @dot_product(%ct: !ct_L2_, %ct_0: !ct_L2_) -> !ct_L0_ attributes
 {lwe.relinearize_degree = #lwe.relinearize_degree<basis = [2]>,
 lwe.rotation_indices = #lwe.rotation_indices<indices = [1, 2, 4, 7]>}
```