### PR TITLE
Preserve attribute during secret.generic lowering

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -124,8 +124,9 @@ struct ConvertFuncCallOp : public OpConversionPattern<func::CallOp> {
       newOperands.push_back(operand);
     }
 
-    rewriter.replaceOpWithNewOp<func::CallOp>(op, callee, resultTypes,
-                                              newOperands);
+    rewriter
+        .replaceOpWithNewOp<func::CallOp>(op, callee, resultTypes, newOperands)
+        ->setDialectAttrs(op->getDialectAttrs());
     return success();
   }
 };
@@ -286,7 +287,41 @@ struct ConvertBootstrapOp : public OpConversionPattern<ckks::BootstrapOp> {
 }  // namespace
 
 struct LWEToOpenfhe : public impl::LWEToOpenfheBase<LWEToOpenfhe> {
+  // See https://github.com/llvm/llvm-project/pull/127772
+  // During dialect conversion, the attribute of the func::CallOp is not
+  // preserved. We save the dialect attributes of func::CallOp before
+  // conversion and restore them after conversion.
+  //
+  // Note that this is not safe as after conversion the order of func::CallOp
+  // may change. However, this is the best we can do for now as we do not have
+  // a map from the old func::CallOp to the new func::CallOp.
+  SmallVector<SmallVector<NamedAttribute>> funcCallOpDialectAttrs;
+
+  void saveFuncCallOpDialectAttrs() {
+    funcCallOpDialectAttrs.clear();
+    auto *module = getOperation();
+    module->walk([&](func::CallOp callOp) {
+      SmallVector<NamedAttribute> dialectAttrs;
+      for (auto namedAttr : callOp->getDialectAttrs()) {
+        dialectAttrs.push_back(namedAttr);
+      }
+      funcCallOpDialectAttrs.push_back(dialectAttrs);
+    });
+  }
+
+  void restoreFuncCallOpDialectAttrs() {
+    auto *module = getOperation();
+    auto *funcCallOpDialectAttrsIter = funcCallOpDialectAttrs.begin();
+    module->walk([&](func::CallOp callOp) {
+      callOp->setDialectAttrs(*funcCallOpDialectAttrsIter);
+      ++funcCallOpDialectAttrsIter;
+    });
+  }
+
   void runOnOperation() override {
+    // Save the dialect attributes of func::CallOp before conversion.
+    saveFuncCallOpDialectAttrs();
+
     MLIRContext *context = &getContext();
     auto *module = getOperation();
     ToOpenfheTypeConverter typeConverter(context);
@@ -388,6 +423,9 @@ struct LWEToOpenfhe : public impl::LWEToOpenfheBase<LWEToOpenfhe> {
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       return signalPassFailure();
     }
+
+    // Restore the dialect attributes of func::CallOp after conversion.
+    restoreFuncCallOpDialectAttrs();
   }
 };
 

--- a/lib/Dialect/Secret/IR/SecretOps.td
+++ b/lib/Dialect/Secret/IR/SecretOps.td
@@ -258,6 +258,13 @@ def Secret_GenericOp : Secret_Op<"generic", [
       return argDict ? argDict.get(name) : nullptr;
     }
 
+    /// Return all of the attributes for the argument at 'index'.
+    ::llvm::ArrayRef<::mlir::NamedAttribute> getArgAttrs(unsigned index) {
+      std::string argName = "arg" + std::to_string(index);
+      auto argDict = this->getOperation()->getAttrOfType<DictionaryAttr>(argName);
+      return argDict ? argDict.getValue() : std::nullopt;
+    }
+
     /// If the an attribute exists with the specified name, change it to the new
     /// value. Otherwise, add a new attribute with the specified name/value.
     void setArgAttr(unsigned index, StringRef name, Attribute value) {
@@ -278,6 +285,12 @@ def Secret_GenericOp : Secret_Op<"generic", [
       }));
 
       this->getOperation()->setAttr(argName, DictionaryAttr::get(getContext(), newAttrs));
+    }
+
+    /// Set the attributes held by the argument at 'index'.
+    void setArgAttrs(unsigned index, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes) {
+      std::string argName = "arg" + std::to_string(index);
+      this->getOperation()->setAttr(argName, DictionaryAttr::get(getContext(), attributes));
     }
 
     // remove the specified attribute, if present, for the argument at 'index',
@@ -304,6 +317,12 @@ def Secret_GenericOp : Secret_Op<"generic", [
         this->getOperation()->setAttr(argName, DictionaryAttr::get(getContext(), newAttrs));
       }
       return attr;
