### PR TITLE
CKKS: Generate Scheme Param

### DIFF
--- a/lib/Dialect/CKKS/IR/BUILD
+++ b/lib/Dialect/CKKS/IR/BUILD
@@ -14,10 +14,12 @@ cc_library(
         "CKKSDialect.cpp",
     ],
     hdrs = [
+        "CKKSAttributes.h",
         "CKKSDialect.h",
         "CKKSOps.h",
     ],
     deps = [
+        ":attributes_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
         "@heir//lib/Dialect:FHEHelpers",
@@ -59,5 +61,15 @@ add_heir_dialect_library(
         ":td_files",
         "@heir//lib/Dialect/LWE/IR:td_files",
         "@heir//lib/Dialect/Polynomial/IR:td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "CKKS",
+    kind = "attribute",
+    td_file = "CKKSAttributes.td",
+    deps = [
+        ":td_files",
     ],
 )

--- a/lib/Dialect/CKKS/IR/CKKSAttributes.h
+++ b/lib/Dialect/CKKS/IR/CKKSAttributes.h
@@ -1,0 +1,9 @@
+#ifndef LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_H_
+#define LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_H_
+
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h.inc"
+
+#endif  // LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_H_

--- a/lib/Dialect/CKKS/IR/CKKSAttributes.td
+++ b/lib/Dialect/CKKS/IR/CKKSAttributes.td
@@ -1,21 +1,21 @@
-#ifndef LIB_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
-#define LIB_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
+#ifndef LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_TD_
+#define LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_TD_
 
-include "BGVDialect.td"
+include "lib/Dialect/CKKS/IR/CKKSDialect.td"
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/OpBase.td"
 
-class BGV_Attribute<string attrName, string attrMnemonic>
-    : AttrDef<BGV_Dialect, attrName> {
+class CKKS_Attribute<string attrName, string attrMnemonic>
+    : AttrDef<CKKS_Dialect, attrName> {
     let mnemonic = attrMnemonic;
     let assemblyFormat = "`<` struct(params) `>`";
 }
 
-def BGV_SchemeParam
-    : BGV_Attribute<"SchemeParam", "scheme_param"> {
-    let summary = "BGV Scheme Parameters";
+def CKKS_SchemeParam
+    : CKKS_Attribute<"SchemeParam", "scheme_param"> {
+    let summary = "CKKS Scheme Parameters";
     let description = [{
       This attribute is used for recording the scheme parameters for CKKS.
 
@@ -23,14 +23,14 @@ def BGV_SchemeParam
         - `int` logN: The log of the degree of the polynomial modulus.
         - `DenseI64ArrayAttr` Q: The array of primes in the ciphertext modulus.
         - `DenseI64ArrayAttr` P: The array of primes in the special modulus, used for key switching.
-        - `int64_t` plaintextModulus: The plaintext modulus.
+        - `int` logDefaultScale: The log of the default scale.
     }];
     let parameters = (ins
       "int":$logN,
       "DenseI64ArrayAttr":$Q,
       "DenseI64ArrayAttr":$P,
-      "int64_t":$plaintextModulus
+      "int":$logDefaultScale
     );
 }
 
-#endif  // LIB_DIALECT_BGV_IR_BGVATTRIBUTES_TD_
+#endif  // LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_TD_

--- a/lib/Dialect/CKKS/IR/CKKSDialect.cpp
+++ b/lib/Dialect/CKKS/IR/CKKSDialect.cpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
 #include "lib/Dialect/CKKS/IR/CKKSOps.h"
 #include "lib/Dialect/FHEHelpers.h"
 #include "mlir/include/mlir/IR/Location.h"     // from @llvm-project
@@ -12,6 +13,8 @@
 // Generated definitions
 #include "lib/Dialect/CKKS/IR/CKKSDialect.cpp.inc"
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.cpp.inc"
 #define GET_OP_CLASSES
 #include "lib/Dialect/CKKS/IR/CKKSOps.cpp.inc"
 
@@ -26,6 +29,10 @@ namespace ckks {
 // Dialect construction: there is one instance per context and it registers its
 // operations, types, and interfaces here.
 void CKKSDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.cpp.inc"
+      >();
   addOperations<
 #define GET_OP_LIST
 #include "lib/Dialect/CKKS/IR/CKKSOps.cpp.inc"

--- a/lib/Dialect/CKKS/IR/CKKSDialect.td
+++ b/lib/Dialect/CKKS/IR/CKKSDialect.td
@@ -13,7 +13,14 @@ def CKKS_Dialect : Dialect {
     The CKKS dialect defines the types and operations of the CKKS cryptosystem.
   }];
 
+  let extraClassDeclaration = [{
+    constexpr const static ::llvm::StringLiteral
+        kSchemeParamAttrName = "ckks.schemeParam";
+  }];
+
   let cppNamespace = "::mlir::heir::ckks";
+
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif  // LIB_DIALECT_CKKS_IR_CKKSDIALECT_TD_

--- a/lib/Dialect/Lattigo/Transforms/BUILD
+++ b/lib/Dialect/Lattigo/Transforms/BUILD
@@ -23,6 +23,7 @@ cc_library(
         ":pass_inc_gen",
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",

--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -7,6 +7,8 @@
 
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 #include "lib/Dialect/Lattigo/IR/LattigoAttributes.h"
 #include "lib/Dialect/Lattigo/IR/LattigoOps.h"
 #include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
@@ -142,11 +144,29 @@ struct LattigoCKKSScheme {
   using NewParametersFromLiteralOp = CKKSNewParametersFromLiteralOp;
   using NewEncoderOp = CKKSNewEncoderOp;
   using NewEvaluatorOp = CKKSNewEvaluatorOp;
+  using SchemeParamAttrType = ckks::SchemeParamAttr;
 
-  static int getLogN(Operation *moduleOp) { return 14; }
+  static int getLogN(Operation *moduleOp) {
+    auto schemeParamAttr = getSchemeParamAttr(moduleOp);
+    if (schemeParamAttr) {
+      return schemeParamAttr.getLogN();
+    }
+    // default logN
+    return 14;
+  }
 
   static ParametersLiteralAttrType getParametersLiteralAttr(
       MLIRContext *ctx, Operation *moduleOp) {
+    auto schemeParamAttr = getSchemeParamAttr(moduleOp);
+    if (schemeParamAttr) {
+      auto logN = schemeParamAttr.getLogN();
+      auto Q = schemeParamAttr.getQ();
+      auto P = schemeParamAttr.getP();
+      auto logDefaultScale = schemeParamAttr.getLogDefaultScale();
+      return ParametersLiteralAttrType::get(ctx, logN, Q, P,
+                                            /*logQ*/ nullptr, /*logP*/ nullptr,
+                                            logDefaultScale);
+    }
     // 128-bit secure parameters enabling depth-7 circuits.
     // LogN:14, LogQP: 431.
     return ParametersLiteralAttrType::get(
@@ -158,9 +178,17 @@ struct LattigoCKKSScheme {
         /*logDefaultScale*/ 45);
   }
 
-  static Attribute getSchemeParamAttr(Operation *moduleOp) { return nullptr; }
+  static SchemeParamAttrType getSchemeParamAttr(Operation *moduleOp) {
+    return moduleOp->getAttrOfType<ckks::SchemeParamAttr>(
+        ckks::CKKSDialect::kSchemeParamAttrName);
+  }
 
-  static void cleanSchemeParamAttr(Operation *moduleOp) {}
+  static void cleanSchemeParamAttr(Operation *moduleOp) {
+    auto schemeParamAttr = getSchemeParamAttr(moduleOp);
+    if (schemeParamAttr) {
+      moduleOp->removeAttr(ckks::CKKSDialect::kSchemeParamAttrName);
+    }
+  }
 };
 
 template <typename LattigoScheme>

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -26,6 +26,7 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -6,6 +6,8 @@
 
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
@@ -188,6 +190,12 @@ LogicalResult convertFunc(func::FuncOp op, int levelBudgetEncode,
   if (auto schemeParamAttr = module->getAttrOfType<bgv::SchemeParamAttr>(
           bgv::BGVDialect::kSchemeParamAttrName)) {
     module->removeAttr(bgv::BGVDialect::kSchemeParamAttrName);
+  }
+
+  // remove ckks.schemeParam attribute if present
+  if (auto schemeParamAttr = module->getAttrOfType<ckks::SchemeParamAttr>(
+          ckks::CKKSDialect::kSchemeParamAttrName)) {
+    module->removeAttr(ckks::CKKSDialect::kSchemeParamAttrName);
   }
 
   // get mulDepth from function argument ciphertext type

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -187,21 +187,9 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
     // Helper for future lowerings that want to know what scheme was used
     module->setAttr(kBGVSchemeAttrName, UnitAttr::get(context));
 
-    // generate scheme parameters
-    auto maxLevel = getMaxLevel();
-    std::vector<double> logPrimes;
-    for (int i = 0; i < maxLevel + 1; i++) {
-      logPrimes.push_back(45);  // all primes of 45 bits
-    }
-
-    // TODO(#661) : Calculate the appropriate values by analyzing the function
-    int64_t plaintextModulus = 4295294977;
-
-    // fallback parameters
-    auto schemeParam =
-        bgv::SchemeParam::getConcreteSchemeParam(plaintextModulus, logPrimes);
-
-    std::vector<int64_t> primes = schemeParam.getQi();
+    // used by LWE type
+    int64_t plaintextModulus;
+    std::vector<int64_t> primes;
 
     // Use previously computed ring parameters
     if (auto schemeParamAttr = module->getAttrOfType<bgv::SchemeParamAttr>(
@@ -210,11 +198,32 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
       // they have different semantic
       // auto logN = schemeParamAttr.getLogN();
       auto Q = schemeParamAttr.getQ();
-      primes.clear();
       for (auto prime : Q.asArrayRef()) {
         primes.push_back(prime);
       }
       plaintextModulus = schemeParamAttr.getPlaintextModulus();
+    } else {
+      // TODO(#661) : Calculate the appropriate values by analyzing the function
+      plaintextModulus = 4295294977;
+
+      // generate fallback scheme parameters
+      auto maxLevel = getMaxLevel();
+      std::vector<double> logPrimes(maxLevel + 1, 45);  // all primes of 45 bits
+
+      auto schemeParam =
+          bgv::SchemeParam::getConcreteSchemeParam(logPrimes, plaintextModulus);
+
+      primes = schemeParam.getQi();
+
+      // annotate bgv::SchemeParamAttr to ModuleOp
+      module->setAttr(
+          bgv::BGVDialect::kSchemeParamAttrName,
+          bgv::SchemeParamAttr::get(
+              context, log2(schemeParam.getRingDim()),
+              DenseI64ArrayAttr::get(context, ArrayRef(schemeParam.getQi())),
+              DenseI64ArrayAttr::get(&getContext(),
+                                     ArrayRef(schemeParam.getPi())),
+              schemeParam.getPlaintextModulus()));
     }
 
     auto rlweRing = getRlweRNSRing(context, primes, polyModDegree);

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/BUILD
@@ -23,6 +23,7 @@ cc_library(
         "@heir//lib/Dialect/RNS/IR:RNSTypes",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Parameters/CKKS:Params",
         "@heir//lib/Utils",
         "@heir//lib/Utils:ConversionUtils",
         "@heir//lib/Utils/Polynomial",

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 #include "lib/Dialect/CKKS/IR/CKKSOps.h"
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
@@ -23,6 +24,7 @@
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Parameters/CKKS/Params.h"
 #include "lib/Utils/ConversionUtils.h"
 #include "lib/Utils/Polynomial/Polynomial.h"
 #include "lib/Utils/Utils.h"
@@ -30,6 +32,7 @@
 #include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
 #include "llvm/include/llvm/ADT/TypeSwitch.h"   // from @llvm-project
 #include "llvm/include/llvm/Support/Casting.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
@@ -48,6 +51,8 @@
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 #include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
 
+#define DEBUG_TYPE "secret-to-ckks"
+
 namespace mlir::heir {
 
 #define GEN_PASS_DEF_SECRETTOCKKS
@@ -59,10 +64,9 @@ namespace {
 // modulus degree.
 // TODO(#536): Integrate a general library to compute appropriate prime moduli
 // given any number of bits.
-FailureOr<polynomial::RingAttr> getRlweRNSRing(MLIRContext *ctx,
-                                               int currentLevel,
-                                               int coefficientModBits,
-                                               int polyModDegree) {
+FailureOr<polynomial::RingAttr> getRlweRNSRing(
+    MLIRContext *ctx, const std::vector<int64_t> &primes, int polyModDegree) {
+  // monomial
   std::vector<::mlir::heir::polynomial::IntMonomial> monomials;
   monomials.emplace_back(1, polyModDegree);
   monomials.emplace_back(1, 0);
@@ -70,15 +74,16 @@ FailureOr<polynomial::RingAttr> getRlweRNSRing(MLIRContext *ctx,
       ::mlir::heir::polynomial::IntPolynomial::fromMonomials(monomials);
   if (failed(result)) return failure();
   ::mlir::heir::polynomial::IntPolynomial xnPlusOne = result.value();
-  // all 40 bit primes...
-  std::vector<int64_t> primes = {1095233372161, 1032955396097, 1005037682689,
-                                 998595133441,  972824936449,  959939837953};
+
+  // moduli chain
   SmallVector<Type, 4> modTypes;
-  for (int i = 0; i <= currentLevel; i++) {
+  for (auto prime : primes) {
     auto type = IntegerType::get(ctx, 64);
     modTypes.push_back(
-        mod_arith::ModArithType::get(ctx, IntegerAttr::get(type, primes[i])));
+        mod_arith::ModArithType::get(ctx, IntegerAttr::get(type, prime)));
   }
+
+  // types
   auto rnsType = rns::RNSType::get(ctx, modTypes);
   return ::mlir::heir::polynomial::RingAttr::get(
       rnsType, polynomial::IntPolynomialAttr::get(ctx, xnPlusOne));
@@ -272,6 +277,24 @@ class SecretGenericTensorInsertConversion
 struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
   using SecretToCKKSBase::SecretToCKKSBase;
 
+  // assume only one main func
+  // also assume max level at entry
+  int getMaxLevel() {
+    int maxLevel = 0;
+    getOperation()->walk([&](func::FuncOp funcOp) {
+      // get mgmtattr from funcop argument
+      for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
+        auto mgmtAttr =
+            funcOp.getArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName);
+        if (mgmtAttr) {
+          maxLevel = cast<mgmt::MgmtAttr>(mgmtAttr).getLevel();
+          break;
+        }
+      }
+    });
+    return maxLevel;
+  }
+
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     auto *module = getOperation();
@@ -279,9 +302,30 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
     // Helper for future lowerings that want to know what scheme was used
     module->setAttr(kCKKSSchemeAttrName, UnitAttr::get(context));
 
-    auto maxLevel = 5;
-    auto rlweRing =
-        getRlweRNSRing(context, maxLevel, coefficientModBits, polyModDegree);
+    // generate scheme parameters
+    auto maxLevel = getMaxLevel();
+    std::vector<double> logPrimes;
+    logPrimes.push_back(firstModBits);
+    for (int i = 0; i < maxLevel; i++) {
+      logPrimes.push_back(scalingModBits);
+    }
+
+    auto schemeParam =
+        ckks::SchemeParam::getConcreteSchemeParam(logPrimes, scalingModBits);
+    LLVM_DEBUG(llvm::dbgs() << "Concrete Scheme Param:\n"
+                            << schemeParam << "\n");
+
+    // annotate ckks::SchemeParamAttr to ModuleOp
+    module->setAttr(
+        ckks::CKKSDialect::kSchemeParamAttrName,
+        ckks::SchemeParamAttr::get(
+            context, log2(schemeParam.getRingDim()),
+            DenseI64ArrayAttr::get(context, ArrayRef(schemeParam.getQi())),
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getPi())),
+            schemeParam.getLogDefaultScale()));
+
+    auto rlweRing = getRlweRNSRing(context, schemeParam.getQi(), polyModDegree);
     if (failed(rlweRing)) {
       return signalPassFailure();
     }

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.td
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.td
@@ -33,9 +33,12 @@ def SecretToCKKS : Pass<"secret-to-ckks"> {
     Option<"polyModDegree", "poly-mod-degree", "int",
            /*default=*/"1024", "Default degree of the cyclotomic polynomial "
            "modulus to use for ciphertext space.">,
-    Option<"coefficientModBits", "coefficient-mod-bits", "int",
-           /*default=*/"29", "Default number of bits of the prime "
-           "coefficient modulus to use " "for the ciphertext space.">
+    Option<"firstModBits", "first-mod-bits", "int",
+           /*default=*/"55", "Default number of bits of the first prime "
+           "coefficient modulus to use for the ciphertext space.">,
+    Option<"scalingModBits", "scaling-mod-bits", "int",
+           /*default=*/"45", "Default number of bits of the scaling prime "
+           "coefficient modulus to use for the ciphertext space.">,
   ];
 }
 

--- a/lib/Parameters/BGV/Params.cpp
+++ b/lib/Parameters/BGV/Params.cpp
@@ -11,198 +11,27 @@
 #include <vector>
 
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
-#include "src/core/include/openfhecore.h"           // from @openfhe
 
 namespace mlir {
 namespace heir {
 namespace bgv {
 
-// struct for recording the maximal Q for each ring dim
-// under certain security condition.
-struct RLWESecurityParam {
-  int ringDim;
-  int logMaxQ;
-};
-
-// 128-bit classic security for uniform ternary secret distribution
-// taken from the "Homomorphic Encryption Standard" Preprint
-// https://ia.cr/2019/939
-// logMaxQ for 65536/131072 taken from OpenFHE
-// https://github.com/openfheorg/openfhe-development/blob/7b8346f4eac27121543e36c17237b919e03ec058/src/core/lib/lattice/stdlatticeparms.cpp#L187
-static struct RLWESecurityParam HEStd_128_classic[] = {
-    {1024, 27},   {2048, 54},   {4096, 109},   {8192, 218},
-    {16384, 438}, {32768, 881}, {65536, 1747}, {131072, 3523}};
-
-// from OpenFHE
-int computeDnum(int level) {
-  if (level > 3) {
-    return 3;
-  }
-  if (level > 0) {
-    return 2;
-  }
-  return 1;
-}
-
-int computeRingDim(int logTotalPQ) {
-  for (auto &param : HEStd_128_classic) {
-    if (param.logMaxQ >= logTotalPQ) {
-      return param.ringDim;
-    }
-  }
-  assert(false && "Failed to find ring dimension, level too large");
-  return 0;
-}
-
 SchemeParam SchemeParam::getConservativeSchemeParam(int level,
                                                     int64_t plaintextModulus) {
-  auto logModuli = 60;  // assume all 60 bit moduli
-  auto dnum = computeDnum(level);
-  std::vector<double> logqi(level + 1, logModuli);
-  std::vector<double> logpi(ceil(static_cast<double>(logqi.size()) / dnum),
-                            logModuli);
-
-  auto totalQP = logModuli * (logqi.size() + logpi.size());
-
-  auto ringDim = computeRingDim(totalQP);
-
-  return SchemeParam(ringDim, plaintextModulus, level, logqi, dnum, logpi);
+  return SchemeParam(RLWESchemeParam::getConservativeRLWESchemeParam(level),
+                     plaintextModulus);
 }
 
-int64_t findPrime(int qi, int ringDim,
-                  const std::vector<int64_t> &existingPrimes) {
-  while (qi < 80) {
-    try {
-      // openfhe FirstPrime will throw exception if it fails to find a prime
-      bool redo = false;
-      int64_t dupPrime;
-      do {
-        int64_t prime;
-        if (!redo) {
-          // first time, use first prime
-          auto res =
-              lbcrypto::FirstPrime<lbcrypto::NativeInteger>(qi, 2 * ringDim);
-          prime = res.ConvertToInt();
-        } else {
-          // start from the duplicated prime
-          auto res = lbcrypto::NextPrime(lbcrypto::NativeInteger(dupPrime),
-                                         2 * ringDim);
-          prime = res.ConvertToInt();
-        }
-        if (std::find(existingPrimes.begin(), existingPrimes.end(), prime) ==
-            existingPrimes.end()) {
-          return prime;
-        }
-        dupPrime = prime;
-        redo = true;
-      } while (redo);
-    } catch (...) {
-      qi += 1;
-    }
-  }
-  assert(false && "failed to generate good qi");
-  return 0;
-}
-
-SchemeParam SchemeParam::getConcreteSchemeParam(int64_t plaintextModulus,
-                                                std::vector<double> logqi) {
-  auto level = logqi.size() - 1;
-  auto dnum = computeDnum(level);
-
-  // sanitize qi
-  for (auto &qi : logqi) {
-    if (qi < 20) {
-      qi = 20;
-    }
-  }
-
-  auto maxLogqi = *std::max_element(logqi.begin(), logqi.end());
-  // make P > Q / dnum
-  std::vector<double> logpi(ceil(static_cast<double>(logqi.size()) / dnum),
-                            maxLogqi);
-
-  double logPQ = std::accumulate(logqi.begin(), logqi.end(), 0.0) +
-                 std::accumulate(logpi.begin(), logpi.end(), 0.0);
-
-  // ringDim will change if newLogPQ is too large
-  auto ringDim = computeRingDim(logPQ);
-  std::vector<int64_t> qiImpl;
-  std::vector<int64_t> piImpl;
-  bool redo = false;
-  do {
-    redo = false;
-    qiImpl.clear();
-    piImpl.clear();
-
-    std::vector<int64_t> existingPrimes;
-    existingPrimes.push_back(plaintextModulus);
-
-    double newLogPQ = 0;
-    for (auto qi : logqi) {
-      auto prime = findPrime(qi, ringDim, existingPrimes);
-      qiImpl.push_back(prime);
-      existingPrimes.push_back(prime);
-      newLogPQ += log2(prime);
-    }
-    for (auto pi : logpi) {
-      auto prime = findPrime(pi, ringDim, existingPrimes);
-      piImpl.push_back(prime);
-      existingPrimes.push_back(prime);
-      newLogPQ += log2(prime);
-    }
-    // if generated primes are too large, increase ringDim
-    auto newRingDim = computeRingDim(newLogPQ);
-    if (newRingDim != ringDim) {
-      ringDim = newRingDim;
-      redo = true;
-    }
-  } while (redo);
-
-  // update logqi and logpi
-  logqi.clear();
-  logpi.clear();
-  for (auto qi : qiImpl) {
-    logqi.push_back(log2(qi));
-  }
-  for (auto pi : piImpl) {
-    logpi.push_back(log2(pi));
-  }
-
-  return SchemeParam(ringDim, plaintextModulus, level, logqi, qiImpl, dnum,
-                     logpi, piImpl);
+SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
+                                                int64_t plaintextModulus) {
+  return SchemeParam(RLWESchemeParam::getConcreteRLWESchemeParam(
+                         std::move(logqi), plaintextModulus),
+                     plaintextModulus);
 }
 
 void SchemeParam::print(llvm::raw_ostream &os) const {
-  auto doubleToString = [](double d) {
-    std::stringstream stream;
-    stream << std::fixed << std::setprecision(2) << d;
-    return stream.str();
-  };
-
-  os << "ringDim: " << ringDim << "\n";
   os << "plaintextModulus: " << plaintextModulus << "\n";
-  os << "level: " << level << "\n";
-  os << "logqi: ";
-  for (auto qi : logqi) {
-    os << doubleToString(qi) << " ";
-  }
-  os << "\n";
-  os << "qi: ";
-  for (auto qi : qi) {
-    os << qi << " ";
-  }
-  os << "\n";
-  os << "dnum: " << dnum << "\n";
-  os << "logpi: ";
-  for (auto pi : logpi) {
-    os << doubleToString(pi) << " ";
-  }
-  os << "\n";
-  os << "pi: ";
-  for (auto pi : pi) {
-    os << pi << " ";
-  }
-  os << "\n";
+  RLWESchemeParam::print(os);
 }
 
 }  // namespace bgv

--- a/lib/Parameters/BGV/Params.h
+++ b/lib/Parameters/BGV/Params.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "lib/Parameters/RLWEParams.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 
 namespace mlir {
@@ -11,106 +12,36 @@ namespace heir {
 namespace bgv {
 
 // Parameter for BGV scheme at ModuleOp level
-class SchemeParam {
+class SchemeParam : public RLWESchemeParam {
  public:
-  SchemeParam(int ringDim, int64_t plaintextModulus, int level,
-              const std::vector<double> &logqi, int dnum,
-              const std::vector<double> &logpi)
-      : ringDim(ringDim),
-        plaintextModulus(plaintextModulus),
-        level(level),
-        logqi(logqi),
-        dnum(dnum),
-        logpi(logpi) {}
-
-  SchemeParam(int ringDim, int64_t plaintextModulus, int level,
-              const std::vector<double> &logqi, const std::vector<int64_t> &qi,
-              int dnum, const std::vector<double> &logpi,
-              const std::vector<int64_t> &pi)
-      : ringDim(ringDim),
-        plaintextModulus(plaintextModulus),
-        level(level),
-        logqi(logqi),
-        qi(qi),
-        dnum(dnum),
-        logpi(logpi),
-        pi(pi) {}
+  SchemeParam(const RLWESchemeParam &rlweSchemeParam, int64_t plaintextModulus)
+      : RLWESchemeParam(rlweSchemeParam), plaintextModulus(plaintextModulus) {}
 
  private:
-  // the N in Z[X]/(X^N+1)
-  int ringDim;
-
   // the plaintext modulus for BGV
   int64_t plaintextModulus;
 
-  // the standard deviation of the error distribution
-  double std0 = 3.2;
-
-  // RNS level, from 0 to L
-  int level;
-
-  // logarithm of the modulus of each level
-  // logqi.size() == level + 1
-  std::vector<double> logqi;
-  // modulus of each level
-  std::vector<int64_t> qi;
-
-  // The following part is for HYBRID key switching technique
-
-  // number of digits
-  // In HYBRID, we decompose Q into `dnum` digits
-  // for example, when Q consists of q0, q1, q2, q3 and dnum = 2,
-  // we have two digits: q0q1 and q2q3
-  int dnum;
-  // logarithm of the special modulus
-  std::vector<double> logpi;
-  // special modulus
-  std::vector<int64_t> pi;
-
  public:
-  int getRingDim() const { return ringDim; }
   int64_t getPlaintextModulus() const { return plaintextModulus; }
-  int getLevel() const { return level; }
-  const std::vector<double> &getLogqi() const { return logqi; }
-  const std::vector<int64_t> &getQi() const { return qi; }
-  int getDnum() const { return dnum; }
-  const std::vector<double> &getLogpi() const { return logpi; }
-  const std::vector<int64_t> &getPi() const { return pi; }
-  double getStd0() const { return std0; }
-
-  void print(llvm::raw_ostream &os) const;
-
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                       const SchemeParam &param) {
-    param.print(os);
-    return os;
-  }
+  void print(llvm::raw_ostream &os) const override;
 
   static SchemeParam getConservativeSchemeParam(int level,
                                                 int64_t plaintextModulus);
 
-  static SchemeParam getConcreteSchemeParam(int64_t plaintextModulus,
-                                            std::vector<double> logqi);
+  static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
+                                            int64_t plaintextModulus);
 };
 
 // Parameter for each BGV ciphertext SSA value.
-class LocalParam {
+class LocalParam : public RLWELocalParam {
  public:
   LocalParam(const SchemeParam *schemeParam, int currentLevel, int dimension)
-      : schemeParam(schemeParam),
-        currentLevel(currentLevel),
-        dimension(dimension) {}
-
- private:
-  const SchemeParam *schemeParam;
-  int currentLevel;
-  int dimension;
+      : RLWELocalParam(schemeParam, currentLevel, dimension) {}
 
  public:
-  const SchemeParam *getSchemeParam() const { return schemeParam; }
-
-  int getCurrentLevel() const { return currentLevel; }
-  int getDimension() const { return dimension; }
+  const SchemeParam *getSchemeParam() const {
+    return static_cast<const SchemeParam *>(schemeParam);
+  }
 };
 
 }  // namespace bgv

--- a/lib/Parameters/BUILD
+++ b/lib/Parameters/BUILD
@@ -1,0 +1,23 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RLWEParams",
+    srcs = ["RLWEParams.cpp"],
+    hdrs = ["RLWEParams.h"],
+    deps = [
+        ":RLWESecurityParams",
+        "@llvm-project//llvm:Support",
+        "@openfhe//:core",
+    ],
+)
+
+cc_library(
+    name = "RLWESecurityParams",
+    srcs = ["RLWESecurityParams.cpp"],
+    hdrs = ["RLWESecurityParams.h"],
+    deps = [
+    ],
+)

--- a/lib/Parameters/CKKS/BUILD
+++ b/lib/Parameters/CKKS/BUILD
@@ -9,6 +9,5 @@ cc_library(
     hdrs = ["Params.h"],
     deps = [
         "//lib/Parameters:RLWEParams",
-        "@llvm-project//llvm:Support",
     ],
 )

--- a/lib/Parameters/CKKS/Params.cpp
+++ b/lib/Parameters/CKKS/Params.cpp
@@ -1,0 +1,33 @@
+#include "lib/Parameters/CKKS/Params.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <ios>
+#include <numeric>
+#include <sstream>
+#include <vector>
+
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace ckks {
+
+SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
+                                                int logDefaultScale) {
+  return SchemeParam(
+      RLWESchemeParam::getConcreteRLWESchemeParam(std::move(logqi)),
+      logDefaultScale);
+}
+
+void SchemeParam::print(llvm::raw_ostream &os) const {
+  os << "logDefaultScale: " << logDefaultScale << "\n";
+  RLWESchemeParam::print(os);
+}
+
+}  // namespace ckks
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Parameters/CKKS/Params.h
+++ b/lib/Parameters/CKKS/Params.h
@@ -1,0 +1,36 @@
+#ifndef LIB_PARAMETERS_CKKS_PARAMS_H_
+#define LIB_PARAMETERS_CKKS_PARAMS_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "lib/Parameters/RLWEParams.h"
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace ckks {
+
+// Parameter for CKKS scheme at ModuleOp level
+class SchemeParam : public RLWESchemeParam {
+ public:
+  SchemeParam(const RLWESchemeParam &rlweSchemeParam, int logDefaultScale)
+      : RLWESchemeParam(rlweSchemeParam), logDefaultScale(logDefaultScale) {}
+
+ private:
+  // log of the default scale used to scale the message
+  int logDefaultScale;
+
+ public:
+  int64_t getLogDefaultScale() const { return logDefaultScale; }
+  void print(llvm::raw_ostream &os) const override;
+
+  static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
+                                            int logDefaultScale);
+};
+
+}  // namespace ckks
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_PARAMETERS_CKKS_PARAMS_H_

--- a/lib/Parameters/RLWEParams.cpp
+++ b/lib/Parameters/RLWEParams.cpp
@@ -1,0 +1,183 @@
+#include "lib/Parameters/RLWEParams.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <ios>
+#include <numeric>
+#include <sstream>
+#include <vector>
+
+#include "lib/Parameters/RLWESecurityParams.h"
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "src/core/include/openfhecore.h"           // from @openfhe
+
+namespace mlir {
+namespace heir {
+
+// from OpenFHE, the empirical way to select dnum based on level
+int computeDnum(int level) {
+  if (level > 3) {
+    return 3;
+  }
+  if (level > 0) {
+    return 2;
+  }
+  return 1;
+}
+
+RLWESchemeParam RLWESchemeParam::getConservativeRLWESchemeParam(int level) {
+  auto logModuli = 60;  // assume all 60 bit moduli
+  auto dnum = computeDnum(level);
+  std::vector<double> logqi(level + 1, logModuli);
+  std::vector<double> logpi(ceil(static_cast<double>(logqi.size()) / dnum),
+                            logModuli);
+
+  auto totalQP = logModuli * (logqi.size() + logpi.size());
+
+  auto ringDim = computeRingDim(totalQP);
+
+  return RLWESchemeParam(ringDim, level, logqi, dnum, logpi);
+}
+
+int64_t findPrime(int qi, int ringDim,
+                  const std::vector<int64_t> &existingPrimes) {
+  while (qi < 80) {
+    try {
+      // openfhe FirstPrime will throw exception if it fails to find a prime
+      bool redo = false;
+      int64_t dupPrime;
+      do {
+        int64_t prime;
+        if (!redo) {
+          // first time, use first prime
+          auto res =
+              lbcrypto::FirstPrime<lbcrypto::NativeInteger>(qi, 2 * ringDim);
+          prime = res.ConvertToInt();
+        } else {
+          // start from the duplicated prime
+          auto res = lbcrypto::NextPrime(lbcrypto::NativeInteger(dupPrime),
+                                         2 * ringDim);
+          prime = res.ConvertToInt();
+        }
+        if (std::find(existingPrimes.begin(), existingPrimes.end(), prime) ==
+            existingPrimes.end()) {
+          return prime;
+        }
+        dupPrime = prime;
+        redo = true;
+      } while (redo);
+    } catch (...) {
+      qi += 1;
+    }
+  }
+  assert(false && "failed to generate good qi");
+  return 0;
+}
+
+RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
+    std::vector<double> logqi, int64_t plaintextModulus) {
+  auto level = logqi.size() - 1;
+  auto dnum = computeDnum(level);
+
+  // sanitize qi
+  for (auto &qi : logqi) {
+    if (qi < 20) {
+      qi = 20;
+    }
+  }
+
+  auto maxLogqi = *std::max_element(logqi.begin(), logqi.end());
+  // make P > Q / dnum
+  std::vector<double> logpi(ceil(static_cast<double>(logqi.size()) / dnum),
+                            maxLogqi);
+
+  double logPQ = std::accumulate(logqi.begin(), logqi.end(), 0.0) +
+                 std::accumulate(logpi.begin(), logpi.end(), 0.0);
+
+  // ringDim will change if newLogPQ is too large
+  auto ringDim = computeRingDim(logPQ);
+  std::vector<int64_t> qiImpl;
+  std::vector<int64_t> piImpl;
+  bool redo = false;
+  do {
+    redo = false;
+    qiImpl.clear();
+    piImpl.clear();
+
+    std::vector<int64_t> existingPrimes;
+    // special treatment for BGV plaintext modulus
+    if (plaintextModulus != 0) {
+      existingPrimes.push_back(plaintextModulus);
+    }
+
+    double newLogPQ = 0;
+    for (auto qi : logqi) {
+      auto prime = findPrime(qi, ringDim, existingPrimes);
+      qiImpl.push_back(prime);
+      existingPrimes.push_back(prime);
+      newLogPQ += log2(prime);
+    }
+    for (auto pi : logpi) {
+      auto prime = findPrime(pi, ringDim, existingPrimes);
+      piImpl.push_back(prime);
+      existingPrimes.push_back(prime);
+      newLogPQ += log2(prime);
+    }
+    // if generated primes are too large, increase ringDim
+    auto newRingDim = computeRingDim(newLogPQ);
+    if (newRingDim != ringDim) {
+      ringDim = newRingDim;
+      redo = true;
+    }
+  } while (redo);
+
+  // update logqi and logpi
+  logqi.clear();
+  logpi.clear();
+  for (auto qi : qiImpl) {
+    logqi.push_back(log2(qi));
+  }
+  for (auto pi : piImpl) {
+    logpi.push_back(log2(pi));
+  }
+
+  return RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi, piImpl);
+}
+
+void RLWESchemeParam::print(llvm::raw_ostream &os) const {
+  auto doubleToString = [](double d) {
+    std::stringstream stream;
+    stream << std::fixed << std::setprecision(2) << d;
+    return stream.str();
+  };
+
+  os << "ringDim: " << ringDim << "\n";
+  os << "level: " << level << "\n";
+  os << "logqi: ";
+  for (auto qi : logqi) {
+    os << doubleToString(qi) << " ";
+  }
+  os << "\n";
+  os << "qi: ";
+  for (auto qi : qi) {
+    os << qi << " ";
+  }
+  os << "\n";
+  os << "dnum: " << dnum << "\n";
+  os << "logpi: ";
+  for (auto pi : logpi) {
+    os << doubleToString(pi) << " ";
+  }
+  os << "\n";
+  os << "pi: ";
+  for (auto pi : pi) {
+    os << pi << " ";
+  }
+  os << "\n";
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Parameters/RLWEParams.h
+++ b/lib/Parameters/RLWEParams.h
@@ -1,0 +1,113 @@
+#ifndef LIB_PARAMETERS_RLWEPARAMS_H_
+#define LIB_PARAMETERS_RLWEPARAMS_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// Parameter for BGV scheme at ModuleOp level
+class RLWESchemeParam {
+ public:
+  RLWESchemeParam(int ringDim, int level, const std::vector<double> &logqi,
+                  int dnum, const std::vector<double> &logpi)
+      : ringDim(ringDim),
+        level(level),
+        logqi(logqi),
+        dnum(dnum),
+        logpi(logpi) {}
+
+  RLWESchemeParam(int ringDim, int level, const std::vector<double> &logqi,
+                  const std::vector<int64_t> &qi, int dnum,
+                  const std::vector<double> &logpi,
+                  const std::vector<int64_t> &pi)
+      : ringDim(ringDim),
+        level(level),
+        logqi(logqi),
+        qi(qi),
+        dnum(dnum),
+        logpi(logpi),
+        pi(pi) {}
+
+ protected:
+  // the N in Z[X]/(X^N+1)
+  int ringDim;
+
+  // the standard deviation of the error distribution
+  double std0 = 3.2;
+
+  // RNS level, from 0 to L
+  int level;
+
+  // logarithm of the modulus of each level
+  // logqi.size() == level + 1
+  std::vector<double> logqi;
+  // modulus of each level
+  std::vector<int64_t> qi;
+
+  // The following part is for HYBRID key switching technique
+
+  // number of digits
+  // In HYBRID, we decompose Q into `dnum` digits
+  // for example, when Q consists of q0, q1, q2, q3 and dnum = 2,
+  // we have two digits: q0q1 and q2q3
+  int dnum;
+  // logarithm of the special modulus
+  std::vector<double> logpi;
+  // special modulus
+  std::vector<int64_t> pi;
+
+ public:
+  int getRingDim() const { return ringDim; }
+  int getLevel() const { return level; }
+  const std::vector<double> &getLogqi() const { return logqi; }
+  const std::vector<int64_t> &getQi() const { return qi; }
+  int getDnum() const { return dnum; }
+  const std::vector<double> &getLogpi() const { return logpi; }
+  const std::vector<int64_t> &getPi() const { return pi; }
+  double getStd0() const { return std0; }
+
+  virtual void print(llvm::raw_ostream &os) const;
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const RLWESchemeParam &param) {
+    param.print(os);
+    return os;
+  }
+
+  static RLWESchemeParam getConservativeRLWESchemeParam(int level);
+
+  // plaintext modulus for BGV
+  // for CKKS this field is not used
+  static RLWESchemeParam getConcreteRLWESchemeParam(
+      std::vector<double> logqi, int64_t plaintextModulus = 0);
+};
+
+// Parameter for each RLWE ciphertext SSA value.
+class RLWELocalParam {
+ public:
+  RLWELocalParam(const RLWESchemeParam *schemeParam, int currentLevel,
+                 int dimension)
+      : schemeParam(schemeParam),
+        currentLevel(currentLevel),
+        dimension(dimension) {}
+
+ protected:
+  const RLWESchemeParam *schemeParam;
+  int currentLevel;
+  int dimension;
+
+ public:
+  const RLWESchemeParam *getRLWESchemeParam() const { return schemeParam; }
+
+  int getCurrentLevel() const { return currentLevel; }
+  int getDimension() const { return dimension; }
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_PARAMETERS_RLWEPARAMS_H_

--- a/lib/Parameters/RLWESecurityParams.cpp
+++ b/lib/Parameters/RLWESecurityParams.cpp
@@ -1,0 +1,27 @@
+#include "lib/Parameters/RLWESecurityParams.h"
+
+#include <cassert>
+
+namespace mlir {
+namespace heir {
+
+// "Security Guidelines for Implementing Homomorphic Encryption"
+// https://ia.cr/2024/463
+
+// 128-bit classic security for uniform ternary secret distribution
+struct RLWESecurityParam rlweSecurityParam128BitClassic[] = {
+    {1024, 26},   {2048, 53},   {4096, 106},   {8192, 214},
+    {16384, 430}, {32768, 868}, {65536, 1747}, {131072, 3523}};
+
+int computeRingDim(int logPQ) {
+  for (auto &param : rlweSecurityParam128BitClassic) {
+    if (param.logMaxQ >= logPQ) {
+      return param.ringDim;
+    }
+  }
+  assert(false && "Failed to find ring dimension, logTotalPQ too large");
+  return 0;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Parameters/RLWESecurityParams.h
+++ b/lib/Parameters/RLWESecurityParams.h
@@ -1,0 +1,20 @@
+#ifndef LIB_PARAMETERS_RLWESECURITYPARAMS_H_
+#define LIB_PARAMETERS_RLWESECURITYPARAMS_H_
+
+namespace mlir {
+namespace heir {
+
+// struct for recording the maximal Q for each ring dim
+// under certain security condition.
+struct RLWESecurityParam {
+  int ringDim;
+  int logMaxQ;
+};
+
+// compute ringDim given logPQ under 128-bit classic security
+int computeRingDim(int logPQ);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_PARAMETERS_RLWESECURITYPARAMS_H_

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -197,7 +197,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
 
     auto concreteSchemeParam =
         NoiseAnalysis::SchemeParamType::getConcreteSchemeParam(
-            schemeParam.getPlaintextModulus(), qiSize);
+            qiSize, schemeParam.getPlaintextModulus());
 
     LLVM_DEBUG(llvm::dbgs() << "Concrete Scheme Param:\n"
                             << concreteSchemeParam << "\n");

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
@@ -23,7 +23,7 @@ module {
     } -> !eui1
     // CHECK: return
     // CHECK-SAME: message_type = tensor<1024xi1>
-    // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+    // CHECK-SAME: polynomialModulus = <1 + x**1024>
     // CHECK-SAME: size = 3
     return %1 : !eui1
   }
@@ -44,7 +44,7 @@ module {
     } -> !efi1
     // CHECK: return
     // CHECK-SAME: message_type = tensor<1024xf32>
-    // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+    // CHECK-SAME: polynomialModulus = <1 + x**1024>
     // CHECK-SAME: size = 3
     return %1 : !efi1
   }
@@ -60,7 +60,7 @@ module {
     } -> !secret.secret<f32>
     // CHECK: return
     // CHECK-SAME: message_type = f32
-    // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+    // CHECK-SAME: polynomialModulus = <1 + x**1024>
     return %0 : !secret.secret<f32>
   }
 
@@ -77,7 +77,7 @@ module {
     } -> !secret.secret<tensor<1x1024xf32>>
     // CHECK: return
     // CHECK-SAME: message_type = tensor<1x1024xf32>
-    // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+    // CHECK-SAME: polynomialModulus = <1 + x**1024>
     return %0 : !secret.secret<tensor<1x1024xf32>>
   }
 }

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/type_converter.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/type_converter.mlir
@@ -8,7 +8,7 @@
 func.func @test_arg_packed(%arg0 : !secret.secret<tensor<1024xf32>>) -> (!secret.secret<tensor<1024xf32>>) {
   // CHECK: return
   // CHECK-SAME: message_type = tensor<1024xf32>
-  // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+  // CHECK-SAME: polynomialModulus = <1 + x**1024>
   return %arg0 : !secret.secret<tensor<1024xf32>>
 }
 
@@ -26,7 +26,7 @@ func.func @test_extract_not_packed(%arg0 : !secret.secret<tensor<1023xf32>>) -> 
   } -> !secret.secret<f32>
   // CHECK: return
   // CHECK-SAME: message_type = f32
-  // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+  // CHECK-SAME: polynomialModulus = <1 + x**1024>
   return %0 : !secret.secret<f32>
 }
 
@@ -76,7 +76,7 @@ func.func @test_insert(%arg0 : !secret.secret<tensor<1023xf32>>, %arg1 : !secret
   } -> !secret.secret<tensor<1023xf32>>
   // CHECK: return
   // CHECK-SAME: message_type = f32
-  // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+  // CHECK-SAME: polynomialModulus = <1 + x**1024>
   return %0 : !secret.secret<tensor<1023xf32>>
 }
 
@@ -87,6 +87,6 @@ func.func @test_insert(%arg0 : !secret.secret<tensor<1023xf32>>, %arg1 : !secret
 func.func @test_2d_arg_packed(%arg0 : !secret.secret<tensor<1x1024xf32>>) -> (!secret.secret<tensor<1x1024xf32>>) {
   // CHECK: return
   // CHECK-SAME: message_type = tensor<1x1024xf32>>
-  // CHECK-SAME: coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>
+  // CHECK-SAME: polynomialModulus = <1 + x**1024>
   return %arg0 : !secret.secret<tensor<1x1024xf32>>
 }


### PR DESCRIPTION
In a similar style with #1379.

CKKS noise analysis is not as suggestive as BGV, which only gives the precision info, while the later can be used for determining overflow or not (correctness). So we may only support user providing the the default scale and the first mod size and we generate the parameter for them.

There are many scale-related techniques like https://github.com/google/heir/issues/1169#issuecomment-2616357068 and https://github.com/google/heir/issues/1169#issuecomment-2617786886. This PR only serves as a baseline for making the pipeline work, as it just generates the primes in an increasing order without caring the scaling factor. These management passes should be implemented later.

I put the parameter generation process in `secret-to-ckks`. As we are not using noise model (so not `validate-noise`), we do not have other pass to put it.

The CKKS SchemeParamAttr is for later integration like the Lattigo CKKS backend #1382.