### PR TITLE
Move AddAndKeySwitchCountAnalysis to a standalone pass

### DIFF
--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -12,6 +12,7 @@ cc_library(
     ],
     deps = [
         ":ConfigureCryptoContext",
+        ":CountAddAndKeySwitch",
         ":pass_inc_gen",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
     ],
@@ -33,6 +34,24 @@ cc_library(
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "CountAddAndKeySwitch",
+    srcs = ["CountAddAndKeySwitch.cpp"],
+    hdrs = [
+        "CountAddAndKeySwitch.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/AddAndKeySwitchCountAnalysis",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",

--- a/lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.cpp
+++ b/lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.cpp
@@ -1,0 +1,38 @@
+#include "lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h"
+
+#include "lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h"
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DEF_COUNTADDANDKEYSWITCH
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+struct CountAddAndKeySwitch
+    : impl::CountAddAndKeySwitchBase<CountAddAndKeySwitch> {
+  using CountAddAndKeySwitchBase::CountAddAndKeySwitchBase;
+
+  void runOnOperation() override {
+    DataFlowSolver solver;
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::SparseConstantPropagation>();
+    solver.load<SecretnessAnalysis>();
+
+    // calculate addCount/keySwitchCount
+    solver.load<CountAnalysis>();
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+    annotateCount(getOperation(), &solver);
+  }
+};
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h
+++ b/lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_OPENFHE_TRANSFORMS_COUNTADDANDKEYSWITCH_H_
+#define LIB_DIALECT_OPENFHE_TRANSFORMS_COUNTADDANDKEYSWITCH_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DECL_COUNTADDANDKEYSWITCH
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_COUNTADDANDKEYSWITCH_H_

--- a/lib/Dialect/Openfhe/Transforms/Passes.h
+++ b/lib/Dialect/Openfhe/Transforms/Passes.h
@@ -3,6 +3,7 @@
 
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
+#include "lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h"
 
 namespace mlir {
 namespace heir {

--- a/lib/Dialect/Openfhe/Transforms/Passes.td
+++ b/lib/Dialect/Openfhe/Transforms/Passes.td
@@ -6,14 +6,14 @@ include "mlir/Pass/PassBase.td"
 def ConfigureCryptoContext : Pass<"openfhe-configure-crypto-context"> {
   let summary = "Configure the crypto context in OpenFHE";
   let description = [{
-     This pass generates helper functions to generate and configure the OpenFHE crypto context for the given function. Generating the crypto context sets the appropriate encryption parameters, while the configuration generates the necessary evaluation keys (relinearization and rotation keys).
+    This pass generates helper functions to generate and configure the OpenFHE crypto context for the given function. Generating the crypto context sets the appropriate encryption parameters, while the configuration generates the necessary evaluation keys (relinearization and rotation keys).
 
-     For example, for an MLIR function `@my_func`, the generated helpers have the following signatures
-     ```mlir
+    For example, for an MLIR function `@my_func`, the generated helpers have the following signatures
+    ```mlir
     func.func  @my_func__generate_crypto_context() -> !openfhe.crypto_context
 
     func.func  @my_func__configure_crypto_context(!openfhe.crypto_context, !openfhe.private_key) -> !openfhe.crypto_context
-     ```
+    ```
   }];
   let dependentDialects = ["mlir::heir::openfhe::OpenfheDialect"];
   let options = [
@@ -28,6 +28,21 @@ def ConfigureCryptoContext : Pass<"openfhe-configure-crypto-context"> {
            /*default=*/"false", "Whether to use insecure parameter for faster evaluation"
            "(should only be used in test) (defaults to false)">
   ];
+}
+
+def CountAddAndKeySwitch : Pass<"openfhe-count-add-and-key-switch"> {
+  let summary = "Count the number of add and key-switch operations in OpenFHE";
+  let description = [{
+    This pass counts the number of add and key-switch operations in the given function.
+
+    This is used for setting the EvalAddCount and EvalKeySwitchCount in OpenFHE library.
+
+    The detailed definition of these counts could be found in the KPZ21 paper
+    [Revisiting Homomorphic Encryption Schemes for Finite Fields](https://ia.cr/2021/201)
+
+    The pass should be run at the secret arithmetic level when management operations
+    have been inserted and the IR is stable.
+  }];
 }
 
 #endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_PASSES_TD_

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -13,6 +13,7 @@
 #include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
+#include "lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h"
 #include "lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.h"
 #include "lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.h"
 #include "lib/Dialect/Secret/Transforms/DistributeGeneric.h"
@@ -158,6 +159,9 @@ void mlirToRLWEPipeline(OpPassManager &pm,
       validateNoiseOptions.model = options.noiseModel;
       validateNoiseOptions.plaintextModulus = options.plaintextModulus;
       pm.addPass(createValidateNoise(validateNoiseOptions));
+
+      // count add and keyswitch for Openfhe
+      pm.addPass(openfhe::createCountAddAndKeySwitch());
       break;
     }
     case RLWEScheme::ckksScheme: {

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -95,6 +95,7 @@ cc_library(
         "@heir//lib/Dialect/Lattigo/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/LinAlg/Conversions/LinalgToTensorExt",
         "@heir//lib/Dialect/Openfhe/Transforms:ConfigureCryptoContext",
+        "@heir//lib/Dialect/Openfhe/Transforms:CountAddAndKeySwitch",
         "@heir//lib/Dialect/Secret/Conversions/SecretToBGV",
         "@heir//lib/Dialect/Secret/Conversions/SecretToCGGI",
         "@heir//lib/Dialect/Secret/Conversions/SecretToCKKS",

--- a/lib/Transforms/SecretInsertMgmt/BUILD
+++ b/lib/Transforms/SecretInsertMgmt/BUILD
@@ -17,7 +17,6 @@ cc_library(
     deps = [
         ":SecretInsertMgmtPatterns",
         ":pass_inc_gen",
-        "@heir//lib/Analysis/AddAndKeySwitchCountAnalysis",
         "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/MulResultAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
@@ -1,6 +1,5 @@
 #include <utility>
 
-#include "lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/MulResultAnalysis/MulResultAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
@@ -88,15 +87,6 @@ struct SecretInsertMgmtBGV
     pipeline.addPass(createCSEPass());
     pipeline.addPass(mgmt::createAnnotateMgmt());
     (void)runPipeline(pipeline, getOperation());
-
-    // calculate addCount/keySwitchCount
-    solver.load<CountAnalysis>();
-    if (failed(solver.initializeAndRun(getOperation()))) {
-      getOperation()->emitOpError() << "Failed to run the analysis.\n";
-      signalPassFailure();
-      return;
-    }
-    annotateCount(getOperation(), &solver);
   }
 };
 

--- a/tests/Dialect/Openfhe/Transforms/eval_add_count.mlir
+++ b/tests/Dialect/Openfhe/Transforms/eval_add_count.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv %s | FileCheck %s
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --openfhe-count-add-and-key-switch %s | FileCheck %s
 
 // CHECK: mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>
 func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16> {secret.secret}) -> i16 {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -68,6 +68,7 @@ cc_binary(
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/Openfhe/Transforms",
         "@heir//lib/Dialect/Openfhe/Transforms:ConfigureCryptoContext",
+        "@heir//lib/Dialect/Openfhe/Transforms:CountAddAndKeySwitch",
         "@heir//lib/Dialect/Polynomial/Conversions/PolynomialToModArith",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/Transforms",


### PR DESCRIPTION
The IR is stable only after `secret-insert-mgmt-bgv` and `optimize-relinearization`, yet the count analysis runs in `secret-insert-mgmt-bgv`, which will result in an incorrect result.

Also only annotate `addCount` and `keySwitchCount` for each SSA when debugging to avoid poluting the IR. 

The pass lives in `lib/Dialect/Openfhe` as it is openfhe specific though it is quite early in the pipeline, see also #1420.