### PR TITLE
BGV: Populate Moduli Chain from Noise Analysis

### DIFF
--- a/lib/Dialect/BGV/IR/BGVAttributes.h
+++ b/lib/Dialect/BGV/IR/BGVAttributes.h
@@ -1,0 +1,9 @@
+#ifndef LIB_DIALECT_BGV_IR_BGVATTRIBUTES_H_
+#define LIB_DIALECT_BGV_IR_BGVATTRIBUTES_H_
+
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/BGV/IR/BGVAttributes.h.inc"
+
+#endif  // LIB_DIALECT_BGV_IR_BGVATTRIBUTES_H_

--- a/lib/Dialect/BGV/IR/BGVAttributes.td
+++ b/lib/Dialect/BGV/IR/BGVAttributes.td
@@ -1,0 +1,40 @@
+#ifndef LIB_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
+#define LIB_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
+
+include "lib/Dialect/BGV/IR/BGVDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+
+class BGV_Attribute<string attrName, string attrMnemonic>
+    : AttrDef<BGV_Dialect, attrName> {
+    let summary = "Attribute for BGV";
+    let description = [{
+        This attribute represents the values for BGV.
+    }];
+    let mnemonic = attrMnemonic;
+    let assemblyFormat = "`<` struct(params) `>`";
+}
+
+def BGV_SchemeParam
+    : BGV_Attribute<"SchemeParam", "scheme_param"> {
+    let summary = "BGV Scheme Parameters";
+    let description = [{
+      This attribute is used for recording the scheme parameters for CKKS.
+
+      The attribute is a struct with the following fields:
+        - `int` logN: The log of the degree of the polynomial modulus.
+        - `DenseI64ArrayAttr` Q: The array of primes in the ciphertext modulus.
+        - `DenseI64ArrayAttr` P: The array of primes in the special modulus, used for key switching.
+        - `int64_t` plaintextModulus: The plaintext modulus.
+    }];
+    let parameters = (ins
+      "int":$logN,
+      "DenseI64ArrayAttr":$Q,
+      "DenseI64ArrayAttr":$P,
+      "int64_t":$plaintextModulus
+    );
+}
+
+#endif  // LIB_DIALECT_BGV_IR_BGVATTRIBUTES_TD_

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 
+#include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVOps.h"
 #include "lib/Dialect/FHEHelpers.h"
 #include "mlir/include/mlir/IR/Location.h"     // from @llvm-project
@@ -11,6 +12,8 @@
 // Generated definitions
 #include "lib/Dialect/BGV/IR/BGVDialect.cpp.inc"
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/BGV/IR/BGVAttributes.cpp.inc"
 #define GET_OP_CLASSES
 #include "lib/Dialect/BGV/IR/BGVOps.cpp.inc"
 
@@ -25,6 +28,10 @@ namespace bgv {
 // Dialect construction: there is one instance per context and it registers its
 // operations, types, and interfaces here.
 void BGVDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "lib/Dialect/BGV/IR/BGVAttributes.cpp.inc"
+      >();
   addOperations<
 #define GET_OP_LIST
 #include "lib/Dialect/BGV/IR/BGVOps.cpp.inc"

--- a/lib/Dialect/BGV/IR/BGVDialect.td
+++ b/lib/Dialect/BGV/IR/BGVDialect.td
@@ -13,7 +13,14 @@ def BGV_Dialect : Dialect {
     The BGV dialect defines the types and operations of the BGV cryptosystem.
   }];
 
+  let extraClassDeclaration = [{
+    constexpr const static ::llvm::StringLiteral
+        kSchemeParamAttrName = "bgv.schemeParam";
+  }];
+
   let cppNamespace = "::mlir::heir::bgv";
+
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif  // LIB_DIALECT_BGV_IR_BGVDIALECT_TD_

