### PR TITLE
tensor_ext: add convert_layout op

### DIFF
--- a/lib/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.td
@@ -12,6 +12,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class TensorExt_Op<string mnemonic, list<Trait> traits = []> :
         Op<TensorExt_Dialect, mnemonic, traits> {
   let cppNamespace = "::mlir::heir::tensor_ext";
+  let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 def TensorExt_RotateOp : TensorExt_Op<"rotate", [Pure, AllTypesMatch<["tensor", "output"]>]> {
@@ -45,6 +46,21 @@ def TensorExt_RotateOp : TensorExt_Op<"rotate", [Pure, AllTypesMatch<["tensor", 
   let results = (outs AnyTensor:$output);
   let assemblyFormat = "operands attr-dict `:` qualified(type($tensor)) `,` type($shift)";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+}
+
+def TensorExt_ConvertLayoutOp : TensorExt_Op<"convert_layout", [Pure, AllTypesMatch<["tensor", "output"]>]> {
+  let summary = "Convert from one layout to another.";
+  let description = [{
+    This op represents the conversion of a tensor from one packed layout to
+    another. This is implemented via a "shift network" of ciphertext rotations,
+    plaintext masks (ciphertext-plaintext multiplications), and additions.
+
+    This op is inserted by layout selection passes.
+  }];
+  let assemblyFormat = "operands attr-dict `:` type($output)";
+  let arguments = (ins AnyRankedTensor:$tensor, Builtin_AffineMapAttr:$from_layout, Builtin_AffineMapAttr:$to_layout);
+  let results = (outs AnyRankedTensor:$output);
   let hasVerifier = 1;
 }
 

--- a/tests/Dialect/TensorExt/IR/convert_layout_verifier.mlir
+++ b/tests/Dialect/TensorExt/IR/convert_layout_verifier.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt --verify-diagnostics --split-input-file %s
+
+
+#row_major = affine_map<(d0, d1) -> (16*d0 + d1)>
+#col_major = affine_map<(d0) -> (d0)>
+func.func @test_convert_layout(%0: tensor<16x16xi32>) -> tensor<16x16xi32> {
+  // expected-error@+1 {{requires tensor rank to match the layout map's dimension count}}
+  %1 = tensor_ext.convert_layout %0 {from_layout = #row_major, to_layout = #col_major} : tensor<16x16xi32>
+  return %1 : tensor<16x16xi32>
+}
+
+// -----
+
+#row_major = affine_map<(d0, d1) -> (16*d0 + d1)>
+#col_major = affine_map<(d0) -> (d0)>
+func.func @test_convert_layout(%0: tensor<16x16xi32>) -> tensor<16x16xi32> {
+  // expected-error@+1 {{requires tensor rank to match the layout map's dimension count}}
+  %1 = tensor_ext.convert_layout %0 {from_layout = #col_major, to_layout = #row_major} : tensor<16x16xi32>
+  return %1 : tensor<16x16xi32>
+}

--- a/tests/Dialect/TensorExt/IR/ops.mlir
+++ b/tests/Dialect/TensorExt/IR/ops.mlir
@@ -7,3 +7,10 @@ func.func @test_rotate(%0: tensor<16xi32>) -> tensor<16xi32> {
   %1 = tensor_ext.rotate %0, %c1 : tensor<16xi32>, i32
   return %1 : tensor<16xi32>
 }
+
+#row_major = affine_map<(d0, d1) -> (16*d0 + d1)>
+#col_major = affine_map<(d0, d1) -> (16*d1 + d0)>
+func.func @test_convert_layout(%0: tensor<16x16xi32>) -> tensor<16x16xi32> {
+  %1 = tensor_ext.convert_layout %0 {from_layout = #row_major, to_layout = #col_major} : tensor<16x16xi32>
+  return %1 : tensor<16x16xi32>
+}


### PR DESCRIPTION
This PR adds an op that represents the conversion of a ciphertext layout from one form to another, using the affine_map layout notation defined in https://docs.google.com/document/d/1TTj0NDZkn0T9NNQj6idbTk2g65tAb7VxsYpt1hKjK_Y/edit?tab=t.0#heading=h.hcusv1ynbv9n