### PR TITLE
Add initial convert-to-ciphertext-semantics pass with kernel for linalg.reduce

### DIFF
--- a/lib/Dialect/TensorExt/IR/TensorExtAttributes.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtAttributes.td
@@ -64,4 +64,22 @@ def SIMDPacking_Attr : TensorExt_Attr<"SIMDPacking", "simd_packing",
   let assemblyFormat =  "`<` struct(params) `>`";
 }
 
+def OriginalType_Attr : TensorExt_Attr<"OriginalType", "original_type"> {
+  let summary = "The original type of a secret tensor whose layout has been converted to ciphertext semantics.";
+  let description = [{
+    This attribute is used to retain the original type of a secret tensor after
+    its conversion to ciphertext semantics, i.e. after applying any padding or
+    replication to fill ciphertext data types. For example, if a
+    `!secret.secret<tensor<32xi8>>` is replicated into a ciphertext of ring
+    dimension 1024, the new type would be `!secret.secret<tensor<1024xi8>>`
+    with attribute `tensor_ext.original_type<!secret.secret<tensor<32xi8>>`.
+  }];
+  let parameters = (ins
+    "::mlir::Type":$originalType,
+    "::mlir::AffineMap":$layout
+  );
+  let assemblyFormat =  "`<` struct(params) `>`";
+}
+
+
 #endif  // LIB_DIALECT_TENSOREXT_IR_TENSOREXTATTRIBUTES_TD_

