### PR TITLE
Cleanup #1306

### DIFF
--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -171,7 +171,7 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::FuncOp funcOp) {
     }
   }
 
-  if (funcOp.getVisibility() == SymbolTable::Visibility::Private) {
+  if (funcOp.isDeclaration()) {
     // function declaration
     os << commaSeparatedTypes(funcOp.getArgumentTypes(), [&](Type type) {
       return convertType(type, funcOp->getLoc()).value();
@@ -186,7 +186,7 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::FuncOp funcOp) {
   os << ")";
 
   // function declaration
-  if (funcOp.getVisibility() == SymbolTable::Visibility::Private) {
+  if (funcOp.isDeclaration()) {
     os << ";\n";
     return success();
   }
@@ -213,7 +213,7 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::CallOp op) {
   }
 
   if (op.getNumResults() != 0) {
-    os << variableNames->getNameForValue(op.getResult(0)) << " = ";
+    emitAutoAssignPrefix(op.getResult(0));
   }
 
   os << canonicalizeDebugPort(op.getCallee()) << "(";


### PR DESCRIPTION
Remaining items for #1306, see https://github.com/google/heir/pull/1306#issuecomment-2613963281 and https://github.com/google/heir/pull/1306#discussion_r1930817862

For func declaration, we could not just call `op.insertArgument`, which will cause segfault at MLIR side.