### PR TITLE
Adding ptxt-ctxt support to arith-to-cggi and cggi ops

### DIFF
--- a/lib/Dialect/CGGI/IR/CGGIOps.td
+++ b/lib/Dialect/CGGI/IR/CGGIOps.td
@@ -10,6 +10,7 @@ include "lib/Dialect/LWE/IR/LWETypes.td"
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/CommonAttrConstraints.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -40,15 +41,25 @@ class CGGI_BinaryOp<string mnemonic>
   let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
 }
 
+class CGGI_ScalarBinaryOp<string mnemonic>
+  : CGGI_Op<mnemonic, [
+    Pure,
+    Commutative
+]> {
+  let arguments = (ins LWECiphertext:$lhs, AnyTypeOf<[Builtin_Integer, LWECiphertext]>:$rhs);
+  let results = (outs LWECiphertext:$output);
+}
+
 def CGGI_AndOp : CGGI_BinaryOp<"and"> { let summary = "Logical AND of two ciphertexts."; }
 def CGGI_NandOp : CGGI_BinaryOp<"nand"> { let summary = "Logical NAND of two ciphertexts."; }
 def CGGI_NorOp  : CGGI_BinaryOp<"nor">  { let summary = "Logical NOR of two ciphertexts."; }
 def CGGI_OrOp  : CGGI_BinaryOp<"or">  { let summary = "Logical OR of two ciphertexts."; }
 def CGGI_XorOp : CGGI_BinaryOp<"xor"> { let summary = "Logical XOR of two ciphertexts."; }
 def CGGI_XNorOp : CGGI_BinaryOp<"xnor"> { let summary = "Logical XNOR of two ciphertexts."; }
