### PR TITLE
Migrate OpAsmDialectInterface to OpAsmAttrInterface

### DIFF
--- a/lib/Dialect/LWE/IR/LWEAttributes.td
+++ b/lib/Dialect/LWE/IR/LWEAttributes.td
@@ -7,6 +7,7 @@ include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/TensorEncoding.td"
+include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "lib/Dialect/LWE/IR/NewLWEAttributes.td"
 
@@ -14,10 +15,19 @@ class LWE_EncodingAttr<string attrName, string attrMnemonic, list<Trait> traits 
     : AttrDef<LWE_Dialect, attrName, traits # [
     // All encoding attributes are required to be compatible with a tensor
     // with an element type relevant to that encoding.
-    DeclareAttrInterfaceMethods<VerifiableTensorEncoding>
+    DeclareAttrInterfaceMethods<VerifiableTensorEncoding>,
+    OpAsmAttrInterface
 ]> {
   let mnemonic = attrMnemonic;
   let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # attrMnemonic # [{";
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 class LWE_EncodingAttrWithScalingFactor<string attrName, string attrMnemonic, list<Trait> traits = []>

--- a/lib/Dialect/LWE/IR/NewLWEAttributes.td
+++ b/lib/Dialect/LWE/IR/NewLWEAttributes.td
@@ -73,9 +73,17 @@ def LWE_ApplicationDataAttr : AttrDef<LWE_Dialect, "ApplicationData"> {
 }
 
 class LWE_EncodingAttrForLWE<string attrName, string attrMnemonic, list<Trait> traits = []>
-    : AttrDef<LWE_Dialect, attrName, traits> {
+    : AttrDef<LWE_Dialect, attrName, traits # [OpAsmAttrInterface]> {
   let mnemonic = attrMnemonic;
   let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # attrMnemonic # [{";
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 class LWE_EncodingAttrWithScalingParam<string attrName, string attrMnemonic, list<Trait> traits = []>
@@ -260,7 +268,7 @@ def LWE_PlaintextSpaceAttr : AttrDef<LWE_Dialect, "PlaintextSpace"> {
   let genVerifyDecl = 1;
 }
 
-def LWE_KeyAttr : AttrDef<LWE_Dialect, "Key"> {
+def LWE_KeyAttr : AttrDef<LWE_Dialect, "Key", [OpAsmAttrInterface]> {
   let mnemonic = "key";
   let description = [{
     An attribute describing the key with which the message is currently
@@ -283,6 +291,14 @@ def LWE_KeyAttr : AttrDef<LWE_Dialect, "Key"> {
   );
 
   let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # mnemonic # [{";
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 def LWE_EncryptionTypeEnum : I32EnumAttr<"LweEncryptionType", "An enum attribute representing an encryption method", [
@@ -293,7 +309,7 @@ def LWE_EncryptionTypeEnum : I32EnumAttr<"LweEncryptionType", "An enum attribute
     let cppNamespace = "::mlir::heir::lwe";
 }
 
-def LWE_CiphertextSpaceAttr : AttrDef<LWE_Dialect, "CiphertextSpace"> {
+def LWE_CiphertextSpaceAttr : AttrDef<LWE_Dialect, "CiphertextSpace", [OpAsmAttrInterface]> {
   let mnemonic = "ciphertext_space";
   let description = [{
     An attribute describing the ciphertext space and the transformation from
@@ -352,9 +368,27 @@ def LWE_CiphertextSpaceAttr : AttrDef<LWE_Dialect, "CiphertextSpace"> {
   );
 
   let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // Helper method for other Type/Attribute containing this Attribute.
+    void getAliasSuffix(::llvm::raw_ostream& os) const {
+      getRing().getAliasSuffix(os);
+      auto size = getSize();
+      if (size != 2) {
+        os << "_D" << size;
+      }
+    }
+
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # mnemonic # [{";
+      getAliasSuffix(os);
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
-def LWE_ModulusChainAttr : AttrDef<LWE_Dialect, "ModulusChain"> {
+def LWE_ModulusChainAttr : AttrDef<LWE_Dialect, "ModulusChain", [OpAsmAttrInterface]> {
   let mnemonic = "modulus_chain";
   let description = [{
     An attribute describing the elements of the modulus chain of an RLWE scheme.
@@ -368,6 +402,16 @@ def LWE_ModulusChainAttr : AttrDef<LWE_Dialect, "ModulusChain"> {
   let assemblyFormat = "`<` `elements` `=` `<` $elements `>``,` `current` `=` $current `>`";
 
   // let genVerifyDecl = 1; // Verify index into list
+
+  let extraClassDeclaration = [{
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # mnemonic # [{";
+      os << "_L" << getElements().size() - 1;
+      os << "_C" << getCurrent();
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 #endif  // LIB_DIALECT_LWE_IR_NEWLWEATTRIBUTES_TD_

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -39,24 +39,6 @@ namespace mlir {
 namespace heir {
 namespace mod_arith {
 
-class ModArithOpAsmDialectInterface : public OpAsmDialectInterface {
- public:
-  using OpAsmDialectInterface::OpAsmDialectInterface;
-
-  AliasResult getAlias(Type type, raw_ostream &os) const override {
-    auto res = llvm::TypeSwitch<Type, AliasResult>(type)
-                   .Case<ModArithType>([&](auto &modArithType) {
-                     os << "Z";
-                     os << modArithType.getModulus().getValue();
-                     os << "_";
-                     os << modArithType.getModulus().getType();
-                     return AliasResult::FinalAlias;
-                   })
-                   .Default([&](Type) { return AliasResult::NoAlias; });
-    return res;
-  }
-};
-
 void ModArithDialect::initialize() {
   addTypes<
 #define GET_TYPEDEF_LIST
@@ -70,8 +52,6 @@ void ModArithDialect::initialize() {
 #define GET_OP_LIST
 #include "lib/Dialect/ModArith/IR/ModArithOps.cpp.inc"
       >();
-
-  addInterface<ModArithOpAsmDialectInterface>();
 }
 
 /// Ensures that the underlying integer type is wide enough for the coefficient

--- a/lib/Dialect/ModArith/IR/ModArithTypes.h
+++ b/lib/Dialect/ModArith/IR/ModArithTypes.h
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_MODARITH_IR_MODARITHTYPES_H_
 
 #include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "mlir/include/mlir/IR/OpImplementation.h"  // from @llvm-project
 
 #define GET_TYPEDEF_CLASSES
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h.inc"

--- a/lib/Dialect/ModArith/IR/ModArithTypes.td
+++ b/lib/Dialect/ModArith/IR/ModArithTypes.td
@@ -7,13 +7,14 @@ include "mlir/IR/DialectBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpAsmInterface.td"
 
 class ModArith_Type<string name, string typeMnemonic, list<Trait> traits = []>
     : TypeDef<ModArith_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
 }
 
-def ModArith_ModArithType : ModArith_Type<"ModArith", "int", [MemRefElementTypeInterface]> {
+def ModArith_ModArithType : ModArith_Type<"ModArith", "int", [MemRefElementTypeInterface, OpAsmTypeInterface]> {
   let summary = "Integer type with modular arithmetic";
   let description = [{
     `mod_arith.int<p>` represents an element of the ring of integers modulo $p$.
@@ -50,6 +51,17 @@ def ModArith_ModArithType : ModArith_Type<"ModArith", "int", [MemRefElementTypeI
     "::mlir::IntegerAttr":$modulus
   );
   let assemblyFormat = "`<` $modulus `>`";
+
+  let extraClassDeclaration = [{
+    // OpAsmTypeInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "Z";
+      os << getModulus().getValue();
+      os << "_";
+      os << getModulus().getType();
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 def ModArithLike: TypeOrValueSemanticsContainer<ModArith_ModArithType, "mod_arith-like">;

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
@@ -4,6 +4,7 @@
 include "lib/Dialect/Polynomial/IR/PolynomialDialect.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/OpAsmInterface.td"
 
 class Polynomial_Attr<string name, string attrMnemonic, list<Trait> traits = []>
     : AttrDef<Polynomial_Dialect, name, traits> {
@@ -119,7 +120,7 @@ def Polynomial_TypedFloatPolynomialAttr : Polynomial_Attr<
   }];
 }
 
-def Polynomial_RingAttr : Polynomial_Attr<"Ring", "ring"> {
+def Polynomial_RingAttr : Polynomial_Attr<"Ring", "ring", [OpAsmAttrInterface]> {
   let summary = "an attribute specifying a polynomial ring";
   let description = [{
     A ring describes the domain in which polynomial arithmetic occurs. The ring
@@ -169,6 +170,14 @@ def Polynomial_RingAttr : Polynomial_Attr<"Ring", "ring"> {
         polynomialModulusAttr);
     }]>,
   ];
+
+  let extraClassDeclaration = [{
+    // Helper method for other Type/Attribute containing this Attribute.
+    void getAliasSuffix(::llvm::raw_ostream& os) const;
+
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const;
+  }];
 }
 
 def Polynomial_PrimitiveRootAttr: Polynomial_Attr<"PrimitiveRoot", "primitive_root"> {

--- a/lib/Dialect/Polynomial/IR/PolynomialTypes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialTypes.td
@@ -3,19 +3,28 @@
 
 include "lib/Dialect/Polynomial/IR/PolynomialAttributes.td"
 include "lib/Dialect/Polynomial/IR/PolynomialDialect.td"
+include "mlir/IR/OpAsmInterface.td"
 
-class Polynomial_Type<string name, string typeMnemonic>
-    : TypeDef<Polynomial_Dialect, name> {
+class Polynomial_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<Polynomial_Dialect, name, traits> {
   let mnemonic = typeMnemonic;
 }
 
-def Polynomial_PolynomialType : Polynomial_Type<"Polynomial", "polynomial"> {
+def Polynomial_PolynomialType : Polynomial_Type<"Polynomial", "polynomial", [OpAsmTypeInterface]> {
   let summary = "An element of a polynomial ring.";
   let description = [{
     A type for polynomials in a polynomial quotient ring.
   }];
   let parameters = (ins Polynomial_RingAttr:$ring);
   let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // OpAsmTypeInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "poly";
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 def PolynomialLike: TypeOrValueSemanticsContainer<Polynomial_PolynomialType, "polynomial-like">;

--- a/lib/Dialect/RNS/IR/RNSDialect.cpp
+++ b/lib/Dialect/RNS/IR/RNSDialect.cpp
@@ -23,23 +23,6 @@ namespace mlir {
 namespace heir {
 namespace rns {
 
-struct RNSOpAsmDialectInterface : public OpAsmDialectInterface {
-  using OpAsmDialectInterface::OpAsmDialectInterface;
-
-  AliasResult getAlias(Type type, raw_ostream &os) const override {
-    auto res = llvm::TypeSwitch<Type, AliasResult>(type)
-                   .Case<RNSType>([&](auto &rnsType) {
-                     os << "rns";
-                     auto size = rnsType.getBasisTypes().size();
-                     os << "_L";
-                     os << size - 1;  // start from 0
-                     return AliasResult::FinalAlias;
-                   })
-                   .Default([&](Type) { return AliasResult::NoAlias; });
-    return res;
-  }
-};
-
 void RNSDialect::initialize() {
   addTypes<
 #define GET_TYPEDEF_LIST
@@ -50,8 +33,6 @@ void RNSDialect::initialize() {
 #define GET_OP_LIST
 #include "lib/Dialect/RNS/IR/RNSOps.cpp.inc"
       >();
-
-  addInterface<RNSOpAsmDialectInterface>();
 }
 
 }  // namespace rns

--- a/lib/Dialect/RNS/IR/RNSTypes.td
+++ b/lib/Dialect/RNS/IR/RNSTypes.td
@@ -5,6 +5,7 @@ include "lib/Dialect/RNS/IR/RNSDialect.td"
 include "lib/Dialect/RNS/IR/RNSTypeInterfaces.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpAsmInterface.td"
 
 // A base class for all types in this dialect
 class RNS_Type<string name, string typeMnemonic, list<Trait> traits = []>
@@ -12,7 +13,7 @@ class RNS_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def RNS : RNS_Type<"RNS", "rns"> {
+def RNS : RNS_Type<"RNS", "rns", [OpAsmTypeInterface]> {
   let summary = "A residue number system representation";
   let description = [{
   }];
@@ -20,6 +21,21 @@ def RNS : RNS_Type<"RNS", "rns"> {
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$basisTypes);
   let assemblyFormat = "`<` $basisTypes `>`";
   let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    // Helper method for other Type/Attribute containing this Type.
+    void getAliasSuffix(::llvm::raw_ostream& os) const {
+      auto level = getBasisTypes().size() - 1; // start from 0
+      os << "_L" << level;
+    }
+
+    // OpAsmTypeInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "rns";
+      getAliasSuffix(os);
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
 }
 
 #endif  // LIB_DIALECT_RNS_IR_RNSTYPES_TD_


### PR DESCRIPTION
See #1435 for detailed description

`LWEOpAsmDialectInterface` is still left there for `getAlias(Type)` because #1435 is also changing these types with `getAsmName`, so after that PR is in these could be safely migrated.

Extra note is the `RingAttr::getAliasSuffix`, which as we do not want PolynomialDialect to depend on RNSDialect I placed a hack there. Originally that function is put in LWEDialect so it has access to RNSType.

One step further in another PR is to enable all dialect attribute with OpAsmAttrInterface and use the mnemonic as alias, and special attribute like CiphertextSpace can override the `extraClassDeclaration`. This can reduce redundancy, but will affect the alias behavior of other attributes (might break tests). The current PR is for migrating the currently existing ones.