### PR TITLE
Lattigo: Add configure-crypto-context pass

### DIFF
--- a/lib/Dialect/Lattigo/IR/LattigoOps.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoOps.cpp
@@ -24,6 +24,29 @@ LogicalResult BGVDecodeOp::verify() {
   return success();
 }
 
+LogicalResult RLWENewEvaluationKeySetOp::verify() {
+  if (getKeys().empty()) {
+    return emitError("must have at least one key");
+  }
+
+  // 0 or 1 relin key + 0 or more galois keys
+  auto galoisKeyIndex = 0;
+  auto firstKey = getKeys()[0];
+  if (isa<RLWERelinearizationKeyType>(firstKey.getType())) {
+    galoisKeyIndex = 1;
+  }
+
+  for (auto key : getKeys().drop_front(galoisKeyIndex)) {
+    if (!isa<RLWEGaloisKeyType>(key.getType())) {
+      if (isa<RLWERelinearizationKeyType>(key.getType())) {
+        return emitError("RLWERelinearizationKey must be the first key");
+      }
+      return emitError("key must be of type RLWEGaloisKey");
+    }
+  }
+  return success();
+}
+
 }  // namespace lattigo
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
@@ -63,11 +63,15 @@ def Lattigo_RLWENewEvaluationKeySetOp : Lattigo_RLWEOp<"new_evaluation_key_set">
   let description = [{
     This operation generates a new RLWE evaluation key set
   }];
+
+  // Tablegen produces an error when validating types when using a TypeOrContainer
+  // type in a Variadic like Variadic<AnyEvaluationKey>.
+  // A workaround uses Variadic<AnyType> and a custom type verifier.
   let arguments = (ins
-    Lattigo_RLWERelinearizationKey:$relinearizationKey,
-    Variadic<Lattigo_RLWEGaloisKey>:$galoisKeys
+    Variadic<AnyType>:$keys
   );
   let results = (outs Lattigo_RLWEEvaluationKeySet:$evaluationKeySet);