--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -14,10 +14,12 @@ cc_library(
         "BGVDialect.cpp",
     ],
     hdrs = [
+        "BGVAttributes.h",
         "BGVDialect.h",
         "BGVOps.h",
     ],
     deps = [
+        ":attributes_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
         "@heir//lib/Dialect:FHEHelpers",
@@ -31,6 +33,7 @@ cc_library(
 td_library(
     name = "td_files",
     srcs = [
+        "BGVAttributes.td",
         "BGVDialect.td",
         "BGVOps.td",
     ],
@@ -59,5 +62,15 @@ add_heir_dialect_library(
         ":td_files",
         "@heir//lib/Dialect/LWE/IR:td_files",
         "@heir//lib/Dialect/Polynomial/IR:td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "BGV",
+    kind = "attribute",
+    td_file = "BGVAttributes.td",
+    deps = [
+        ":td_files",
     ],
 )

--- a/lib/Dialect/Lattigo/Transforms/BUILD
+++ b/lib/Dialect/Lattigo/Transforms/BUILD
@@ -21,6 +21,7 @@ cc_library(
     hdrs = ["ConfigureCryptoContext.h"],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -25,6 +25,7 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -4,6 +4,8 @@
 #include <set>
 #include <string>
 
+#include "lib/Dialect/BGV/IR/BGVAttributes.h"
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
@@ -181,6 +183,12 @@ LogicalResult convertFunc(func::FuncOp op, int levelBudgetEncode,
 
   ImplicitLocOpBuilder builder =
       ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
+
+  // remove bgv.schemeParam attribute if present
+  if (auto schemeParamAttr = module->getAttrOfType<bgv::SchemeParamAttr>(
+          bgv::BGVDialect::kSchemeParamAttrName)) {
+    module->removeAttr(bgv::BGVDialect::kSchemeParamAttrName);
+  }
 
   // get mulDepth from function argument ciphertext type
   int64_t mulDepth = 0;

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Parameters/BGV:Params",
         "@heir//lib/Utils",
         "@heir//lib/Utils:ConversionUtils",
         "@heir//lib/Utils/Polynomial",

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.td
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.td
@@ -32,9 +32,6 @@ def SecretToBGV : Pass<"secret-to-bgv"> {
     Option<"polyModDegree", "poly-mod-degree", "int",
            /*default=*/"1024", "Default degree of the cyclotomic polynomial "
            "modulus to use for ciphertext space.">,
-    Option<"coefficientModBits", "coefficient-mod-bits", "int",
-           /*default=*/"29", "Default number of bits of the prime "
-           "coefficient modulus to use " "for the ciphertext space.">
   ];
 }
 

--- a/lib/Parameters/BGV/BUILD
+++ b/lib/Parameters/BGV/BUILD
@@ -9,5 +9,6 @@ cc_library(
     hdrs = ["Params.h"],
     deps = [
         "@llvm-project//llvm:Support",
+        "@openfhe//:core",
     ],
 )

--- a/lib/Parameters/BGV/Params.h
+++ b/lib/Parameters/BGV/Params.h
@@ -23,6 +23,19 @@ class SchemeParam {
         dnum(dnum),
         logpi(logpi) {}
 
+  SchemeParam(int ringDim, int64_t plaintextModulus, int level,
+              const std::vector<double> &logqi, const std::vector<int64_t> &qi,
+              int dnum, const std::vector<double> &logpi,
+              const std::vector<int64_t> &pi)
+      : ringDim(ringDim),
+        plaintextModulus(plaintextModulus),
+        level(level),
+        logqi(logqi),
+        qi(qi),
+        dnum(dnum),
+        logpi(logpi),
+        pi(pi) {}
+
  private:
   // the N in Z[X]/(X^N+1)
   int ringDim;
@@ -39,6 +52,8 @@ class SchemeParam {
   // logarithm of the modulus of each level
   // logqi.size() == level + 1
   std::vector<double> logqi;
+  // modulus of each level
+  std::vector<int64_t> qi;
 
   // The following part is for HYBRID key switching technique
 
@@ -49,14 +64,18 @@ class SchemeParam {
   int dnum;
   // logarithm of the special modulus
   std::vector<double> logpi;
+  // special modulus
+  std::vector<int64_t> pi;
 
  public:
   int getRingDim() const { return ringDim; }
   int64_t getPlaintextModulus() const { return plaintextModulus; }
   int getLevel() const { return level; }
   const std::vector<double> &getLogqi() const { return logqi; }
+  const std::vector<int64_t> &getQi() const { return qi; }
   int getDnum() const { return dnum; }
   const std::vector<double> &getLogpi() const { return logpi; }
+  const std::vector<int64_t> &getPi() const { return pi; }
   double getStd0() const { return std0; }
 
   void print(llvm::raw_ostream &os) const;
@@ -69,6 +88,9 @@ class SchemeParam {
 
   static SchemeParam getConservativeSchemeParam(int level,
                                                 int64_t plaintextModulus);
+
+  static SchemeParam getConcreteSchemeParam(int64_t plaintextModulus,
+                                            std::vector<double> logqi);
 };
 
 // Parameter for each BGV ciphertext SSA value.

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -43,6 +43,16 @@ struct MlirToRLWEPipelineOptions : public SimdVectorizerOptions {
       llvm::cl::desc("Modulus switching right before the first multiplication "
                      "(default to false)"),
       llvm::cl::init(false)};
+  PassOptions::Option<int64_t> plaintextModulus{
+      *this, "plaintext-modulus",
+      llvm::cl::desc("Plaintext modulus for BGV scheme (default to 65537)"),
+      llvm::cl::init(65537)};
+  PassOptions::Option<std::string> noiseModel{
+      *this, "noise-model",
+      llvm::cl::desc("Noise model to use during parameter generation, see "
+                     "--validate-noise pass options for available models"
+                     "(default to bgv-noise-by-bound-coeff-average-case-pk)"),
+      llvm::cl::init("bgv-noise-by-bound-coeff-average-case-pk")};
 };
 
 struct BackendOptions : public PassPipelineOptions<BackendOptions> {

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -112,6 +112,7 @@ cc_library(
         "@heir//lib/Transforms/OptimizeRelinearization",
         "@heir//lib/Transforms/SecretInsertMgmt",
         "@heir//lib/Transforms/Secretize",
+        "@heir//lib/Transforms/ValidateNoise",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.td
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.td
@@ -34,6 +34,11 @@ def ValidateNoise : Pass<"validate-noise"> {
     Noise Bound: 29.27 Budget: 149.73 Total: 179.00 for value: <block argument> of type 'tensor<8xi16>' at index: 1
     ```
   }];
+
+  let dependentDialects = [
+    "mlir::heir::bgv::BGVDialect",
+  ];
+
   let options = [
     Option<"model", "model", "std::string",
            /*default=*/"", "Noise model to validate against.">,

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/ops.mlir
@@ -21,7 +21,7 @@ module {
     } -> !eui1
     // CHECK: return
     // CHECK-SAME: message_type = tensor<1024xi1>
-    // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+    // CHECK-SAME: polynomialModulus = <1 + x**1024>
     // CHECK-SAME: size = 3
     return %1 : !eui1
   }

--- a/tests/Examples/openfhe/BUILD
+++ b/tests/Examples/openfhe/BUILD
@@ -62,7 +62,7 @@ openfhe_end_to_end_test(
     name = "box_blur_64x64_test",
     generated_lib_header = "box_blur_64x64_lib.h",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=4096",
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=786433",
         "--scheme-to-openfhe=entry-function=box_blur",
     ],
     mlir_src = "box_blur_64x64.mlir",
@@ -74,7 +74,7 @@ openfhe_end_to_end_test(
     name = "roberts_cross_64x64_test",
     generated_lib_header = "roberts_cross_64x64_lib.h",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=4096",
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=536903681",
         "--scheme-to-openfhe=entry-function=roberts_cross",
     ],
     mlir_src = "roberts_cross_64x64.mlir",

--- a/tests/Examples/openfhe/errors/BUILD
+++ b/tests/Examples/openfhe/errors/BUILD
@@ -6,5 +6,7 @@ glob_lit_tests(
     name = "all_tests",
     data = ["@heir//tests:test_utilities"],
     driver = "@heir//tests:run_lit.sh",
+    # TODO(#1397): Move type detection earlier
+    exclude = ["dot_product_8f_type_error.mlir"],
     test_file_exts = ["mlir"],
 )

--- a/tests/Transforms/optimize_relinearization/optimize_relinearization.mlir
+++ b/tests/Transforms/optimize_relinearization/optimize_relinearization.mlir
@@ -213,3 +213,19 @@ func.func @rotation_needs_linear_inputs(%arg0: tensor<8xi16>, %arg1: tensor<8xi1
   %7 = arith.addi %1, %6 : tensor<8xi16>
   func.return %7 : tensor<8xi16>
 }
+
+// CHECK-LABEL: func.func @modreduce_needs_linear_inputs
+// CHECK: secret.generic
+// CHECK: arith.muli
+// CHECK-NEXT: arith.muli
+// CHECK-NEXT: arith.subi
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK-NEXT: secret.yield
+func.func @modreduce_needs_linear_inputs(%a: i64, %b: i64) -> (i64) {
+    %0 = arith.muli %a, %a : i64
+    %1 = arith.muli %b, %b : i64
+    %2 = arith.subi %0, %1 : i64
+    %ret = mgmt.modreduce %2 : i64
+    func.return %ret : i64
+}


### PR DESCRIPTION
Depends on #1343. Implements part of #1168.

For `dot_product.mlir`, it will generate the following parameter:

```
ringDim: 8192
plaintextModulus: 65537
level: 2
logqi: 25 40 47 
qi: 33832961 1099511922689 140737488486401 
dnum: 2
logpi: 47 47 
pi: 140737488928769 140737489256449 
```

### Idea

The idea behind the parameter generation is simple: For each level, the mod reduce should be able to decrease the noise by that amount (e.g. from 69.5 to 23), so the modulus for that level should be at least 47 bit.

For special modulus, the selection is conservative in that we only make sure `P > Q / dnum` and make no other optimization. We default to the HYBRID key switching technique for now.

I understand there are implementation using optimizers like KPZ21 and MML+23. This PR is meant for making the pipeline aware of concrete parameters, like `LWE` dialect and backend. Further PR could optimize the selection process.

### Current status / Discussion

* The parameter selection procedure lives in `--validate-noise` pass for simplicity. It should be separated into another pass use some attribute to communicate with other passes (e.g. `bgv.schemeParam` attribute). Need design discussion.
* `LWE` dialect (`secret-to-bgv`) has not been touched. I now directly pass the generated parameter to attr, then backend will pick it up somewhere; further design should pass the information in `LWE` Types and backend will get information there.
* For the prime generation part, I directly use utility functions from `@openfhe//nbtheory.h`. It is quite crude for now.
* We need a way for user to specify the plaintext modulus. The current default modulus 4295294977 is too large, though when set it to smaller one the box_blur test (iirc) will fail.

### Example

The noise analysis for the generated param

```
Noise Bound: 29.27 Budget: 81 Total: 112 for value: <block argument> of type 'tensor<8xi16>' at index: 0 
Noise Bound: 29.27 Budget: 81 Total: 112 for value: <block argument> of type 'tensor<8xi16>' at index: 1 
Noise Bound: 66.53 Budget: 44 Total: 112 for value: %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 2, dimension = 3>} : tensor<8xi16> 
Noise Bound: 66.53 Budget: 44 Total: 112 for value: %2 = mgmt.relinearize %1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16> 
Noise Bound: 66.53 Budget: 44 Total: 112 for value: %3 = tensor_ext.rotate %2, %c4 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index 
Noise Bound: 67.53 Budget: 43 Total: 112 for value: %4 = arith.addi %2, %3 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16> 
Noise Bound: 67.53 Budget: 43 Total: 112 for value: %5 = tensor_ext.rotate %4, %c2 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index 
Noise Bound: 68.53 Budget: 42 Total: 112 for value: %6 = arith.addi %4, %5 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16> 
Noise Bound: 68.53 Budget: 42 Total: 112 for value: %7 = tensor_ext.rotate %6, %c1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index 
Noise Bound: 69.53 Budget: 41 Total: 112 for value: %8 = arith.addi %6, %7 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16> 
Noise Bound: 23.01 Budget: 40 Total: 65 for value: %9 = mgmt.modreduce %8 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16> 
Noise Bound: 63.01 Budget: 0 Total: 65 for value: %extracted = tensor.extract %9[%c7] {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16> 
Noise Bound: 23.01 Budget: 0 Total: 25 for value: %10 = mgmt.modreduce %extracted {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16 
```

Note that there is nealy no budget given current param generation process. It is OK if we do have a correct bound.

Lattigo Output (using #1374). <del>Though for the last line it seems to indicate the error exceeds the allowed range, yet its decryption is correct. I will investigate more on the Lattigo `rlwe.Norm` function to understand what happened.</del> Resolved by https://github.com/google/heir/pull/1374#issuecomment-2646146712, check the correct trace there.

<details>
```
[1 2 3 4 5 6 7 8]
Noise: 22.71 Total 112
[2 3 4 5 6 7 8 9]
Noise: 22.36 Total 112
[2 6 12 20 30 42 56 72]
Noise: 49.76 Total 112
[2 6 12 20 30 42 56 72]
Noise: 49.76 Total 112
[30 42 56 72 2 6 12 20]
Noise: 49.76 Total 112
[32 48 68 92 32 48 68 92]
Noise: 50.46 Total 112
[68 92 32 48 68 92 32 48]
Noise: 50.46 Total 112
[100 140 100 140 100 140 100 140]
Noise: 50.84 Total 112
[140 100 140 100 140 100 140 100]
Noise: 50.84 Total 112
[240 240 240 240 240 240 240 240]
Noise: 51.84 Total 112
[240 240 240 240 240 240 240 240]
Noise: 23.96 Total 65
[0 0 0 0 0 0 0 240]
Noise: 41.30 Total 65
[240 0 0 0 0 0 0 0]
Noise: 41.30 Total 65
[240 0 0 0 0 0 0 0]
Noise: 41.30 Total 65
[240 0 0 0 0 0 0 0]
Noise: 29.07 Total 25
```
</details>