### PR TITLE
Pass Attribute to debug function call

### DIFF
--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -147,6 +147,11 @@ class LattigoEmitter {
     return "err" + std::to_string(errCount++);
   }
 
+  std::string getDebugAttrMapName() {
+    static int debugAttrMapCount = 0;
+    return "debugAttrMap" + std::to_string(debugAttrMapCount++);
+  }
+
   std::string getCommaSeparatedNames(::mlir::ValueRange values) {
     return commaSeparatedValues(values,
                                 [&](Value value) { return getName(value); });

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -101,7 +101,13 @@ class OpenFhePkeEmitter {
   LogicalResult emitType(::mlir::Type type, ::mlir::Location loc);
 
   // Canonicalize Debug Port
+  bool isDebugPort(::llvm::StringRef debugPortName);
   ::llvm::StringRef canonicalizeDebugPort(::llvm::StringRef debugPortName);
+
+  std::string getDebugAttrMapName() {
+    static int debugAttrMapCount = 0;
+    return "debugAttrMap" + std::to_string(debugAttrMapCount++);
+  }
 
   void emitAutoAssignPrefix(::mlir::Value result);
   LogicalResult emitTypedAssignPrefix(::mlir::Value result,

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -168,3 +168,21 @@ module attributes {scheme.bgv} {
     return %evaluator : !evaluator
   }
 }
+
+// -----
+
+// CHECK-LABEL: func dot_product
+// CHECK: ["bound"] = "50"
+// CHECK: ["complex"] = "{test = 1.200000e+00 : f64}"
+// CHECK: ["random"] = "3 : i64"
+// CHECK: ["secret.secret"] = "unit"
+// CHECK: ["asm.is_block_arg"] = "1"
+// CHECK: ["asm.result_ssa_format"]
+
+module attributes {scheme.bgv} {
+  func.func private @__heir_debug_0(!lattigo.bgv.evaluator, !lattigo.bgv.parameter, !lattigo.bgv.encoder, !lattigo.rlwe.decryptor, !lattigo.rlwe.ciphertext)
+  func.func @dot_product(%evaluator: !lattigo.bgv.evaluator, %param: !lattigo.bgv.parameter, %encoder: !lattigo.bgv.encoder, %decryptor: !lattigo.rlwe.decryptor, %ct: !lattigo.rlwe.ciphertext, %ct_0: !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext attributes {mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>} {
+    call @__heir_debug_0(%evaluator, %param, %encoder, %decryptor, %ct) {bound = "50", random = 3, complex = {test = 1.2}, secret.secret} : (!lattigo.bgv.evaluator, !lattigo.bgv.parameter, !lattigo.bgv.encoder, !lattigo.rlwe.decryptor, !lattigo.rlwe.ciphertext) -> ()
+    return %ct : !lattigo.rlwe.ciphertext
+  }
+}

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -179,3 +179,34 @@ module attributes {scheme.ckks} {
     return %1 : !openfhe.crypto_context
   }
 }
+
+// -----
+
+!Z2147565569_i64_ = !mod_arith.int<2147565569 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L0_C0_ = #lwe.modulus_chain<elements = <2147565569 : i64>, current = 0>
+!rns_L0_ = !rns.rns<!Z2147565569_i64_>
+#ring_Z65537_i64_1_x8_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**8>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x8_, encoding = #full_crt_packing_encoding>
+#ring_rns_L0_1_x8_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**8>>
+!pt = !lwe.new_lwe_plaintext<application_data = <message_type = i16>, plaintext_space = #plaintext_space>
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x8_, encryption_type = lsb>
+!ct_L0_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L0_C0_>
+
+// CHECK: __heir_debug(CryptoContextT, PrivateKeyT, CiphertextT, const std::map<std::string, std::string>&)
+// CHECK: ["bound"] = "50"
+// CHECK: ["complex"] = "{test = 1.200000e+00 : f64}"
+// CHECK: ["random"] = "3 : i64"
+// CHECK: ["secret.secret"] = "unit"
+// CHECK: ["asm.is_block_arg"] = "1"
+// CHECK: ["asm.result_ssa_format"]
+
+module attributes {scheme.bgv} {
+  func.func private @__heir_debug_0(!openfhe.crypto_context, !openfhe.private_key, !ct_L0_)
+  func.func @add(%cc: !openfhe.crypto_context, %sk: !openfhe.private_key, %ct: !ct_L0_) -> !ct_L0_ {
+    call @__heir_debug_0(%cc, %sk, %ct) {bound = "50", random = 3, complex = {test = 1.2}, secret.secret} : (!openfhe.crypto_context, !openfhe.private_key, !ct_L0_) -> ()
+    return %ct : !ct_L0_
+  }
+}

--- a/tests/Examples/lattigo/dot_product_8_debug.go
+++ b/tests/Examples/lattigo/dot_product_8_debug.go
@@ -8,11 +8,22 @@ import (
 	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
 )
 
-func __heir_debug(evaluator *bgv.Evaluator, param bgv.Parameters, encoder *bgv.Encoder, decryptor *rlwe.Decryptor, ct *rlwe.Ciphertext) {
+func __heir_debug(evaluator *bgv.Evaluator, param bgv.Parameters, encoder *bgv.Encoder, decryptor *rlwe.Decryptor, ct *rlwe.Ciphertext, debugAttrMap map[string]string) {
+	// print op
+	isBlockArgument := debugAttrMap["asm.is_block_arg"]
+	if isBlockArgument == "1" {
+		fmt.Println("Input")
+	} else {
+		fmt.Println(debugAttrMap["asm.op_name"])
+	}
+
+	// print the decryption result
 	value := make([]int64, 8)
 	pt := decryptor.DecryptNew(ct)
 	encoder.Decode(pt, value)
-	fmt.Println(value)
+	fmt.Printf("  %v\n", value)
+
+	// print the noise
 
 	// get a new pt with no noise
 	// in Lattigo, Decrypt won't mod T
@@ -34,5 +45,5 @@ func __heir_debug(evaluator *bgv.Evaluator, param bgv.Parameters, encoder *bgv.E
 		total += param.LogQi()[i]
 	}
 	// t * e for BGV
-	fmt.Printf("Noise: %.2f Total: %d\n", max+param.LogT(), total)
+	fmt.Printf("  Noise: %.2f Total: %d\n", max+param.LogT(), total)
 }

--- a/tests/Examples/openfhe/dot_product_8_debug_test.cpp
+++ b/tests/Examples/openfhe/dot_product_8_debug_test.cpp
@@ -44,15 +44,26 @@ DCRTPoly DecryptCore(const std::vector<DCRTPoly>& cv,
   return b;
 }
 
+#define OP
 #define DECRYPT
 #define NOISE
 
-void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct) {
+void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct,
+                  const std::map<std::string, std::string>& debugAttrMap) {
+#ifdef OP
+  auto isBlockArgument = debugAttrMap.at("asm.is_block_arg");
+  if (isBlockArgument == "1") {
+    std::cout << "Input" << std::endl;
+  } else {
+    std::cout << debugAttrMap.at("asm.op_name") << std::endl;
+  }
+#endif
+
 #ifdef DECRYPT
   PlaintextT ptxt;
   cc->Decrypt(sk, ct, &ptxt);
   ptxt->SetLength(8);
-  std::cout << ptxt << std::endl;
+  std::cout << "  " << ptxt << std::endl;
 #endif
 
 #ifdef NOISE
@@ -73,7 +84,7 @@ void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct) {
     logQ += logqi;
   }
 
-  std::cout << "cv " << cv.size() << " Ql " << sizeQl << " logQ: " << logQ
+  std::cout << "  cv " << cv.size() << " Ql " << sizeQl << " logQ: " << logQ
             << " logqi: " << logqi_v << " budget " << logQ - noise - 1
             << " noise: " << noise << std::endl;
 #endif


### PR DESCRIPTION
Fixes #1415

Because heir-translate does not have the `func::FuncOp OpAsmOpInterface` hack some `%arg0` is present instead of `%evaluator` or `%cc`. Should be fixed later when I get `OpAsmTypeInterface` integrated upstream in MLIR (https://github.com/llvm/llvm-project/pull/124700).

<del>For Openfhe, the debug output is quite verbose because of LWE type. For printing op in generic form by AsmPrinter we can not have type alias.</del> resolved now with post-processing in debug function

### Example

#### Lattigo

```
<block argument> 
  [1 2 3 4 5 6 7 8]
  Noise: 22.30 Total: 96
<block argument> 
  [2 3 4 5 6 7 8 9]
  Noise: 22.49 Total: 96
%ct = lattigo.bgv.mul %arg0, %arg4, %arg5 
  [2 6 12 20 30 42 56 72]
  Noise: 49.79 Total: 96
%ct_0 = lattigo.bgv.relinearize %arg0, %ct 
  [2 6 12 20 30 42 56 72]
  Noise: 49.79 Total: 96
```

#### Openfhe

```
<block argument> 
  ( 1 2 3 4 5 6 7 8 ... )
  cv 2 Ql 4 logQ: 122.323 logqi: [ 31.0008 37 37 17.3219 ] budget 94.7219 noise: 26.6009
<block argument> 
  ( 2 3 4 5 6 7 8 9 ... )
  cv 2 Ql 4 logQ: 122.323 logqi: [ 31.0008 37 37 17.3219 ] budget 94.843 noise: 26.4798
%ct = openfhe.mul_no_relin %arg0, %arg2, %arg3 
  ( 2 6 12 20 30 42 56 72 ... )
  cv 3 Ql 3 logQ: 105.001 logqi: [ 31.0008 37 37 ] budget 52.7384 noise: 51.2625
%ct_0 = openfhe.relin %arg0, %ct 
  ( 2 6 12 20 30 42 56 72 ... )
  cv 2 Ql 3 logQ: 105.001 logqi: [ 31.0008 37 37 ] budget 52.7384 noise: 51.2625
```