### PR TITLE
Lattigo: Add more e2e tests

### DIFF
--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -241,7 +241,11 @@ LogicalResult convertFuncForScheme(func::FuncOp op) {
   // generate Galois Keys on demand
   auto rotIndices = findAllRotIndices(op);
   for (auto rotIndex : rotIndices) {
-    auto galoisElement = static_cast<int>(pow(5, rotIndex)) % (1 << (logN + 1));
+    auto galoisElement = 1;
+    while (rotIndex > 0) {
+      galoisElement = (galoisElement * 5) % (1 << (logN + 1));
+      rotIndex--;
+    }
     auto galoisElementAttr = IntegerAttr::get(
         IntegerType::get(builder.getContext(), 64), galoisElement);
     auto gkType =

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -25,6 +25,16 @@ heir_lattigo_lib(
 )
 
 heir_lattigo_lib(
+    name = "simple_sum",
+    go_library_name = "simplesum",
+    heir_opt_flags = [
+        "--mlir-to-bgv=ciphertext-degree=32",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "simple_sum.mlir",
+)
+
+heir_lattigo_lib(
     name = "dot_product_8",
     go_library_name = "dotproduct8",
     heir_opt_flags = [
@@ -55,6 +65,26 @@ heir_lattigo_lib(
     mlir_src = "dot_product_8.mlir",
 )
 
+heir_lattigo_lib(
+    name = "box_blur",
+    go_library_name = "boxblur",
+    heir_opt_flags = [
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=4295294977",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "box_blur_64x64.mlir",
+)
+
+heir_lattigo_lib(
+    name = "roberts_cross",
+    go_library_name = "robertscross",
+    heir_opt_flags = [
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=536903681",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "roberts_cross_64x64.mlir",
+)
+
 # CKKS
 
 heir_lattigo_lib(
@@ -79,6 +109,12 @@ go_test(
 )
 
 go_test(
+    name = "simplesum_test",
+    srcs = ["simple_sum_test.go"],
+    embed = [":simplesum"],
+)
+
+go_test(
     name = "dotproduct8_test",
     srcs = ["dot_product_8_test.go"],
     embed = [":dotproduct8"],
@@ -94,6 +130,22 @@ go_test(
     name = "dotproduct8debug_test",
     srcs = ["dot_product_8_debug_handler_test.go"],
     embed = [":dotproduct8debug"],
+)
+
+# disabled now for logN = 12 in parameter generation
+# which does not satisfy the requirement of logN >= 13
+# for 4096 input size
+# go_test(
+#     name = "boxblur_test",
+#     srcs = ["box_blur_test.go"],
+#     embed = [":boxblur"],
+# )
+
+# happens to have logN = 13
+go_test(
+    name = "robertscross_test",
+    srcs = ["roberts_cross_test.go"],
+    embed = [":robertscross"],
 )
 
 # CKKS

--- a/tests/Examples/lattigo/box_blur_64x64.mlir
+++ b/tests/Examples/lattigo/box_blur_64x64.mlir
@@ -1,0 +1,29 @@
+func.func @box_blur(%arg0: tensor<4096xi16> {secret.secret}) -> tensor<4096xi16> {
+  %c4096 = arith.constant 4096 : index
+  %c64 = arith.constant 64 : index
+  %0 = affine.for %x = 0 to 64 iter_args(%arg0_x = %arg0) -> (tensor<4096xi16>) {
+    %1 = affine.for %y = 0 to 64 iter_args(%arg0_y = %arg0_x) -> (tensor<4096xi16>) {
+      %c0_si16 = arith.constant 0 : i16
+      %2 = affine.for %j = -1 to 2 iter_args(%value_j = %c0_si16) -> (i16) {
+        %6 = affine.for %i = -1 to 2 iter_args(%value_i = %value_j) -> (i16) {
+          %7 = arith.addi %x, %i : index
+          %8 = arith.muli %7, %c64 : index
+          %9 = arith.addi %y, %j : index
+          %10 = arith.addi %8, %9 : index
+          %11 = arith.remui %10, %c4096 : index
+          %12 = tensor.extract %arg0[%11] : tensor<4096xi16>
+          %13 = arith.addi %value_i, %12 : i16
+          affine.yield %13 : i16
+        }
+        affine.yield %6 : i16
+      }
+      %3 = arith.muli %c64, %x : index
+      %4 = arith.addi %3, %y : index
+      %5 = arith.remui %4, %c4096 : index
+      %6 = tensor.insert %2 into %arg0_y[%5] : tensor<4096xi16>
+      affine.yield %6 : tensor<4096xi16>
+    }
+    affine.yield %1 : tensor<4096xi16>
+  }
+  return %0 : tensor<4096xi16>
+}

--- a/tests/Examples/lattigo/box_blur_test.go
+++ b/tests/Examples/lattigo/box_blur_test.go
@@ -1,0 +1,44 @@
+package boxblur
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := box_blur__configure()
+
+	input := make([]int16, 4096)
+	expected := make([]int16, 4096)
+
+	for i := 0; i < 4096; i++ {
+		input[i] = int16(i)
+	}
+
+	for row := 0; row < 64; row++ {
+		for col := 0; col < 64; col++ {
+			sum := int16(0)
+			for di := -1; di < 2; di++ {
+				for dj := -1; dj < 2; dj++ {
+					index := (row*64 + col + di*64 + dj) % 4096
+					if index < 0 {
+						index += 4096
+					}
+					sum += input[index]
+				}
+			}
+			expected[row*64+col] = sum
+		}
+	}
+
+	ct0 := box_blur__encrypt__arg0(evaluator, params, ecd, enc, input)
+
+	resultCt := box_blur(evaluator, params, ecd, ct0)
+
+	result := box_blur__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	for i := 0; i < 4096; i++ {
+		if result[i] != expected[i] {
+			t.Errorf("Decryption error at %d: %d != %d", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/roberts_cross_64x64.mlir
+++ b/tests/Examples/lattigo/roberts_cross_64x64.mlir
@@ -1,0 +1,61 @@
+func.func @roberts_cross(%img: tensor<4096xi16> {secret.secret}) -> tensor<4096xi16> {
+  %c4096 = arith.constant 4096 : index
+  %c64 = arith.constant 64 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %c-1 =  arith.constant -1 : index
+
+  // Each point p = img[x][y], where x is row and y is column, in the new image will equal:
+  // (img[x-1][y-1] - img[x][y])^2 + (img[x-1][y] - img[x][y-1])^2
+  %r = affine.for %x = 0 to 64 iter_args(%imgx = %img) -> tensor<4096xi16> {
+    %1 = affine.for %y = 0 to 64 iter_args(%imgy = %imgx) -> tensor<4096xi16> {
+
+      // fetch img[x-1][y-1]
+      %4 = arith.addi %x, %c-1 : index
+      %5 = arith.muli %4, %c64 : index
+      %6 = arith.addi %y, %c-1 : index
+      %7 = arith.addi %5, %6 : index
+      %8 = arith.remui %7, %c4096 : index
+      %9 = tensor.extract %img[%8] : tensor<4096xi16>
+
+      // fetch img[x][y]
+      %10 = arith.muli %x, %c64 : index
+      %11 = arith.addi %10, %y : index
+      %12 = arith.remui %11, %c4096 : index
+      %13 = tensor.extract %img[%12] : tensor<4096xi16>
+
+      // subtract those two
+      %14 = arith.subi %9, %13 : i16
+
+      // fetch img[x-1][y]
+      %15 = arith.addi %x, %c-1 : index
+      %16 = arith.muli %15, %c64 : index
+      %18 = arith.addi %16, %y : index
+      %19 = arith.remui %18, %c4096 : index
+      %20 = tensor.extract %img[%19] : tensor<4096xi16>
+
+      // fetch img[x][y-1]
+      %21 = arith.muli %x, %c64 : index
+      %22 = arith.addi %y, %c-1 : index
+      %23 = arith.addi %21, %22 : index
+      %24 = arith.remui %23, %c4096 : index
+      %25 = tensor.extract %img[%24] : tensor<4096xi16>
+
+      // subtract those two
+      %26 = arith.subi %20, %25 : i16
+
+      // square each difference
+      %27 = arith.muli %14, %14 :  i16
+      %28 = arith.muli %26, %26 :  i16
+
+      // add the squares
+      %29 = arith.addi %27, %28 : i16
+
+      // save to result[x][y]
+      %30 = tensor.insert %29 into %imgy[%12] : tensor<4096xi16>
+      affine.yield %30: tensor<4096xi16>
+    }
+    affine.yield %1 : tensor<4096xi16>
+  }
+  return %r : tensor<4096xi16>
+}

--- a/tests/Examples/lattigo/roberts_cross_test.go
+++ b/tests/Examples/lattigo/roberts_cross_test.go
@@ -1,0 +1,52 @@
+package robertscross
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := roberts_cross__configure()
+
+	input := make([]int16, 4096)
+	expected := make([]int16, 4096)
+
+	for i := 0; i < 4096; i++ {
+		input[i] = int16(i)
+	}
+
+	for row := 0; row < 64; row++ {
+		for col := 0; col < 64; col++ {
+			xY := (row*64 + col) % 4096
+			xYm1 := (row*64 + col - 1) % 4096
+			xm1Y := ((row-1)*64 + col) % 4096
+			xm1Ym1 := ((row-1)*64 + col - 1) % 4096
+
+			if xYm1 < 0 {
+				xYm1 += 4096
+			}
+			if xm1Y < 0 {
+				xm1Y += 4096
+			}
+			if xm1Ym1 < 0 {
+				xm1Ym1 += 4096
+			}
+
+			v1 := input[xm1Ym1] - input[xY]
+			v2 := input[xm1Y] - input[xYm1]
+			sum := v1*v1 + v2*v2
+			expected[row*64+col] = sum
+		}
+	}
+
+	ct0 := roberts_cross__encrypt__arg0(evaluator, params, ecd, enc, input)
+
+	resultCt := roberts_cross(evaluator, params, ecd, ct0)
+
+	result := roberts_cross__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	for i := 0; i < 4096; i++ {
+		if result[i] != expected[i] {
+			t.Errorf("Decryption error at %d: %d != %d", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/simple_sum.mlir
+++ b/tests/Examples/lattigo/simple_sum.mlir
@@ -1,0 +1,10 @@
+func.func @simple_sum(%arg0: tensor<32xi16> {secret.secret}) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %i = 0 to 32 iter_args(%sum_iter = %c0_si16) -> i16 {
+    %1 = tensor.extract %arg0[%i] : tensor<32xi16>
+    %2 = arith.addi %1, %sum_iter : i16
+    affine.yield %2 : i16
+  }
+  return %0 : i16
+}

--- a/tests/Examples/lattigo/simple_sum_test.go
+++ b/tests/Examples/lattigo/simple_sum_test.go
@@ -1,0 +1,26 @@
+package simplesum
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := simple_sum__configure()
+
+	// Vector of plaintext values
+	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+		12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+		23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
+
+	expected := int16(16 * 33)
+
+	ct0 := simple_sum__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+
+	resultCt := simple_sum(evaluator, params, ecd, ct0)
+
+	result := simple_sum__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tests/Examples/openfhe/box_blur_test.cpp
+++ b/tests/Examples/openfhe/box_blur_test.cpp
@@ -1,16 +1,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "gmock/gmock.h"                               // from @googletest
-#include "gtest/gtest.h"                               // from @googletest
-#include "src/core/include/lattice/hal/lat-backend.h"  // from @openfhe
-#include "src/pke/include/constants.h"                 // from @openfhe
-#include "src/pke/include/cryptocontext-fwd.h"         // from @openfhe
-#include "src/pke/include/gen-cryptocontext.h"         // from @openfhe
-#include "src/pke/include/key/keypair.h"               // from @openfhe
-#include "src/pke/include/openfhe.h"                   // from @openfhe
-#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-params.h"  // from @openfhe
-#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns.h"  // from @openfhe
+#include "gmock/gmock.h"              // from @googletest
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
 
 // Generated headers (block clang-format from messing up order)
 #include "tests/Examples/openfhe/box_blur_64x64_lib.h"

--- a/tests/Examples/openfhe/roberts_cross_test.cpp
+++ b/tests/Examples/openfhe/roberts_cross_test.cpp
@@ -1,16 +1,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "gmock/gmock.h"                               // from @googletest
-#include "gtest/gtest.h"                               // from @googletest
-#include "src/core/include/lattice/hal/lat-backend.h"  // from @openfhe
-#include "src/pke/include/constants.h"                 // from @openfhe
-#include "src/pke/include/cryptocontext-fwd.h"         // from @openfhe
-#include "src/pke/include/gen-cryptocontext.h"         // from @openfhe
-#include "src/pke/include/key/keypair.h"               // from @openfhe
-#include "src/pke/include/openfhe.h"                   // from @openfhe
-#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-params.h"  // from @openfhe
-#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns.h"  // from @openfhe
+#include "gmock/gmock.h"              // from @googletest
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
 
 // Generated headers (block clang-format from messing up order)
 #include "tests/Examples/openfhe/roberts_cross_64x64_lib.h"

--- a/tests/Examples/openfhe/simple_sum_test.cpp
+++ b/tests/Examples/openfhe/simple_sum_test.cpp
@@ -1,15 +1,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "gtest/gtest.h"                               // from @googletest
-#include "src/core/include/lattice/hal/lat-backend.h"  // from @openfhe
-#include "src/pke/include/constants.h"                 // from @openfhe
-#include "src/pke/include/cryptocontext-fwd.h"         // from @openfhe
-#include "src/pke/include/gen-cryptocontext.h"         // from @openfhe
-#include "src/pke/include/key/keypair.h"               // from @openfhe
-#include "src/pke/include/openfhe.h"                   // from @openfhe
-#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns-params.h"  // from @openfhe
-#include "src/pke/include/scheme/bgvrns/gen-cryptocontext-bgvrns.h"  // from @openfhe
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
 
 // Generated headers (block clang-format from messing up order)
 #include "tests/Examples/openfhe/simple_sum_lib.h"


### PR DESCRIPTION
For more coverage.

Now I come to understand why roberts_cross and box_blur has to select big plaintext modulus: if it is too small, the parameter selection (either by Openfhe or by --validate-noise) will select logN < 13 and the 4096 input vector wont fit in the ciphertext...

You might question: why logN = 12 (namely N = 4096) wont work. This is related to #1186, so in brief when N = 4096 we have the structure Z2048xZ2 so there is only 2048 slots in one row and the heir-vectorizer is not aware of this.

This should also be handled by the layout conversion pass. 

These issues should be handled temporarily in another PR by enabling the parameter selection process to have a minimal logN (specified by ciphertext-degree, the naming issue also related to #1402)

Also fix a bug when `pow(5, index)` becomes so large like `5 ** 16 = 152587890625`