+    }
+
+    /// Remove the attributes held by the argument at 'index'.
+    void removeArgAttrs(unsigned index) {
+      std::string argName = "arg" + std::to_string(index);
+      this->getOperation()->removeAttr(argName);
     }
 
     //===------------------------------------------------------------------===//

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -234,7 +234,7 @@ LogicalResult OpenFhePkeEmitter::printOperation(func::CallOp op) {
          << "\"] = \"";
       // Use AsmPrinter to print Attribute
       if (mlir::isa<StringAttr>(attr.getValue())) {
-        os << mlir::cast<StringAttr>(attr.getValue()).getValue() << "\"\n";
+        os << mlir::cast<StringAttr>(attr.getValue()).getValue() << "\";\n";
       } else {
         os << attr.getValue() << "\";\n";
       }

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/preserve_attr.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/preserve_attr.mlir
@@ -1,0 +1,25 @@
+// RUN: heir-opt --lwe-to-lattigo %s | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+!skey_L1_ = !lwe.new_lwe_secret_key<key = #key, ring = #ring_rns_L1_1_x1024_>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = <ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+module attributes {scheme.bgv} {
+  func.func private @__heir_debug_0(!skey_L1_, !ct_L1_)
+  func.func @test_ops(%sk: !skey_L1_, %ct: !ct_L1_, %ct_0: !ct_L1_) {
+    %ct_1 = lwe.radd %ct, %ct_0 : (!ct_L1_, !ct_L1_) -> !ct_L1_
+    // CHECK: call
+    // CHECK-SAME: {message.size = "1"}
+    call @__heir_debug_0(%sk, %ct_1) {message.size = "1"} : (!skey_L1_, !ct_L1_) -> ()
+    return
+  }
+}

--- a/tests/Dialect/LWE/Conversions/lwe_to_openfhe/BUILD
+++ b/tests/Dialect/LWE/Conversions/lwe_to_openfhe/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/LWE/Conversions/lwe_to_openfhe/preserve_attr.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_openfhe/preserve_attr.mlir
@@ -1,0 +1,25 @@
+// RUN: heir-opt --lwe-to-openfhe %s | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+!skey_L1_ = !lwe.new_lwe_secret_key<key = #key, ring = #ring_rns_L1_1_x1024_>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = <ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+module attributes {scheme.bgv} {
+  func.func private @__heir_debug_0(!skey_L1_, !ct_L1_)
+  func.func @test_ops(%sk: !skey_L1_, %ct: !ct_L1_, %ct_0: !ct_L1_) {
+    %ct_1 = lwe.radd %ct, %ct_0 : (!ct_L1_, !ct_L1_) -> !ct_L1_
+    // CHECK: call
+    // CHECK-SAME: {message.size = "1"}
+    call @__heir_debug_0(%sk, %ct_1) {message.size = "1"} : (!skey_L1_, !ct_L1_) -> ()
+    return
+  }
+}

