### PR TITLE
add drop-unit-dims transform

### DIFF
--- a/lib/Transforms/DropUnitDims/BUILD
+++ b/lib/Transforms/DropUnitDims/BUILD
@@ -1,0 +1,26 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "DropUnitDims",
+    srcs = ["DropUnitDims.cpp"],
+    hdrs = ["DropUnitDims.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "DropUnitDims",
+    td_file = "DropUnitDims.td",
+)

--- a/lib/Transforms/DropUnitDims/DropUnitDims.cpp
+++ b/lib/Transforms/DropUnitDims/DropUnitDims.cpp
@@ -1,0 +1,26 @@
+#include "lib/Transforms/DropUnitDims/DropUnitDims.h"
+
+#include "mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_DROPUNITDIMS
+#include "lib/Transforms/DropUnitDims/DropUnitDims.h.inc"
+
+struct DropUnitDims : impl::DropUnitDimsBase<DropUnitDims> {
+  using DropUnitDimsBase::DropUnitDimsBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    linalg::populateContractionOpRankReducingPatterns(patterns);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/DropUnitDims/DropUnitDims.h
+++ b/lib/Transforms/DropUnitDims/DropUnitDims.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_DROPUNITDIMS_DROPUNITDIMS_H_
+#define LIB_TRANSFORMS_DROPUNITDIMS_DROPUNITDIMS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/DropUnitDims/DropUnitDims.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/DropUnitDims/DropUnitDims.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_DROPUNITDIMS_DROPUNITDIMS_H_

--- a/lib/Transforms/DropUnitDims/DropUnitDims.td
+++ b/lib/Transforms/DropUnitDims/DropUnitDims.td
@@ -1,0 +1,20 @@
+#ifndef LIB_TRANSFORMS_DROPUNITDIMS_DROPUNITDIMS_TD_
+#define LIB_TRANSFORMS_DROPUNITDIMS_DROPUNITDIMS_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def DropUnitDims : Pass<"drop-unit-dims"> {
+  let summary = "Drops unit dimensions from linalg ops.";
+  let description = [{
+  This pass converts `linalg` whose operands have unit dimensions
+  in their types to specialized ops that drop these unit dimensions.
+
+  For example, a `linalg.matmul` whose RHS has type `tensor<32x1xi32>` is
+  converted to a `linalg.matvec` op on the underlying `tensor<32xi32>`.
+  }];
+  let dependentDialects = [
+    "mlir::linalg::LinalgDialect",
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_DROPUNITDIMS_DROPUNITDIMS_TD_

--- a/tests/Transforms/drop_unit_dims/BUILD
+++ b/tests/Transforms/drop_unit_dims/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/drop_unit_dims/matmul_to_matvec.mlir
+++ b/tests/Transforms/drop_unit_dims/matmul_to_matvec.mlir
@@ -1,0 +1,31 @@
+// RUN: heir-opt %s --drop-unit-dims | FileCheck %s
+
+// CHECK-LABEL: collapse_matmul_rhs
+// CHECK-NOT: linalg.matmul
+// CHECK: tensor.collapse_shape
+// CHECK: linalg.matvec
+func.func @collapse_matmul_rhs(%vec : !secret.secret<tensor<4x1xi16>>) -> !secret.secret<tensor<4x1xi16>> {
+  %matrix = arith.constant dense<[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]> : tensor<4x4xi16>
+  %bias = arith.constant dense<[[17], [18], [19], [20]]> : tensor<4x1xi16>
+  %out = secret.generic ins (%vec : !secret.secret<tensor<4x1xi16>>) {
+  ^body(%pt_vec: tensor<4x1xi16>):
+    %0 = linalg.matmul ins(%matrix, %pt_vec : tensor<4x4xi16>, tensor<4x1xi16>) outs(%bias : tensor<4x1xi16>) -> tensor<4x1xi16>
+    secret.yield %0 : tensor<4x1xi16>
+  } -> !secret.secret<tensor<4x1xi16>>
+  return %out : !secret.secret<tensor<4x1xi16>>
+}
+
+// CHECK-LABEL: collapse_matmul_lhs
+// CHECK-NOT: linalg.matmul
+// CHECK: tensor.collapse_shape
+// CHECK: linalg.vecmat
+func.func @collapse_matmul_lhs(%vec : !secret.secret<tensor<1x4xi16>>) -> !secret.secret<tensor<1x4xi16>> {
+  %matrix = arith.constant dense<[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]> : tensor<4x4xi16>
+  %bias = arith.constant dense<[[17, 18, 19, 20]]> : tensor<1x4xi16>
+  %out = secret.generic ins (%vec : !secret.secret<tensor<1x4xi16>>) {
+  ^body(%pt_vec: tensor<1x4xi16>):
+    %0 = linalg.matmul ins(%pt_vec, %matrix : tensor<1x4xi16>, tensor<4x4xi16>) outs(%bias : tensor<1x4xi16>) -> tensor<1x4xi16>
+    secret.yield %0 : tensor<1x4xi16>
+  } -> !secret.secret<tensor<1x4xi16>>
+  return %out : !secret.secret<tensor<1x4xi16>>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -94,6 +94,7 @@ cc_binary(
         "@heir//lib/Transforms/ConvertSecretForToStaticFor",
         "@heir//lib/Transforms/ConvertSecretInsertToStaticInsert",
         "@heir//lib/Transforms/ConvertSecretWhileToStaticFor",
+        "@heir//lib/Transforms/DropUnitDims",
         "@heir//lib/Transforms/ElementwiseToAffine",
         "@heir//lib/Transforms/ForwardInsertToExtract",
         "@heir//lib/Transforms/ForwardStoreToLoad",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -57,6 +57,7 @@
 #include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h"
 #include "lib/Transforms/ConvertSecretInsertToStaticInsert/ConvertSecretInsertToStaticInsert.h"
 #include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h"
+#include "lib/Transforms/DropUnitDims/DropUnitDims.h"
 #include "lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.h"
 #include "lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.h"
 #include "lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.h"
@@ -265,6 +266,7 @@ int main(int argc, char **argv) {
   registerConvertSecretWhileToStaticForPasses();
   registerConvertSecretExtractToStaticExtractPasses();
   registerConvertSecretInsertToStaticInsertPasses();
+  registerDropUnitDims();
   registerAnnotateSecretnessPasses();
   registerApplyFoldersPasses();
   registerForwardInsertToExtractPasses();


### PR DESCRIPTION
This transform (pulled from https://github.com/google/heir/pull/1264) converts linalg operations (like matmul) whose operands have dimensions with unit size to simpler named linalg operations (like matvec) that operate on the tensors of reduced rank.

The patterns are all upstream, and this wraps them in a pass.

Note that the simplified operations are surrounded by `collapse_shape` and `expand_shape` so as to maintain type consistency.