### PR TITLE
Lattigo: support secret key encryption

### DIFF
--- a/lib/Dialect/Lattigo/IR/LattigoOps.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoOps.cpp
@@ -48,6 +48,17 @@ LogicalResult RLWENewEvaluationKeySetOp::verify() {
   return success();
 }
 
+LogicalResult RLWENewEncryptorOp::verify() {
+  auto keyTypeIsPublic =
+      mlir::isa<RLWEPublicKeyType>(getEncryptionKey().getType());
+  auto encryptorIsPublic = getEncryptor().getType().getPublicKey();
+  if (keyTypeIsPublic != encryptorIsPublic) {
+    return emitError(
+        "encryption key and encryptor must have the same public/secret type");
+  }
+  return success();
+}
+
 }  // namespace lattigo
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
@@ -82,9 +82,10 @@ def Lattigo_RLWENewEncryptorOp : Lattigo_RLWEOp<"new_encryptor"> {
   let arguments = (ins
     // accepts only BGV for now
     Lattigo_BGVParameter:$params,
-    Lattigo_RLWEPublicKey:$publicKey
+    Lattigo_RLWEPublicKeyOrSecretKey:$encryptionKey
   );
   let results = (outs Lattigo_RLWEEncryptor:$encryptor);
+  let hasVerifier = 1;
 }
 
 def Lattigo_RLWENewDecryptorOp : Lattigo_RLWEOp<"new_decryptor"> {

--- a/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
@@ -31,6 +31,8 @@ def Lattigo_RLWEPublicKey : Lattigo_RLWEType<"PublicKey", "public_key"> {
   let nameSuggestion = "pk";
 }
 
+def Lattigo_RLWEPublicKeyOrSecretKey : AnyTypeOf<[Lattigo_RLWEPublicKey, Lattigo_RLWESecretKey]>;
+
 def Lattigo_RLWERelinearizationKey : Lattigo_RLWEType<"RelinearizationKey", "relinearization_key"> {
   let description = [{
     This type represents the relinearization key for the RLWE encryption scheme.
@@ -60,6 +62,8 @@ def Lattigo_RLWEEncryptor : Lattigo_RLWEType<"Encryptor", "encryptor"> {
   let description = [{
     This type represents the encryptor for the RLWE encryption scheme.
   }];
+  let parameters = (ins "bool":$publicKey);
+  let assemblyFormat = "`<` struct(params) `>`";
   let nameSuggestion = "encryptor";
 }
 

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -196,7 +196,7 @@ LogicalResult LattigoEmitter::printOperation(tensor::ExtractOp op) {
 }
 
 LogicalResult LattigoEmitter::printOperation(RLWENewEncryptorOp op) {
-  return printNewMethod(op.getResult(), {op.getParams(), op.getPublicKey()},
+  return printNewMethod(op.getResult(), {op.getParams(), op.getEncryptionKey()},
                         "rlwe.NewEncryptor", false);
 }
 

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -116,6 +116,11 @@ class LattigoEmitter {
     if (value == Value()) {
       return "nil";
     }
+    // when the value has no uses, we can not assign it a name
+    // otherwise GO would complain "declared and not used"
+    if (value.use_empty()) {
+      return "_";
+    }
     return variableNames->getNameForValue(value);
   }
 

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -8,7 +8,8 @@
 !ct = !lattigo.rlwe.ciphertext
 !pt = !lattigo.rlwe.plaintext
 
-!encryptor = !lattigo.rlwe.encryptor
+!encryptor = !lattigo.rlwe.encryptor<publicKey = true>
+!encryptor_sk = !lattigo.rlwe.encryptor<publicKey = false>
 !decryptor = !lattigo.rlwe.decryptor
 !key_generator = !lattigo.rlwe.key_generator
 
@@ -65,6 +66,7 @@ module {
   // CHECK: [[gk5:[^, ].*]] := [[kgen]].GenGaloisKeyNew(5, [[sk]])
   // CHECK: [[evalKeySet:[^, ].*]] := rlwe.NewMemEvaluationKeySet([[rk]], [[gk5]])
   // CHECK: [[enc:[^, ].*]] := rlwe.NewEncryptor([[param]], [[pk]])
+  // CHECK: [[encSk:[^, ].*]] := rlwe.NewEncryptor([[param]], [[sk]])
   // CHECK: [[dec:[^, ].*]] := rlwe.NewDecryptor([[param]], [[sk]])
   // CHECK: [[eval:[^, ].*]] := bgv.NewEvaluator([[param]], [[evalKeySet]])
   // CHECK: [[value1:[^, ].*]] := []int64
@@ -94,6 +96,7 @@ module {
     %gk5 = lattigo.rlwe.gen_galois_key %kgen, %sk {galoisElement = 5} : (!key_generator, !sk) -> !gk5
     %eval_key_set = lattigo.rlwe.new_evaluation_key_set %rk, %gk5 : (!rk, !gk5) -> !eval_key_set
     %encryptor = lattigo.rlwe.new_encryptor %param, %pk : (!params, !pk) -> !encryptor
+    %encryptor_sk = lattigo.rlwe.new_encryptor %param, %sk : (!params, !sk) -> !encryptor_sk
     %decryptor = lattigo.rlwe.new_decryptor %param, %sk : (!params, !sk) -> !decryptor
 
     %evaluator = lattigo.bgv.new_evaluator %param, %eval_key_set : (!params, !eval_key_set) -> !evaluator

--- a/tests/Dialect/Lattigo/IR/ops.mlir
+++ b/tests/Dialect/Lattigo/IR/ops.mlir
@@ -11,7 +11,8 @@
 !ct = !lattigo.rlwe.ciphertext
 !pt = !lattigo.rlwe.plaintext
 
-!encryptor = !lattigo.rlwe.encryptor
+!encryptor = !lattigo.rlwe.encryptor<publicKey = true>
+!encryptor_sk = !lattigo.rlwe.encryptor<publicKey = false>
 !decryptor = !lattigo.rlwe.decryptor
 !key_generator = !lattigo.rlwe.key_generator
 
@@ -87,10 +88,17 @@ module {
     return
   }
 
-  // CHECK-LABEL: func @test_rlwe_new_encryptor
-  func.func @test_rlwe_new_encryptor(%params: !params, %pk: !pk) {
+  // CHECK-LABEL: func @test_rlwe_new_encryptor_pk
+  func.func @test_rlwe_new_encryptor_pk(%params: !params, %pk: !pk) {
     // CHECK: %[[v1:.*]] = lattigo.rlwe.new_encryptor
     %encryptor = lattigo.rlwe.new_encryptor %params, %pk : (!params, !pk) -> !encryptor
+    return
+  }
+
+  // CHECK-LABEL: func @test_rlwe_new_encryptor_sk
+  func.func @test_rlwe_new_encryptor_sk(%params: !params, %sk: !sk) {
+    // CHECK: %[[v1:.*]] = lattigo.rlwe.new_encryptor
+    %encryptor = lattigo.rlwe.new_encryptor %params, %sk : (!params, !sk) -> !encryptor_sk
     return
   }
 

--- a/tests/Dialect/Lattigo/IR/verifier.mlir
+++ b/tests/Dialect/Lattigo/IR/verifier.mlir
@@ -79,3 +79,27 @@ func.func @test_rlwe_new_evaluation_key_set_operands_other_types(%gk: !gk) {
   %ekset = lattigo.rlwe.new_evaluation_key_set %gk, %c : (!gk, i32) -> !ekset
   return
 }
+
+// -----
+
+!params = !lattigo.bgv.parameter
+!encryptor_pk = !lattigo.rlwe.encryptor<publicKey = true>
+!sk = !lattigo.rlwe.secret_key
+
+func.func @test_rlwe_new_encryptor_pk_input_sk(%params: !params, %sk: !sk) {
+  // expected-error@+1 {{encryption key and encryptor must have the same public/secret type}}
+  %encryptor = lattigo.rlwe.new_encryptor %params, %sk : (!params, !sk) -> !encryptor_pk
+  return
+}
+
+// -----
+
+!params = !lattigo.bgv.parameter
+!encryptor_sk = !lattigo.rlwe.encryptor<publicKey = false>
+!pk = !lattigo.rlwe.public_key
+
+func.func @test_rlwe_new_encryptor_pk_input_sk(%params: !params, %pk: !pk) {
+  // expected-error@+1 {{encryption key and encryptor must have the same public/secret type}}
+  %encryptor = lattigo.rlwe.new_encryptor %params, %pk : (!params, !pk) -> !encryptor_sk
+  return
+}

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -33,6 +33,16 @@ heir_lattigo_lib(
 )
 
 heir_lattigo_lib(
+    name = "dot_product_8_sk",
+    go_library_name = "dotproduct8sk",
+    heir_opt_flags = [
+        "--mlir-to-bgv=ciphertext-degree=8 use-public-key=false",
+        "--scheme-to-lattigo=entry-function=dot_product",
+    ],
+    mlir_src = "dot_product_8.mlir",
+)
+
+heir_lattigo_lib(
     name = "dot_product_8_debug",
     extra_srcs = ["dot_product_8_debug.go"],
     go_library_name = "dotproduct8debug",
@@ -55,6 +65,12 @@ go_test(
     name = "dotproduct8_test",
     srcs = ["dot_product_8_test.go"],
     embed = [":dotproduct8"],
+)
+
+go_test(
+    name = "dotproduct8sk_test",
+    srcs = ["dot_product_8_sk_test.go"],
+    embed = [":dotproduct8sk"],
 )
 
 go_test(

--- a/tests/Examples/lattigo/dot_product_8_sk_test.go
+++ b/tests/Examples/lattigo/dot_product_8_sk_test.go
@@ -1,0 +1,26 @@
+package dotproduct8sk
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := dot_product__configure()
+
+	// Vector of plaintext values
+	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8}
+	arg1 := []int16{2, 3, 4, 5, 6, 7, 8, 9}
+
+	expected := int16(240)
+
+	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
+
+	resultCt := dot_product(evaluator, params, ecd, ct0, ct1)
+
+	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}


### PR DESCRIPTION
Cf. https://github.com/google/heir/pull/1374#issuecomment-2646153253.

This reuses the `lwe-add-client-interface` to determine whether to use public key encryption or not, and `lattigo-configure-crypto-context` would find such information by checking the encryptor type in IR.