### PR TITLE
FuncOp insertArgument works for declaration

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -113,13 +113,7 @@ struct AddEvaluatorArg : public OpConversionPattern<func::FuncOp> {
 
     rewriter.modifyOpInPlace(op, [&] {
       SmallVector<unsigned> argIndices(selectedEvaluators.size(), 0);
-      if (op.isDeclaration()) {
-        auto newFuncType = op.getTypeWithArgsAndResults(
-            argIndices, selectedEvaluators, {}, {});
-        op.setType(newFuncType);
-      } else {
-        op.insertArguments(argIndices, selectedEvaluators, argAttrs, argLocs);
-      }
+      op.insertArguments(argIndices, selectedEvaluators, argAttrs, argLocs);
     });
     return success();
   }
@@ -150,16 +144,7 @@ struct RemoveKeyArg : public OpConversionPattern<func::FuncOp> {
       return failure();
     }
 
-    rewriter.modifyOpInPlace(op, [&] {
-      if (op.isDeclaration()) {
-        // without for deletion
-        auto newFuncType = op.getTypeWithoutArgsAndResults(
-            argsToErase, /* resultIndices= */ BitVector(op->getNumResults()));
-        op.setType(newFuncType);
-      } else {
-        op.eraseArguments(argsToErase);
-      }
-    });
+    rewriter.modifyOpInPlace(op, [&] { op.eraseArguments(argsToErase); });
     return success();
   }
 };

--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -94,14 +94,7 @@ struct AddCryptoContextArg : public OpConversionPattern<func::FuncOp> {
 
     auto cryptoContextType = openfhe::CryptoContextType::get(getContext());
     rewriter.modifyOpInPlace(op, [&] {
-      if (op.isDeclaration()) {
-        auto newFuncType = op.getTypeWithArgsAndResults(
-            ArrayRef<unsigned int>{0}, ArrayRef<Type>{cryptoContextType}, {},
-            {});
-        op.setType(newFuncType);
-      } else {
-        op.insertArgument(0, cryptoContextType, nullptr, op.getLoc());
-      }
+      op.insertArgument(0, cryptoContextType, nullptr, op.getLoc());
     });
 
     return success();


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/124693 is in, we are now able to `insertArgument` directly for funcOp declaration without getting segfault at MLIR side.