### PR TITLE
optimize-relinearization: Remove requirement that arguments have equal key-basis degrees

### DIFF
--- a/lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.h
+++ b/lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.h
@@ -1,8 +1,6 @@
 #ifndef LIB_ANALYSIS_OPTIMIZE_RELINEARIZATIONANALYSIS_H
 #define LIB_ANALYSIS_OPTIMIZE_RELINEARIZATIONANALYSIS_H
 
-#include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
-#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "llvm/include/llvm/ADT/DenseMap.h"                // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
@@ -13,10 +11,12 @@ namespace heir {
 class OptimizeRelinearizationAnalysis {
  public:
   OptimizeRelinearizationAnalysis(Operation *op, DataFlowSolver *solver,
-                                  bool useLocBasedVariableNames)
+                                  bool useLocBasedVariableNames,
+                                  bool allowMixedDegreeOperands)
       : opToRunOn(op),
         solver(solver),
-        useLocBasedVariableNames(useLocBasedVariableNames) {}
+        useLocBasedVariableNames(useLocBasedVariableNames),
+        allowMixedDegreeOperands(allowMixedDegreeOperands) {}
   ~OptimizeRelinearizationAnalysis() = default;
 
   LogicalResult solve();
@@ -40,7 +40,8 @@ class OptimizeRelinearizationAnalysis {
  private:
   Operation *opToRunOn;
   DataFlowSolver *solver;
-  bool useLocBasedVariableNames = false;
+  bool useLocBasedVariableNames;
+  bool allowMixedDegreeOperands;
   llvm::DenseMap<Operation *, bool> solution;
   llvm::DenseMap<Value, int> solutionKeyBasisDegreeBeforeRelin;
 };

--- a/lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.cpp
+++ b/lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.cpp
@@ -1,35 +1,21 @@
 #include "lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.h"
 
-#include <iterator>
-#include <numeric>
-#include <optional>
-#include <vector>
-
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
-#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
-#include "lib/Dialect/Mgmt/Transforms/Passes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
-#include "lib/Dialect/Utils.h"
-#include "llvm/include/llvm/ADT/STLExtras.h"    // from @llvm-project
-#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
-#include "llvm/include/llvm/ADT/TypeSwitch.h"   // from @llvm-project
-#include "llvm/include/llvm/Support/Debug.h"    // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Builders.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"     // from @llvm-project
-#include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
-#include "mlir/include/mlir/IR/Types.h"                 // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"              // from @llvm-project
-#include "mlir/include/mlir/Pass/PassManager.h"         // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
-#include "mlir/include/mlir/Transforms/Passes.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"           // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"      // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"          // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -53,8 +39,8 @@ struct OptimizeRelinearization
       op.erase();
     });
 
-    OptimizeRelinearizationAnalysis analysis(genericOp, solver,
-                                             useLocBasedVariableNames);
+    OptimizeRelinearizationAnalysis analysis(
+        genericOp, solver, useLocBasedVariableNames, allowMixedDegreeOperands);
     if (failed(analysis.solve())) {
       genericOp->emitError("Failed to solve the optimization problem");
       return signalPassFailure();

--- a/lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.td
+++ b/lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.td
@@ -38,6 +38,13 @@ def OptimizeRelinearization : Pass <"optimize-relinearization"> {
            /*default=*/"false",
            "When true, the ILP uses op source locations in variable names, "
            "which can help debug ILP model bugs.">,
+    Option<"allowMixedDegreeOperands",
+           "allow-mixed-degree-operands",
+           "bool",
+           /*default=*/"true",
+           "When true, allow ops to have mixed-degree ciphertexts as inputs, e.g., "
+           "adding two ciphertexts with different key bases; this is supported by "
+           "many FHE backends, like OpenFHE and Lattigo">,
   ];
 }
 

--- a/tests/Transforms/optimize_relinearization/force_equal_args.mlir
+++ b/tests/Transforms/optimize_relinearization/force_equal_args.mlir
@@ -1,0 +1,24 @@
+// RUN: heir-opt --mlir-print-local-scope --secretize --mlir-to-secret-arithmetic --optimize-relinearization='allow-mixed-degree-operands=false' %s | FileCheck %s
+
+// CHECK-LABEL: func.func @relinearize_both_add_operands
+// CHECK: secret.generic
+// CHECK: arith.muli
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: arith.muli
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: tensor_ext.rotate
+// CHECK-NEXT: arith.addi
+// CHECK-NOT: mgmt.relinearize
+// CHECK-NEXT: secret.yield
+func.func @relinearize_both_add_operands(%arg0: tensor<8xi16>, %arg1: tensor<8xi16>) -> tensor<8xi16> {
+  %0 = arith.muli %arg0, %arg0: tensor<8xi16>
+  %1 = mgmt.relinearize %0  : tensor<8xi16>
+  %2 = arith.muli %arg1, %arg1: tensor<8xi16>
+  %3 = mgmt.relinearize %2  : tensor<8xi16>
+
+  // Rotation requires degree 1 key basis input
+  %c1 = arith.constant 1 : index
+  %6 = tensor_ext.rotate %3, %c1 : tensor<8xi16>, index
+  %7 = arith.addi %1, %6 : tensor<8xi16>
+  func.return %7 : tensor<8xi16>
+}

