### PR TITLE
Lower tensor_ext.permute via Vos-Vos-Erkin shift networks

### DIFF
--- a/lib/Dialect/TensorExt/IR/BUILD
+++ b/lib/Dialect/TensorExt/IR/BUILD
@@ -44,6 +44,7 @@ cc_library(
         ":canonicalize_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
+        "@heir//lib/Utils:AffineMapUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 
+#include "lib/Utils/AffineMapUtils.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"             // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"       // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
@@ -81,6 +82,47 @@ LogicalResult ConvertLayoutOp::verify() {
 LogicalResult AssignLayoutOp::verify() {
   return verifyLayoutMatchesType(getLayout().getValue(), getTensor().getType(),
                                  *this);
+}
+
+LogicalResult PermuteOp::verify() {
+  auto tensorTy = getInput().getType();
+  // TODO(#924): Support more general vector inputs.
+  if (tensorTy.getRank() != 1) {
+    return emitOpError() << "requires a 1-D input tensor"
+                            "single non-unit dimension, but found "
+                         << tensorTy;
+  }
+
+  // Assert it's a permutation; would that be too slow for a verifier?
+  auto affineMapAttr = dyn_cast<AffineMapAttr>(getPermutation());
+  SmallVector<int64_t> permutationResult;
+  if (affineMapAttr) {
+    if (failed(makeExplicit1DMapping(affineMapAttr.getValue(),
+                                     tensorTy.getNumElements(),
+                                     permutationResult))) {
+      return emitOpError()
+             << "failed to materialize affine map attr as permutation";
+    }
+
+    if (!isPermutation(permutationResult)) {
+      return emitOpError() << "expected permutation, but got an affine_map "
+                              "attr that was not a permutation.";
+    }
+  } else {
+    auto denseElementsAttr = dyn_cast<DenseIntElementsAttr>(getPermutation());
+    if (denseElementsAttr) {
+      permutationResult = llvm::map_to_vector(
+          denseElementsAttr, [](const APInt &i) { return i.getSExtValue(); });
+      if (!isPermutation(permutationResult)) {
+        return emitOpError() << "expected permutation, but got a dense "
+                                "attr that was not a permutation.";
+      }
+    } else {
+      return emitOpError() << "unknown permutation type";
+    }
+  }
+
+  return success();
 }
 
 }  // namespace tensor_ext

--- a/lib/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.td
@@ -3,6 +3,7 @@
 
 include "lib/Dialect/TensorExt/IR/TensorExtDialect.td"
 include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/CommonAttrConstraints.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -42,10 +43,38 @@ def TensorExt_RotateOp : TensorExt_Op<"rotate", [Pure, AllTypesMatch<["tensor", 
     ```
   }];
 
-  let arguments = (ins AnyTensor:$tensor, SignlessIntegerOrIndexLike:$shift);
-  let results = (outs AnyTensor:$output);
+  let arguments = (ins AnyRankedTensor:$tensor, SignlessIntegerOrIndexLike:$shift);
+  let results = (outs AnyRankedTensor:$output);
   let assemblyFormat = "operands attr-dict `:` qualified(type($tensor)) `,` type($shift)";
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+}
+
+def PermutationLike : AnyAttrOf<[
+  // A permutation defined by a compact affine map with one dimension and one result expression.
+  // E.g., affine_map<(d0) -> ((d0 - 4) mod 64)> compactly represents a
+  // permutation defined by a single shift.
+  Builtin_AffineMapAttr,
+  // A permutation defined explicitly by mapping i -> a[i] for indices i of the array attr.
+  // E.g., An array [3, 2, 0, 1] defines the permutation
+  //
+  //      0 -> 3, 1 -> 2, 2 -> 0, 3 -> 1
+  //
+  AnyI64ElementsAttr,
+]>;
+
+def TensorExt_PermuteOp : TensorExt_Op<"permute", [Pure, AllTypesMatch<["input", "output"]>]> {
+  let summary = "Permute a tensor by a static permutation.";
+  let description = [{
+    This op represents a permutation of a tensor.
+
+    This is lowered from a `convert_layout` op, and is implemented in terms of
+    `rotate` operations.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input, PermutationLike:$permutation);
+  let results = (outs AnyRankedTensor:$output);
+  let assemblyFormat = "operands attr-dict `:` type($input)";
   let hasVerifier = 1;
 }
 

--- a/lib/Dialect/TensorExt/Transforms/BUILD
+++ b/lib/Dialect/TensorExt/Transforms/BUILD
@@ -13,6 +13,7 @@ cc_library(
     deps = [
         ":AlignTensorSizes",
         ":CollapseInsertionChains",
+        ":ImplementShiftNetwork",
         ":InsertRotate",
         ":RotateAndReduce",
         ":pass_inc_gen",
@@ -104,6 +105,27 @@ cc_library(
         "@llvm-project//mlir:TransformUtils",
     ],
 )
+
+cc_library(
+    name = "ImplementShiftNetwork",
+    srcs = ["ImplementShiftNetwork.cpp"],
+    hdrs = [
+        "ImplementShiftNetwork.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Utils:AffineMapUtils",
+        "@heir//lib/Utils/ADT:FrozenVector",
+        "@heir//lib/Utils/Graph",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
 # TensorExt pass tablegen and headers.
 
 gentbl_cc_library(

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
@@ -1,0 +1,390 @@
+#include "lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h"
+
+#include <utility>
+
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Utils/ADT/FrozenVector.h"
+#include "lib/Utils/AffineMapUtils.h"
+#include "lib/Utils/Graph/Graph.h"
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"    // from @llvm-project
+
+#define DEBUG_TYPE "implement-shift-network"
+
+namespace mlir {
+namespace heir {
+namespace tensor_ext {
+
+#define GEN_PASS_DEF_IMPLEMENTSHIFTNETWORK
+#include "lib/Dialect/TensorExt/Transforms/Passes.h.inc"
+
+// A permutation of 0..n-1. This vector should always have size n and contain
+// each integer from 0 to n-1 exactly once.
+using Permutation = FrozenVector<int64_t>;
+
+// A group of indices to rotate together
+using RotationGroup = DenseSet<int64_t>;
+
+// Convert an input->output index mapping to a canonical left-shift amount for
+// a given tensor size.
+// Example: 1 -> 13 with a 64-size tensor should produce a rotation of 52
+// Example: 13 -> 1 with a 64-size tensor should produce a rotation of 12
+inline int64_t normalizeShift(int64_t input, int64_t output,
+                              int64_t tensorSize) {
+  int64_t shift = (output - input) % tensorSize;
+  shift = -shift;  // Account for leftward rotations
+  if (shift < 0) {
+    shift += tensorSize;
+  }
+  return shift;
+}
+
+// The ShiftStrategy class applies power-of-two shifts to each set bit in
+// LSB-to-MSB order, 1, 2, 4, 8, .... Each shift amount is considered a "round"
+// in which a group of indices are attempted to be shifted together. This can be
+// used both to identify conflicts for the graph coloring technique of
+// Vos-Vos-Erkin, and also to construct the concrete shift network after a
+// partition has been decided by Vos-Vos-Erkin.
+struct ShiftRound {
+  // Maps the index of the original input to its current position in the
+  // tensor. This may contain multiple indices mapping to the same slot due to
+  // conflicts in the shifting strategy.
+  SmallVector<int64_t> positions;
+  // The set of indices that are rotated left in this round. This can be used
+  // to generate a mask to select the indices that need rotating.
+  SmallVector<int64_t> rotatedIndices;
+  // The amount rotated left;
+  int64_t rotationAmount;
+};
+
+class ShiftStrategy {
+ public:
+  ShiftStrategy() = default;
+
+  SmallVector<ShiftRound> getRounds() const { return rounds; }
+
+  // Run the shifting strategy and populate the `rounds` member variable.
+  void evaluate(const Permutation &permutation, const RotationGroup &group) {
+    int64_t ciphertextSize = permutation.size();
+
+    // Stores the amount that each ciphertext index is shifted left. The
+    // RotationGroup might be a subset of indices, so we have to populate the
+    // entire set of shifts with zeros except possibly for those in the
+    // RotationGroup (some of those may also be zero if they're fixed points of
+    // the permutation).
+    SmallVector<int64_t> shifts;
+    shifts.resize(ciphertextSize, 0);
+    for (int64_t index : group) {
+      shifts[index] = normalizeShift(index, permutation[index], ciphertextSize);
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Shifts for permutation: ";
+      for (int64_t shift : shifts) {
+        llvm::dbgs() << shift << " ";
+      }
+      llvm::dbgs() << "\n";
+    });
+
+    // The identity permutation is a base case where no shifts are applied.
+    Permutation identityPerm = FrozenVector<int64_t>(identity(ciphertextSize));
+    for (int64_t rotationAmount = 1; rotationAmount < ciphertextSize;
+         rotationAmount <<= 1) {
+      ShiftRound round;
+      ArrayRef<int64_t> lastRoundPositions =
+          !rounds.empty() ? ArrayRef<int64_t>(rounds.back().positions)
+                          : identityPerm;
+      int inputIndex = 0;
+      for (int64_t shift : shifts) {
+        // The bit is set, implying we would rotate by 2**bit in this round
+        if (shift & rotationAmount) {
+          // subtract because we are left-shifting by a positive amount
+          int64_t dest = lastRoundPositions[inputIndex] - rotationAmount;
+          if (dest < 0) {
+            dest += ciphertextSize;  // wrap around the bottom of the vector
+          }
+          round.positions.push_back(dest);
+          round.rotatedIndices.push_back(inputIndex);
+        } else {
+          // Otherwise the value is unchanged from last round
+          round.positions.push_back(lastRoundPositions[inputIndex]);
+        }
+        ++inputIndex;
+      }
+      round.rotationAmount = rotationAmount;
+      rounds.push_back(round);
+      LLVM_DEBUG({
+        llvm::dbgs() << "Round " << rotationAmount << ": ";
+        int inputIndex = 0;
+        for (int64_t index : round.positions) {
+          llvm::dbgs() << inputIndex++ << ": " << index << ", ";
+        }
+        llvm::dbgs() << "\n";
+        llvm::dbgs() << "Indices affected: ";
+        for (int64_t index : round.rotatedIndices) {
+          llvm::dbgs() << index << " ";
+        }
+        llvm::dbgs() << "\n";
+      });
+    }
+  }
+
+ private:
+  SmallVector<ShiftRound> rounds;
+};
+
+// Cf. https://www.jeremykun.com/2024/09/02/shift-networks/
+// and https://link.springer.com/chapter/10.1007/978-3-031-17140-6_20
+// for an explanation of the algorithm.
+class VosVosErkinShiftNetworks {
+ public:
+  VosVosErkinShiftNetworks(int64_t ciphertextSize)
+      : ciphertextSize(ciphertextSize) {}
+
+  // Computes a partition of the slot indices of a ciphertext into
+  // RotationGroups that are compatible with respect to the target permutation.
+  // Each RotationGroup corresponds to a set of indices that should be rotated
+  // together via power-of-two rotations.
+  //
+  // The returned ArrayRef is owned by this VosVosErkinShiftNetworks instance.
+  // The resulting set of rotation groups are is cached, and the cache is used
+  // on further calls to avoid recomputing the shift network.
+  ArrayRef<RotationGroup> computeShiftNetwork(const Permutation &permutation) {
+    if (rotationGroups.count(permutation)) {
+      return rotationGroups[permutation];
+    }
+
+    ShiftStrategy strategy;
+    RotationGroup allIndices;
+    for (int64_t i = 0; i < ciphertextSize; i++) {
+      allIndices.insert(i);
+    }
+    strategy.evaluate(permutation, allIndices);
+
+    // Create a graph whose vertices are the input indices to permute, and
+    // whose edges are conflicts: an edge being present means the two indices
+    // cannot participate in the same rotation group.
+    graph::UndirectedGraph<int64_t> conflictGraph;
+    for (int64_t i = 0; i < ciphertextSize; i++) {
+      conflictGraph.addVertex(i);
+    }
+    for (const ShiftRound &round : strategy.getRounds()) {
+      for (int64_t i = 0; i < ciphertextSize; i++) {
+        for (int64_t j = i + 1; j < ciphertextSize; j++) {
+          if (round.positions[i] == round.positions[j]) {
+            conflictGraph.addEdge(i, j);
+          }
+        }
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Conflict graph:\n";
+      for (int64_t vertex : conflictGraph.getVertices()) {
+        llvm::dbgs() << "  " << vertex << ": ";
+        for (int64_t neighbor : conflictGraph.edgesIncidentTo(vertex)) {
+          llvm::dbgs() << neighbor << " ";
+        }
+        llvm::dbgs() << "\n";
+      }
+    });
+
+    graph::GreedyGraphColoring<int64_t> colorer;
+    std::unordered_map<int64_t, int> coloring = colorer.color(conflictGraph);
+
+    SmallVector<RotationGroup> resultRotationGroups;
+    resultRotationGroups.reserve(64);
+    for (const auto &entry : coloring) {
+      int64_t index = entry.first;
+      int64_t color = entry.second;
+      if (color >= resultRotationGroups.size()) {
+        resultRotationGroups.resize(color + 1);
+      }
+      resultRotationGroups[color].insert(index);
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Splitting permutation into permutation groups:\n";
+      for (int i = 0; i < resultRotationGroups.size(); i++) {
+        llvm::dbgs() << "Group " << i << ": ";
+        llvm::SmallVector<int64_t> group = llvm::SmallVector<int64_t>(
+            resultRotationGroups[i].begin(), resultRotationGroups[i].end());
+        llvm::sort(group);
+        for (int64_t index : group) {
+          llvm::dbgs() << index << " ";
+        }
+        llvm::dbgs() << "\n";
+      }
+    });
+
+    rotationGroups[permutation] = resultRotationGroups;
+    return rotationGroups[permutation];
+  }
+
+  int64_t getCiphertextSize() const { return ciphertextSize; }
+
+ private:
+  int64_t ciphertextSize;
+  DenseMap<Permutation, llvm::SmallVector<RotationGroup>> rotationGroups;
+};
+
+// Create a tensor with zeros everywhere except for the indices specified in
+// the input `indices` vector.
+Value createMask(TypedValue<RankedTensorType> tensor,
+                 const SmallVector<int64_t> &indices, IRRewriter &rewriter) {
+  auto elementType = tensor.getType().getElementType();
+  SmallVector<Attribute> maskAttrs(tensor.getType().getDimSize(0),
+                                   rewriter.getIntegerAttr(elementType, 0));
+  for (int64_t index : indices) {
+    maskAttrs[index] = rewriter.getIntegerAttr(elementType, 1);
+  }
+
+  auto denseAttr = DenseElementsAttr::get(tensor.getType(), maskAttrs);
+  auto constant =
+      rewriter.create<arith::ConstantOp>(tensor.getLoc(), denseAttr);
+  return constant.getResult();
+}
+
+Value rotateGroup(TypedValue<RankedTensorType> tensor,
+                  const RotationGroup &group, int64_t ciphertextSize,
+                  const Permutation &permutation, IRRewriter &rewriter) {
+  std::optional<Value> result = std::nullopt;
+
+  // Re-run the shift strategy on a single rotation group, and use the
+  // rotatedIndices in each round to construct a mask and a rotation op.
+  ShiftStrategy strategy;
+  strategy.evaluate(permutation, group);
+
+  [[maybe_unused]] int roundNum = 0;
+  for (const ShiftRound &round : strategy.getRounds()) {
+    int64_t rotationAmount = round.rotationAmount;
+    if (round.rotatedIndices.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "Skipping shift by " << rotationAmount
+                              << " because no inputs have that bit set\n");
+      continue;
+    }
+
+    Value mask = createMask(tensor, round.rotatedIndices, rewriter);
+    arith::MulIOp maskOp =
+        rewriter.create<arith::MulIOp>(tensor.getLoc(), tensor, mask);
+    Value rotated = rewriter.create<tensor_ext::RotateOp>(
+        tensor.getLoc(), maskOp.getResult(),
+        rewriter.create<arith::ConstantIntOp>(tensor.getLoc(), rotationAmount,
+                                              rewriter.getI32Type()));
+
+    if (result.has_value()) {
+      result = rewriter.create<arith::AddIOp>(tensor.getLoc(), result.value(),
+                                              rotated);
+    } else {
+      result = rotated;
+    }
+  }
+
+  return result.has_value() ? result.value() : tensor;
+}
+
+LogicalResult convertPermuteOp(PermuteOp op,
+                               VosVosErkinShiftNetworks &shiftNetworks,
+                               int64_t ciphertextSize) {
+  LLVM_DEBUG(llvm::dbgs() << "Converting layout op: " << op << "\n");
+  IRRewriter rewriter(op.getContext());
+  ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+  RankedTensorType tensorTy = op.getInput().getType();
+
+  // Only support a 1-D tensor until sharding is supported
+  if (op.getInput().getType().getRank() != 1) {
+    return op.emitError("requires a one-dimensional tensor");
+  }
+
+  SmallVector<int64_t> permutation;
+
+  // Convert the affine map to an explicit permutation, or else use the dense
+  // array attr as an explicit permutation.
+  auto affineMapAttr = dyn_cast<AffineMapAttr>(op.getPermutation());
+  if (affineMapAttr) {
+    AffineMap permutationMap = simplifyAffineMap(affineMapAttr.getValue());
+    LLVM_DEBUG(llvm::dbgs()
+               << "Expanding permutation from " << permutationMap << "\n");
+    if (failed(makeExplicit1DMapping(permutationMap, tensorTy.getNumElements(),
+                                     permutation)))
+      return failure();
+  } else {
+    auto denseElementsAttr =
+        dyn_cast<DenseIntElementsAttr>(op.getPermutation());
+    if (denseElementsAttr) {
+      permutation = llvm::map_to_vector(
+          denseElementsAttr, [](const APInt &i) { return i.getSExtValue(); });
+    } else {
+      return failure();
+    }
+  }
+
+  if (!isPermutation(permutation)) {
+    auto diag = op.emitError(
+        "expected a permutation, but got a mapping that was not a "
+        "permutation.");
+    Diagnostic &note = diag.attachNote() << "mapping was:\n";
+    printPermutation(permutation, note);
+    return diag;
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "PermuteOp produces underlying permutation: ";
+    printPermutation(permutation, llvm::dbgs());
+  });
+
+  FrozenVector<int64_t> permKey = FrozenVector<int64_t>(std::move(permutation));
+  ArrayRef<RotationGroup> rotationGroup =
+      shiftNetworks.computeShiftNetwork(permKey);
+  assert(!rotationGroup.empty() &&
+         "Shift network must have at least one group");
+
+  // Process each rotation group separately with a full set of power-of-two
+  // shifts. Then sum the results together.
+  rewriter.setInsertionPointAfter(op);
+  std::optional<Value> result = std::nullopt;
+  [[maybe_unused]] int groupIndex = 0;
+  for (const RotationGroup &group : rotationGroup) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Implementing rotations for group " << groupIndex++ << "\n");
+    Value perGroupResult =
+        rotateGroup(op.getInput(), group, ciphertextSize, permKey, rewriter);
+    if (result.has_value())
+      result =
+          rewriter.create<arith::AddIOp>(op.getLoc(), *result, perGroupResult);
+    else
+      result = perGroupResult;
+  }
+
+  rewriter.replaceOp(op, result.value());
+  return success();
+}
+
+struct ImplementShiftNetwork
+    : impl::ImplementShiftNetworkBase<ImplementShiftNetwork> {
+  using ImplementShiftNetworkBase::ImplementShiftNetworkBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    VosVosErkinShiftNetworks shiftNetworks{ciphertextSize};
+
+    getOperation()->walk([&](PermuteOp op) {
+      if (failed(convertPermuteOp(op, shiftNetworks, ciphertextSize))) {
+        signalPassFailure();
+      }
+    });
+  }
+};
+
+}  // namespace tensor_ext
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_TENSOREXT_TRANSFORMS_IMPLEMENTSHIFTNETWORK_H_
+#define LIB_DIALECT_TENSOREXT_TRANSFORMS_IMPLEMENTSHIFTNETWORK_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace tensor_ext {
+
+#define GEN_PASS_DECL_IMPLEMENTSHIFTNETWORK
+#include "lib/Dialect/TensorExt/Transforms/Passes.h.inc"
+
+}  // namespace tensor_ext
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_TENSOREXT_TRANSFORMS_IMPLEMENTSHIFTNETWORK_H_

--- a/lib/Dialect/TensorExt/Transforms/Passes.td
+++ b/lib/Dialect/TensorExt/Transforms/Passes.td
@@ -157,4 +157,115 @@ def AlignTensorSizes : Pass<"align-tensor-sizes"> {
   ];
 }
 
+def ImplementShiftNetwork : Pass<"implement-shift-network"> {
+  let summary = "Implement tensor_ext.convert_layout ops as shift newtorks";
+
+  let description = [{
+  This pass converts `tensor_ext.permute` ops into a network of
+  `tensor_ext.rotate` ops, aiming to minimize the overall latency of the
+  permutation.
+
+  The input IR must have tensors that correspond to plaintexts or
+  ciphertexts.
+
+  The method uses graph coloring, an approach based on Vos-Vos-Erkin 2022,
+  ["Efficient Circuits for Permuting and Mapping Packed Values Across
+   Leveled Homomorphic Ciphertexts"](https://link.springer.com/chapter/10.1007/978-3-031-17140-6_20).
+
+  Example, Figure 3 from the paper above:
+
+  ```mlir
+  // Provide an explicit permutation, though an affine_map can also be used.
+  #map = dense<[13, 8, 4, 0, 11, 7, 14, 5, 15, 3, 12, 6, 10, 2, 9, 1]> : tensor<16xi64>
+  func.func @figure3(%0: tensor<16xi32>) -> tensor<16xi32> {
+    %1 = tensor_ext.permute %0 {permutation = #map} : tensor<16xi32>
+    return %1 : tensor<16xi32>
+  }
+  ```
+
+  Then running `--implement-shift-network=ciphertext-size=16` produces
+  a shift network composed of plaintext-ciphertext masks (`arith.constant` + `arith.muli`)
+  followed by rotations and additions. The Vos-Vos-Erkin method splits the work
+  into multiple independent groups that are added together at the end.
+
+  ```mlir
+  func.func @figure3(%arg0: tensor<16xi32>) -> tensor<16xi32> {
+    %cst = arith.constant dense<[1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0]> : tensor<16xi32>
+    %0 = arith.muli %arg0, %cst : tensor<16xi32>
+    %c1_i32 = arith.constant 1 : i32
+    %1 = tensor_ext.rotate %0, %c1_i32 : tensor<16xi32>, i32
+    %cst_0 = arith.constant dense<[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]> : tensor<16xi32>
+    %2 = arith.muli %arg0, %cst_0 : tensor<16xi32>
+    %c2_i32 = arith.constant 2 : i32
+    %3 = tensor_ext.rotate %2, %c2_i32 : tensor<16xi32>, i32
+    %4 = arith.addi %1, %3 : tensor<16xi32>
+    %cst_1 = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]> : tensor<16xi32>
+    %5 = arith.muli %arg0, %cst_1 : tensor<16xi32>
+    %c4_i32 = arith.constant 4 : i32
+    %6 = tensor_ext.rotate %5, %c4_i32 : tensor<16xi32>, i32
+    %7 = arith.addi %4, %6 : tensor<16xi32>
+    %cst_2 = arith.constant dense<[0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]> : tensor<16xi32>
+    %8 = arith.muli %arg0, %cst_2 : tensor<16xi32>
+    %c8_i32 = arith.constant 8 : i32
+    %9 = tensor_ext.rotate %8, %c8_i32 : tensor<16xi32>, i32
+    %10 = arith.addi %7, %9 : tensor<16xi32>
+    %cst_3 = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]> : tensor<16xi32>
+    %11 = arith.muli %arg0, %cst_3 : tensor<16xi32>
+    %c1_i32_4 = arith.constant 1 : i32
+    %12 = tensor_ext.rotate %11, %c1_i32_4 : tensor<16xi32>, i32
+    %cst_5 = arith.constant dense<[0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0]> : tensor<16xi32>
+    %13 = arith.muli %arg0, %cst_5 : tensor<16xi32>
+    %c2_i32_6 = arith.constant 2 : i32
+    %14 = tensor_ext.rotate %13, %c2_i32_6 : tensor<16xi32>, i32
+    %15 = arith.addi %12, %14 : tensor<16xi32>
+    %cst_7 = arith.constant dense<[0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0]> : tensor<16xi32>
+    %16 = arith.muli %arg0, %cst_7 : tensor<16xi32>
+    %c4_i32_8 = arith.constant 4 : i32
+    %17 = tensor_ext.rotate %16, %c4_i32_8 : tensor<16xi32>, i32
+    %18 = arith.addi %15, %17 : tensor<16xi32>
+    %cst_9 = arith.constant dense<[0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0]> : tensor<16xi32>
+    %19 = arith.muli %arg0, %cst_9 : tensor<16xi32>
+    %c8_i32_10 = arith.constant 8 : i32
+    %20 = tensor_ext.rotate %19, %c8_i32_10 : tensor<16xi32>, i32
+    %21 = arith.addi %18, %20 : tensor<16xi32>
+    %22 = arith.addi %10, %21 : tensor<16xi32>
+    %cst_11 = arith.constant dense<[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0]> : tensor<16xi32>
+    %23 = arith.muli %arg0, %cst_11 : tensor<16xi32>
+    %c1_i32_12 = arith.constant 1 : i32
+    %24 = tensor_ext.rotate %23, %c1_i32_12 : tensor<16xi32>, i32
+    %cst_13 = arith.constant dense<[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1]> : tensor<16xi32>
+    %25 = arith.muli %arg0, %cst_13 : tensor<16xi32>
+    %c2_i32_14 = arith.constant 2 : i32
+    %26 = tensor_ext.rotate %25, %c2_i32_14 : tensor<16xi32>, i32
+    %27 = arith.addi %24, %26 : tensor<16xi32>
+    %cst_15 = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]> : tensor<16xi32>
+    %28 = arith.muli %arg0, %cst_15 : tensor<16xi32>
+    %c4_i32_16 = arith.constant 4 : i32
+    %29 = tensor_ext.rotate %28, %c4_i32_16 : tensor<16xi32>, i32
+    %30 = arith.addi %27, %29 : tensor<16xi32>
+    %cst_17 = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1]> : tensor<16xi32>
+    %31 = arith.muli %arg0, %cst_17 : tensor<16xi32>
+    %c8_i32_18 = arith.constant 8 : i32
+    %32 = tensor_ext.rotate %31, %c8_i32_18 : tensor<16xi32>, i32
+    %33 = arith.addi %30, %32 : tensor<16xi32>
+    %34 = arith.addi %22, %33 : tensor<16xi32>
+    return %34 : tensor<16xi32>
+  }
+  ```
+  }];
+
+  let dependentDialects = ["mlir::heir::tensor_ext::TensorExtDialect"];
+
+  // TODO(#4102): reevaluate flag name
+  let options = [
+    Option<
+      "ciphertextSize",
+      "ciphertext-size",
+      "int",
+      /*default=*/"1024",
+      "Power of two length of the ciphertexts the data is packed in."
+    >
+  ];
+}
+
 #endif  // LIB_DIALECT_TENSOREXT_TRANSFORMS_PASSES_TD_

--- a/lib/Utils/ADT/BUILD
+++ b/lib/Utils/ADT/BUILD
@@ -1,0 +1,12 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "FrozenVector",
+    hdrs = ["FrozenVector.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+    ],
+)

--- a/lib/Utils/ADT/FrozenVector.h
+++ b/lib/Utils/ADT/FrozenVector.h
@@ -1,0 +1,70 @@
+#ifndef LIB_UTILS_ADT_FROZENVECTOR_H_
+#define LIB_UTILS_ADT_FROZENVECTOR_H_
+
+#include "llvm/include/llvm/ADT/DenseMapInfo.h"  // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"   // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// A FrozenVector is a wrapper around a SmallVector, immutable after the
+// initial creation, and paired with a DenseMapInfo specialization so it can be
+// used as the key in a DenseMap.
+template <typename T, unsigned N = 4>
+class FrozenVector {
+ private:
+  llvm::SmallVector<T, N> vector;
+
+ public:
+  FrozenVector() = default;
+  FrozenVector(const llvm::SmallVector<T, N>& other) : vector(other) {}
+  FrozenVector(llvm::SmallVector<T, N>&& other) : vector(std::move(other)) {}
+
+  using iterator = typename llvm::SmallVector<T, N>::const_iterator;
+
+  iterator begin() const { return vector.begin(); }
+  iterator end() const { return vector.end(); }
+  size_t size() const { return vector.size(); }
+  bool empty() const { return vector.empty(); }
+  const T& operator[](size_t idx) const { return vector[idx]; }
+  const T& front() const { return vector.front(); }
+  const T& back() const { return vector.back(); }
+
+  operator llvm::ArrayRef<T>() const { return vector; }
+
+  bool operator==(const FrozenVector& other) const {
+    return vector == other.vector;
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+namespace llvm {
+
+// DenseMapInfo specialization to enable use as DenseMap key
+template <typename T, unsigned N>
+struct DenseMapInfo<::mlir::heir::FrozenVector<T, N>> {
+  static ::mlir::heir::FrozenVector<T, N> getEmptyKey() {
+    return ::mlir::heir::FrozenVector<T, N>();
+  }
+
+  static ::mlir::heir::FrozenVector<T, N> getTombstoneKey() {
+    llvm::SmallVector<T, N> tombstone;
+    tombstone.push_back(DenseMapInfo<T>::getTombstoneKey());
+    return ::mlir::heir::FrozenVector<T, N>(std::move(tombstone));
+  }
+
+  static unsigned getHashValue(const ::mlir::heir::FrozenVector<T, N>& val) {
+    return hash_combine_range(val.begin(), val.end());
+  }
+
+  static bool isEqual(const ::mlir::heir::FrozenVector<T, N>& lhs,
+                      const ::mlir::heir::FrozenVector<T, N>& rhs) {
+    return lhs == rhs;
+  }
+};
+
+}  // namespace llvm
+
+#endif  // LIB_UTILS_ADT_FROZENVECTOR_H_

--- a/lib/Utils/AffineMapUtils.cpp
+++ b/lib/Utils/AffineMapUtils.cpp
@@ -1,0 +1,53 @@
+#include "lib/Utils/AffineMapUtils.h"
+
+#include "mlir/include/mlir/IR/AffineMap.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"          // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+LogicalResult makeExplicit1DMapping(AffineMap map, unsigned rank,
+                                    SmallVector<int64_t> &result) {
+  if (map.getNumResults() != 1) return failure();
+  if (map.getNumDims() != 1) return failure();
+  if (map.getNumSymbols() != 0) return failure();
+
+  OpBuilder b(map.getContext());
+  result.resize(rank);
+
+  SmallVector<Attribute> permInputs;
+  permInputs.reserve(rank);
+  for (size_t permInput = 0; permInput < rank; ++permInput) {
+    permInputs.push_back(b.getIndexAttr(permInput));
+  }
+
+  llvm::copy(llvm::map_range(
+                 permInputs,
+                 [&](Attribute permInput) {
+                   SmallVector<Attribute> results;
+                   // AffineMap::constantFold is the mechanism to evaluate the
+                   // affine map on statically known inputs.
+                   if (failed(map.constantFold(permInput, results))) {
+                     assert(false && "constant folding should never fail here");
+                     return -1L;
+                   }
+                   return cast<IntegerAttr>(results[0]).getInt();
+                 }),
+             result.begin());
+
+  return success();
+}
+
+bool isPermutation(ArrayRef<int64_t> materializedMapping) {
+  DenseSet<int64_t> seen;
+  for (int64_t i : materializedMapping) {
+    if (i < 0 || i >= materializedMapping.size()) return false;
+    if (!seen.insert(i).second) return false;
+  }
+  return true;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/AffineMapUtils.h
+++ b/lib/Utils/AffineMapUtils.h
@@ -1,0 +1,51 @@
+#ifndef LIB_UTILS_AFFINEMAPUTILS_H_
+#define LIB_UTILS_AFFINEMAPUTILS_H_
+
+#include <cstdint>
+#include <numeric>
+
+#include "llvm/include/llvm/Support/Debug.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/AffineMap.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"       // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"         // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// Construct an identity permutation of size n
+inline ::llvm::SmallVector<int64_t> identity(int64_t n) {
+  ::llvm::SmallVector<int64_t> permutation;
+  permutation.resize(n);
+  std::iota(permutation.begin(), permutation.end(), 0);
+  return permutation;
+}
+
+// Populates `result` with a concrete permutation corresponding to the
+// evaluation of `map` on the 1D input domain {1..rank}. Returns failure() if
+// the map is not a permutation.
+::llvm::LogicalResult makeExplicit1DMapping(
+    ::mlir::AffineMap map, unsigned rank, ::llvm::SmallVector<int64_t> &result);
+
+// Returns true if the materialized mapping is a permutation.
+bool isPermutation(::llvm::ArrayRef<int64_t> materializedMapping);
+
+template <typename T>
+void printPermutation(::llvm::ArrayRef<int64_t> permutation, T &os) {
+  for (int i = 0; i < permutation.size(); i++) {
+    os << i << " -> " << permutation[i] << ", ";
+    if (i % 10 == 9) {
+      os << "\n";
+    }
+  }
+  os << "\n";
+}
+
+template void printPermutation(::llvm::ArrayRef<int64_t>,
+                               ::llvm::raw_ostream &);
+template void printPermutation(::llvm::ArrayRef<int64_t>, ::mlir::Diagnostic &);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_UTILS_AFFINEMAPUTILS_H_

--- a/lib/Utils/BUILD
+++ b/lib/Utils/BUILD
@@ -16,6 +16,17 @@ cc_library(
 )
 
 cc_library(
+    name = "AffineMapUtils",
+    srcs = ["AffineMapUtils.cpp"],
+    hdrs = ["AffineMapUtils.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
     name = "ConversionUtils",
     srcs = ["ConversionUtils.cpp"],
     hdrs = ["ConversionUtils.h"],

--- a/lib/Utils/Graph/Graph.h
+++ b/lib/Utils/Graph/Graph.h
@@ -188,7 +188,7 @@ class UndirectedGraph {
 
   // Returns the edges incident to the given vertex.
   std::vector<V> edgesIncidentTo(V vertex) const {
-    if (vertices.count(vertex)) {
+    if (vertices.count(vertex) && edges.count(vertex)) {
       std::vector<V> result(edges.at(vertex).begin(), edges.at(vertex).end());
       // Note: The vertices are sorted to ensure determinism in the output.
       std::sort(result.begin(), result.end());

--- a/tests/Dialect/TensorExt/Transforms/implement_shift_network.mlir
+++ b/tests/Dialect/TensorExt/Transforms/implement_shift_network.mlir
@@ -1,0 +1,189 @@
+// RUN: heir-opt --implement-shift-network=ciphertext-size=64 %s | FileCheck %s
+
+// When the permutation is itself a cyclic shift, the resulting shift network
+// should also have a single shift.
+#map1 = affine_map<(d0) -> ((d0 - 1) mod 64)>
+// CHECK-LABEL: @test_no_conflicts
+// CHECK-SAME: [[arg0:%[^:]*]]: tensor<64xi32>
+// CHECK-NEXT: [[mask:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask:%[^:]*]] = arith.muli [[arg0]], [[mask]]
+// CHECK-NEXT: [[rot_amt:%[^:]*]] = arith.constant 1
+// CHECK-NEXT: [[rot_result:%[^:]*]] = tensor_ext.rotate [[mul_mask]], [[rot_amt]]
+// CHECK-NEXT: return [[rot_result]]
+func.func @test_no_conflicts(%0: tensor<64xi32>) -> tensor<64xi32> {
+  %1 = tensor_ext.permute %0 {permutation = #map1} : tensor<64xi32>
+  return %1 : tensor<64xi32>
+}
+
+// This test has a larger set of rotations because the Vos-Vos-Erkin method
+// forces each rotation to be decomposed into power-of-two rotations, even if
+// it could be done in a single rotation. In this case it's a (left-)rotation
+// by 63 which is equivalent to a single (right)-rotation by -1, which requires
+// all power-of-two components to be used.
+//
+// TODO(#744): perhaps this test should only produce one rotation.
+// CHECK-LABEL: @test_no_conflicts_2
+// CHECK-SAME: [[arg0:%[^:]*]]: tensor<64xi32>
+
+// Rot by 1
+// CHECK-NEXT: [[mask1:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask1:%[^:]*]] = arith.muli [[arg0]], [[mask1]]
+// CHECK-NEXT: [[rot_amt1:%[^:]*]] = arith.constant 1
+// CHECK-NEXT: [[rot_result1:%[^:]*]] = tensor_ext.rotate [[mul_mask1]], [[rot_amt1]]
+
+// Rot by 2
+// CHECK-NEXT: [[mask2:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask2:%[^:]*]] = arith.muli [[arg0]], [[mask2]]
+// CHECK-NEXT: [[rot_amt2:%[^:]*]] = arith.constant 2
+// CHECK-NEXT: [[rot_result2:%[^:]*]] = tensor_ext.rotate [[mul_mask2]], [[rot_amt2]]
+// CHECK-NEXT: [[combined_result2:%[^:]*]] = arith.addi [[rot_result1]], [[rot_result2]]
+
+// Rot by 4
+// CHECK-NEXT: [[mask4:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask4:%[^:]*]] = arith.muli [[arg0]], [[mask4]]
+// CHECK-NEXT: [[rot_amt4:%[^:]*]] = arith.constant 4
+// CHECK-NEXT: [[rot_result4:%[^:]*]] = tensor_ext.rotate [[mul_mask4]], [[rot_amt4]]
+// CHECK-NEXT: [[combined_result4:%[^:]*]] = arith.addi [[combined_result2]], [[rot_result4]]
+
+// Rot by 8
+// CHECK-NEXT: [[mask8:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask8:%[^:]*]] = arith.muli [[arg0]], [[mask8]]
+// CHECK-NEXT: [[rot_amt8:%[^:]*]] = arith.constant 8
+// CHECK-NEXT: [[rot_result8:%[^:]*]] = tensor_ext.rotate [[mul_mask8]], [[rot_amt8]]
+// CHECK-NEXT: [[combined_result8:%[^:]*]] = arith.addi [[combined_result4]], [[rot_result8]]
+
+// Rot by 16
+// CHECK-NEXT: [[mask16:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask16:%[^:]*]] = arith.muli [[arg0]], [[mask16]]
+// CHECK-NEXT: [[rot_amt16:%[^:]*]] = arith.constant 16
+// CHECK-NEXT: [[rot_result16:%[^:]*]] = tensor_ext.rotate [[mul_mask16]], [[rot_amt16]]
+// CHECK-NEXT: [[combined_result16:%[^:]*]] = arith.addi [[combined_result8]], [[rot_result16]]
+
+// Rot by 32
+// CHECK-NEXT: [[mask32:%[^:]*]] = arith.constant dense<1>
+// CHECK-NEXT: [[mul_mask32:%[^:]*]] = arith.muli [[arg0]], [[mask32]]
+// CHECK-NEXT: [[rot_amt32:%[^:]*]] = arith.constant 32
+// CHECK-NEXT: [[rot_result32:%[^:]*]] = tensor_ext.rotate [[mul_mask32]], [[rot_amt32]]
+// CHECK-NEXT: [[combined_result32:%[^:]*]] = arith.addi [[combined_result16]], [[rot_result32]]
+
+// CHECK-NEXT: return [[combined_result32]]
+#map2 = affine_map<(d0) -> ((d0 + 1) mod 64)>
+func.func @test_no_conflicts_2(%0: tensor<64xi32>) -> tensor<64xi32> {
+  %1 = tensor_ext.permute %0 {permutation = #map2} : tensor<64xi32>
+  return %1 : tensor<64xi32>
+}
+
+
+// This test is similar to Figure 3 from the Vos-Vos-Erkin paper, but with the
+// indices outside of 1..16 being fixed to the identity permutation. This makes
+// the graph significantly more complicated, since indices that shift are
+// passing through many indices that are fixed points. I think it makes for a
+// nice example that exercises many of the edge cases of the algorithm.
+//
+// CHECK-LABEL: @figure3
+//
+// Group:  2 4 6 7 10 12 14 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 37 38 39 40 41 42 45 47 48 49 50 51 53 54 55 56 57 58 61 63
+// Shifts: 0 0 62 0 57 0 56 2 0 0 62 0 2 0 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+// Indices shifted by 1:  4 14
+// CHECK: arith.constant dense<[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot1_1:%[^ ]*]] = arith.constant 1
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot1_1]]
+// Indices shifted by 2:  2 7 10 12
+// CHECK: arith.constant dense<[0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot1_2:%[^ ]*]] = arith.constant 2
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot1_2]]
+// Indices shifted by 4:  2 10 14
+// CHECK: arith.constant dense<[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot1_4:%[^ ]*]] = arith.constant 4
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot1_4]]
+// Indices shifted by 8:  2 4 6 10
+// CHECK: arith.constant dense<[0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot1_8:%[^ ]*]] = arith.constant 8
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot1_8]]
+// Indices shifted by 16: 2 4 6 10
+// CHECK: arith.constant dense<[0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot1_16:%[^ ]*]] = arith.constant 16
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot1_16]]
+// Indices shifted by 32: 2 4 6 10
+// CHECK: arith.constant dense<[0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot1_32:%[^ ]*]] = arith.constant 32
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot1_32]]
+//
+// Group:  0 1 5 8 11 15 36 43 44 46 52 59 60 62
+// Shifts: 51 57 0 0 0 62 0 0 57 0 0 5 0 0 0 14 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+// Indices shifted by 1:  0 1 8 11
+// CHECK: arith.constant dense<[1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot2_1:%[^ ]*]] = arith.constant 1
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot2_1]]
+// Indices shifted by 2:  0 5 15
+// CHECK: arith.constant dense<[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot2_2:%[^ ]*]] = arith.constant 2
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot2_2]]
+// Indices shifted by 4:  5 11 15
+// CHECK: arith.constant dense<[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot2_4:%[^ ]*]] = arith.constant 4
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot2_4]]
+// Indices shifted by 8:  1 5 8 15
+// CHECK: arith.constant dense<[0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot2_8:%[^ ]*]] = arith.constant 8
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot2_8]]
+// Indices shifted by 16: 0 1 5 8
+// CHECK: arith.constant dense<[1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot2_16:%[^ ]*]] = arith.constant 16
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot2_16]]
+// Indices shifted by 32: 0 1 5 8
+// CHECK: arith.constant dense<[1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot2_32:%[^ ]*]] = arith.constant 32
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot2_32]]
+//
+// Group:  3 9 13
+// Shifts: 0 0 0 3 0 0 0 0 0 6 0 0 0 11 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+// Indices shifted by 1:  3 13
+// CHECK: arith.constant dense<[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot3_1:%[^ ]*]] = arith.constant 1
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot3_1]]
+// Indices shifted by 2:  3 9 13
+// CHECK: arith.constant dense<[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot3_2:%[^ ]*]] = arith.constant 2
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot3_2]]
+// Indices shifted by 4:  9
+// CHECK: arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot3_4:%[^ ]*]] = arith.constant 4
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot3_4]]
+// Indices shifted by 8:  13
+// CHECK: arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]>
+// CHECK: [[rot3_8:%[^ ]*]] = arith.constant 8
+// CHECK: tensor_ext.rotate
+// CHECK-SAME: [[rot3_8]]
+// Indices shifted by 16:
+// Indices shifted by 32:
+// CHECK-NOT: tensor_ext.rotate
+#map3 = dense<[13, 8, 4, 0, 11, 7, 14, 5, 15, 3, 12, 6, 10, 2, 9, 1, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]> : tensor<64xi64>
+func.func @figure3(%0: tensor<64xi32>) -> tensor<64xi32> {
+  %1 = tensor_ext.permute %0 {permutation = #map3} : tensor<64xi32>
+  return %1 : tensor<64xi32>
+}
+
+
+// CHECK-LABEL: func.func @identity
+// CHECK-NEXT: return
+#identityperm = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]> : tensor<64xi64>
+func.func @identity(%0: tensor<64xi32>) -> tensor<64xi32> {
+  %1 = tensor_ext.permute %0 {permutation = #identityperm} : tensor<64xi32>
+  return %1 : tensor<64xi32>
+}

--- a/tests/Dialect/TensorExt/Transforms/implement_shift_network_example.mlir
+++ b/tests/Dialect/TensorExt/Transforms/implement_shift_network_example.mlir
@@ -1,0 +1,8 @@
+// RUN: heir-opt --implement-shift-network=ciphertext-size=16 %s | FileCheck %s
+
+#map = dense<[13, 8, 4, 0, 11, 7, 14, 5, 15, 3, 12, 6, 10, 2, 9, 1]> : tensor<16xi64>
+// CHECK-LABEL: @figure3
+func.func @figure3(%0: tensor<16xi32>) -> tensor<16xi32> {
+  %1 = tensor_ext.permute %0 {permutation = #map} : tensor<16xi32>
+  return %1 : tensor<16xi32>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -85,6 +85,7 @@ cc_binary(
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/Transforms",
         "@heir//lib/Dialect/TensorExt/Transforms:CollapseInsertionChains",
+        "@heir//lib/Dialect/TensorExt/Transforms:ImplementShiftNetwork",
         "@heir//lib/Dialect/TensorExt/Transforms:InsertRotate",
         "@heir//lib/Dialect/TensorExt/Transforms:RotateAndReduce",
         "@heir//lib/Dialect/TfheRust/IR:Dialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -46,6 +46,7 @@
 #include "lib/Dialect/Secret/Transforms/Passes.h"
 #include "lib/Dialect/TOSA/Conversions/TosaToSecretArith/TosaToSecretArith.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h"
 #include "lib/Dialect/TensorExt/Transforms/Passes.h"
 #include "lib/Dialect/TfheRust/IR/TfheRustDialect.h"
 #include "lib/Dialect/TfheRustBool/IR/TfheRustBoolDialect.h"


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/919

This PR implements the Vos-Vos-Erkin shift network technique described in https://doi.org/10.1007/978-3-031-17140-6_20

In support of this, this PR adds:

- A new FrozenVector data type to represent an explicit permutation and use it as a hash map key.
- New utility functions for working with permutations; in particular expanding an affine map to an explicit permutation
- A new op `tensor_ext.permute` to represent the input to the pass. I expect the layout materialization pass to lower `convert_layout` to permute.
- A bug fix in the graph coloring routine.

Implementation notes:

- This PR only supports the baseline "power of two" shifting strategy, however, the strategy itself is extracted into its own class so that later work can generalize. Some ways I can see generalizing include:
   - Trying other bases like negative powers of two (right rotations instead of left rotations).
   - Trying random reorderings of the basis elements (e.g., shift first by 4 then by 16 then by 1 then by...) which can produce a graph with fewer conflicts and hence fewer colors.
   - Evaluate many such strategies and use the one that produces the smallest number of rotation groups.
- This requires writing out the permutation explicitly in memory, which for large ciphertexts (N = 65536) means each `tensor_ext.permute` lowering will require ~0.5 MiB of RAM. If we had ~1k of these ops to lower, it would take ~1 GiB of RAM. This seems OK to me, since if we are doing 1k layout conversions we probably have bigger problems.



