### PR TITLE
Lattigo: support encoding scalar

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -329,13 +329,19 @@ struct ConvertRlweEncodeOp : public OpConversionPattern<EncodeOp> {
     if (failed(result2)) return result2;
     Value params = result2.value();
 
+    Value input = adaptor.getInput();
+    // if input is scalar, convert it to 1 dim tensor
+    if (!isa<RankedTensorType>(input.getType())) {
+      input = rewriter.create<tensor::FromElementsOp>(op.getLoc(), input);
+    }
+
     auto alloc = rewriter.create<AllocOp>(
         op.getLoc(), this->typeConverter->convertType(op.getOutput().getType()),
         params);
 
     rewriter.replaceOpWithNewOp<LattigoEncodeOp>(
         op, this->typeConverter->convertType(op.getOutput().getType()),
-        evaluator, adaptor.getInput(), alloc);
+        evaluator, input, alloc);
     return success();
   }
 };

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -57,7 +57,8 @@ LogicalResult LattigoEmitter::translate(Operation &op) {
           // Arith ops
           .Case<arith::ConstantOp>([&](auto op) { return printOperation(op); })
           // Tensor ops
-          .Case<tensor::ExtractOp>([&](auto op) { return printOperation(op); })
+          .Case<tensor::ExtractOp, tensor::FromElementsOp>(
+              [&](auto op) { return printOperation(op); })
           // Lattigo ops
           .Case<RLWENewEncryptorOp, RLWENewDecryptorOp, RLWENewKeyGeneratorOp,
                 RLWEGenKeyPairOp, RLWEGenRelinearizationKeyOp,
@@ -192,6 +193,14 @@ LogicalResult LattigoEmitter::printOperation(tensor::ExtractOp op) {
   // only support 1-dim tensor for now
   os << getName(op.getResult()) << " := " << getName(op.getTensor()) << "[";
   os << getName(op.getIndices()[0]) << "]\n";
+  return success();
+}
+
+LogicalResult LattigoEmitter::printOperation(tensor::FromElementsOp op) {
+  os << getName(op.getResult()) << " := []"
+     << convertType(getElementTypeOrSelf(op.getResult().getType())) << "{";
+  os << getCommaSeparatedNames(op.getOperands());
+  os << "}\n";
   return success();
 }
 

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -56,6 +56,7 @@ class LattigoEmitter {
   LogicalResult printOperation(::mlir::func::CallOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractOp op);
+  LogicalResult printOperation(::mlir::tensor::FromElementsOp op);
   // Lattigo ops
   LogicalResult printOperation(RLWENewEncryptorOp op);
   LogicalResult printOperation(RLWENewDecryptorOp op);

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/BUILD
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/scalar_encode.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/scalar_encode.mlir
@@ -1,0 +1,28 @@
+// RUN: heir-opt %s --lwe-to-lattigo | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z4295294977_i64_ = !mod_arith.int<4295294977 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z4295294977_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z4295294977_i64_, polynomialModulus = <1 + x**1024>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z4295294977_i64_1_x1024_, encoding = #full_crt_packing_encoding>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+!pkey_L1_ = !lwe.new_lwe_public_key<key = #key, ring = #ring_rns_L1_1_x1024_>
+!pt = !lwe.new_lwe_plaintext<application_data = <message_type = i64>, plaintext_space = #plaintext_space>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i64>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+module attributes {scheme.bgv} {
+  // CHECK-LABEL: func @foo__encrypt__arg0
+  func.func @foo__encrypt__arg0(%arg0: i64, %pk: !pkey_L1_) -> !ct_L1_ {
+    // CHECK: tensor.from_elements
+    // CHECK-NEXT: lattigo.bgv.new_plaintext
+    // CHECK-NEXT: lattigo.bgv.encode
+    %pt = lwe.rlwe_encode %arg0 {encoding = #full_crt_packing_encoding, ring = #ring_Z4295294977_i64_1_x1024_} : i64 -> !pt
+    // CHECK-NEXT: lattigo.rlwe.encrypt
+    %ct = lwe.rlwe_encrypt %pt, %pk : (!pt, !pkey_L1_) -> !ct_L1_
+    return %ct : !ct_L1_
+  }
+}


### PR DESCRIPTION
Currently `lattigo.bgv.encode` does not support scalar input, which is the same as the Lattigo requirement where the API only supports `int64{}` or `uint64{}`.

However, for functions like the `foo(int a, int b)`, we need a way to convert the argument to tensor for the encode op.

In the meantime, the `lwe.rlwe_encode` takes `SignlessIntegerOrFloatLike` input, which supports both scalar and tensor.

Instead of changing the `lattigo.bgv.encode` op input type requirement, we can just add another op `tensor.from_elements` during lowering.