--- a/tests/Transforms/optimize_relinearization/issue_1284.mlir
+++ b/tests/Transforms/optimize_relinearization/issue_1284.mlir
@@ -1,0 +1,25 @@
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --optimize-relinearization %s | FileCheck %s
+
+// CHECK-LABEL: func.func @repro
+// CHECK-COUNT-1: mgmt.relinearize
+// CHECK-NOT: mgmt.relinearize
+func.func @repro(%x: i16 {secret.secret}, %y: i16 {secret.secret}, %p: i16) -> (i16) {
+    %xx = arith.muli %x, %x : i16
+    %yy = arith.muli %y, %y : i16
+    %0 = arith.addi %xx, %yy : i16
+    %xp = arith.muli %x, %p : i16
+    %1 = arith.addi %xp, %0 : i16
+    func.return %1 : i16
+}
+
+// CHECK-LABEL: func.func @repro2
+// CHECK-COUNT-1: mgmt.relinearize
+// CHECK-NOT: mgmt.relinearize
+func.func @repro2(%x: i16 {secret.secret}, %y: i16 {secret.secret}, %p: i16) -> (i16) {
+    %xx = arith.muli %x, %x : i16
+    %yy = arith.muli %y, %y : i16
+    %0 = arith.addi %xx, %yy : i16
+    %xp = arith.muli %x, %p : i16
+    %1 = arith.addi %0, %xp : i16
+    func.return %1 : i16
+}

--- a/tests/Transforms/optimize_relinearization/optimize_relinearization.mlir
+++ b/tests/Transforms/optimize_relinearization/optimize_relinearization.mlir
@@ -195,11 +195,11 @@ func.func @smoke_test(%arg0: tensor<8xi16>, %arg1: tensor<8xi16>) -> tensor<8xi1
 // CHECK-LABEL: func.func @rotation_needs_linear_inputs
 // CHECK: secret.generic
 // CHECK: arith.muli
-// CHECK-NEXT: mgmt.relinearize
 // CHECK-NEXT: arith.muli
 // CHECK-NEXT: mgmt.relinearize
 // CHECK-NEXT: tensor_ext.rotate
 // CHECK-NEXT: arith.addi
+// CHECK-NEXT: mgmt.relinearize
 // CHECK-NEXT: secret.yield
 func.func @rotation_needs_linear_inputs(%arg0: tensor<8xi16>, %arg1: tensor<8xi16>) -> tensor<8xi16> {
   %0 = arith.muli %arg0, %arg0: tensor<8xi16>


### PR DESCRIPTION
This PR modifies the ILP for optimize-relinearization to permit the possibility that the operands to an op like `arith.addi` have mixed key-basis degrees. E.g., you can add a ciphertext with basis (1, s) to another with basis (1, s, s^2).

Based on the discussion in https://github.com/google/heir/issues/1284, Lattigo and OpenFHE both support this for BGV.

To hedge against the possibility a future backend does not support this, I made the relaxation optional via a new pass option (`allow-mixed-level-ops`).

The impact of this relaxation on the ILP is not as trivial as I had hoped. When removing the constraints on key basis degree for operands, I had to add new constraints that the output degree is at least as big as each input degree. _Ideally_ this comes paired with an objective term that makes the output degree as small as possible, which would implement a `result_degree = max(arg0_degree, ..., argN_degree)` function. However, adding this to the objective causes the solver to "cheat" by inserting relinearization terms earlier than necessary to as to reduce cost of the new terms.

The "right" solution here is to properly cost model the solver's choices (https://github.com/google/heir/issues/1018). Instead of minimizing the total number of relin ops, have a cost for each op at each level, as well as the cost of doing a relin op from each starting level.

In the interim, we simply ignore the fact that the solver may assign a larger key-basis-degree for the output of an add op than necessary. It doesn't seem to affect the correctness of any results; hallucinating larger key-basis degree doesn't change whether or not you need to relinearize, just the mechanics of how to relinearize, which is handled opaquely by the backend anyway. In particular, if the output degree of an op were truly 1, but the solver decided to make it 2, this would require inserting a relin op when it's not necessary, so the solver naturally avoids this situation. But if the degree were 2 and the solver hallucinated it should be 3, we still relin.

Fixes https://github.com/google/heir/issues/1284