### PR TITLE
Add external debug port during execution

### DIFF
--- a/lib/Dialect/LWE/Transforms/AddDebugPort.cpp
+++ b/lib/Dialect/LWE/Transforms/AddDebugPort.cpp
@@ -1,0 +1,118 @@
+#include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
+
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/FunctionInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+#define GEN_PASS_DEF_ADDDEBUGPORT
+#include "lib/Dialect/LWE/Transforms/Passes.h.inc"
+
+FailureOr<Type> getPrivateKeyType(func::FuncOp op) {
+  const auto *type = llvm::find_if(op.getArgumentTypes(), [](Type type) {
+    return mlir::isa<NewLWECiphertextType>(type);
+  });
+
+  if (type == op.getArgumentTypes().end()) {
+    return op.emitError(
+        "Function does not have an argument of LWECiphertextType");
+  }
+
+  auto lweCiphertextType = cast<NewLWECiphertextType>(*type);
+
+  auto lwePrivateKeyType = NewLWESecretKeyType::get(
+      op.getContext(), lweCiphertextType.getKey(),
+      lweCiphertextType.getCiphertextSpace().getRing());
+  return lwePrivateKeyType;
+}
+
+func::FuncOp getOrCreateExternalDebugFunc(
+    ModuleOp module, Type lwePrivateKeyType,
+    NewLWECiphertextType lweCiphertextType,
+    const DenseMap<Type, int> &typeToInt) {
+  std::string funcName =
+      "__heir_debug_" + std::to_string(typeToInt.at(lweCiphertextType));
+
+  auto *context = module.getContext();
+  auto lookup = module.lookupSymbol<func::FuncOp>(funcName);
+  if (lookup) return lookup;
+
+  auto debugFuncType =
+      FunctionType::get(context, {lwePrivateKeyType, lweCiphertextType}, {});
+
+  ImplicitLocOpBuilder b =
+      ImplicitLocOpBuilder::atBlockBegin(module.getLoc(), module.getBody());
+  auto funcOp = b.create<func::FuncOp>(funcName, debugFuncType);
+  // required for external func call
+  funcOp.setPrivate();
+  return funcOp;
+}
+
+LogicalResult insertExternalCall(func::FuncOp op, Type lwePrivateKeyType) {
+  auto module = op->getParentOfType<ModuleOp>();
+
+  // map ciphertext type to unique int
+  DenseMap<Type, int> typeToInt;
+
+  // implicit assumption the first argument is private key
+  auto privateKey = op.getArgument(0);
+
+  ImplicitLocOpBuilder b =
+      ImplicitLocOpBuilder::atBlockBegin(module.getLoc(), module.getBody());
+  op.walk([&](Operation *op) {
+    b.setInsertionPointAfter(op);
+    for (Value result : op->getResults()) {
+      Type resultType = result.getType();
+      if (auto lweCiphertextType = dyn_cast<NewLWECiphertextType>(resultType)) {
+        // update typeToInt
+        if (!typeToInt.count(resultType)) {
+          typeToInt[resultType] = typeToInt.size();
+        }
+        b.create<func::CallOp>(
+            getOrCreateExternalDebugFunc(module, lwePrivateKeyType,
+                                         lweCiphertextType, typeToInt),
+            ArrayRef<Value>{privateKey, result});
+      }
+    }
+    return WalkResult::advance();
+  });
+  return success();
+}
+
+LogicalResult convertFunc(func::FuncOp op) {
+  auto type = getPrivateKeyType(op);
+  if (failed(type)) return failure();
+  auto lwePrivateKeyType = type.value();
+
+  op.insertArgument(0, lwePrivateKeyType, nullptr, op.getLoc());
+  if (failed(insertExternalCall(op, lwePrivateKeyType))) {
+    return failure();
+  }
+  return success();
+}
+
+struct AddDebugPort : impl::AddDebugPortBase<AddDebugPort> {
+  using AddDebugPortBase::AddDebugPortBase;
+
+  void runOnOperation() override {
+    auto result =
+        getOperation()->walk<WalkOrder::PreOrder>([&](func::FuncOp op) {
+          if (op.getSymName() == entryFunction && failed(convertFunc(op))) {
+            op->emitError("Failed to add client interface for func");
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
+    if (result.wasInterrupted()) signalPassFailure();
+  }
+};
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/LWE/Transforms/AddDebugPort.h
+++ b/lib/Dialect/LWE/Transforms/AddDebugPort.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_LWE_TRANSFORMS_ADDDEBUGPORT_H_
+#define LIB_DIALECT_LWE_TRANSFORMS_ADDDEBUGPORT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+#define GEN_PASS_DECL_ADDDEBUGPORT
+#include "lib/Dialect/LWE/Transforms/Passes.h.inc"
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_LWE_TRANSFORMS_ADDDEBUGPORT_H_

--- a/lib/Dialect/LWE/Transforms/BUILD
+++ b/lib/Dialect/LWE/Transforms/BUILD
@@ -12,6 +12,7 @@ cc_library(
     ],
     deps = [
         ":AddClientInterface",
+        ":AddDebugPort",
         ":SetDefaultParameters",
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
@@ -23,6 +24,23 @@ cc_library(
     srcs = ["AddClientInterface.cpp"],
     hdrs = [
         "AddClientInterface.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "AddDebugPort",
+    srcs = ["AddDebugPort.cpp"],
+    hdrs = [
+        "AddDebugPort.h",
     ],
     deps = [
         ":pass_inc_gen",

--- a/lib/Dialect/LWE/Transforms/Passes.h
+++ b/lib/Dialect/LWE/Transforms/Passes.h
@@ -3,6 +3,7 @@
 
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/AddClientInterface.h"
+#include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
 #include "lib/Dialect/LWE/Transforms/SetDefaultParameters.h"
 
 namespace mlir {

--- a/lib/Dialect/LWE/Transforms/Passes.td
+++ b/lib/Dialect/LWE/Transforms/Passes.td
@@ -22,6 +22,39 @@ def AddClientInterface : Pass<"lwe-add-client-interface"> {
   ];
 }
 
+def AddDebugPort : Pass<"lwe-add-debug-port"> {
+  let summary = "Add debug port to (R)LWE encrypted functions";
+  let description = [{
+  This pass adds debug ports to the specified function in the IR. The debug ports
+  are prefixed with "__heir_debug" and are invoked after each homomorphic operation in the
+  function. The debug ports are declarations and user should provide functions with
+  the same name in their code.
+
+  For example, if the function is called "foo", the secret key is added to its
+  arguments, and the debug port is called after each homomorphic operation:
+  ```mlir
+  // declaration of external debug function
+  func.func private @__heir_debug(%sk : !sk, %ct : !ct)
+
+  // secret key added as function arg
+  func.func @foo(%sk : !sk, ...) {
+    %ct = lwe.radd ...
+    // invoke external debug function
+    __heir_debug(%sk, %ct)
+    %ct1 = lwe.rmul ...
+    __heir_debug(%sk, %ct1)
+    ...
+  }
+  ```
+  }];
+  let dependentDialects = ["mlir::heir::lwe::LWEDialect"];
+  let options = [
+    Option<"entryFunction", "entry-function", "std::string",
+           /*default=*/"", "Default entry function "
+           "name of entry function.">,
+  ];
+}
+
 def SetDefaultParameters : Pass<"lwe-set-default-parameters"> {
   let summary = "Set default parameters for LWE ops";
   let description = [{

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -8,6 +8,7 @@
 #include "lib/Dialect/CKKS/Conversions/CKKSToLWE/CKKSToLWE.h"
 #include "lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.h"
 #include "lib/Dialect/LWE/Transforms/AddClientInterface.h"
+#include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
 #include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
@@ -227,6 +228,13 @@ RLWEPipelineBuilder mlirToOpenFheRLWEPipelineBuilder(const RLWEScheme scheme) {
       default:
         llvm::errs() << "Unsupported RLWE scheme: " << scheme;
         exit(EXIT_FAILURE);
+    }
+
+    // insert debug handler calls
+    if (options.debug) {
+      lwe::AddDebugPortOptions addDebugPortOptions;
+      addDebugPortOptions.entryFunction = options.entryFunction;
+      pm.addPass(lwe::createAddDebugPort(addDebugPortOptions));
     }
 
     // Convert to OpenFHE

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -43,6 +43,11 @@ struct MlirToRLWEPipelineOptions
       llvm::cl::desc("Modulus switching right before the first multiplication "
                      "(default to false)"),
       llvm::cl::init(false)};
+  PassOptions::Option<bool> debug{
+      *this, "insert-debug-handler-calls",
+      llvm::cl::desc("Insert function calls to an externally-defined debug "
+                     "function (cf. --lwe-add-debug-port)"),
+      llvm::cl::init(false)};
 };
 
 using RLWEPipelineBuilder =

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -91,6 +91,7 @@ cc_library(
         "@heir//lib/Dialect/LWE/Conversions/LWEToOpenfhe",
         "@heir//lib/Dialect/LWE/Conversions/LWEToPolynomial",
         "@heir//lib/Dialect/LWE/Transforms:AddClientInterface",
+        "@heir//lib/Dialect/LWE/Transforms:AddDebugPort",
         "@heir//lib/Dialect/Lattigo/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/LinAlg/Conversions/LinalgToTensorExt",
         "@heir//lib/Dialect/Openfhe/Transforms:ConfigureCryptoContext",

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -80,7 +80,7 @@ LogicalResult OpenFhePkeEmitter::translate(Operation &op) {
           // Builtin ops
           .Case<ModuleOp>([&](auto op) { return printOperation(op); })
           // Func ops
-          .Case<func::FuncOp, func::ReturnOp>(
+          .Case<func::FuncOp, func::CallOp, func::ReturnOp>(
               [&](auto op) { return printOperation(op); })
           // Arith ops
           .Case<arith::ConstantOp, arith::ExtSIOp, arith::IndexCastOp,
@@ -121,8 +121,15 @@ LogicalResult OpenFhePkeEmitter::printOperation(ModuleOp moduleOp) {
   return success();
 }
 
+StringRef OpenFhePkeEmitter::canonicalizeDebugPort(StringRef debugPortName) {
+  if (debugPortName.rfind("__heir_debug") == 0) {
+    return "__heir_debug";
+  }
+  return debugPortName;
+}
+
 LogicalResult OpenFhePkeEmitter::printOperation(func::FuncOp funcOp) {
-  if (funcOp.getNumResults() != 1) {
+  if (funcOp.getNumResults() > 1) {
     return emitError(funcOp.getLoc(),
                      llvm::formatv("Only functions with a single return type "
                                    "are supported, but this function has ",
@@ -130,13 +137,17 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::FuncOp funcOp) {
     return failure();
   }
 
-  Type result = funcOp.getResultTypes()[0];
-  if (failed(emitType(result, funcOp->getLoc()))) {
-    return emitError(funcOp.getLoc(),
-                     llvm::formatv("Failed to emit type {0}", result));
+  if (funcOp.getNumResults() == 1) {
+    Type result = funcOp.getResultTypes()[0];
+    if (failed(emitType(result, funcOp->getLoc()))) {
+      return emitError(funcOp.getLoc(),
+                       llvm::formatv("Failed to emit type {0}", result));
+    }
+  } else {
+    os << "void";
   }
 
-  os << " " << funcOp.getName() << "(";
+  os << " " << canonicalizeDebugPort(funcOp.getName()) << "(";
   os.indent();
 
   // Check the types without printing to enable failure outside of
@@ -150,12 +161,26 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::FuncOp funcOp) {
     }
   }
 
-  os << commaSeparatedValues(funcOp.getArguments(), [&](Value value) {
-    return convertType(value.getType(), funcOp->getLoc()).value() + " " +
-           variableNames->getNameForValue(value);
-  });
+  if (funcOp.isDeclaration()) {
+    os << commaSeparatedTypes(funcOp.getArgumentTypes(), [&](Type type) {
+      return convertType(type, funcOp->getLoc()).value();
+    });
+  } else {
+    os << commaSeparatedValues(funcOp.getArguments(), [&](Value value) {
+      return convertType(value.getType(), funcOp->getLoc()).value() + " " +
+             variableNames->getNameForValue(value);
+    });
+  }
   os.unindent();
-  os << ") {\n";
+  os << ")";
+
+  // function declaration finishes here
+  if (funcOp.isDeclaration()) {
+    os << ";\n";
+    return success();
+  }
+
+  os << " {\n";
   os.indent();
 
   for (Block &block : funcOp.getBlocks()) {
@@ -168,6 +193,23 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::FuncOp funcOp) {
 
   os.unindent();
   os << "}\n";
+  return success();
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(func::CallOp op) {
+  if (op.getNumResults() > 1) {
+    return emitError(op.getLoc(), "Only one return value supported");
+  }
+
+  if (op.getNumResults() != 0) {
+    os << variableNames->getNameForValue(op.getResult(0)) << " = ";
+  }
+
+  os << canonicalizeDebugPort(op.getCallee()) << "(";
+  os << commaSeparatedValues(op.getOperands(), [&](Value value) {
+    return variableNames->getNameForValue(value);
+  });
+  os << ");\n";
   return success();
 }
 

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -60,6 +60,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::tensor::InsertOp op);
   LogicalResult printOperation(::mlir::tensor::SplatOp op);
   LogicalResult printOperation(::mlir::func::FuncOp op);
+  LogicalResult printOperation(::mlir::func::CallOp op);
   LogicalResult printOperation(::mlir::func::ReturnOp op);
   LogicalResult printOperation(::mlir::heir::lwe::RLWEDecodeOp op);
   LogicalResult printOperation(
@@ -99,6 +100,9 @@ class OpenFhePkeEmitter {
 
   // Emit an OpenFhe type
   LogicalResult emitType(::mlir::Type type, ::mlir::Location loc);
+
+  // Canonicalize Debug Port
+  ::llvm::StringRef canonicalizeDebugPort(::llvm::StringRef debugPortName);
 
   void emitAutoAssignPrefix(::mlir::Value result);
   LogicalResult emitTypedAssignPrefix(::mlir::Value result,

--- a/tests/Examples/openfhe/BUILD
+++ b/tests/Examples/openfhe/BUILD
@@ -33,6 +33,15 @@ openfhe_end_to_end_test(
 )
 
 openfhe_end_to_end_test(
+    name = "dot_product_8_debug_test",
+    generated_lib_header = "dot_product_8_debug_lib.h",
+    heir_opt_flags = ["--mlir-to-openfhe-bgv=entry-function=dot_product ciphertext-degree=8 insert-debug-handler-calls=true"],
+    mlir_src = "dot_product_8.mlir",
+    tags = ["notap"],
+    test_src = "dot_product_8_debug_test.cpp",
+)
+
+openfhe_end_to_end_test(
     name = "box_blur_64x64_test",
     generated_lib_header = "box_blur_64x64_lib.h",
     heir_opt_flags = ["--mlir-to-openfhe-bgv=entry-function=box_blur ciphertext-degree=4096"],

--- a/tests/Examples/openfhe/dot_product_8_debug_test.cpp
+++ b/tests/Examples/openfhe/dot_product_8_debug_test.cpp
@@ -1,0 +1,47 @@
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/dot_product_8_debug_lib.h"
+
+void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct) {
+  PlaintextT ptxt;
+  cc->Decrypt(sk, ct, &ptxt);
+  ptxt->SetLength(8);
+  std::cout << ptxt << std::endl;
+}
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(DotProduct8Test, RunTest) {
+  auto cryptoContext = dot_product__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      dot_product__configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<int16_t> arg0 = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<int16_t> arg1 = {2, 3, 4, 5, 6, 7, 8, 9};
+  int64_t expected = 240;
+
+  auto arg0Encrypted =
+      dot_product__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg1Encrypted =
+      dot_product__encrypt__arg1(cryptoContext, arg1, publicKey);
+  auto outputEncrypted =
+      dot_product(cryptoContext, secretKey, arg0Encrypted, arg1Encrypted);
+  auto actual =
+      dot_product__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
Partially address #1266. This PR illustrate we can print decryption result after each step, for debugging. Also, I use such interface for evaluating noise magnititude after each step, so this is part of the param selection support.

This PR does the following things

* Implement `lwe-add-debug-port` pass that
  + Add secret key arg to main func
  + call `__heir_debug` after each HE op
* Modify `lwe-to-openfhe` to support these func declacation and `func.call`
* Add e2e demo

### Example

For dot_product_8, the execution result is
```shell
$ ./bazel-out/k8-dbg/bin/tests/Examples/openfhe/dot_product_8_debug_test
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DotProduct8Test
[ RUN      ] DotProduct8Test.RunTest
( 2 6 12 20 30 42 56 72 ... )
( 2 6 12 20 30 42 56 72 ... )
( 30 42 56 72 2 6 12 20 ... )
( 32 48 68 92 32 48 68 92 ... )
( 68 92 32 48 68 92 32 48 ... )
( 100 140 100 140 100 140 100 140 ... )
( 140 100 140 100 140 100 140 100 ... )
( 240 240 240 240 240 240 240 240 ... )
( 240 240 240 240 240 240 240 240 ... )
( 0 0 0 0 0 0 0 240 ... )
( 240 ... )
( 240 ... )
( 240 ... )
[       OK ] DotProduct8Test.RunTest (4923 ms)
[----------] 1 test from DotProduct8Test (4923 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4923 ms total)
[  PASSED  ] 1 test.
```

IR after `lwe-add-debug-port`

```mlir
  // Notice that due to type issue we have multiple debug func
  func.func private @__heir_debug_4(!skey_L2_, !ct_L0_)
  func.func private @__heir_debug_3(!skey_L2_, !ct_L1_)
  func.func private @__heir_debug_2(!skey_L2_, !ct_L1_1)
  func.func private @__heir_debug_1(!skey_L2_, !ct_L2_)
  func.func private @__heir_debug_0(!skey_L2_, !ct_L2_D3_)
  func.func @dot_product(%sk: !skey_L2_, %ct: !ct_L2_, %ct_0: !ct_L2_) -> !ct_L0_ {
    %ct_1 = lwe.rmul %ct, %ct_0 : (!ct_L2_, !ct_L2_) -> !ct_L2_D3_
    call @__heir_debug_0(%sk, %ct_1) : (!skey_L2_, !ct_L2_D3_) -> ()
    %ct_2 = bgv.relinearize %ct_1 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !ct_L2_D3_ -> !ct_L2_
    call @__heir_debug_1(%sk, %ct_2) : (!skey_L2_, !ct_L2_) -> ()
...
```

IR after `lwe-to-openfhe`

```mlir
  func.func private @__heir_debug_0(!openfhe.crypto_context, !openfhe.private_key, !ct_L2_D3_)
  func.func @dot_product(%cc: !openfhe.crypto_context, %sk: !openfhe.private_key, %ct: !ct_L2_, %ct_0: !ct_L2_) -> !ct_L0_ {
      %ct_1 = openfhe.mul_no_relin %cc, %ct, %ct_0 : (!openfhe.crypto_context, !ct_L2_, !ct_L2_) -> !ct_L2_D3_
    call @__heir_debug_0(%cc, %sk, %ct_1) : (!openfhe.crypto_context, !openfhe.private_key, !ct_L2_D3_) -> ()
    %ct_2 = openfhe.relin %cc, %ct_1 : (!openfhe.crypto_context, !ct_L2_D3_) -> !ct_L2_
    call @__heir_debug_1(%cc, %sk, %ct_2) : (!openfhe.crypto_context, !openfhe.private_key, !ct_L2_) -> ()
```

Then `heir-translate` would canonicalize all those debug call

```cpp
void __heir_debug(CryptoContextT, PrivateKeyT, CiphertextT);
CiphertextT dot_product(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct, CiphertextT ct1) {
  const auto& ct2 = cc->EvalMultNoRelin(ct, ct1);
  __heir_debug(cc, sk, ct2);
  const auto& ct3 = cc->Relinearize(ct2);
  __heir_debug(cc, sk, ct3);
...
```

In user file, user can specify what they want to debug, for example, printing decryption result

```cpp
void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct) {
  PlaintextT ptxt;
  cc->Decrypt(sk, ct, &ptxt);
  ptxt->SetLength(8);
  std::cout << ptxt << std::endl;
}
```

### Discussion

* Since `.mlir` does not have `AnyType`, we have to use `__heir_debug_#number` to address various LWE types. I could not think of better solution for now.
* Currently we can not tell which output corresponds to which variable, because we can not get variable name in mlir. This harms readablity. In my branch I hacked to get the following debug output, containing operation information and the "bound" attr from IR. I did so by passing all them as string arg to the debug port (at heir-translate stage), but in MLIR we cannot do such call.

```
ct=Encrypt pk, pt       cv 2 Ql 4 budget 123.592 noise: 42.4077 bound 26.5 gap -15.9077
ct=Encrypt pk, pt       cv 2 Ql 4 budget 123.493 noise: 42.5071 bound 26.5 gap -16.0071
ct2=EvalMultNoRelin ct, ct1     cv 3 Ql 3 budget 66.7256 noise: 83.2744 bound 26.5 gap -56.7744
```

