### PR TITLE
Detect entry-function using heuristics

### DIFF
--- a/lib/Dialect/LWE/Transforms/BUILD
+++ b/lib/Dialect/LWE/Transforms/BUILD
@@ -46,6 +46,7 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Utils:TransformUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",

--- a/lib/Dialect/Lattigo/Transforms/BUILD
+++ b/lib/Dialect/Lattigo/Transforms/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@heir//lib/Utils:TransformUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",

--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -11,6 +11,7 @@
 #include "lib/Dialect/Lattigo/IR/LattigoOps.h"
 #include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
 #include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Utils/TransformUtils.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"     // from @llvm-project
@@ -283,16 +284,12 @@ struct ConfigureCryptoContext
   using ConfigureCryptoContextBase::ConfigureCryptoContextBase;
 
   void runOnOperation() override {
-    auto result =
-        getOperation()->walk<WalkOrder::PreOrder>([&](func::FuncOp op) {
-          auto funcName = op.getSymName();
-          if ((funcName == entryFunction) && failed(convertFunc(op))) {
-            op->emitError("Failed to configure the crypto context for func");
-            return WalkResult::interrupt();
-          }
-          return WalkResult::advance();
-        });
-    if (result.wasInterrupted()) signalPassFailure();
+    auto funcOp =
+        detectEntryFunction(cast<ModuleOp>(getOperation()), entryFunction);
+    if (funcOp && failed(convertFunc(funcOp))) {
+      funcOp->emitError("Failed to configure the crypto context for func");
+      signalPassFailure();
+    }
   }
 };
 

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@heir//lib/Utils:TransformUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",

--- a/lib/Utils/BUILD
+++ b/lib/Utils/BUILD
@@ -60,3 +60,15 @@ cc_library(
         "@llvm-project//mlir:Support",
     ],
 )
