### PR TITLE
pass analysis state through external func.call ops

### DIFF
--- a/lib/Analysis/BUILD
+++ b/lib/Analysis/BUILD
@@ -1,0 +1,14 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Utils",
+    hdrs = ["Utils.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:FuncDialect",
+    ],
+)

--- a/lib/Analysis/DimensionAnalysis/BUILD
+++ b/lib/Analysis/DimensionAnalysis/BUILD
@@ -8,6 +8,7 @@ cc_library(
     srcs = ["DimensionAnalysis.cpp"],
     hdrs = ["DimensionAnalysis.h"],
     deps = [
+        "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",

--- a/lib/Analysis/DimensionAnalysis/DimensionAnalysis.cpp
+++ b/lib/Analysis/DimensionAnalysis/DimensionAnalysis.cpp
@@ -1,12 +1,12 @@
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
-#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
 #include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
@@ -78,6 +78,15 @@ LogicalResult DimensionAnalysis::visitOperation(
         }
       });
   return success();
+}
+
+void DimensionAnalysis::visitExternalCall(
+    CallOpInterface call, ArrayRef<const DimensionLattice *> argumentLattices,
+    ArrayRef<DimensionLattice *> resultLattices) {
+  auto callback = std::bind(&DimensionAnalysis::propagateIfChangedWrapper, this,
+                            std::placeholders::_1, std::placeholders::_2);
+  ::mlir::heir::visitExternalCall<DimensionState, DimensionLattice>(
+      call, argumentLattices, resultLattices, callback);
 }
 
 int getDimension(Value value, DataFlowSolver *solver) {

--- a/lib/Analysis/DimensionAnalysis/DimensionAnalysis.h
+++ b/lib/Analysis/DimensionAnalysis/DimensionAnalysis.h
@@ -26,6 +26,7 @@ class DimensionState {
     assert(isInitialized());
     return dimension.value();
   }
+  DimensionType get() const { return getDimension(); }
 
   bool operator==(const DimensionState &rhs) const {
     return dimension == rhs.dimension;
@@ -78,6 +79,14 @@ class DimensionAnalysis
   LogicalResult visitOperation(Operation *op,
                                ArrayRef<const DimensionLattice *> operands,
                                ArrayRef<DimensionLattice *> results) override;
+
+  void visitExternalCall(CallOpInterface call,
+                         ArrayRef<const DimensionLattice *> argumentLattices,
+                         ArrayRef<DimensionLattice *> resultLattices) override;
+
+  void propagateIfChangedWrapper(AnalysisState *state, ChangeResult changed) {
+    propagateIfChanged(state, changed);
+  }
 };
 
 // this function will assert false when Lattice does not exist or not

--- a/lib/Analysis/LevelAnalysis/BUILD
+++ b/lib/Analysis/LevelAnalysis/BUILD
@@ -8,6 +8,7 @@ cc_library(
     srcs = ["LevelAnalysis.cpp"],
     hdrs = ["LevelAnalysis.h"],
     deps = [
+        "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -33,6 +33,7 @@ class LevelState {
     assert(isInitialized());
     return level.value();
   }
+  LevelType get() const { return getLevel(); }
 
   bool operator==(const LevelState &rhs) const { return level == rhs.level; }
 
@@ -82,6 +83,14 @@ class LevelAnalysis
   LogicalResult visitOperation(Operation *op,
                                ArrayRef<const LevelLattice *> operands,
                                ArrayRef<LevelLattice *> results) override;
+
+  void visitExternalCall(CallOpInterface call,
+                         ArrayRef<const LevelLattice *> argumentLattices,
+                         ArrayRef<LevelLattice *> resultLattices) override;
+
+  void propagateIfChangedWrapper(AnalysisState *state, ChangeResult changed) {
+    propagateIfChanged(state, changed);
+  }
 };
 
 void annotateLevel(Operation *top, DataFlowSolver *solver);

--- a/lib/Analysis/MulResultAnalysis/BUILD
+++ b/lib/Analysis/MulResultAnalysis/BUILD
@@ -8,6 +8,7 @@ cc_library(
     srcs = ["MulResultAnalysis.cpp"],
     hdrs = ["MulResultAnalysis.h"],
     deps = [
+        "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//llvm:Support",

--- a/lib/Analysis/MulResultAnalysis/MulResultAnalysis.cpp
+++ b/lib/Analysis/MulResultAnalysis/MulResultAnalysis.cpp
@@ -1,6 +1,6 @@
 #include "lib/Analysis/MulResultAnalysis/MulResultAnalysis.h"
 
-#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -72,6 +72,15 @@ LogicalResult MulResultAnalysis::visitOperation(
         }
       });
   return success();
+}
+
+void MulResultAnalysis::visitExternalCall(
+    CallOpInterface call, ArrayRef<const MulResultLattice *> argumentLattices,
+    ArrayRef<MulResultLattice *> resultLattices) {
+  auto callback = std::bind(&MulResultAnalysis::propagateIfChangedWrapper, this,
+                            std::placeholders::_1, std::placeholders::_2);
+  ::mlir::heir::visitExternalCall<MulResultState, MulResultLattice>(
+      call, argumentLattices, resultLattices, callback);
 }
 
 }  // namespace heir

