### PR TITLE
Adding support of the Hello World Small example to CGGI-to-tfhe-rs

### DIFF
--- a/lib/Dialect/TfheRust/IR/BUILD
+++ b/lib/Dialect/TfheRust/IR/BUILD
@@ -41,6 +41,7 @@ cc_library(
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":types_inc_gen",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",
@@ -55,6 +56,7 @@ td_library(
         "TfheRustTypes.td",
     ],
     deps = [
+        "@llvm-project//mlir:ArithOpsTdFiles",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",

--- a/lib/Dialect/TfheRust/IR/TfheRustOps.h
+++ b/lib/Dialect/TfheRust/IR/TfheRustOps.h
@@ -3,9 +3,10 @@
 
 #include "lib/Dialect/TfheRust/IR/TfheRustDialect.h"
 #include "lib/Dialect/TfheRust/IR/TfheRustTypes.h"
-#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/TfheRust/IR/TfheRustOps.td
+++ b/lib/Dialect/TfheRust/IR/TfheRustOps.td
@@ -5,6 +5,7 @@ include "TfheRustDialect.td"
 include "TfheRustTypes.td"
 
 include "mlir/IR/BuiltinAttributes.td"
+include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/OpBase.td"
@@ -17,6 +18,10 @@ class TfheRust_Op<string mnemonic, list<Trait> traits = []> :
   }];
   let cppNamespace = "::mlir::heir::tfhe_rust";
 }
+
+/*******************
+ * BOOL OPERATIONS *
+ *******************/
 
 class TfheRust_BinaryOp<string mnemonic>
   : TfheRust_Op<mnemonic, [
@@ -32,6 +37,14 @@ class TfheRust_BinaryOp<string mnemonic>
   let results = (outs TfheRust_CiphertextLikeType:$output);
 }
 
+def TfheRust_BitAndOp : TfheRust_BinaryOp<"bitand"> { let summary = "Logical AND of two tfhe ciphertexts."; }
+def TfheRust_BitOrOp : TfheRust_BinaryOp<"bitor"> { let summary = "Logical OR of two tfhe ciphertexts."; }
+def TfheRust_BitXorOp : TfheRust_BinaryOp<"bitxor"> { let summary = "Logical XOR of two tfhe ciphertexts."; }
+
+/********************
+ * ARITH OPERATIONS *
+ ********************/
+
 class TfheRust_ScalarBinaryOp<string mnemonic>
   : TfheRust_Op<mnemonic, [
     Pure,
@@ -46,29 +59,21 @@ class TfheRust_ScalarBinaryOp<string mnemonic>
   let summary = "Arithmetic sub of two tfhe ciphertexts.";
 }
 
-def TfheRust_CreateTrivialOp : TfheRust_Op<"create_trivial", [Pure]> {
-  let arguments = (ins TfheRust_ServerKey:$serverKey, AnyInteger:$value);
-  let results = (outs TfheRust_CiphertextLikeType:$output);
-  let hasCanonicalizer = 1;
-}
-
-def TfheRust_BitAndOp : TfheRust_BinaryOp<"bitand"> { let summary = "Logical AND of two tfhe ciphertexts."; }
 def TfheRust_AddOp : TfheRust_ScalarBinaryOp<"add"> { let summary = "Arithmetic add of two tfhe ciphertexts."; }
 def TfheRust_MulOp : TfheRust_ScalarBinaryOp<"mul"> { let summary = "Arithmetic mul of two tfhe ciphertexts."; }
 
 def TfheRust_SubOp : TfheRust_Op<"sub", [
     Pure,
-    AllTypesMatch<["lhs","rhs","output"]>
+    AllTypesMatch<["lhs","output"]>
 ]> {
   let arguments = (ins
     TfheRust_ServerKey:$serverKey,
     TfheRust_CiphertextLikeType:$lhs,
-    TfheRust_CiphertextLikeType:$rhs
+    AnyTypeOf<[Builtin_Integer, TfheRust_CiphertextType]>:$rhs
   );
   let results = (outs TfheRust_CiphertextType:$output);
   let summary = "Arithmetic sub of two tfhe ciphertexts.";
 }