+
+cc_library(
+    name = "TransformUtils",
+    srcs = ["TransformUtils.cpp"],
+    hdrs = ["TransformUtils.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/lib/Utils/TransformUtils.cpp
+++ b/lib/Utils/TransformUtils.cpp
@@ -1,0 +1,45 @@
+#include "lib/Utils/TransformUtils.h"
+
+namespace mlir {
+namespace heir {
+
+func::FuncOp detectEntryFunction(ModuleOp moduleOp,
+                                 std::string_view entryFunction) {
+  // get from user input
+  auto entryFunc = moduleOp.lookupSymbol<func::FuncOp>(entryFunction);
+  if (!entryFunc) {
+    // detect the entry function with the following heuristic:
+    // 1. the function name does not contain "__"
+    // 2. the function is not a declaration
+    // 3. the function is not called by any other function
+    // 4. the first function that satisfies the above conditions
+
+    // get all the called functions
+    std::set<std::string> calledFuncs;
+    moduleOp->walk<WalkOrder::PreOrder>([&](func::CallOp callOp) {
+      auto callee = callOp.getCallee();
+      calledFuncs.insert(std::string(callee));
+    });
+
+    moduleOp->walk<WalkOrder::PreOrder>([&](func::FuncOp funcOp) {
+      auto funcSymName = funcOp.getSymName();
+      if (funcSymName.find("__") != std::string::npos ||
+          calledFuncs.find(std::string(funcSymName)) != calledFuncs.end() ||
+          funcOp.isDeclaration()) {
+        return WalkResult::advance();
+      }
+      entryFunc = funcOp;
+      return WalkResult::interrupt();
+    });
+  }
+  // still no result then emit warning
+  if (!entryFunc) {
+    moduleOp->emitWarning(
+        "Entry function not found, please provide entry-function in the pass "
+        "options");
+  }
+  return entryFunc;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/TransformUtils.h
+++ b/lib/Utils/TransformUtils.h
@@ -1,0 +1,16 @@
+#ifndef LIB_UTILS_TRANSFORMUTILS_H_
+#define LIB_UTILS_TRANSFORMUTILS_H_
+
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+func::FuncOp detectEntryFunction(ModuleOp moduleOp,
+                                 std::string_view entryFunction);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_UTILS_TRANSFORMUTILS_H_

--- a/tests/Dialect/LWE/Transforms/add_debug_port.mlir
+++ b/tests/Dialect/LWE/Transforms/add_debug_port.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-print-local-scope --lwe-add-debug-port=entry-function=simple_sum %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --lwe-add-debug-port %s | FileCheck %s
 
 !Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
 !Z65537_i64_ = !mod_arith.int<65537 : i64>

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_detect.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_detect.mlir
@@ -1,0 +1,61 @@
+// RUN: heir-opt --lattigo-configure-crypto-context --split-input-file %s | FileCheck %s
+
+// Test whether detection works for one main function
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+module attributes {scheme.bgv} {
+  func.func @add(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    %res = lattigo.bgv.add %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+    return %res : !ct
+  }
+}
+
+// CHECK: @add
+// CHECK: @add__configure
+
+// -----
+
+// Test whether called function is skipped
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+module attributes {scheme.bgv} {
+  func.func @sub(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    %res = lattigo.bgv.add %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+    return %res : !ct
+  }
+  func.func @add(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    %res = lattigo.bgv.add %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+    %sub = call @sub(%evaluator, %res) : (!evaluator, !ct) -> !ct
+    return %sub : !ct
+  }
+}
+
+// CHECK: @sub
+// CHECK: @add
+// CHECK: @add__configure
+
+// -----
+
+// Test whether function declaration is skipped
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+module attributes {scheme.bgv} {
+  func.func private @sub(%evaluator : !evaluator, %ct : !ct) -> !ct
+  func.func @add(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    %res = lattigo.bgv.add %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+    return %res : !ct
+  }
+}
+
+// CHECK: @sub
+// CHECK: @add
+// CHECK: @add__configure

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_detect_diagnostic.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_detect_diagnostic.mlir
@@ -1,0 +1,13 @@
+// RUN: heir-opt --lattigo-configure-crypto-context --verify-diagnostics %s
+
+!evaluator = !lattigo.bgv.evaluator
+!params = !lattigo.bgv.parameter
+!ct = !lattigo.rlwe.ciphertext
+
+// expected-warning@+1 {{Entry function not found, please provide entry-function in the pass options}}
+module attributes {scheme.bgv} {
+  func.func @__add(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    %res = lattigo.bgv.add %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
+    return %res : !ct
+  }
+}

--- a/tests/Dialect/Openfhe/Transforms/configure_crypto_context_detect.mlir
+++ b/tests/Dialect/Openfhe/Transforms/configure_crypto_context_detect.mlir
@@ -1,0 +1,67 @@
+// RUN: heir-opt --openfhe-configure-crypto-context --split-input-file %s | FileCheck %s
+
+// Test whether detection works for one main function
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #full_crt_packing_encoding>
+#ring_rns_L0_1_x32_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**32>>
+#ring_rns_L1_1_x32_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**32>>
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x32_, encryption_type = lsb>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x32_, encryption_type = lsb>
+!ct_L0_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<32xi16>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+func.func @simple_sum(%arg0: !openfhe.crypto_context, %arg1: !ct_L1_) -> !ct_L0_ {
+  %14 = openfhe.mod_reduce %arg0, %arg1 : (!openfhe.crypto_context, !ct_L1_) -> !ct_L0_
+  return %14 : !ct_L0_
+}
+
+// CHECK: @simple_sum
+// CHECK: @simple_sum__generate_crypto_context
+// CHECK: @simple_sum__configure_crypto_context
+
+// -----
+
+// Test whether called function is skipped
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #full_crt_packing_encoding>
+#ring_rns_L0_1_x32_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**32>>
+#ring_rns_L1_1_x32_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**32>>
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x32_, encryption_type = lsb>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x32_, encryption_type = lsb>
+!ct_L0_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<32xi16>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+func.func @test(%arg0: !openfhe.crypto_context, %arg1: !ct_L0_) -> !ct_L0_ {
+  return %arg1 : !ct_L0_
+}
+
+func.func @simple_sum(%arg0: !openfhe.crypto_context, %arg1: !ct_L1_) -> !ct_L0_ {
+  %0 = openfhe.mod_reduce %arg0, %arg1 : (!openfhe.crypto_context, !ct_L1_) -> !ct_L0_
+  %1 = call @test(%arg0, %0) : (!openfhe.crypto_context, !ct_L0_) -> !ct_L0_
+  return %1 : !ct_L0_
+}
+
+// CHECK: @test
+// CHECK: @simple_sum
+// CHECK: @simple_sum__generate_crypto_context
+// CHECK: @simple_sum__configure_crypto_context

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -19,7 +19,7 @@ heir_lattigo_lib(
     go_library_name = "binops",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=4",
-        "--scheme-to-lattigo=entry-function=add",
+        "--scheme-to-lattigo",
     ],
     mlir_src = "binops.mlir",
 )
@@ -29,7 +29,7 @@ heir_lattigo_lib(
     go_library_name = "dotproduct8",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=8",
-        "--scheme-to-lattigo=entry-function=dot_product",
+        "--scheme-to-lattigo",
     ],
     mlir_src = "dot_product_8.mlir",
 )
@@ -39,7 +39,7 @@ heir_lattigo_lib(
     go_library_name = "dotproduct8sk",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=8 use-public-key=false",
-        "--scheme-to-lattigo=entry-function=dot_product",
+        "--scheme-to-lattigo",
     ],
     mlir_src = "dot_product_8.mlir",
 )
@@ -50,7 +50,7 @@ heir_lattigo_lib(
     go_library_name = "dotproduct8debug",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=8",
-        "--scheme-to-lattigo=entry-function=dot_product insert-debug-handler-calls=true",
+        "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
     mlir_src = "dot_product_8.mlir",
 )
@@ -62,7 +62,7 @@ heir_lattigo_lib(
     go_library_name = "dotproduct8f",
     heir_opt_flags = [
         "--mlir-to-ckks=ciphertext-degree=8",
-        "--scheme-to-lattigo=entry-function=dot_product",
+        "--scheme-to-lattigo",
     ],
     mlir_src = "dot_product_8f.mlir",
 )

--- a/tests/Examples/openfhe/BUILD
+++ b/tests/Examples/openfhe/BUILD
@@ -27,7 +27,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "simple_sum_lib.h",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=32",
-        "--scheme-to-openfhe=entry-function=simple_sum",
+        "--scheme-to-openfhe",
     ],
     mlir_src = "simple_sum.mlir",
     tags = ["notap"],
@@ -39,7 +39,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "dot_product_8_lib.h",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=8",
-        "--scheme-to-openfhe=entry-function=dot_product",
+        "--scheme-to-openfhe",
     ],
     mlir_src = "dot_product_8.mlir",
     tags = ["notap"],