--- a/lib/Dialect/TensorExt/IR/TensorExtDialect.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtDialect.td
@@ -20,6 +20,8 @@ def TensorExt_Dialect : Dialect {
   let extraClassDeclaration = [{
     constexpr const static ::llvm::StringLiteral
         kLayoutAttrName = "tensor_ext.layout";
+    constexpr const static ::llvm::StringLiteral
+        kOriginalTypeAttrName = "tensor_ext.original_type";
   }];
 
 

--- a/lib/Transforms/ConvertToCiphertextSemantics/BUILD
+++ b/lib/Transforms/ConvertToCiphertextSemantics/BUILD
@@ -1,0 +1,36 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ConvertToCiphertextSemantics",
+    srcs = ["ConvertToCiphertextSemantics.cpp"],
+    hdrs = ["ConvertToCiphertextSemantics.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:SecretPatterns",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Utils",
+        "@heir//lib/Utils:AffineMapUtils",
+        "@heir//lib/Utils:AttributeUtils",
+        "@heir//lib/Utils:ContextAwareConversionUtils",
+        "@heir//lib/Utils:ContextAwareDialectConversion",
+        "@heir//lib/Utils:ContextAwareTypeConversion",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TensorTransforms",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ConvertToCiphertextSemantics",
+    td_file = "ConvertToCiphertextSemantics.td",
+)

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -1,0 +1,669 @@
+#include "lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h"
+
+#include "lib/Dialect/Secret/IR/SecretPatterns.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "lib/Utils/AffineMapUtils.h"
+#include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/ContextAwareConversionUtils.h"
+#include "lib/Utils/ContextAwareDialectConversion.h"
+#include "lib/Utils/ContextAwareTypeConversion.h"
+#include "lib/Utils/Utils.h"
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/Transforms/Transforms.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+#define DEBUG_TYPE "convert-to-ciphertext-semantics"
+
+namespace mlir {
+namespace heir {
+
+auto &kLayoutAttrName = tensor_ext::TensorExtDialect::kLayoutAttrName;
+auto &kMaterializedAttrName = "tensor_ext.layout_materialized";
+auto &kOriginalTypeAttrName =
+    tensor_ext::TensorExtDialect::kOriginalTypeAttrName;
+
+// An unset value of a permutation as it's being built up.
+static constexpr int kUnset = -1;
+
+#define GEN_PASS_DEF_CONVERTTOCIPHERTEXTSEMANTICS
+#include "lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h.inc"
+
+bool isPowerOfTwo(int64_t n) { return (n > 0) && ((n & (n - 1)) == 0); }
+
+// This type converter converts types like tensor<NxMxi16> where the dimensions
+// represent tensor-semantic data to tensor<ciphertext_count x num_slots x
+// i16>, where the last dimension represents the ciphertext or plaintext slot
+// count, and the other dimensions are determined by a layout attribute
+// indexing.
+//
+// The presence of a layout attribute on the op definine a value is required
+// for this type converter to trigger. So patterns that use this and convert
+// types must remove any layout attributes when they are done.
+//
+// TODO(#1450): Determine if we should support non-cyclic slot algebras here
+// i.e., for the usual 2xN/2 case, how would we determine this situation
+// at this stage of the compilation pipeline, and how would this pass update
+// to convert to tensor<AxBx2xN/2xi16> where the last two dimensions now
+// correspond to the slot algebra direct product?
+struct LayoutMaterializationTypeConverter
+    : public UniquelyNamedAttributeAwareTypeConverter {
+ public:
+  LayoutMaterializationTypeConverter(int ciphertextSize)
+      : UniquelyNamedAttributeAwareTypeConverter(kLayoutAttrName),
+        ciphertextSize(ciphertextSize) {
+    addConversion([&](Type type, Attribute attr) { return std::nullopt; });
+    addConversion([&](secret::SecretType type,
+                      AffineMapAttr attr) -> std::optional<Type> {
+      auto innerType = type.getValueType();
+      auto rankedTensorType = dyn_cast<RankedTensorType>(innerType);
+      if (!rankedTensorType) return std::nullopt;
+
+      auto convertedInnerType = materializeLayout(rankedTensorType, attr);
+      if (failed(convertedInnerType)) return std::nullopt;
+
+      return secret::SecretType::get(convertedInnerType.value());
+    });
+    addConversion(
+        [&](RankedTensorType type, AffineMapAttr attr) -> std::optional<Type> {
+          return materializeLayout(type, attr);
+        });
+  }
+
+  FailureOr<Type> materializeLayout(RankedTensorType type,
+                                    AffineMapAttr attr) const {
+    AffineMap layout = attr.getValue();
+    MLIRContext *ctx = type.getContext();
+    OpBuilder b(ctx);
+
+    // Each ciphertext will always have ciphertextSize many slots, so the main
+    // goal is to determine how many ciphertexts are needed. We do this by
+    // iterating over the input type's index domain, and apply the layout
+    // affine map to each index, and keep track of the maximum value of each
+    // index of the map results. These maxima (plus 1 for zero indexing)
+    // will be the shape of the new type.
+    SmallVector<int64_t> outputTensorShape(layout.getNumResults(), 0);
+    outputTensorShape[layout.getNumResults() - 1] = ciphertextSize;
+
+    // Evaluate the affine map on the input indices and update the
+    // outputTensorShape to be a max over visited indices.
+    IndexTupleConsumer evaluateNextIndex =
+        [&](const std::vector<int64_t> &indices) {
+          SmallVector<int64_t> results;
+          evaluateStatic(layout, indices, results);
+
+          // minus 1 to skip the last dimension (ciphertext dimension)
+          for (int i = 0; i < layout.getNumResults() - 1; ++i) {
+            // 1 + to account for zero indexing
+            outputTensorShape[i] =
+                std::max(outputTensorShape[i], 1 + results[i]);
+          }
+        };
+
+    iterateIndices(type.getShape(), evaluateNextIndex);
+    return RankedTensorType::get(outputTensorShape, type.getElementType());
+  }
+
+ private:
+  // The number of slots available in each ciphertext.
+  int ciphertextSize;
+};
+
+bool hasMaterializedAttr(Operation *op) {
+  return op->hasAttr(kMaterializedAttrName);
+}
+
+void setMaterializedAttr(Operation *op) {
+  op->setAttr(kMaterializedAttrName, UnitAttr::get(op->getContext()));
+}
+
+struct ConvertFunc : public ContextAwareFuncConversion {
+ public:
+  using ContextAwareFuncConversion::ContextAwareFuncConversion;
+
+  ConvertFunc(const ContextAwareTypeConverter &typeConverter,
+              MLIRContext *context)
+      : ContextAwareFuncConversion(typeConverter, context) {}
+
+  LogicalResult finalizeFuncOpModification(
+      func::FuncOp op, ArrayRef<Type> oldArgTypes,
+      ArrayRef<Type> oldResultTypes, PatternRewriter &rewriter) const override {
+    // Replace layout arg attrs with secret.original_type arg attrs This is
+    // necessary so that later encoding/decoding functions can know what the
+    // original type of the tensor was and how it was encoded.
+    //
+    rewriter.modifyOpInPlace(op, [&] {
+      setMaterializedAttr(op);
+      for (int i = 0; i < op.getNumArguments(); ++i) {
+        auto layoutAttr = op.getArgAttr(i, kLayoutAttrName);
+        if (!layoutAttr) continue;
+
+        AffineMap layout = cast<AffineMapAttr>(layoutAttr).getValue();
+        op.setArgAttr(i, kOriginalTypeAttrName,
+                      tensor_ext::OriginalTypeAttr::get(
+                          getContext(), oldArgTypes[i], layout));
+      }
+
+      for (int i = 0; i < op.getNumResults(); ++i) {
+        auto layoutAttr = dyn_cast_or_null<AffineMapAttr>(
+            op.getResultAttr(i, kLayoutAttrName));
+        if (!layoutAttr) continue;
+
+        op.setResultAttr(
+            i, kOriginalTypeAttrName,
+            tensor_ext::OriginalTypeAttr::get(getContext(), oldResultTypes[i],
+                                              layoutAttr.getValue()));
+      }
+    });
+    return success();
+  };
+};
+
+struct ConvertGeneric : public ConvertAnyContextAware<secret::GenericOp> {
+ public:
+  ConvertGeneric(const ContextAwareTypeConverter &typeConverter,
+                 MLIRContext *context)
+      : ConvertAnyContextAware(typeConverter, context) {
+    setDebugName("ConvertGeneric");
+  }
+
+  LogicalResult finalizeOpModification(
+      secret::GenericOp op,
+      ContextAwareConversionPatternRewriter &rewriter) const override {
+    rewriter.modifyOpInPlace(op, [&] { setMaterializedAttr(op); });
+    return success();
+  };
+};
+
+// Convert an op generically, marking it as materialized. Lowest priority
+// because it is only meant to handle ops that don't have special
+// materialization rules.
+struct ConvertAnyAddingMaterializedAttr : public ConvertAnyContextAware<> {
+  ConvertAnyAddingMaterializedAttr(
+      const ContextAwareTypeConverter &typeConverter, MLIRContext *context)
+      : ConvertAnyContextAware(typeConverter, context, /*benefit=*/0) {
+    setDebugName("ConvertAnyAddingMaterializedAttr");
+  }
+
+  LogicalResult finalizeOpModification(
+      Operation *op,
+      ContextAwareConversionPatternRewriter &rewriter) const override {
+    rewriter.modifyOpInPlace(op, [&] { setMaterializedAttr(op); });
+    return success();
+  };
+};
+
+class ConvertAssignLayout
+    : public ContextAwareOpConversionPattern<tensor_ext::AssignLayoutOp> {
+ public:
+  using ContextAwareOpConversionPattern<
+      tensor_ext::AssignLayoutOp>::ContextAwareOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor_ext::AssignLayoutOp op, OpAdaptor adaptor,
+      ContextAwareConversionPatternRewriter &rewriter) const final {
+    // This pattern is different because its inputs do not have a layout,
+    // so the type converter doesn't convert their input types. Instead,
+    // the result's layout is defined by this op.
+    //
+    // The input hence needs to be reshaped to fit the output layout, and
+    // by default we assume all values are repeated cyclically according
+    // to the layout.
+    RankedTensorType ciphertextSemanticType =
+        cast<RankedTensorType>(getTypeConverter()->convertType(
+            op.getResult().getType(), op.getLayout()));
+    LLVM_DEBUG(llvm::dbgs() << "Converting AssignLayoutOp to use result type "
+                            << ciphertextSemanticType << "\n");
+    RankedTensorType dataSemanticType = op.getTensor().getType();
+    Value input = adaptor.getTensor();
+
+    // TODO(#1542): support multi-packed ciphertexts
+    if (ciphertextSemanticType.getRank() != 1) {
+      return op.emitError()
+             << "Does not support packing into multiple ciphertexts yet";
+    }
+
+    if (ciphertextSemanticType == input.getType()) {
+      // No conversion needed, the input is already the right size
+      rewriter.replaceOp(op, input);
+      return success();
+    }
+
+    // Otherwise, tile into the ciphertext
+    int dataSize = dataSemanticType.getNumElements();
+    int ciphertextSize = ciphertextSemanticType.getShape().back();
+    // TODO(#704): align tensor sizes when they don't align with num slots
+    if (ciphertextSize % dataSize != 0) {
+      return op.emitError() << "Ciphertext size must be a multiple of data "
+                               "size, or else repetition assumption fails!";
+    }
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    int64_t numIters = ciphertextSize / dataSize;
+    SmallVector<Value> repeatedInputs(numIters, input);
+    auto concatOp = b.create<tensor::ConcatOp>(
+        op.getLoc(), ciphertextSemanticType, /*axis=*/0, repeatedInputs);
+    setMaterializedAttr(concatOp);
+    concatOp->setAttr(kLayoutAttrName, op->getAttr(kLayoutAttrName));
+
+    rewriter.replaceOp(op, concatOp);
+    return success();
+  };
+};
+
+// Return the first output index not mapped to by the partial permutation.
+int64_t getMinUnusedTarget(llvm::ArrayRef<int64_t> perm) {
+  std::vector<int64_t> unmappedOutputsVector(perm.size());
+  std::iota(unmappedOutputsVector.begin(), unmappedOutputsVector.end(), 0);
+  std::set<int64_t> unmappedOutputs(unmappedOutputsVector.begin(),
+                                    unmappedOutputsVector.end());
+  for (long target : perm) {
+    if (target != kUnset) {
+      unmappedOutputs.erase(target);
+    }
+  }
+
+  if (unmappedOutputs.empty()) {
+    return -1;
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Unmapped outputs: ";
+    for (int64_t i : unmappedOutputs) {
+      llvm::dbgs() << i << " ";
+    }
+    llvm::dbgs() << "\n";
+  });
+
+  return *unmappedOutputs.begin();
+}
+
+// Return the first unused input index not mapped from by the partial
+// permutation.
+int64_t getMinUnusedInput(llvm::ArrayRef<int64_t> perm) {
+  for (int64_t i = 0; i < perm.size(); ++i) {
+    if (perm[i] == kUnset) return i;
+  }
+  return -1;
+}
+
+class ConvertConvertLayout
+    : public ContextAwareOpConversionPattern<tensor_ext::ConvertLayoutOp> {
+ public:
+  using ContextAwareOpConversionPattern<
+      tensor_ext::ConvertLayoutOp>::ContextAwareOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor_ext::ConvertLayoutOp op, OpAdaptor adaptor,
+      ContextAwareConversionPatternRewriter &rewriter) const final {
+    RankedTensorType dataSemanticType = op.getTensor().getType();
+    RankedTensorType ciphertextSemanticType =
+        cast<RankedTensorType>(adaptor.getTensor().getType());
+    LLVM_DEBUG(llvm::dbgs()
+               << "ConvertConvertLayout: dataSemanticType=" << dataSemanticType
+               << ", ciphertextSemanticType=" << ciphertextSemanticType
+               << "\n");
+    AffineMap fromLayout = op.getFromLayout().getValue();
+    AffineMap toLayout = op.getToLayout().getValue();
+
+    // TODO(#1542): support multi-packed ciphertexts
+    if (ciphertextSemanticType.getRank() != 1) {
+      return op.emitError()
+             << "Does not support packing into multiple ciphertexts yet";
+    }
+
+    int64_t numSlots = ciphertextSemanticType.getShape().back();
+    SmallVector<int64_t> permutation(numSlots, kUnset);
+
+    // The algorithm here allows the permutation to be built up "cyclically"
+    // in the following sense: after the original layout permutation is
+    // exhausted, we then repeat that layout permutation with offsets
+    // corresponding to the first unused input and target indices.
+    //
+    // Example: tensor<4xi16> in a ciphertext of size 16,
+    //
+    //  Converting layout d0 -> d0 to d0 -> 4*d0:
+    //
+    //   (0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3)
+    //
+    //     maps to the corresponding layout
+    //
+    //   (0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3)
+    //
+    int64_t minUnusedTarget = 0;
+    int64_t minUnusedInput = 0;
+    while (minUnusedInput != -1) {
+      LLVM_DEBUG({
+        if (minUnusedInput > 0) {
+          llvm::dbgs() << "Repeating for cyclic repetition with"
+                       << " minUnusedInput=" << minUnusedInput
+                       << " minUnusedTarget=" << minUnusedTarget << "\n";
+        }
+      });
+      IndexTupleConsumer evaluateNextIndex =
+          [&](const std::vector<int64_t> &indices) {
+            SmallVector<int64_t> fromResults;
+            SmallVector<int64_t> toResults;
+            evaluateStatic(fromLayout, indices, fromResults);
+            evaluateStatic(toLayout, indices, toResults);
+            int64_t input =
+                (minUnusedInput + fromResults[fromResults.size() - 1]) %
+                numSlots;
+            int64_t output =
+                (minUnusedTarget + toResults[toResults.size() - 1]) % numSlots;
+            permutation[input] = output;
+          };
+      iterateIndices(dataSemanticType.getShape(), evaluateNextIndex);
+      minUnusedTarget = getMinUnusedTarget(permutation);
+      minUnusedInput = getMinUnusedInput(permutation);
+    }
+
+    auto permuteOp = rewriter.create<tensor_ext::PermuteOp>(
+        op.getLoc(), adaptor.getTensor(),
+        rewriter.getI64TensorAttr(permutation));
+    permuteOp->setAttr(kLayoutAttrName, op->getAttr(kLayoutAttrName));
+    setMaterializedAttr(permuteOp);
+    rewriter.replaceOp(op, permuteOp);
+    return success();
+  };
+};
+
+// If the mapping is a partial rotation, return the rotation shift amount.
+std::optional<int64_t> tryDetectPartialRotation(
+    ::llvm::ArrayRef<int64_t> perm) {
+  std::optional<int64_t> rotation = std::nullopt;
+  for (int64_t i = 0; i < perm.size(); ++i) {
+    int64_t input = i;
+    int64_t output = perm[i];
+    if (output == kUnset) continue;
+    // We rotate left in this codebase, so invert normal output - input
+    int64_t shiftAmount = -(output - input);
+    if (!rotation.has_value()) {
+      rotation = shiftAmount;
+    } else if (shiftAmount != rotation.value()) {
+      return std::nullopt;
+    }
+  }
+  return rotation;
+}
+
+// Extend a partial permutation to a full permutation in an FHE-friendly way.
+void extendPermutationGreedily(::llvm::MutableArrayRef<int64_t> perm) {
+  std::set<int64_t> unmappedInputs;
+
+  // Start with values 0..n-1 and remove when found in the permutation
+  std::vector<int64_t> unmappedOutputsVector(perm.size());
+  std::iota(unmappedOutputsVector.begin(), unmappedOutputsVector.end(), 0);
+  std::set<int64_t> unmappedOutputs(unmappedOutputsVector.begin(),
+                                    unmappedOutputsVector.end());
+
+  for (int64_t i = 0; i < perm.size(); ++i) {
+    if (perm[i] == kUnset) {
+      unmappedInputs.insert(i);
+    } else {
+      unmappedOutputs.erase(perm[i]);
+    }
+  }
+
+  // Set iteration is in sorted order, so we're mapping each unused input to
+  // the first output index that hasn't been mapped to yet.
+  for (const auto &[input, output] :
+       llvm::zip(unmappedInputs, unmappedOutputs)) {
+    perm[input] = output;
+  }
+}
+
+// Extend a partial permutation to a full permutation in an FHE-friendly way.
+//
+// FHE-friendly means that the output permutation should lower to a small shift
+// network. For example, if the permutation can be extended to a single
+// rotation, it should be.
+//
+// The input partialPermutation must already be correctly sized (size n for a
+// permutation on 1..n). Unset entries of the permutation are indicated by
+// kUnset.
+void extendPartialPermutation(MutableArrayRef<int64_t> partialPermutation) {
+  // If the partially set entries correspond to a single rotation, extend it.
+  std::optional<int64_t> rotation =
+      tryDetectPartialRotation(partialPermutation);
+  if (rotation.has_value()) {
+    LLVM_DEBUG(llvm::dbgs() << "Detected partial rotation of offset "
+                            << rotation.value() << "\n");
+    for (int64_t i = 0; i < partialPermutation.size(); ++i) {
+      if (partialPermutation[i] == kUnset) {
+        int64_t target = i - rotation.value();
+        if (target < 0) target += partialPermutation.size();
+        partialPermutation[i] = target;
+      }
+    }
+    return;
+  }
+
+  // Otherwise, try to fill in the unset entries greedily.
+  extendPermutationGreedily(partialPermutation);
+}
+
+class ConvertLinalgReduce
+    : public ContextAwareOpConversionPattern<linalg::ReduceOp> {
+ public:
+  using ContextAwareOpConversionPattern<
+      linalg::ReduceOp>::ContextAwareOpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      linalg::ReduceOp op, OpAdaptor adaptor,
+      ContextAwareConversionPatternRewriter &rewriter) const final {
+    // Ensure the reduction op is single addition or multiplication, otherwise
+    // there is no kernel.
+    Block *body = op.getBlock();
+    if (body->getOperations().size() != 2) {
+      return op.emitError(
+          "linalg.reduce only supported with a single reduction operation");
+    }
+
+    // TODO(#1543): support multi-dimension reductions
+    if (op.getDimensions().size() != 1) {
+      return op.emitError(
+          "linalg.reduce only supported with a single reduction dimension");
+    }
+
+    if (!op.isSingleInputOutput()) {
+      return op.emitError(
+          "linalg.reduce only supported with a single reduction dimension");
+    }
+
+    Operation *innerOp = &body->getOperations().front();
+    if (!isa<arith::AddFOp, arith::MulFOp, arith::AddIOp, arith::MulIOp>(
+            innerOp)) {
+      return op.emitError()
+             << "linalg.reduce only supported with a single addition or "
+                "multiplication operation, but found: "
+             << innerOp->getName();
+    }
+
+    // Example: To reduce a tensor<32x32xi16> along dimension 0 using addition,
+    // that is laid out in a ciphertext-semantic tensor<1024xi16> via some
+    // mapping, we need to compute the permutations required to align the
+    // inputs along rows.
+    //
+    // If the layouts are chosen well, for this example if the layout is
+    // row-major, then that permutation corresponds to a simple set of
+    // rotations.
+    //
+    // TODO(#1542): support multi-packed ciphertexts
+
+    RankedTensorType dataSemanticType =
+        cast<RankedTensorType>(op.getInputs()[0].getType());
+    RankedTensorType ciphertextSemanticType =
+        cast<RankedTensorType>(adaptor.getInputs()[0].getType());
+    FailureOr<Attribute> layoutFetchResult =
+        getTypeConverter()->getContextualAttr(adaptor.getInputs()[0]);
+    if (failed(layoutFetchResult)) {
+      return op.emitError() << "failed to fetch layout attribute for input";
+    }
+    AffineMap layout =
+        cast<AffineMapAttr>(layoutFetchResult.value()).getValue();
+
+    // See DestinationStyleOpInterface: 1-1 relationship between inits and op
+    // results, but the init is type converted already and is the starting
+    // point for the reduction kernel implementation.
+    Value init = adaptor.getInits()[0];
+    Value input = adaptor.getInputs()[0];
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "ConvertLinalgReduce:\n"
+               << "\n  - data semantic type: " << dataSemanticType
+               << "\n  - ciphertext semantic type: " << ciphertextSemanticType
+               << "\n  - layout: " << layout << "\n  - dimensions: "
+               << llvm::join(llvm::map_range(
+                                 op.getDimensions(),
+                                 [](int64_t d) { return std::to_string(d); }),
+                             ", ")
+               << "\n  - op: " << innerOp->getName() << "\n  - init: " << init
+               << "\n\n");
+
+    int64_t reductionDim = op.getDimensions()[0];
+    int64_t reductionDimSize = dataSemanticType.getShape()[reductionDim];
+
+    // In the example from above (row-major <32x32> -> <1024>), all values
+    // in the reduced dimension need to map to the same slot. E.g.,
+    //
+    //   (0, 0), (1, 0), (2, 0), ... (31, 0)
+    //
+    // should map to slot (0) in each term of the sum, while
+    //
+    //   (0, 1), (1, 1), (2, 1), ... (31, 1)
+    //
+    // should all map to slot (1). Viewing this with a different iteration
+    // order, there is one summand for each entry of the reduced dimension, and
+    // in that summand we must map
+    //
+    //   (i, 0), (i, 1), (i, 2), ... (i, 31)
+    //
+    // to
+    //
+    //   (0, 1, 2, ..., 31)
+    //
+    // For this example row-major layout, the entry (i, 3) maps to 32*i + 3,
+    // and we need it to map to 3. So this adds a requirement that the
+    // permutation maps 32*i + 3 -> 3. This can be calculated generically by
+    // evaluating the layout at (i, 3) and mapping it to the static index tuple
+    // given by the non-iterating dimensions of the tensor (dim 1 in the
+    // example, which has a value of 3) in this step of the iteration.
+    //
+    // The mechanism above populates one part of a larger permutation of the
+    // ciphertext-semantic tensor, and then we have to find a way to extend
+    // that to a permutation of the whole tensor in a way that will produce
+    // simple shift networks. For now we identify the case that the partial
+    // permutation can be extended to a simple shift, and then we fill in the
+    // rest of the permutation according to that shift. Otherwise, we fill in
+    // the rest of the permutation in a greedy order.
+    //
+    // TODO(#521): Extend rotate-and-reduce so it can be run after this kernel
+    // and find additional rotation optimizations.
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    Value result = init;
+    for (int64_t dimIndex = 0; dimIndex < reductionDimSize; ++dimIndex) {
+      SmallVector<int64_t> permutation(ciphertextSemanticType.getNumElements(),
+                                       kUnset);
+      SmallVector<int64_t> fixedIndices = {reductionDim};
+      SmallVector<int64_t> fixedValues = {dimIndex};
+
+      // For each entry with the reduced index fixed, populate the permutation
+      // with the desired partial mapping.
+      IndexTupleConsumer evaluateNextIndex =
+          [&](const std::vector<int64_t> &indices) {
+            SmallVector<int64_t> results;
+            evaluateStatic(layout, indices, results);
+
+            // Since we are reducing along a dimension, the input that gives us
+            // the desired output slot should be the slot that the layout maps
+            // the first entry of the reduced dimension to.
+            //
+            // From the running example tensor<32x32> -> tensor<1024> row-major
+            // layout reducing dim 0, if we're at entry dimIndex = 3, then we're
+            // saying that all entries (3, j) should map to (0, j) so that all
+            // the values (0, j), (1, j), (2, j), ... (31, j) are aligned.
+            std::vector<int64_t> inputsForDesiredResults(indices);
+            for (long fixedIndex : fixedIndices) {
+              inputsForDesiredResults[fixedIndex] = 0;
+            }
+            SmallVector<int64_t> desiredResults;
+            evaluateStatic(layout, inputsForDesiredResults, desiredResults);
+
+            // The last dimension of the layout output is the ciphertext
+            // dimension, and it contains the slot that the entry is mapped to.
+            permutation[results[results.size() - 1]] =
+                desiredResults[desiredResults.size() - 1];
+          };
+
+      iterateIndices(dataSemanticType.getShape(), evaluateNextIndex,
+                     fixedIndices, fixedValues);
+      extendPartialPermutation(permutation);
+
+      auto permuteOp = b.create<tensor_ext::PermuteOp>(
+          input, b.getI64TensorAttr(permutation));
+
+      SmallVector<Value> operands = {result, permuteOp};
+      SmallVector<Type> newResultTypes = {permuteOp.getType()};
+      Operation *nextOp = rewriter.create(
+          OperationState(op->getLoc(), innerOp->getName().getStringRef(),
+                         operands, newResultTypes));
+      permuteOp->setAttr(kLayoutAttrName, op->getAttr(kLayoutAttrName));
+      nextOp->setAttr(kLayoutAttrName, op->getAttr(kLayoutAttrName));
+      setMaterializedAttr(permuteOp);
+      setMaterializedAttr(nextOp);
+      result = nextOp->getResult(0);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  };
+};
+
+struct ConvertToCiphertextSemantics
+    : impl::ConvertToCiphertextSemanticsBase<ConvertToCiphertextSemantics> {
+  using ConvertToCiphertextSemanticsBase::ConvertToCiphertextSemanticsBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto *module = getOperation();
+
+    LayoutMaterializationTypeConverter typeConverter =
+        LayoutMaterializationTypeConverter(ciphertextSize);
+
+    RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+    target.markUnknownOpDynamicallyLegal([&](Operation *op) {
+      return isa<ModuleOp>(op) || hasMaterializedAttr(op);
+    });
+
+    patterns.add<ConvertFunc, ConvertGeneric, ConvertAssignLayout,
+                 ConvertConvertLayout, ConvertLinalgReduce,
+                 ConvertAnyAddingMaterializedAttr>(typeConverter, context);
+
+    if (failed(applyContextAwarePartialConversion(module, target,
+                                                  std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    // Hoist tensor.concat ops from constant layouts out of the generic
+    RewritePatternSet cleanupPatterns(context);
+    cleanupPatterns.add<secret::HoistPlaintextOps>(context);
+    walkAndApplyPatterns(module, std::move(cleanupPatterns));
+
+    // Decompose tensor.concat into repeated tensor.insert_slice ops.
+    // Note ConvertAssignLayout generates tensor.concat
+    RewritePatternSet cleanupPatterns2(context);
+    tensor::populateDecomposeTensorConcatPatterns(cleanupPatterns2);
+    walkAndApplyPatterns(module, std::move(cleanupPatterns2));
+
+    clearAttrs(module, kLayoutAttrName);
+    clearAttrs(module, kMaterializedAttrName);
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_CONVERTTOCIPHERTEXTSEMANTICS_CONVERTTOCIPHERTEXTSEMANTICS_H_
+#define LIB_TRANSFORMS_CONVERTTOCIPHERTEXTSEMANTICS_CONVERTTOCIPHERTEXTSEMANTICS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_CONVERTTOCIPHERTEXTSEMANTICS_CONVERTTOCIPHERTEXTSEMANTICS_H_

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.td
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.td
@@ -1,0 +1,67 @@
+#ifndef LIB_TRANSFORMS_CONVERTTOCIPHERTEXTSEMANTICS_CONVERTTOCIPHERTEXTSEMANTICS_TD_
+#define LIB_TRANSFORMS_CONVERTTOCIPHERTEXTSEMANTICS_CONVERTTOCIPHERTEXTSEMANTICS_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertToCiphertextSemantics : Pass<"convert-to-ciphertext-semantics"> {
+  let summary = "Converts programs with tensor semantics to ciphertext semantics";
+  let description = [{
+  This pass performs two inherently intertwined transformations:
+
+  1. Convert a program from tensor semantics to ciphertext semantics, explained below.
+  2. Implement ops defined on tensor-semantic types in terms of ops defined on
+     ciphertext-semantic types.
+
+  A program is defined to have _tensor semantics_ if the tensor-typed values
+  are manipulated according to standard MLIR tensor operations and semantics.
+
+  A program is defined to have _ciphertext semantics_ if the tensor-typed
+  values correspond to tensors of FHE ciphertexts, where the last dimension of
+  the tensor type is the number of ciphertext slots.
+
+  For example, a tensor of type `tensor<32x32xi16>` with tensor semantics might
+  be converted by this pass, depending on the pass options, to a single
+  ciphertext-semantics `tensor<65536xi16>`. A larger tensor might, depending on
+  the layout chosen by earlier passes, be converted to a `tensor<4x32768xi16>`,
+  where the trailing dimension corresponds to the number of slots in the
+  ciphertext.
+
+  Tensors with ciphertext semantics can be thought of as an intermediate step
+  between lowering from tensor types with tensor semantics to concrete `lwe`
+  dialect ciphertext types in a particular FHE scheme. Having this intermediate
+  step is useful because some optimizations are easier to implement, and can be
+  implemented more generically, in the abstract FHE computational model
+  where the data types are large tensors, and the operations are SIMD additions,
+  multiplications, and cyclic rotations.
+
+  Function arguments and return values are annotated with the original tensor
+  type in the `secret.original_type` attribute. This enables later lowerings
+  to implement appropriate encoding and decoding routines for FHE schemes.
+
+  The second role of this pass is to implement FHE kernels for various high-level
+  tensor operations, such as `linalg.matvec`. This must happen at the same time
+  as the type conversion because the high-level ops like `linalg.matvec` are
+  not well-defined on ciphertext-semantic tensors, while their implementation
+  as SIMD/rotation ops are not well-defined on tensor-semantic tensors.
+
+  TODO(#1541): provide example docs
+  }];
+  let dependentDialects = [
+    "mlir::heir::tensor_ext::TensorExtDialect",
+    "mlir::linalg::LinalgDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+
+  // TODO(#4102): reevaluate flag name
+  let options = [
+    Option<
+      "ciphertextSize",
+      "ciphertext-size",
+      "int",
+      /*default=*/"1024",
+      "Power of two length of the ciphertexts the data is packed in."
+    >
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_CONVERTTOCIPHERTEXTSEMANTICS_CONVERTTOCIPHERTEXTSEMANTICS_TD_

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.td
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.td
@@ -83,23 +83,23 @@ def LayoutPropagation : Pass<"layout-propagation"> {
       %cst = arith.constant dense<0> : tensor<32xi16>
       %cst_0 = arith.constant dense<0> : tensor<32xi16>
       %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<32x32xi16>>, !secret.secret<tensor<32x32xi16>>)
-                          attrs = {arg0 = {layout = #map}, arg1 = {layout = #map}, layout = [#map1]} {
+                          attrs = {arg0 = {tensor_ext.layout = #map}, arg1 = {tensor_ext.layout = #map}, layout = [#map1]} {
       ^body(%input0: tensor<32x32xi16>, %input1: tensor<32x32xi16>):
-        %1 = tensor_ext.assign_layout %cst {layout = #map1} : tensor<32xi16>
+        %1 = tensor_ext.assign_layout %cst {tensor_ext.layout = #map1} : tensor<32xi16>
         %reduced = linalg.reduce { arith.addi {overflowFlags = #arith.overflow<none>} }
                     ins(%input0 : tensor<32x32xi16>)
                     outs(%1 : tensor<32xi16>)
-                    dimensions = [0]  {layout = [#map1]}
+                    dimensions = [0]  {tensor_ext.layout = [#map1]}
 
-        %2 = tensor_ext.assign_layout %cst_0 {layout = #map1} : tensor<32xi16>
+        %2 = tensor_ext.assign_layout %cst_0 {tensor_ext.layout = #map1} : tensor<32xi16>
         %3 = tensor_ext.convert_layout %2 {from_layout = #map1, layout = [#map2], to_layout = #map2} : tensor<32xi16>
         %reduced_1 = linalg.reduce { arith.addi {overflowFlags = #arith.overflow<none>} }
                     ins(%input1 : tensor<32x32xi16>)
                     outs(%3 : tensor<32xi16>)
-                    dimensions = [1]  {layout = [#map2]}
+                    dimensions = [1]  {tensor_ext.layout = [#map2]}
 
         %4 = tensor_ext.convert_layout %reduced_1 {from_layout = #map2, layout = [#map1], to_layout = #map1} : tensor<32xi16>
-        %5 = arith.addi %reduced, %4 {layout = [#map1]} : tensor<32xi16>
+        %5 = arith.addi %reduced, %4 {tensor_ext.layout = [#map1]} : tensor<32xi16>
         secret.yield %5 : tensor<32xi16>
       } -> !secret.secret<tensor<32xi16>>
       return %0 : !secret.secret<tensor<32xi16>>

--- a/lib/Utils/AffineMapUtils.cpp
+++ b/lib/Utils/AffineMapUtils.cpp
@@ -8,6 +8,7 @@
 #include "mlir/include/mlir/IR/AffineMap.h"          // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"       // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"          // from @llvm-project
 
 namespace mlir {
@@ -52,6 +53,28 @@ bool isPermutation(ArrayRef<int64_t> materializedMapping) {
     if (!seen.insert(i).second) return false;
   }
   return true;
+}
+
+inline Attribute getIndexAttr(MLIRContext *ctx, int64_t value) {
+  return IntegerAttr::get(IndexType::get(ctx), value);
+}
+
+void evaluateStatic(AffineMap map, ArrayRef<int64_t> values,
+                    SmallVector<int64_t> &results) {
+  MLIRContext *context = map.getContext();
+  SmallVector<Attribute> mapInputs = llvm::map_to_vector(
+      values, [&](int64_t i) { return getIndexAttr(context, i); });
+
+  // Evaluate the affine map on the inputs
+  SmallVector<Attribute> foldResults;
+  if (failed(map.constantFold(mapInputs, foldResults))) {
+    assert(false && "constant folding should never fail here");
+  }
+
+  results.reserve(foldResults.size());
+  for (Attribute attr : foldResults) {
+    results.push_back(cast<IntegerAttr>(attr).getInt());
+  }
 }
 
 }  // namespace heir

--- a/lib/Utils/AffineMapUtils.h
+++ b/lib/Utils/AffineMapUtils.h
@@ -46,6 +46,10 @@ template void printPermutation(::llvm::ArrayRef<int64_t>,
                                ::llvm::raw_ostream &);
 template void printPermutation(::llvm::ArrayRef<int64_t>, ::mlir::Diagnostic &);
 
+// Evaluate an affine map on statically known inputs and populate `results`.
+void evaluateStatic(AffineMap map, ArrayRef<int64_t> values,
+                    SmallVector<int64_t> &results);
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/lib/Utils/ContextAwareConversionUtils.h
+++ b/lib/Utils/ContextAwareConversionUtils.h
@@ -45,10 +45,10 @@ template <typename T = void>
 struct ConvertAnyContextAware : public ContextAwareConversionPattern {
   ConvertAnyContextAware(
       const ContextAwareTypeConverter &anyContextAwareTypeConverter,
-      MLIRContext *context)
+      MLIRContext *context, int benefit = 1)
       : ContextAwareConversionPattern(anyContextAwareTypeConverter,
                                       RewritePattern::MatchAnyOpTypeTag(),
-                                      /*benefit=*/1, context) {
+                                      benefit, context) {
     setDebugName("ConvertAnyContextAware");
     setHasBoundedRewriteRecursion(true);
   }
@@ -84,10 +84,10 @@ template <>
 struct ConvertAnyContextAware<void> : public ContextAwareConversionPattern {
   ConvertAnyContextAware<void>(
       const ContextAwareTypeConverter &anyContextAwareTypeConverter,
-      MLIRContext *context)
+      MLIRContext *context, int benefit = 1)
       : ContextAwareConversionPattern(anyContextAwareTypeConverter,
                                       RewritePattern::MatchAnyOpTypeTag(),
-                                      /*benefit=*/1, context) {
+                                      benefit, context) {
     setDebugName("ConvertAnyContextAware");
     setHasBoundedRewriteRecursion(true);
   }

--- a/lib/Utils/Utils.cpp
+++ b/lib/Utils/Utils.cpp
@@ -69,5 +69,62 @@ bool containsArgumentOfType(Operation *op, TypePredicate predicate) {
   });
 }
 
+void iterateIndices(ArrayRef<int64_t> shape, const IndexTupleConsumer &process,
+                    ArrayRef<int64_t> fixedIndices,
+                    ArrayRef<int64_t> fixedIndexValues) {
+  if (shape.empty()) return;
+  assert(fixedIndices.size() == fixedIndexValues.size() &&
+         "size mismatch on fixed indices");
+  for (size_t i = 0; i < fixedIndices.size(); ++i) {
+    assert(fixedIndices[i] >= 0 ||
+           fixedIndices[i] < static_cast<int64_t>(shape.size()) &&
+               "Fixed index is out of range");
+    assert(fixedIndexValues[i] >= 0 ||
+           fixedIndexValues[i] < shape[fixedIndices[i]] &&
+               "Fixed index value is out of range");
+  }
+
+  std::map<int64_t, int64_t> fixedIndexToValue;
+  for (size_t i = 0; i < fixedIndices.size(); ++i) {
+    fixedIndexToValue[fixedIndices[i]] = fixedIndexValues[i];
+  }
+
+  auto isFixed = [&fixedIndexToValue](int64_t idx) -> bool {
+    return fixedIndexToValue.count(idx) > 0;
+  };
+
+  std::vector<int64_t> indices(shape.size(), 0);
+  // Pre-populate with fixed indices
+  for (size_t i = 0; i < fixedIndices.size(); ++i) {
+    indices[fixedIndices[i]] = fixedIndexValues[i];
+  }
+
+  bool done = false;
+
+  while (!done) {
+    // Process current indices
+    process(indices);
+
+    int dim = shape.size() - 1;
+    while (dim >= 0) {
+      if (!isFixed(dim)) {
+        indices[dim]++;
+        if (indices[dim] < shape[dim]) {
+          // No carry needed
+          break;
+        }
+        // Reset this digit and move to the next
+        indices[dim] = 0;
+      }
+      dim--;
+    }
+
+    // If we've decremented past the first dimension, we're done
+    if (dim < 0) {
+      done = true;
+    }
+  }
+}
+
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Utils/Utils.h
+++ b/lib/Utils/Utils.h
@@ -23,6 +23,8 @@ typedef std::function<bool(const Type &)> TypePredicate;
 
 typedef std::function<bool(Dialect *)> DialectPredicate;
 
+using IndexTupleConsumer = std::function<void(const std::vector<int64_t> &)>;
+
 template <typename... OpTys>
 OpPredicate OpEqual() {
   return [](Operation *op) { return mlir::isa<OpTys...>(op); };
@@ -101,6 +103,21 @@ template <typename... TypeTys>
 bool containsArgumentOfType(Operation *op) {
   return containsArgumentOfType(op, TypeEqual<TypeTys...>());
 }
+
+// A helper to iterate over the space of indices of a multidimensional tensor
+// whose shape is given by `shape`, passing each index tuple visited to
+// `process`.
+//
+// If fixedIndices and fixedIndexValues are nonempty, iterate over the
+// remaining indices and always populate the index tuple provided to
+// `process` with these fixed index values.
+//
+// E.g., if shape is {2, 3, 4}, fixedIndices is {1}, and fixedIndexValues is
+// {2}, then this will iterate over the first and third dimensions in the usual
+// order, but dimension 1 will always be 2.
+void iterateIndices(ArrayRef<int64_t> shape, const IndexTupleConsumer &process,
+                    ArrayRef<int64_t> fixedIndices = {},
+                    ArrayRef<int64_t> fixedIndexValues = {});
 
 }  // namespace heir
 }  // namespace mlir

--- a/tests/Transforms/convert_to_ciphertext_semantics/BUILD
+++ b/tests/Transforms/convert_to_ciphertext_semantics/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/convert_to_ciphertext_semantics/convert_to_ciphertext_semantics.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/convert_to_ciphertext_semantics.mlir
@@ -1,0 +1,22 @@
+// RUN: heir-opt %s --convert-to-ciphertext-semantics | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0 * 32 + d1)>
+
+// CHECK-LABEL: @convert_minimal_example(
+// CHECK-SAME: [[arg0:%[^:]*]]: !secret.secret<tensor<1024xi16>>
+// CHECK-SAME: {tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<32x32xi16>>, layout = (d0, d1) -> (d0 * 32 + d1)>
+// CHECK-SAME: -> (!secret.secret<tensor<1024xi16>> {tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<32x32xi16>>, layout = (d0, d1) -> (d0 * 32 + d1)>})
+func.func @convert_minimal_example(
+    %arg0: !secret.secret<tensor<32x32xi16>> {tensor_ext.layout = affine_map<(d0, d1) -> (d0 * 32 + d1)>}) ->
+       (!secret.secret<tensor<32x32xi16>> {tensor_ext.layout = affine_map<(d0, d1) -> (d0 * 32 + d1)>}) {
+  %0 = secret.generic ins(%arg0 : !secret.secret<tensor<32x32xi16>>)
+                      attrs = {
+                        __argattrs=[{tensor_ext.layout = #map}],
+                        __resattrs=[{tensor_ext.layout = #map}]
+                      } {
+  ^body(%input0: tensor<32x32xi16>):
+    %1 = arith.addi %input0, %input0 {tensor_ext.layout = [#map]} : tensor<32x32xi16>
+    secret.yield %1 : tensor<32x32xi16>
+  } -> !secret.secret<tensor<32x32xi16>>
+  return %0 : !secret.secret<tensor<32x32xi16>>
+}

--- a/tests/Transforms/convert_to_ciphertext_semantics/linalg_reduce.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/linalg_reduce.mlir
@@ -1,0 +1,123 @@
+// RUN: heir-opt %s --convert-to-ciphertext-semantics=ciphertext-size=16 | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+#map1 = affine_map<(d0) -> (d0)>
+#map2 = affine_map<(d0) -> (d0 * 4)>
+
+// CHECK-LABEL: @convert_linalg_reduce
+// CHECK-SAME: [[arg0:%[^:]*]]: [[materialized_ty:!secret.secret<tensor<16xi16>>]]
+// CHECK-SAME: tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<4x4xi16>>, layout = (d0, d1) -> (d0 * 4 + d1)>}
+// CHECK-SAME: [[arg1:%[^:]*]]: [[materialized_ty]]
+// CHECK-SAME: tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<4x4xi16>>, layout = (d0, d1) -> (d0 * 4 + d1)>
+// CHECK-SAME: -> ([[materialized_ty]] {tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<4xi16>>, layout = (d0) -> (d0)>})
+func.func @convert_linalg_reduce(
+    %arg0: !secret.secret<tensor<4x4xi16>> {tensor_ext.layout = affine_map<(d0, d1) -> (d0 * 4 + d1)>},
+    %arg1: !secret.secret<tensor<4x4xi16>> {tensor_ext.layout = affine_map<(d0, d1) -> (d0 * 4 + d1)>}) ->
+       (!secret.secret<tensor<4xi16>> {tensor_ext.layout = affine_map<(d0) -> (d0)>}) {
+  // CHECK: [[cst:%[^ ]+]] = arith.constant dense<0> : tensor<4xi16>
+  %cst = arith.constant dense<0> : tensor<4xi16>
+
+  // lifted the first tensor_ext.assign_layout
+  // CHECK: [[encoded_cst1:%[^ ]+]] = secret.generic {
+  // CHECK-NEXT: tensor.empty() : tensor<16xi16>
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [0] [4] [1]
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [4] [4] [1]
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [8] [4] [1]
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [12] [4] [1]
+  // CHECK-NEXT: secret.yield
+
+  // lifted the second tensor_ext.assign_layout
+  // CHECK: [[encoded_cst2:%[^ ]+]] = secret.generic {
+  // CHECK-NEXT: tensor.empty() : tensor<16xi16>
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [0] [4] [1]
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [4] [4] [1]
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [8] [4] [1]
+  // CHECK-NEXT: tensor.insert_slice [[cst]] into
+  // CHECK-SAME: [12] [4] [1]
+  // CHECK-NEXT: secret.yield
+
+  // CHECK: secret.generic ins(
+  // CHECK-SAME: [[arg0]], [[arg1]], [[encoded_cst1]], [[encoded_cst2]]
+  // CHECK-NEXT: ^body(
+  // CHECK-SAME: [[pt_arg0:%[^ ]*]]:
+  // CHECK-SAME: [[pt_arg1:%[^ ]*]]:
+  // CHECK-SAME: [[pt_cst1:%[^ ]*]]:
+  // CHECK-SAME: [[pt_cst2:%[^ ]*]]:
+  %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<4x4xi16>>, !secret.secret<tensor<4x4xi16>>)
+                      attrs = {
+                        __argattrs = [{tensor_ext.layout = #map}, {tensor_ext.layout = #map}],
+                        __resattrs = [{tensor_ext.layout = #map1}]
+                      } {
+  ^body(%input0: tensor<4x4xi16>, %input1: tensor<4x4xi16>):
+    %1 = tensor_ext.assign_layout %cst {layout = #map1, tensor_ext.layout = [#map1]} : tensor<4xi16>
+
+    // First reduction
+    // CHECK:  [[rotate1:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]>
+    // CHECK:  [[sum1:%[^ ]*]] = arith.addi [[pt_cst1]], [[rotate1]]
+    // CHECK:  [[rotate2:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]>
+    // CHECK:  [[sum2:%[^ ]*]] = arith.addi [[sum1]], [[rotate2]] : tensor<16xi16>
+    // CHECK:  [[rotate3:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]>
+    // CHECK:  [[sum3:%[^ ]*]] = arith.addi [[sum2]], [[rotate3]] : tensor<16xi16>
+    // CHECK:  [[rotate4:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3]>
+    // CHECK:  [[sum4:%[^ ]*]] = arith.addi [[sum3]], [[rotate4]] : tensor<16xi16>
+    %reduced = linalg.reduce { arith.addi {overflowFlags = #arith.overflow<none>} }
+      ins(%input0 : tensor<4x4xi16>)
+      outs(%1 : tensor<4xi16>)
+      dimensions = [0]  {tensor_ext.layout = [#map1]}
+
+    %2 = tensor_ext.assign_layout %cst {layout = #map1, tensor_ext.layout = [#map1]} : tensor<4xi16>
+    // CHECK:  [[converted1:%[^ ]*]] = tensor_ext.permute [[pt_cst2]] {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]>
+    %3 = tensor_ext.convert_layout %2 {from_layout = #map1, tensor_ext.layout = [#map2], to_layout = #map2} : tensor<4xi16>
+
+    // second reduction
+    // CHECK:  [[rotate1_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]>
+    // CHECK:  [[sum1_2:%[^ ]*]] = arith.addi [[converted1]], [[rotate1_2]]
+    // CHECK:  [[rotate2_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]>
+    // CHECK:  [[sum2_2:%[^ ]*]] = arith.addi [[sum1_2]], [[rotate2_2]] : tensor<16xi16>
+    // CHECK:  [[rotate3_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]>
+    // CHECK:  [[sum3_2:%[^ ]*]] = arith.addi [[sum2_2]], [[rotate3_2]] : tensor<16xi16>
+    // CHECK:  [[rotate4_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]>
+    // CHECK:  [[sum4_2:%[^ ]*]] = arith.addi [[sum3_2]], [[rotate4_2]] : tensor<16xi16>
+    %reduced_1 = linalg.reduce { arith.addi {overflowFlags = #arith.overflow<none>} }
+      ins(%input1 : tensor<4x4xi16>)
+      outs(%3 : tensor<4xi16>)
+      dimensions = [1]  {tensor_ext.layout = [#map2]}
+
+    // CHECK: [[converted2:%[^ ]*]] = tensor_ext.permute [[sum4_2]] {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]>
+    %4 = tensor_ext.convert_layout %reduced_1 {from_layout = #map2, tensor_ext.layout = [#map1], to_layout = #map1} : tensor<4xi16>
+    // CHECK: arith.addi [[sum4]], [[converted2]]
+    %5 = arith.addi %reduced, %4 {tensor_ext.layout = [#map1]} : tensor<4xi16>
+    secret.yield %5 : tensor<4xi16>
+  } -> !secret.secret<tensor<4xi16>>
+  return %0 : !secret.secret<tensor<4xi16>>
+}
+
+func.func @reduce_mulop(
+    %arg0: !secret.secret<tensor<4x4xi16>> {tensor_ext.layout = affine_map<(d0, d1) -> (d0 * 4 + d1)>}) ->
+       (!secret.secret<tensor<4xi16>> {tensor_ext.layout = affine_map<(d0) -> (d0)>}) {
+  %cst = arith.constant dense<0> : tensor<4xi16>
+  %0 = secret.generic ins(%arg0 : !secret.secret<tensor<4x4xi16>>)
+                      attrs = {
+                        __argattrs = [{tensor_ext.layout = #map}],
+                        __resattrs = [{tensor_ext.layout = #map1}]
+                      } {
+  ^body(%input0: tensor<4x4xi16>):
+    %1 = tensor_ext.assign_layout %cst {layout = #map1, tensor_ext.layout = [#map1]} : tensor<4xi16>
+
+    // CHECK-COUNT-4: arith.muli
+    %reduced = linalg.reduce { arith.muli }
+      ins(%input0 : tensor<4x4xi16>)
+      outs(%1 : tensor<4xi16>)
+      dimensions = [0]  {tensor_ext.layout = [#map1]}
+
+    secret.yield %reduced : tensor<4xi16>
+  } -> !secret.secret<tensor<4xi16>>
+  return %0 : !secret.secret<tensor<4xi16>>
+}

--- a/tests/Transforms/layout_propagation/insert_conversion.mlir
+++ b/tests/Transforms/layout_propagation/insert_conversion.mlir
@@ -24,23 +24,25 @@ func.func @insert_conversion(%arg0: !stensor, %arg1: !stensor) -> !stensor2 {
   // CHECK: secret.generic
   // CHECK-SAME: ins(%[[arg0]], %[[arg1]]
   // CHECK-SAME: attrs = {__argattrs = [
-  // CHECK-SAME {layout = [[input_map]]},
-  // CHECK-SAME {layout = [[input_map]]}],
+  // CHECK-SAME {tensor_ext.layout = [[input_map]]},
+  // CHECK-SAME {tensor_ext.layout = [[input_map]]}],
   // Note this one denotes the layout of the result of the generic op
-  // CHECK-SAME: layout = [
+  // CHECK-SAME: tensor_ext.layout = [
   // CHECK-SAME: [[row_reduced_map]]
   %0 = secret.generic ins(%arg0, %arg1: !stensor, !stensor) {
   ^body(%pt_arg0: !tensor, %pt_arg1: !tensor):
-    // CHECK: tensor_ext.assign_layout [[init0]] {layout = [[row_reduced_map]]}
+    // CHECK: tensor_ext.assign_layout [[init0]] {layout = [[row_reduced_map]], tensor_ext.layout = [[row_reduced_map]]}
 
     // result of sum has row-major layout, i.e., with implicit repetition at the end
     // (1, 2, ..., 32, 1, 2, ..., 32, ...)
     // CHECK: [[unconverted:[^ ]+]] = linalg.reduce
-    // CHECK-SAME: {layout = [[[row_reduced_map]]]}
+    // CHECK-SAME: {tensor_ext.layout = [
+    // CHECK-SAM: [[row_reduced_map]]]}
     %1 = linalg.reduce { arith.addi } ins(%pt_arg0:!tensor) outs(%out_1:!tensor2) dimensions = [0]
 
     // CHECK: tensor_ext.assign_layout [[init1]]
     // CHECK-sAME: layout = [[row_reduced_map]]
+    // CHECK-sAME: tensor_ext.layout = [[row_reduced_map]]
     // CHECK: tensor_ext.convert_layout
     // CHECK-SAME: from_layout = [[row_reduced_map]]
     // CHECK-SAME: to_layout = [[col_reduced_map]]
@@ -49,12 +51,12 @@ func.func @insert_conversion(%arg0: !stensor, %arg1: !stensor) -> !stensor2 {
     // (1, x, ..., x, 2, x, ..., x, 3, x, ..., x, ...)
     // At this stage, layout inference would annotate this with #strided attr
     // CHECK: [[to_convert:%.+]] = linalg.reduce
-    // CHECK-SAME: {layout = [[[col_reduced_map]]]}
+    // CHECK-SAME: {tensor_ext.layout = [[[col_reduced_map]]]}
     %2 = linalg.reduce { arith.addi } ins(%pt_arg1:!tensor) outs(%out_2:!tensor2) dimensions = [1]
 
     // CHECK: [[converted:%.+]] = tensor_ext.convert_layout [[to_convert]]
     // CHECK-SAME: from_layout = [[col_reduced_map]]
-    // CHECK-SAME: layout = [
+    // CHECK-SAME: tensor_ext.layout = [
     // CHECK-SAME: [[row_reduced_map]]]
     // CHECK-SAME: to_layout = [[row_reduced_map]]
     // CHECK: arith.addi [[unconverted]], [[converted]]

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -108,6 +108,7 @@ cc_binary(
         "@heir//lib/Transforms/ConvertSecretForToStaticFor",
         "@heir//lib/Transforms/ConvertSecretInsertToStaticInsert",
         "@heir//lib/Transforms/ConvertSecretWhileToStaticFor",
+        "@heir//lib/Transforms/ConvertToCiphertextSemantics",
         "@heir//lib/Transforms/DropUnitDims",
         "@heir//lib/Transforms/ElementwiseToAffine",
         "@heir//lib/Transforms/ForwardInsertToExtract",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -60,6 +60,7 @@
 #include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h"
 #include "lib/Transforms/ConvertSecretInsertToStaticInsert/ConvertSecretInsertToStaticInsert.h"
 #include "lib/Transforms/ConvertSecretWhileToStaticFor/ConvertSecretWhileToStaticFor.h"
+#include "lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.h"
 #include "lib/Transforms/DropUnitDims/DropUnitDims.h"
 #include "lib/Transforms/ElementwiseToAffine/ElementwiseToAffine.h"
 #include "lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.h"
@@ -248,6 +249,7 @@ int main(int argc, char **argv) {
   registerConvertSecretWhileToStaticForPasses();
   registerConvertSecretExtractToStaticExtractPasses();
   registerConvertSecretInsertToStaticInsertPasses();
+  registerConvertToCiphertextSemanticsPasses();
   registerDropUnitDims();
   registerAnnotateSecretnessPasses();
   registerApplyFoldersPasses();


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/521

This pass implements a conversion from "data semantics" to "ciphertext semantics," which jointly does the following:

1. Converts types expressed as data-semantic tensors (just usual data tensors) with layout attributes into "ciphertext semantic" tensors, which are just tensors whose last dimension corresponds to the number of slots in a ciphertext.
2. Lowers `tensor_ext.assign_layout` to implement data replication according to the layout described.
3. Lowers `tensor_ext.convert_layout` to `tensor_ext.permute`, realizing the layout conversion as a concrete permutation on the underlying ciphertexts (which can then be lowered via `implement-shift-networks`
4. Implements linalg kernels formerly in `linalg-to-tensor-ext`.

Example: the following program (`linalg_reduce.mlir` test case in this PR) implements a program that takes two square input tensors, sums one along dimension 0 and the other along dimension 1, and then sums the results:

```mlir
#map = affine_map<(d0, d1) -> (d0 * 4 + d1)>
#map1 = affine_map<(d0) -> (d0)>
#map2 = affine_map<(d0) -> (d0 * 4)>

func.func @convert_linalg_reduce(
    %arg0: !secret.secret<tensor<4x4xi16>> {tensor_ext.layout = #map},
    %arg1: !secret.secret<tensor<4x4xi16>> {tensor_ext.layout = #map}) ->
       (!secret.secret<tensor<4xi16>> {tensor_ext.layout = #map1}) {
  %cst = arith.constant dense<0> : tensor<4xi16>
  %cst_0 = arith.constant dense<0> : tensor<4xi16>

  %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<4x4xi16>>, !secret.secret<tensor<4x4xi16>>)
                      attrs = {
                        __argattrs = [{tensor_ext.layout = #map}, {tensor_ext.layout = #map}],
                        __resattrs = [{tensor_ext.layout = #map1}]
                      } {
  ^body(%input0: tensor<4x4xi16>, %input1: tensor<4x4xi16>):
    %1 = tensor_ext.assign_layout %cst {layout = #map1, tensor_ext.layout = [#map1]} : tensor<4xi16>

    %reduced = linalg.reduce { arith.addi }
      ins(%input0 : tensor<4x4xi16>)
      outs(%1 : tensor<4xi16>)
      dimensions = [0]  {tensor_ext.layout = [#map1]}

    %2 = tensor_ext.assign_layout %cst_0 {layout = #map1, tensor_ext.layout = [#map1]} : tensor<4xi16>
    %3 = tensor_ext.convert_layout %2 {from_layout = #map1, tensor_ext.layout = [#map2], to_layout = #map2} : tensor<4xi16>

    %reduced_1 = linalg.reduce { arith.addi }
      ins(%input1 : tensor<4x4xi16>)
      outs(%3 : tensor<4xi16>)
      dimensions = [1]  {tensor_ext.layout = [#map2]}

    %4 = tensor_ext.convert_layout %reduced_1 {from_layout = #map2, tensor_ext.layout = [#map1], to_layout = #map1} : tensor<4xi16>
    %5 = arith.addi %reduced, %4 {tensor_ext.layout = [#map1]} : tensor<4xi16>
    secret.yield %5 : tensor<4xi16>
  } -> !secret.secret<tensor<4xi16>>
  return %0 : !secret.secret<tensor<4xi16>>
}
```

This is lowered by `--convert-to-ciphertext-semantics=ciphertext-size=16` to

```mlir
func.func @convert_linalg_reduce(
    %arg0: !secret.secret<tensor<16xi16>> {
         tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<4x4xi16>>, layout = (d0, d1) -> (d0 * 4 + d1)>}, 
    %arg1: !secret.secret<tensor<16xi16>> {
          tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<4x4xi16>>, layout = (d0, d1) -> (d0 * 4 + d1)>}
) -> (!secret.secret<tensor<16xi16>> {
     tensor_ext.original_type = #tensor_ext.original_type<originalType = !secret.secret<tensor<4xi16>>, layout = (d0) -> (d0)>}) attributes {tensor_ext.layout_materialized} {
  %cst = arith.constant dense<0> : tensor<4xi16>
  %cst_0 = arith.constant dense<0> : tensor<4xi16>
  %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<16xi16>>, !secret.secret<tensor<16xi16>>) {
  ^body(%input0: tensor<16xi16>, %input1: tensor<16xi16>):
    // encode the constant initializer to the first linalg.reduce as a ciphertext
    %1 = tensor.empty() : tensor<16xi16>
    %inserted_slice = tensor.insert_slice %cst into %1[0] [4] [1] : tensor<4xi16> into tensor<16xi16>
    %inserted_slice_1 = tensor.insert_slice %cst into %inserted_slice[4] [4] [1] : tensor<4xi16> into tensor<16xi16>
    %inserted_slice_2 = tensor.insert_slice %cst into %inserted_slice_1[8] [4] [1] : tensor<4xi16> into tensor<16xi16>
    %inserted_slice_3 = tensor.insert_slice %cst into %inserted_slice_2[12] [4] [1] : tensor<4xi16> into tensor<16xi16>

    // the rotate-and-reduce kernel for the first linalg.reduce
    %2 = tensor_ext.permute %input0 {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : tensor<16xi64>} : tensor<16xi16>
    %3 = arith.addi %inserted_slice_3, %2 : tensor<16xi16>
    %4 = tensor_ext.permute %input0 {permutation = dense<[12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]> : tensor<16xi64>} : tensor<16xi16>
    %5 = arith.addi %3, %4 : tensor<16xi16>
    %6 = tensor_ext.permute %input0 {permutation = dense<[8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]> : tensor<16xi64>} : tensor<16xi16>
    %7 = arith.addi %5, %6 : tensor<16xi16>
    %8 = tensor_ext.permute %input0 {permutation = dense<[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3]> : tensor<16xi64>} : tensor<16xi16>
    %9 = arith.addi %7, %8 : tensor<16xi16>

    // encode the constant initializer to the second linalg.reduce
    %10 = tensor.empty() : tensor<16xi16>
    %inserted_slice_4 = tensor.insert_slice %cst_0 into %10[0] [4] [1] : tensor<4xi16> into tensor<16xi16>
    %inserted_slice_5 = tensor.insert_slice %cst_0 into %inserted_slice_4[4] [4] [1] : tensor<4xi16> into tensor<16xi16>
    %inserted_slice_6 = tensor.insert_slice %cst_0 into %inserted_slice_5[8] [4] [1] : tensor<4xi16> into tensor<16xi16>
    %inserted_slice_7 = tensor.insert_slice %cst_0 into %inserted_slice_6[12] [4] [1] : tensor<4xi16> into tensor<16xi16>

    // the rotate-and-reduce kernel for the second linalg.reduce
    %11 = tensor_ext.permute %inserted_slice_7 {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]> : tensor<16xi64>} : tensor<16xi16>
    %12 = tensor_ext.permute %input1 {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : tensor<16xi64>} : tensor<16xi16>
    %13 = arith.addi %11, %12 : tensor<16xi16>
    %14 = tensor_ext.permute %input1 {permutation = dense<[15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]> : tensor<16xi64>} : tensor<16xi16>
    %15 = arith.addi %13, %14 : tensor<16xi16>
    %16 = tensor_ext.permute %input1 {permutation = dense<[14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]> : tensor<16xi64>} : tensor<16xi16>
    %17 = arith.addi %15, %16 : tensor<16xi16>
    %18 = tensor_ext.permute %input1 {permutation = dense<[13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]> : tensor<16xi64>} : tensor<16xi16>
    %19 = arith.addi %17, %18 : tensor<16xi16>

    // the layout conversion to make the two reduction outputs align
    %20 = tensor_ext.permute %19 {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]> : tensor<16xi64>} : tensor<16xi16>

    // sum the two reductions
    %21 = arith.addi %9, %20 : tensor<16xi16>
    secret.yield %21 : tensor<16xi16>
  } -> !secret.secret<tensor<16xi16>>
  return %0 : !secret.secret<tensor<16xi16>>
}
```