### PR TITLE
Lattigo: fix calculation of galois element for rotation

### DIFF
--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -126,7 +126,7 @@ LogicalResult convertFunc(func::FuncOp op) {
   // generate Galois Keys on demand
   auto rotIndices = findAllRotIndices(op);
   for (auto rotIndex : rotIndices) {
-    auto galoisElement = static_cast<int>(pow(5, rotIndex)) % (1 << logN);
+    auto galoisElement = static_cast<int>(pow(5, rotIndex)) % (1 << (logN + 1));
     auto galoisElementAttr = IntegerAttr::get(
         IntegerType::get(builder.getContext(), 64), galoisElement);
     auto gkType =


### PR DESCRIPTION
The rotation index to galois element calculation should be `(5 ** index) % M` instead of `(5 ** index) % N)`

See https://github.com/tuneinsight/lattigo/blob/945cdf37938c253a48d76e29be461c2401cff730/core/rlwe/params.go#L577-L580, where NthRoot refers to the multiplicative order of the primitive root