-
 
 def TfheRust_ScalarLeftShiftOp : TfheRust_Op<"scalar_left_shift", [
     Pure,
@@ -94,7 +99,45 @@ def TfheRust_ScalarRightShiftOp : TfheRust_Op<"scalar_right_shift", [
   let results = (outs TfheRust_CiphertextType:$output);
 }
 
-def TfheRust_ApplyLookupTableOp : TfheRust_Op<"apply_lookup_table", [
+/**********************
+ * COMPARE OPERATIONS *
+ **********************/
+
+def TfheRust_EqOp : TfheRust_ScalarBinaryOp<"eq"> { let summary = "High level operation to check equality of two ciphertexts."; }
+def TfheRust_NeqOp : TfheRust_ScalarBinaryOp<"neq"> { let summary = "High level operation to check inequality of two ciphertexts."; }
+def TfheRust_MinOp : TfheRust_ScalarBinaryOp<"min"> { let summary = "High level operation to return minimum of two ciphertexts."; }
+def TfheRust_MaxOp : TfheRust_ScalarBinaryOp<"max"> { let summary = "High level operation to return maximum of two ciphertexts."; }
+def TfheRust_CmpOp : TfheRust_Op<"cmp", [
+    Pure,
+]> {
+  let arguments = (ins
+  TfheRust_ServerKey:$serverKey,
+  Arith_CmpIPredicateAttr:$predicate,
+  TfheRust_CiphertextType:$lhs,
+  AnyTypeOf<[Builtin_Integer, TfheRust_CiphertextType]>:$rhs);
+  let results = (outs TfheRust_EncryptedBool:$output);
+  let summary = [{
+  High level operation to check the relation of two ciphertexts.
+  - equal (mnemonic: "eq"; integer value: 0)
+  - not equal (mnemonic: "ne"; integer value: 1)
+  - signed less than (mnemonic: "slt"; integer value: 2)
+  - signed less than or equal (mnemonic: "sle"; integer value: 3)
+  - signed greater than (mnemonic: "sgt"; integer value: 4)
+  - signed greater than or equal (mnemonic: "sge"; integer value: 5)
+  - unsigned less than (mnemonic: "ult"; integer value: 6)
+  - unsigned less than or equal (mnemonic: "ule"; integer value: 7)
+  - unsigned greater than (mnemonic: "ugt"; integer value: 8)
+  - unsigned greater than or equal (mnemonic: "uge"; integer value: 9)
+
+  Note: https://mlir.llvm.org/docs/Dialects/ArithOps/#arithcmpi-arithcmpiop
+}];
+}
+
+ /******************
+ * PBS OPERATIONS *
+ ******************/
+
+ def TfheRust_ApplyLookupTableOp : TfheRust_Op<"apply_lookup_table", [
     Pure,
     AllTypesMatch<["input", "output"]>
 ]> {
@@ -115,6 +158,32 @@ def TfheRust_GenerateLookupTableOp : TfheRust_Op<"generate_lookup_table", [Pure]
     Builtin_IntegerAttr:$truthTable
   );
   let results = (outs TfheRust_LookupTable:$lookupTable);
+  let hasCanonicalizer = 1;
+}
+
+
+def TfheRust_SelectOp : TfheRust_Op<"cmux", [
+    Pure
+]> {
+  let arguments = (
+    ins TfheRust_ServerKey:$serverKey,
+  TfheRust_EncryptedBool:$select,
+  TfheRust_CiphertextLikeType:$trueCtxt,
+  TfheRust_CiphertextLikeType:$falseCtxt
+  );
+  let results = (outs TfheRust_CiphertextLikeType:$output);
+  let summary = [{Multiplexer operations, the `select` ciphertext will return the `trueCtxt`
+  if in contains a 1. In the other case, it will will return the `falseCtxt`.
+  }];
+}
+
+ /**************************
+ * MAINTENANCE OPERATIONS *
+ **************************/
+
+def TfheRust_CreateTrivialOp : TfheRust_Op<"create_trivial", [Pure]> {
+  let arguments = (ins TfheRust_ServerKey:$serverKey, AnyInteger:$value);
+  let results = (outs TfheRust_CiphertextLikeType:$output);
   let hasCanonicalizer = 1;
 }
 

--- a/lib/Dialect/TfheRust/IR/TfheRustTypes.td
+++ b/lib/Dialect/TfheRust/IR/TfheRustTypes.td
@@ -39,12 +39,18 @@ class TfheRust_EncryptedInt<int width>
 }
 
 // Available options are https://docs.rs/tfhe/latest/tfhe/index.html#types