--- a/lib/Analysis/MulResultAnalysis/MulResultAnalysis.h
+++ b/lib/Analysis/MulResultAnalysis/MulResultAnalysis.h
@@ -84,6 +84,14 @@ class MulResultAnalysis
   LogicalResult visitOperation(Operation *op,
                                ArrayRef<const MulResultLattice *> operands,
                                ArrayRef<MulResultLattice *> results) override;
+
+  void visitExternalCall(CallOpInterface call,
+                         ArrayRef<const MulResultLattice *> argumentLattices,
+                         ArrayRef<MulResultLattice *> resultLattices) override;
+
+  void propagateIfChangedWrapper(AnalysisState *state, ChangeResult changed) {
+    propagateIfChanged(state, changed);
+  }
 };
 
 }  // namespace heir

--- a/lib/Analysis/SecretnessAnalysis/BUILD
+++ b/lib/Analysis/SecretnessAnalysis/BUILD
@@ -9,6 +9,7 @@ cc_library(
     srcs = ["SecretnessAnalysis.cpp"],
     hdrs = ["SecretnessAnalysis.h"],
     deps = [
+        "@heir//lib/Analysis:Utils",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:FuncDialect",

--- a/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
+++ b/lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h
@@ -25,6 +25,7 @@ class Secretness {
     assert(isInitialized());
     return *secretness;
   }
+  const bool &get() const { return getSecretness(); }
   void setSecretness(bool value) { secretness = value; }
 
   // Check if the Secretness state is initialized. It can be uninitialized if
@@ -104,6 +105,14 @@ class SecretnessAnalysis
   LogicalResult visitOperation(Operation *operation,
                                ArrayRef<const SecretnessLattice *> operands,
                                ArrayRef<SecretnessLattice *> results) override;
+
+  void visitExternalCall(CallOpInterface call,
+                         ArrayRef<const SecretnessLattice *> argumentLattices,
+                         ArrayRef<SecretnessLattice *> resultLattices) override;
+
+  void propagateIfChangedWrapper(AnalysisState *state, ChangeResult changed) {
+    propagateIfChanged(state, changed);
+  }
 };
 
 /**

--- a/lib/Analysis/Utils.h
+++ b/lib/Analysis/Utils.h
@@ -1,0 +1,37 @@
+#ifndef LIB_ANALYSIS_UTILS_H_
+#define LIB_ANALYSIS_UTILS_H_
+
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/CallInterfaces.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// A generalized version of visitExternalCall that joins all arguments to the
+// func.call op, and then propagates this joined value to all results. This is
+// useful for debug functions where there is a single operand that is not
+// changed by the external call, but can also be useful for some analyses like
+// secretness, where the result of the call is secret if any operand is secret.
+template <typename StateT, typename LatticeT>
+void visitExternalCall(CallOpInterface call,
+                       ArrayRef<const LatticeT *> argumentLattices,
+                       ArrayRef<LatticeT *> resultLattices,
+                       const std::function<void(AnalysisState *, ChangeResult)>
+                           &propagateIfChanged) {
+  StateT resultState = StateT();
+
+  for (const LatticeT *operand : argumentLattices) {
+    const StateT operandState = operand->getValue();
+    resultState = StateT::join(resultState, operandState);
+  }
+
+  for (LatticeT *result : resultLattices) {
+    propagateIfChanged(result, result->join(resultState));
+  }
+}
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_ANALYSIS_UTILS_H_

--- a/tests/Transforms/annotate_secretness/annotate_secretness.mlir
+++ b/tests/Transforms/annotate_secretness/annotate_secretness.mlir
@@ -34,3 +34,13 @@ func.func @multi_result_secretness(%s: i32 {secret.secret}, %p: i32) {
     %s1, %s2 = arith.addui_extended %s, %p : i32, i1
     func.return
 }
+
+func.func private @callee(!secret.secret<i32>) -> !secret.secret<i32>
+// CHECK: @func_call
+// CHECK-SAME: ([[S:%.*]]: [[ST:.*]])
+func.func @func_call(%s: !secret.secret<i32>) {
+    // CHECK: call
+    // CHECK-SAME: {secretness = true}
+    %1 = func.call @callee(%s) : (!secret.secret<i32>) -> !secret.secret<i32>
+    func.return
+}


### PR DESCRIPTION
Hongren was doing some debug work involving external func calls (`func.func private ...`), and Asra is also working on a prototype that involves external calls, and we identified a few places where `func.call` is not supported in the various passes and lowerings.

This PR adds support for `func.call` to the three analysis passes involved in `annotate-mgmt`. The core assumption here is that external calls imply a join of the lattices of its operands. For secretness this makes a lot of sense (return type is secret if any operand is secret, since we can't know what else happens in the function). For Level/Dimension it's a little bit less clear, but at least for functions with a single operand this implicitly causes the lattice to pass through the call op, where it would otherwise be an uninitialized lattice state.