+  let hasVerifier = 1;
 }
 
 def Lattigo_RLWENewEncryptorOp : Lattigo_RLWEOp<"new_encryptor"> {

--- a/lib/Dialect/Lattigo/Transforms/BUILD
+++ b/lib/Dialect/Lattigo/Transforms/BUILD
@@ -1,0 +1,37 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":ConfigureCryptoContext",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "ConfigureCryptoContext",
+    srcs = ["ConfigureCryptoContext.cpp"],
+    hdrs = ["ConfigureCryptoContext.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    header_filename = "Passes.h.inc",
+    pass_name = "Lattigo",
+    td_file = "Passes.td",
+)

--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -1,0 +1,161 @@
+#include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
+
+#include "lib/Dialect/Lattigo/IR/LattigoOps.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+#define GEN_PASS_DEF_CONFIGURECRYPTOCONTEXT
+#include "lib/Dialect/Lattigo/Transforms/Passes.h.inc"
+
+// Helper function to check if the function has RelinearizeOp
+bool hasRelinOp(func::FuncOp op) {
+  bool result = false;
+  op.walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (isa<BGVRelinearizeOp>(op)) {
+      result = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return result;
+}
+
+// Helper function to find all the rotation indices in the function
+// TODO(#1186): handle rotate rows
+SmallVector<int64_t> findAllRotIndices(func::FuncOp op) {
+  std::set<int64_t> distinctRotIndices;
+  op.walk([&](BGVRotateColumnsOp rotOp) {
+    distinctRotIndices.insert(rotOp.getOffset().getInt());
+    return WalkResult::advance();
+  });
+  SmallVector<int64_t> rotIndicesResult(distinctRotIndices.begin(),
+                                        distinctRotIndices.end());
+  return rotIndicesResult;
+}
+
+LogicalResult convertFunc(func::FuncOp op) {
+  auto module = op->getParentOfType<ModuleOp>();
+  std::string configFuncName("");
+  llvm::raw_string_ostream configNameOs(configFuncName);
+  configNameOs << op.getSymName() << "__configure";
+
+  ImplicitLocOpBuilder builder =
+      ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
+
+  // __configure() -> (evaluator, params, encoder, encryptor, decryptor)
+  SmallVector<Type> funcArgTypes;
+  SmallVector<Type> funcResultTypes;
+
+  Type evaluatorType = BGVEvaluatorType::get(builder.getContext());
+  Type paramsType = BGVParameterType::get(builder.getContext());
+  Type encoderType = BGVEncoderType::get(builder.getContext());
+  Type encryptorType = RLWEEncryptorType::get(builder.getContext());
+  Type decryptorType = RLWEDecryptorType::get(builder.getContext());
+  funcResultTypes.push_back(evaluatorType);
+  funcResultTypes.push_back(paramsType);
+  funcResultTypes.push_back(encoderType);
+  funcResultTypes.push_back(encryptorType);
+  funcResultTypes.push_back(decryptorType);
+
+  FunctionType configFuncType =
+      FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
+
+  auto configFuncOp =
+      builder.create<func::FuncOp>(configFuncName, configFuncType);
+  builder.setInsertionPointToEnd(configFuncOp.addEntryBlock());
+
+  // TODO(#465): Allow custom params
+  // 128-bit secure parameters enabling depth-7 circuits.
+  // LogN:14, LogQP: 431.
+  auto logN = 14;
+  auto paramAttr = BGVParametersLiteralAttr::get(
+      builder.getContext(), /*logN*/ logN, /*Q*/ nullptr, /*P*/ nullptr,
+      /*logQ*/
+      DenseI32ArrayAttr::get(builder.getContext(),
+                             {55, 45, 45, 45, 45, 45, 45, 45}),
+      /*logP*/ DenseI32ArrayAttr::get(builder.getContext(), {61}),
+      /*ptm*/ 0x10001);
+  auto paramType = BGVParameterType::get(builder.getContext());
+
+  auto params =
+      builder.create<BGVNewParametersFromLiteralOp>(paramType, paramAttr);
+
+  auto encoder = builder.create<BGVNewEncoderOp>(encoderType, params);
+  auto kgenType = RLWEKeyGeneratorType::get(builder.getContext());
+  auto kgen = builder.create<RLWENewKeyGeneratorOp>(kgenType, params);
+  auto skType = RLWESecretKeyType::get(builder.getContext());
+  auto pkType = RLWEPublicKeyType::get(builder.getContext());
+  SmallVector<Type> keypairTypes = {skType, pkType};
+  auto keypair = builder.create<RLWEGenKeyPairOp>(keypairTypes, kgen);
+  auto sk = keypair.getResult(0);
+  auto pk = keypair.getResult(1);
+  auto encryptor =
+      builder.create<RLWENewEncryptorOp>(encryptorType, params, pk);
+  auto decryptor =
+      builder.create<RLWENewDecryptorOp>(decryptorType, params, sk);
+
+  SmallVector<Value> evalKeys;
+
+  // generate Relinearization Key on demand
+  if (hasRelinOp(op)) {
+    auto rkType = RLWERelinearizationKeyType::get(builder.getContext());
+    auto rk = builder.create<RLWEGenRelinearizationKeyOp>(rkType, kgen, sk);
+    evalKeys.push_back(rk);
+  }
+
+  // generate Galois Keys on demand
+  auto rotIndices = findAllRotIndices(op);
+  for (auto rotIndex : rotIndices) {
+    auto galoisElement = int(pow(5, rotIndex)) % (1 << logN);
+    auto galoisElementAttr = IntegerAttr::get(
+        IntegerType::get(builder.getContext(), 64), galoisElement);
+    auto gkType =
+        RLWEGaloisKeyType::get(builder.getContext(), galoisElementAttr);
+    auto gk =
+        builder.create<RLWEGenGaloisKeyOp>(gkType, kgen, sk, galoisElementAttr);
+    evalKeys.push_back(gk);
+  }
+
+  Value evalKeySet(nullptr);
+  if (!evalKeys.empty()) {
+    auto evalKeyType = RLWEEvaluationKeySetType::get(builder.getContext());
+    evalKeySet =
+        builder.create<RLWENewEvaluationKeySetOp>(evalKeyType, evalKeys);
+  }
+
+  // evalKeySet is optional so nulltpr is acceptable
+  auto evaluator =
+      builder.create<BGVNewEvaluatorOp>(evaluatorType, params, evalKeySet);
+
+  SmallVector<Value> results = {evaluator, params, encoder, encryptor,
+                                decryptor};
+  builder.create<func::ReturnOp>(results);
+  return success();
+}
+
+struct ConfigureCryptoContext
+    : impl::ConfigureCryptoContextBase<ConfigureCryptoContext> {
+  using ConfigureCryptoContextBase::ConfigureCryptoContextBase;
+
+  void runOnOperation() override {
+    auto result =
+        getOperation()->walk<WalkOrder::PreOrder>([&](func::FuncOp op) {
+          auto funcName = op.getSymName();
+          if ((funcName == entryFunction) && failed(convertFunc(op))) {
+            op->emitError("Failed to configure the crypto context for func");
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
+    if (result.wasInterrupted()) signalPassFailure();
+  }
+};
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_LATTIGO_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+#define LIB_DIALECT_LATTIGO_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+#define GEN_PASS_DECL_CONFIGURECRYPTOCONTEXT
+#include "lib/Dialect/Lattigo/Transforms/Passes.h.inc"
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_LATTIGO_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_

--- a/lib/Dialect/Lattigo/Transforms/Passes.h
+++ b/lib/Dialect/Lattigo/Transforms/Passes.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_LATTIGO_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_LATTIGO_TRANSFORMS_PASSES_H_
+
+#include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
+#include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
+
+namespace mlir {
+namespace heir {
+namespace lattigo {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Lattigo/Transforms/Passes.h.inc"
+
+}  // namespace lattigo
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_LATTIGO_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/Lattigo/Transforms/Passes.td
+++ b/lib/Dialect/Lattigo/Transforms/Passes.td
@@ -1,0 +1,24 @@
+#ifndef LIB_DIALECT_LATTIGO_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_LATTIGO_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ConfigureCryptoContext : Pass<"lattigo-configure-crypto-context"> {
+  let summary = "Configure the crypto context in Lattigo";
+  let description = [{
+    This pass generates helper functions to configure the Lattigo objects for the given function.
+
+    For example, for an MLIR function `@my_func`, the generated helpers have the following signatures
+    ```mlir
+    func.func @my_func__configure() -> (!lattigo.bgv.evaluator, !lattigo.bgv.parameter, !lattigo.bgv.encoder, !lattigo.rlwe.encryptor, !lattigo.rlwe.decryptor)
+    ```
+  }];
+  let dependentDialects = ["mlir::heir::lattigo::LattigoDialect"];
+  let options = [
+    Option<"entryFunction", "entry-function", "std::string",
+           /*default=*/"", "Default entry function "
+           "name of entry function.">,
+  ];
+}
+
+#endif  // LIB_DIALECT_LATTIGO_TRANSFORMS_PASSES_TD_

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -8,6 +8,7 @@
 #include "lib/Dialect/CKKS/Conversions/CKKSToLWE/CKKSToLWE.h"
 #include "lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.h"
 #include "lib/Dialect/LWE/Transforms/AddClientInterface.h"
+#include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.h"
@@ -274,6 +275,12 @@ RLWEPipelineBuilder mlirToLattigoRLWEPipelineBuilder(const RLWEScheme scheme) {
     // Simplify, in case the lowering revealed redundancy
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createCSEPass());
+
+    auto configureCryptoContextOptions =
+        lattigo::ConfigureCryptoContextOptions{};
+    configureCryptoContextOptions.entryFunction = options.entryFunction;
+    pm.addPass(
+        lattigo::createConfigureCryptoContext(configureCryptoContextOptions));
   };
 }
 

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -91,6 +91,7 @@ cc_library(
         "@heir//lib/Dialect/LWE/Conversions/LWEToOpenfhe",
         "@heir//lib/Dialect/LWE/Conversions/LWEToPolynomial",
         "@heir//lib/Dialect/LWE/Transforms:AddClientInterface",
+        "@heir//lib/Dialect/Lattigo/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/LinAlg/Conversions/LinalgToTensorExt",
         "@heir//lib/Dialect/Openfhe/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/Secret/Conversions/SecretToBGV",

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -108,6 +108,10 @@ class LattigoEmitter {
 
   // helper on name and type
   std::string getName(::mlir::Value value) {
+    // special case for 'nil' emission
+    if (value == Value()) {
+      return "nil";
+    }
     return variableNames->getNameForValue(value);
   }
 

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -134,3 +134,28 @@ func.func @test_constant() -> () {
   %dense = arith.constant dense<2> : tensor<4xi32>
   return
 }
+
+// -----
+
+!rk = !lattigo.rlwe.relinearization_key
+!gk = !lattigo.rlwe.galois_key<galoisElement = 5>
+!ekset = !lattigo.rlwe.evaluation_key_set
+
+// CHECK-LABEL: test_new_evaluation_key_set_no_relin_key
+// CHECK: rlwe.NewMemEvaluationKeySet(nil, [[gk:[^, ].*]])
+func.func @test_new_evaluation_key_set_no_relin_key(%gk : !gk) -> (!ekset) {
+  %ekset = lattigo.rlwe.new_evaluation_key_set %gk : (!gk) -> !ekset
+  return %ekset : !ekset
+}
+
+// -----
+
+!params = !lattigo.bgv.parameter
+!evaluator = !lattigo.bgv.evaluator
+
+// CHECK-LABEL: test_new_evaluator_no_key_set
+// CHECK: bgv.NewEvaluator([[params:[^, ].*]], nil)
+func.func @test_new_evaluator_no_key_set(%params : !params) -> (!evaluator) {
+  %evaluator = lattigo.bgv.new_evaluator %params : (!params) -> !evaluator
+  return %evaluator : !evaluator
+}

--- a/tests/Dialect/Lattigo/IR/verifier.mlir
+++ b/tests/Dialect/Lattigo/IR/verifier.mlir
@@ -45,3 +45,37 @@ func.func @test_bgv_decode_no_scalar(%encoder: !encoder, %pt: !pt, %value : !val
   %decoded = lattigo.bgv.decode %encoder, %pt, %value : (!encoder, !pt, !value_scalar) -> !value_scalar
   return
 }
+
+// -----
+
+!rk = !lattigo.rlwe.relinearization_key
+!gk = !lattigo.rlwe.galois_key<galoisElement = 5>
+!ekset = !lattigo.rlwe.evaluation_key_set
+
+func.func @test_rlwe_new_evaluation_key_set_operands_order(%rk: !rk, %gk: !gk) {
+  // expected-error@+1 {{RLWERelinearizationKey must be the first key}}
+  %ekset = lattigo.rlwe.new_evaluation_key_set %gk, %rk : (!gk, !rk) -> !ekset
+  return
+}
+
+// -----
+
+!ekset = !lattigo.rlwe.evaluation_key_set
+
+func.func @test_rlwe_new_evaluation_key_set_operands_empty() {
+  // expected-error@+1 {{must have at least one key}}
+  %ekset = lattigo.rlwe.new_evaluation_key_set : () -> !ekset
+  return
+}
+
+// -----
+
+!gk = !lattigo.rlwe.galois_key<galoisElement = 5>
+!ekset = !lattigo.rlwe.evaluation_key_set
+
+func.func @test_rlwe_new_evaluation_key_set_operands_other_types(%gk: !gk) {
+  %c = arith.constant 42 : i32
+  // expected-error@+1 {{key must be of type RLWEGaloisKey}}
+  %ekset = lattigo.rlwe.new_evaluation_key_set %gk, %c : (!gk, i32) -> !ekset
+  return
+}

--- a/tests/Dialect/Lattigo/Transforms/BUILD
+++ b/tests/Dialect/Lattigo/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_add.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_add.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --lattigo-configure-crypto-context=entry-function=add %s | FileCheck %s
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+func.func @add(%evaluator : !evaluator, %ct : !ct) -> !ct {
+  %res = lattigo.bgv.add %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+  return %res : !ct
+}
+
+// CHECK: @add
+// CHECK: @add__configure
+// CHECK-NOT: lattigo.rlwe.gen_relinearization_key
+// CHECK-NOT: lattigo.rlwe.gen_galois_key

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_relin.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_relin.mlir
@@ -1,0 +1,16 @@
+// RUN: heir-opt --lattigo-configure-crypto-context=entry-function=relin %s | FileCheck %s
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+func.func @relin(%evaluator : !evaluator, %ct : !ct) -> !ct {
+  %ct1 = lattigo.bgv.mul %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+  %res = lattigo.bgv.relinearize %evaluator, %ct1 : (!evaluator, !ct) -> !ct
+  return %res : !ct
+}
+
+// CHECK: @relin
+// CHECK: @relin__configure
+// CHECK: lattigo.rlwe.gen_relinearization_key
+// CHECK-NOT: lattigo.rlwe.gen_galois_key

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_rotate.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_rotate.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --lattigo-configure-crypto-context=entry-function=rotate %s | FileCheck %s
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+func.func @rotate(%evaluator : !evaluator, %ct : !ct) -> !ct {
+  %res = lattigo.bgv.rotate_columns %evaluator, %ct {offset = 1} : (!evaluator, !ct) -> !ct
+  return %res : !ct
+}
+
+// CHECK: @rotate
+// CHECK: @rotate__configure
+// CHECK-NOT: lattigo.rlwe.gen_relinearization_key
+// CHECK: lattigo.rlwe.gen_galois_key

--- a/tests/Examples/lattigo/binops_test.go
+++ b/tests/Examples/lattigo/binops_test.go
@@ -2,36 +2,10 @@ package binops
 
 import (
 	"testing"
-
-	"github.com/tuneinsight/lattigo/v6/core/rlwe"
-	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
 )
 
 func TestBinops(t *testing.T) {
-	var err error
-	var params bgv.Parameters
-
-	// 128-bit secure parameters enabling depth-7 circuits.
-	// LogN:14, LogQP: 431.
-	if params, err = bgv.NewParametersFromLiteral(
-		bgv.ParametersLiteral{
-			LogN:             14,                                    // log2(ring degree)
-			LogQ:             []int{55, 45, 45, 45, 45, 45, 45, 45}, // log2(primes Q) (ciphertext modulus)
-			LogP:             []int{61},                             // log2(primes P) (auxiliary modulus)
-			PlaintextModulus: 0x10001,                               // log2(scale)
-		}); err != nil {
-		panic(err)
-	}
-
-	kgen := rlwe.NewKeyGenerator(params)
-	sk := kgen.GenSecretKeyNew()
-	ecd := bgv.NewEncoder(params)
-	enc := rlwe.NewEncryptor(params, sk)
-	dec := rlwe.NewDecryptor(params, sk)
-	relinKeys := kgen.GenRelinearizationKeyNew(sk)
-	galKey := kgen.GenGaloisKeyNew(5, sk)
-	evalKeys := rlwe.NewMemEvaluationKeySet(relinKeys, galKey)
-	evaluator := bgv.NewEvaluator(params, evalKeys /*scaleInvariant=*/, false)
+	evaluator, params, ecd, enc, dec := add__configure()
 
 	// Vector of plaintext values
 	// 0, 1, 2, 3

--- a/tests/Examples/lattigo/dot_product_8_test.go
+++ b/tests/Examples/lattigo/dot_product_8_test.go
@@ -2,43 +2,10 @@ package dotproduct8
 
 import (
 	"testing"
-
-	"github.com/tuneinsight/lattigo/v6/core/rlwe"
-	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
 )
 
 func TestBinops(t *testing.T) {
-	var err error
-	var params bgv.Parameters
-
-	// 128-bit secure parameters enabling depth-7 circuits.
-	// LogN:14, LogQP: 431.
-	if params, err = bgv.NewParametersFromLiteral(
-		bgv.ParametersLiteral{
-			LogN:             14,                                    // log2(ring degree)
-			LogQ:             []int{55, 45, 45, 45, 45, 45, 45, 45}, // log2(primes Q) (ciphertext modulus)
-			LogP:             []int{61},                             // log2(primes P) (auxiliary modulus)
-			PlaintextModulus: 0x10001,                               // log2(scale)
-		}); err != nil {
-		panic(err)
-	}
-
-	kgen := rlwe.NewKeyGenerator(params)
-	sk := kgen.GenSecretKeyNew()
-	ecd := bgv.NewEncoder(params)
-	enc := rlwe.NewEncryptor(params, sk)
-	dec := rlwe.NewDecryptor(params, sk)
-	relinKeys := kgen.GenRelinearizationKeyNew(sk)
-	// 5^7 % (2^14) = 12589
-	galKey12589 := kgen.GenGaloisKeyNew(12589, sk)
-	// 5^4 = 625
-	galKey625 := kgen.GenGaloisKeyNew(625, sk)
-	// 5^2 = 25
-	galKey25 := kgen.GenGaloisKeyNew(25, sk)
-	// 5^1 = 5
-	galKey5 := kgen.GenGaloisKeyNew(5, sk)
-	evalKeys := rlwe.NewMemEvaluationKeySet(relinKeys, galKey5, galKey25, galKey625, galKey12589)
-	evaluator := bgv.NewEvaluator(params, evalKeys /*scaleInvariant=*/, false)
+	evaluator, params, ecd, enc, dec := dot_product__configure()
 
 	// Vector of plaintext values
 	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -54,6 +54,8 @@ cc_binary(
         "@heir//lib/Dialect/LWE/Transforms",
         "@heir//lib/Dialect/LWE/Transforms:AddClientInterface",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@heir//lib/Dialect/Lattigo/Transforms",
+        "@heir//lib/Dialect/Lattigo/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/LinAlg/Conversions/LinalgToTensorExt",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -23,6 +23,7 @@
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/Passes.h"
 #include "lib/Dialect/Lattigo/IR/LattigoDialect.h"
+#include "lib/Dialect/Lattigo/Transforms/Passes.h"
 #include "lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Mgmt/Transforms/Passes.h"
@@ -251,6 +252,7 @@ int main(int argc, char **argv) {
 
   // Custom passes in HEIR
   cggi::registerCGGIPasses();
+  lattigo::registerLattigoPasses();
   lwe::registerLWEPasses();
   mgmt::registerMgmtPasses();
   openfhe::registerOpenfhePasses();


### PR DESCRIPTION
Similar to `--openfhe-configure-crypto-context`.

The helper function signature is
```mlir
func.func @my_func__configure() -> (!lattigo.bgv.evaluator, !lattigo.bgv.parameter, !lattigo.bgv.encoder, !lattigo.rlwe.encryptor, !lattigo.rlwe.decryptor)
```

This is somewhat a violation of #1145. I do not find a scheme/LWE level configure function obvious and if we go on that direction, the design of the configure function needs discussion.