-def CGGI_AddOp : CGGI_BinaryOp<"add"> { let summary = "Arithmetic addition of two ciphertexts."; }
-def CGGI_MulOp : CGGI_BinaryOp<"mul"> {
-  let summary = "Arithmetic multiplication of two ciphertexts.";
+
+def CGGI_AddOp : CGGI_ScalarBinaryOp<"add"> { let summary = "Arithmetic addition of two ciphertexts. One of the two ciphertext is allowed to be a scalar, this will result in the scalar addition to a ciphertext."; }
+def CGGI_MulOp : CGGI_ScalarBinaryOp<"mul"> {
+  let summary = "Arithmetic multiplication of two ciphertexts. One of the two ciphertext is allowed to be a scalar, this will result in the scalar multiplication to a ciphertext.";
   let description = [{
     While CGGI does not have a native multiplication operation,
     some backend targets provide a multiplication
@@ -58,6 +69,18 @@ def CGGI_MulOp : CGGI_BinaryOp<"mul"> {
     to this op the appropriate CGGI ops.
   }];
 }
+
+def CGGI_SubOp : CGGI_Op<"sub", [
+    Pure,
+    SameOperandsAndResultType,
+    ElementwiseMappable,
+    Scalarizable
+]> {
+  let arguments = (ins LWECiphertext:$lhs, LWECiphertext:$rhs);
+  let results = (outs LWECiphertext:$output);
+  let summary = "Subtraction of two ciphertexts.";
+}
+
 
 def CGGI_NotOp : CGGI_Op<"not", [
     Pure,
@@ -282,17 +305,6 @@ def CGGI_MultiLutLinCombOp : CGGI_Op<"multi_lut_lincomb", [
   let hasVerifier = 1;
 }
 
-def CGGI_SubOp : CGGI_Op<"sub", [
-    Pure,
-    SameOperandsAndResultType,
-    ElementwiseMappable,
-    Scalarizable
-]> {
-  let arguments = (ins LWECiphertextLike:$lhs, LWECiphertextLike:$rhs);
-  let results = (outs LWECiphertextLike:$output);
-  let assemblyFormat = "operands attr-dict `:` qualified(type($output))";
-  let summary = "Subtraction of two ciphertexts.";
-}
 
 
 def CGGI_ScalarShiftRightOp : CGGI_Op<"sshr", [

--- a/lib/Utils/ConversionUtils.h
+++ b/lib/Utils/ConversionUtils.h
@@ -16,6 +16,7 @@
 #include "lib/Dialect/TfheRust/IR/TfheRustTypes.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"             // from @llvm-project
 #include "llvm/include/llvm/Support/Casting.h"           // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
@@ -93,8 +94,8 @@ struct ConvertBinOp : public OpConversionPattern<SourceArithOp> {
       ConversionPatternRewriter &rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto result =
-        b.create<TargetModArithOp>(adaptor.getLhs(), adaptor.getRhs());
+    auto result = b.create<TargetModArithOp>(
+        adaptor.getLhs().getType(), adaptor.getLhs(), adaptor.getRhs());
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/tests/Dialect/Arith/Conversions/ArithToCGGI/arith-to-cggi.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToCGGI/arith-to-cggi.mlir
@@ -3,34 +3,28 @@
 // CHECK-LABEL: @test_lower_add
 // CHECK-SAME: (%[[LHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>, %[[RHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>) -> [[T:.*]] {
 func.func @test_lower_add(%lhs : i32, %rhs : i32) -> i32 {
-  // CHECK: %[[ADD:.*]] = cggi.add %[[LHS]], %[[RHS]] : [[T]]
+  // CHECK: %[[ADD:.*]] = cggi.add %[[LHS]], %[[RHS]] : ([[T]], [[T]]) -> [[T]]
   // CHECK: return %[[ADD:.*]] : [[T]]
   %res = arith.addi %lhs, %rhs : i32
   return %res : i32
 }
 
-// CHECK-LABEL: @test_lower_add_vec
-// CHECK-SAME: (%[[LHS:.*]]: tensor<4x!lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>>, %[[RHS:.*]]: tensor<4x!lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>>) -> [[T:.*]] {
-func.func @test_lower_add_vec(%lhs : tensor<4xi32>, %rhs : tensor<4xi32>) -> tensor<4xi32> {
-  // CHECK: %[[ADD:.*]] = cggi.add %[[LHS]], %[[RHS]] : [[T]]
+// CHECK-LABEL: @test_lower_cte_add
+// CHECK-SAME: (%[[LHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>) -> [[T:.*]] {
+func.func @test_lower_cte_add(%in : i32) -> i32 {
+  // CHECK: %[[CTE:.*]] = arith.constant 7 : i32
+  // CHECK: %[[ADD:.*]] = cggi.add %[[LHS]], %[[CTE]] : ([[T]], i32) -> [[T]]
   // CHECK: return %[[ADD:.*]] : [[T]]
-  %res = arith.addi %lhs, %rhs : tensor<4xi32>
-  return %res : tensor<4xi32>
+  %c7 = arith.constant 7 : i32
+  %res = arith.addi %in, %c7 : i32
+  return %res : i32
 }
 
-// CHECK-LABEL: @test_lower_sub_vec
-// CHECK-SAME: (%[[LHS:.*]]: [[T:.*]], %[[RHS:.*]]: [[T]]) -> [[T]] {
-func.func @test_lower_sub_vec(%lhs : tensor<4xi32>, %rhs : tensor<4xi32>) -> tensor<4xi32> {
-  // CHECK: %[[ADD:.*]] = cggi.sub %[[LHS]], %[[RHS]] : [[T]]
-  // CHECK: return %[[ADD:.*]] : [[T]]
-  %res = arith.subi %lhs, %rhs : tensor<4xi32>
-  return %res : tensor<4xi32>
-}
 
 // CHECK-LABEL: @test_lower_sub
 // CHECK-SAME: (%[[LHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding1>, %[[RHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding1>) -> [[T:.*]] {
 func.func @test_lower_sub(%lhs : i16, %rhs : i16) -> i16 {
-  // CHECK: %[[ADD:.*]] = cggi.sub %[[LHS]], %[[RHS]] : [[T]]
+  // CHECK: %[[ADD:.*]] = cggi.sub %[[LHS]], %[[RHS]] : ([[T]], [[T]]) -> [[T]]
   // CHECK: return %[[ADD:.*]] : [[T]]
   %res = arith.subi %lhs, %rhs : i16
   return %res : i16
@@ -39,21 +33,11 @@ func.func @test_lower_sub(%lhs : i16, %rhs : i16) -> i16 {
 // CHECK-LABEL: @test_lower_mul
 // CHECK-SAME: (%[[LHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding2>, %[[RHS:.*]]: !lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding2>) -> [[T:.*]] {
 func.func @test_lower_mul(%lhs : i8, %rhs : i8) -> i8 {
-  // CHECK: %[[ADD:.*]] = cggi.mul %[[LHS]], %[[RHS]] : [[T]]
+  // CHECK: %[[ADD:.*]] = cggi.mul %[[LHS]], %[[RHS]] : ([[T]], [[T]]) -> [[T]]
   // CHECK: return %[[ADD:.*]] : [[T]]
   %res = arith.muli %lhs, %rhs : i8
   return %res : i8
 }
-
-// CHECK-LABEL: @test_lower_mul_vec
-// CHECK-SAME: (%[[LHS:.*]]: [[T:.*]], %[[RHS:.*]]: [[T]]) -> [[T]] {
-func.func @test_lower_mul_vec(%lhs : tensor<4xi8>, %rhs : tensor<4xi8>) -> tensor<4xi8> {
-  // CHECK: %[[ADD:.*]] = cggi.mul %[[LHS]], %[[RHS]] : [[T]]
-  // CHECK: return %[[ADD:.*]] : [[T]]
-  %res = arith.muli %lhs, %rhs : tensor<4xi8>
-  return %res : tensor<4xi8>
-}
-
 
 // CHECK-LABEL: @test_affine
 // CHECK-SAME: (%[[ARG:.*]]: memref<1x1x!lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>>) -> [[T:.*]] {
@@ -62,7 +46,6 @@ func.func @test_affine(%arg0: memref<1x1xi32>) -> memref<1x1xi32> {
   %c429_i32 = arith.constant 429 : i32
   %c33_i8 = arith.constant 33 : i32
   %0 = affine.load %arg0[0, 0] : memref<1x1xi32>
-  %c0 = arith.constant 0 : index
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1xi32>
   %25 = arith.muli %0, %c33_i8 : i32
   %26 = arith.addi %c429_i32, %25 : i32

--- a/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/arith.mlir
+++ b/tests/Dialect/CGGI/Conversions/cggi_to_tfhe_rust/arith.mlir
@@ -12,8 +12,8 @@ func.func @test_affine(%arg0: memref<1x1x!ct_ty>) -> memref<1x1x!ct_ty> {
   %2 = affine.load %arg0[0, 0] : memref<1x1x!ct_ty>
   %c0 = arith.constant 0 : index
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x!ct_ty>
-  %3 = cggi.mul %2, %1 : !ct_ty
-  %4 = cggi.add %3, %0 : !ct_ty
+  %3 = cggi.mul %2, %1 : (!ct_ty, !ct_ty) -> !ct_ty
+  %4 = cggi.add %3, %0 : (!ct_ty, !ct_ty) -> !ct_ty
   %5 = cggi.sshr %4 {shiftAmount = 2 : index} : (!ct_ty) -> !ct_ty
   affine.store %5, %alloc[0, 0] : memref<1x1x!ct_ty>
   return %alloc : memref<1x1x!ct_ty>


### PR DESCRIPTION
Follow-up of #1267 
Making it possible to add/mul a plaintext to a ciphertext in CGGI dialect. 
arith-to-cggi conversion pass update