### PR TITLE
Enable clangd to warn on unused include

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+Diagnostics:
+  UnusedIncludes: Strict


### PR DESCRIPTION
Check #1296 and https://clangd.llvm.org/guides/include-cleaner

Note that project config is in https://clangd.llvm.org/config#files and after clangd-17 this option is on by default (https://clangd.llvm.org/config#unusedincludes). I am using clangd-14.

One worrying false positive warning is that, for `Dialect.cpp` (e.g. `LattigoDialect.cpp`), clangd would say `TypeSwtich.h` and `DialectImplementation.h` are not used, whilst they are used in some `cpp.inc`.