### PR TITLE
fix: fixed !st and 3rd point of TODO list for mlir_emitter.py, issue #1162

### DIFF
--- a/heir_py/mlir_emitter.py
+++ b/heir_py/mlir_emitter.py
@@ -237,6 +237,6 @@ class TextualMlirEmitter:
 
     # Handling other complex types or custom classes
     else:
-        return 'unknown'  # Default type if not recognized
+        return 'unknown' 
 
 


### PR DESCRIPTION
This change resolve firts and third point of #1162  by the implementation of infer_type function that return the infer type instead of always "i64"

Signed-of-by: Andrea Vaccaro <andreavaccaro1227@gmail.com>