@@ -51,7 +51,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "dot_product_8_debug_lib.h",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=8",
-        "--scheme-to-openfhe=entry-function=dot_product insert-debug-handler-calls=true",
+        "--scheme-to-openfhe=insert-debug-handler-calls=true",
     ],
     mlir_src = "dot_product_8.mlir",
     tags = ["notap"],
@@ -63,7 +63,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "box_blur_64x64_lib.h",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=786433",
-        "--scheme-to-openfhe=entry-function=box_blur",
+        "--scheme-to-openfhe",
     ],
     mlir_src = "box_blur_64x64.mlir",
     tags = ["notap"],
@@ -75,7 +75,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "roberts_cross_64x64_lib.h",
     heir_opt_flags = [
         "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=536903681",
-        "--scheme-to-openfhe=entry-function=roberts_cross",
+        "--scheme-to-openfhe",
     ],
     mlir_src = "roberts_cross_64x64.mlir",
     tags = ["notap"],
@@ -89,7 +89,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "dot_product_8f_lib.h",
     heir_opt_flags = [
         "--mlir-to-ckks=ciphertext-degree=8",
-        "--scheme-to-openfhe=entry-function=dot_product",
+        "--scheme-to-openfhe",
     ],
     heir_translate_flags = [],
     mlir_src = "dot_product_8f.mlir",
@@ -122,7 +122,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "halevi_shoup_matmul_lib.h",
     heir_opt_flags = [
         "--mlir-to-ckks=ciphertext-degree=16",
-        "--scheme-to-openfhe=entry-function=matmul",
+        "--scheme-to-openfhe",
     ],
     heir_translate_flags = [
         "--openfhe-include-type=source-relative",
@@ -136,7 +136,7 @@ openfhe_end_to_end_test(
     name = "simple_ckks_bootstrapping_test",
     generated_lib_header = "simple_ckks_bootstrapping_lib.h",
     heir_opt_flags = [
-        "--openfhe-configure-crypto-context=entry-function=simple_ckks_bootstrapping insecure=true",
+        "--openfhe-configure-crypto-context=insecure=true",
     ],
     heir_translate_flags = [
         "--openfhe-include-type=source-relative",

--- a/tests/Examples/openfhe/simple_sum.mlir
+++ b/tests/Examples/openfhe/simple_sum.mlir
@@ -3,7 +3,7 @@
 // in the BUILD file for this directory, and the openfhe_end_to_end_test macro
 // in test.bzl
 //
-// heir-opt --mlir-to-bgv='ciphertext-degree=32' --scheme-to-openfhe='entry-function=simple_sum' %s | bazel-bin/tools/heir-translate --emit-openfhe-pke
+// heir-opt --mlir-to-bgv='ciphertext-degree=32' --scheme-to-openfhe %s | bazel-bin/tools/heir-translate --emit-openfhe-pke
 
 func.func @simple_sum(%arg0: tensor<32xi16> {secret.secret}) -> i16 {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
Fixes #1418 

The detection code could be put into a separate compilation unit, looking for where to put it.

There are also entry-function option for `tosa-to-boolean-jaxite` but as I am not so familiar there I did not touch them.