### PR TITLE
Use `isSecret` in place of manual lattice lookups where possible

### DIFF
--- a/lib/Analysis/DimensionAnalysis/DimensionAnalysis.cpp
+++ b/lib/Analysis/DimensionAnalysis/DimensionAnalysis.cpp
@@ -108,7 +108,7 @@ void annotateDimension(Operation *top, DataFlowSolver *solver) {
       if (op->getNumResults() == 0) {
         return;
       }
-      if (!ensureSecretness(op->getResult(0), solver)) {
+      if (!isSecret(op->getResult(0), solver)) {
         return;
       }
       op->setAttr("dimension",

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
@@ -84,7 +84,7 @@ static int getMaxLevel(Operation *top, DataFlowSolver *solver) {
       if (op->getNumResults() == 0) {
         return;
       }
-      if (!ensureSecretness(op->getResult(0), solver)) {
+      if (!isSecret(op->getResult(0), solver)) {
         return;
       }
       // ensure result is secret
@@ -121,7 +121,7 @@ void annotateLevel(Operation *top, DataFlowSolver *solver) {
       if (op->getNumResults() == 0) {
         return;
       }
-      if (!ensureSecretness(op->getResult(0), solver)) {
+      if (!isSecret(op->getResult(0), solver)) {
         return;
       }
       auto level = getLevel(op->getResult(0));

--- a/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
+++ b/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
@@ -133,7 +133,7 @@ class SecretnessAnalysisDependent {
    * @return true if the value is secret, false if the secretness of the value
    * is unknown or false.
    */
-  bool ensureSecretness(Operation *op, Value value) {
+  bool isSecretInternal(Operation *op, Value value) {
     // create dependency on SecretnessAnalysis
     auto *lattice =
         getChildAnalysis()->template getOrCreateFor<SecretnessLattice>(
@@ -157,7 +157,7 @@ class SecretnessAnalysisDependent {
   void getSecretResults(Operation *op,
                         SmallVectorImpl<OpResult> &secretResults) {
     for (const auto &result : op->getOpResults()) {
-      if (ensureSecretness(op, result)) {
+      if (isSecretInternal(op, result)) {
         secretResults.push_back(result);
       }
     }
@@ -176,7 +176,7 @@ class SecretnessAnalysisDependent {
   void getSecretOperands(Operation *op,
                          SmallVectorImpl<OpOperand *> &secretOperands) {
     for (auto &operand : op->getOpOperands()) {
-      if (ensureSecretness(op, operand.get())) {
+      if (isSecretInternal(op, operand.get())) {
         secretOperands.push_back(&operand);
       }
     }
@@ -188,9 +188,9 @@ void annotateSecretness(Operation *top, DataFlowSolver *solver);
 
 // this method is used when DataFlowSolver has finished running the secretness
 // analysis
-bool ensureSecretness(Value value, DataFlowSolver *solver);
+bool isSecret(Value value, DataFlowSolver *solver);
 
-bool ensureSecretness(ValueRange values, DataFlowSolver *solver);
+bool isSecret(ValueRange values, DataFlowSolver *solver);
 
 void getSecretOperands(Operation *op,
                        SmallVectorImpl<OpOperand *> &secretOperands,

--- a/lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.cpp
+++ b/lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.cpp
@@ -235,16 +235,8 @@ struct ConvertLinalgMatmul : public OpRewritePattern<mlir::linalg::MatmulOp> {
     // Determine if the left or right operand is secret to determine which
     // matrix to diagonalize, or if both are secret or both are public, then
     // return failure.
-    auto isSecret = [&](Value value) {
-      auto *operandLookup = solver->lookupState<SecretnessLattice>(value);
-      Secretness operandSecretness =
-          operandLookup ? operandLookup->getValue() : Secretness();
-      return (operandSecretness.isInitialized() &&
-              operandSecretness.getSecretness());
-    };
-
-    bool isLeftOperandSecret = isSecret(op.getInputs()[0]);
-    bool isRightOperandSecret = isSecret(op.getInputs()[1]);
+    bool isLeftOperandSecret = isSecret(op.getInputs()[0], solver);
+    bool isRightOperandSecret = isSecret(op.getInputs()[1], solver);
 
     LLVM_DEBUG({
       llvm::dbgs() << "Left operand is secret: " << isLeftOperandSecret << "\n"

--- a/lib/Dialect/TOSA/Conversions/TosaToSecretArith/TosaToSecretArith.cpp
+++ b/lib/Dialect/TOSA/Conversions/TosaToSecretArith/TosaToSecretArith.cpp
@@ -62,16 +62,7 @@ struct ConvertTosaSigmoid : public OpRewritePattern<mlir::tosa::SigmoidOp> {
 
   LogicalResult matchAndRewrite(mlir::tosa::SigmoidOp op,
                                 PatternRewriter &rewriter) const override {
-    auto isSecret = [&](Value value) {
-      auto *operandLookup = solver->lookupState<SecretnessLattice>(value);
-      Secretness operandSecretness =
-          operandLookup ? operandLookup->getValue() : Secretness();
-      return (operandSecretness.isInitialized() &&
-              operandSecretness.getSecretness());
-    };
-
-    // Do not support lowering for non-secret operands
-    bool operandIsSecret = isSecret(op.getOperand());
+    bool operandIsSecret = isSecret(op.getOperand(), solver);
     if (!operandIsSecret) {
       return failure();
     }

--- a/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.cpp
+++ b/lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.cpp
@@ -36,22 +36,8 @@ struct SecretForToStaticForConversion : OpRewritePattern<scf::ForOp> {
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
-    auto *lowerBoundSecretnessLattice =
-        solver->lookupState<SecretnessLattice>(forOp.getLowerBound());
-
-    auto *upperBoundSecretnessLattice =
-        solver->lookupState<SecretnessLattice>(forOp.getUpperBound());
-
-    if (!lowerBoundSecretnessLattice && !upperBoundSecretnessLattice)
-      return failure();
-
-    // Get secretness state of the lower and upper bounds
-    bool isLowerBoundSecret =
-        lowerBoundSecretnessLattice &&
-        lowerBoundSecretnessLattice->getValue().getSecretness();
-    bool isUpperBoundSecret =
-        upperBoundSecretnessLattice &&
-        upperBoundSecretnessLattice->getValue().getSecretness();
+    bool isLowerBoundSecret = isSecret(forOp.getLowerBound(), solver);
+    bool isUpperBoundSecret = isSecret(forOp.getUpperBound(), solver);
 
     // If both bounds are non-secret constants, return
     if (!isLowerBoundSecret && !isUpperBoundSecret) return failure();


### PR DESCRIPTION
A quick cleanup to replace some uses of manual lattice lookups to use a helper function when possible. Impossible cases involve emitting warnings when the lattice is uninitialized, before choosing some default behavior.