-foreach i = [8, 16, 32, 64, 128, 256] in {
+foreach i = [2, 4, 8, 16, 32, 64, 128, 256] in {
   def TfheRust_EncryptedInt # i : TfheRust_EncryptedInt<i>;
+}
+
+def TfheRust_EncryptedBool : TfheRust_Type<"EncryptedBool", "bool", [PassByReference, MemRefElementTypeInterface]> {
+  let summary = [{ An encrypted bool corresponding to tfhe-rs's FHEBool, not in the Boolean TFHE-rs.
+  Note this is not an encryption of a boolean, but the outcome of operations as Eq or Cmp.}];
 }
 
 def TfheRust_CiphertextType :
   AnyTypeOf<[
+    TfheRust_EncryptedBool,
     TfheRust_EncryptedUInt2,
     TfheRust_EncryptedUInt3,
     TfheRust_EncryptedUInt4,
@@ -64,6 +70,7 @@ def TfheRust_CiphertextType :
     TfheRust_EncryptedInt128,
     TfheRust_EncryptedInt256,
   ]>;
+
 
 def TfheRust_CiphertextLikeType : TypeOrValueSemanticsContainer<TfheRust_CiphertextType, "tfhe-ciphertext-like">;
 

--- a/lib/Target/TfheRust/TfheRustEmitter.cpp
+++ b/lib/Target/TfheRust/TfheRustEmitter.cpp
@@ -757,7 +757,7 @@ FailureOr<std::string> TfheRustEmitter::convertType(Type type) {
   // they will need to chance to the right values once we try to compile it
   // against a specific API version.
 
-  if (type.hasTrait<EncryptedInteger>()) {
+  if (type.hasTrait<EncryptedInteger>() || isa<EncryptedBoolType>(type)) {
     return std::string("Ciphertext");
   }
 

--- a/lib/Utils/ConversionUtils.h
+++ b/lib/Utils/ConversionUtils.h
@@ -521,12 +521,7 @@ inline Type encrytpedUIntTypeFromWidth(MLIRContext *ctx, int width) {
   // notion of signedness.
   switch (width) {
     case 1:
-      // The minimum bit width of the integer tfhe_rust API is UInt2
-      // https://docs.rs/tfhe/latest/tfhe/index.html#types
-      // This may happen if there are no LUT or boolean gate operations that
-      // require a minimum bit width (e.g. shuffling bits in a program that
-      // multiplies by two).
-      [[fallthrough]];
+      return tfhe_rust::EncryptedBoolType::get(ctx);
     case 2:
       return tfhe_rust::EncryptedUInt2Type::get(ctx);
     case 3:
@@ -551,6 +546,33 @@ inline Type encrytpedUIntTypeFromWidth(MLIRContext *ctx, int width) {
       return tfhe_rust::EncryptedUInt128Type::get(ctx);
     case 256:
       return tfhe_rust::EncryptedUInt256Type::get(ctx);
+    default:
+      llvm_unreachable("Unsupported bitwidth");
+  }
+}
+
+inline Type encrytpedIntTypeFromWidth(MLIRContext *ctx, int width) {
+  // Only supporting unsigned types because the LWE dialect does not have a
+  // notion of signedness.
+  switch (width) {
+    case 1:
+      return tfhe_rust::EncryptedBoolType::get(ctx);
+    case 2:
+      return tfhe_rust::EncryptedInt2Type::get(ctx);
+    case 4:
+      return tfhe_rust::EncryptedInt4Type::get(ctx);
+    case 8:
+      return tfhe_rust::EncryptedInt8Type::get(ctx);
+    case 16:
+      return tfhe_rust::EncryptedInt16Type::get(ctx);
+    case 32:
+      return tfhe_rust::EncryptedInt32Type::get(ctx);
+    case 64:
+      return tfhe_rust::EncryptedInt64Type::get(ctx);
+    case 128:
+      return tfhe_rust::EncryptedInt128Type::get(ctx);
+    case 256:
+      return tfhe_rust::EncryptedInt256Type::get(ctx);
     default:
       llvm_unreachable("Unsupported bitwidth");
   }

--- a/tests/Dialect/CGGI/Transforms/boolean_vectorizer.mlir
+++ b/tests/Dialect/CGGI/Transforms/boolean_vectorizer.mlir
@@ -5,9 +5,7 @@
 !pt_ty = !lwe.lwe_plaintext<encoding = #encoding>
 
 // CHECK-LABEL: add_one
-// CHECK-DAG: cggi.packed_gates {{%.*}}, {{%.*}} {gates = #cggi.cggi_bool_gates<0 : i32, 0 : i32>} : (tensor<2x!lwe.lwe_ciphertext
-// CHECK-DAG: cggi.packed_gates {{%.*}}, {{%.*}} {gates = #cggi.cggi_bool_gates<0 : i32, 4 : i32>} : (tensor<2x!lwe.lwe_ciphertext
-// CHECK-DAG: cggi.packed_gates {{%.*}}, {{%.*}} {gates = #cggi.cggi_bool_gates<4 : i32, 4 : i32>} : (tensor<2x!lwe.lwe_ciphertext
+// CHECK-COUNT-15: {{%.*}} = cggi.packed_gates {{%.*}}, {{%.*}}
 func.func @add_one(%arg0: tensor<8x!ct_ty>, %arg1: tensor<8x!ct_ty>) -> tensor<8x!ct_ty> {
   %true = arith.constant true
   %false = arith.constant false
@@ -73,6 +71,7 @@ func.func @add_one(%arg0: tensor<8x!ct_ty>, %arg1: tensor<8x!ct_ty>) -> tensor<8
   %fa6_s = cggi.xor %fa6_1, %fa5_c : !ct_ty
   %fa6_c = cggi.xor %fa6_2, %fa6_3 : !ct_ty
   %from_elements = tensor.from_elements %fa6_s, %fa5_s, %fa4_s, %fa3_s, %fa2_s, %fa1_s, %fa0_s, %ha_s : tensor<8x!ct_ty>
-  // CHECK: return
+  // CHECK: {{%.*}} = tensor.from_elements {{.*}} : tensor<8x!lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>>
+  // CHECK: return {{%.*}} : tensor<8x!lwe.lwe_ciphertext<encoding = #unspecified_bit_field_encoding>>
   return %from_elements : tensor<8x!ct_ty>
 }


### PR DESCRIPTION
Further upgrade of the lowering of the Hello World Example to CGGI-to-tfhe-rs by extending the operations and introducing a new type: the tfhe_rust.bool, which can be using using the tfhe-rs parameters and not the tfhe-rs-bool implementation