--- a/tests/Dialect/LWE/Transforms/add_debug_port_message_size_attr.mlir
+++ b/tests/Dialect/LWE/Transforms/add_debug_port_message_size_attr.mlir
@@ -1,0 +1,23 @@
+// RUN: heir-opt --lwe-add-debug-port %s | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = <ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+module attributes {scheme.bgv} {
+  func.func @test_ops(%ct: !ct_L1_, %ct_0: !ct_L1_) {
+    // CHECK: lwe.radd
+    %ct_1 = lwe.radd %ct, %ct_0 : (!ct_L1_, !ct_L1_) -> !ct_L1_
+    // CHECK: call @__heir_debug
+    // CHECK-SAME: {message.size = "1"}
+    return
+  }
+}

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/preserve_attr.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/preserve_attr.mlir
@@ -1,0 +1,18 @@
+// RUN: heir-opt --secret-to-bgv %s | FileCheck %s
+
+!eui1 = !secret.secret<tensor<1024xi1>>
+#mgmt = #mgmt.mgmt<level = 0, dimension = 2>
+#mgmt1 = #mgmt.mgmt<level = 0, dimension = 3>
+
+module {
+  // CHECK-LABEL: func @test_preserve_attr
+  func.func @test_preserve_attr(%arg0 : !eui1 {mgmt.mgmt = #mgmt}, %arg1 : !eui1 {mgmt.mgmt = #mgmt}, %arg2 : !eui1 {mgmt.mgmt = #mgmt}) -> (!eui1) {
+    %0 = secret.generic ins(%arg0, %arg1 :  !eui1, !eui1) attrs = {mgmt.mgmt = #mgmt} {
+    // CHECK: {dialect.attr = 1 : i64}
+      ^bb0(%ARG0 : tensor<1024xi1>, %ARG1 : tensor<1024xi1>):
+        %1 = arith.addi %ARG0, %ARG1 {dialect.attr = 1} : tensor<1024xi1>
+        secret.yield %1 : tensor<1024xi1>
+    } -> !eui1
+    return %0 : !eui1
+  }
+}

--- a/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_preserve_attr.mlir
+++ b/tests/Dialect/Secret/Transforms/secret_distribute_generic/distribute_generic_preserve_attr.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt --secret-distribute-generic %s | FileCheck %s
+
+// CHECK-LABEL: test_distribute_generic_preserve_attr
+// CHECK-SAME: %[[value:.*]]: !secret.secret<i32> {dialect.attr = 2 : i64}, %[[cond:.*]]: i1) -> !secret.secret<i32> {
+func.func @test_distribute_generic_preserve_attr(%value: !secret.secret<i32>, %cond: i1) -> !secret.secret<i32> {
+  // CHECK-NEXT: %[[g0:.*]] = secret.generic ins(%[[value]] : !secret.secret<i32>) {
+  // CHECK-NEXT: ^[[bb0:.*]](%[[clear_g0_in0:.*]]: i32):
+  // CHECK-NEXT:   %[[g0_op:.*]] = arith.muli %[[clear_g0_in0]], %[[clear_g0_in0]] {dialect.attr = 1 : i64} : i32
+  // CHECK-NEXT:   secret.yield %[[g0_op]] : i32
+  // CHECK-NEXT: } -> !secret.secret<i32>
+
+  // CHECK-NEXT: return %[[g0]] : !secret.secret<i32>
+  %Z = secret.generic
+    ins(%value : !secret.secret<i32>) attrs = {arg0 = {dialect.attr = 2}} {
+    ^bb0(%clear_value: i32):
+      %0 = arith.muli %clear_value, %clear_value {dialect.attr = 1} : i32
+      secret.yield %0 : i32
+    } -> (!secret.secret<i32>)
+  func.return %Z : !secret.secret<i32>
+}

--- a/tests/Examples/lattigo/dot_product_8_debug.go
+++ b/tests/Examples/lattigo/dot_product_8_debug.go
@@ -3,6 +3,7 @@ package dotproduct8debug
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/tuneinsight/lattigo/v6/core/rlwe"
 	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
@@ -18,7 +19,12 @@ func __heir_debug(evaluator *bgv.Evaluator, param bgv.Parameters, encoder *bgv.E
 	}
 
 	// print the decryption result
-	value := make([]int64, 8)
+	messageSizeStr := debugAttrMap["message.size"]
+	messageSize, err := strconv.Atoi(messageSizeStr)
+	if err != nil {
+		panic(err)
+	}
+	value := make([]int64, messageSize)
 	pt := decryptor.DecryptNew(ct)
 	encoder.Decode(pt, value)
 	fmt.Printf("  %v\n", value)

--- a/tests/Examples/openfhe/dot_product_8_debug_test.cpp
+++ b/tests/Examples/openfhe/dot_product_8_debug_test.cpp
@@ -62,7 +62,7 @@ void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct,
 #ifdef DECRYPT
   PlaintextT ptxt;
   cc->Decrypt(sk, ct, &ptxt);
-  ptxt->SetLength(8);
+  ptxt->SetLength(std::stod(debugAttrMap.at("message.size")));
   std::cout << "  " << ptxt << std::endl;
 #endif
 


### PR DESCRIPTION
Fixes #1426 

* `secret-distribute-generic` preserves the dialect attrs from secret.generic op argument to the func.func op argument
* `secret-to-<scheme>` preserves the dialect attrs from secret.generic's inner op to converted op
* `<scheme>-to-lwe` preserves the attribute originally
* `lwe-add-debug-port` will transplant the attr to the CallOp, for debugging purpose, see #1422 
* `lwe-to-<backend>` will preserve the attr in CallOp
  + It will discard attributes for backend ops, so `lwe.add {attr}` will be converted to `backend.add` instead of `backend.add {attr}`
  + Due to MLIR issue, these attributes are lost during type conversion, so there is no test now, should be fixed after https://github.com/llvm/llvm-project/pull/127772 is in
  
Conceptually, this PR suggests that dialect attribute should be preserved and managed by the programmer (of corresponding dialect) while other attribute has no guarantee on how long it will live.