### PR TITLE
Update conversion pass comb-to-cggi to secret-to-cggi in demo

### DIFF
--- a/scripts/jupyter/Demo.ipynb
+++ b/scripts/jupyter/Demo.ipynb
@@ -644,7 +644,7 @@
     }
    ],
    "source": [
-    "%%heir_opt --secret-distribute-generic --comb-to-cggi --cse\n",
+    "%%heir_opt --secret-distribute-generic --secret-to-cggi --cse\n",
     "module {\n",
     "  func.func @cmux(%arg0: !secret.secret<i16>, %arg1: !secret.secret<i16>, %arg2: !secret.secret<i1>) -> !secret.secret<i16> {\n",
     "    %0 = secret.cast %arg0 : !secret.secret<i16> to !secret.secret<memref<16xi1>>\n",


### PR DESCRIPTION
Going through the demo I noticed that the pass comb-to-cggi didn't seem to exist, it got renamed to secret-to-cggi in #1058 . Updating that was a good excuse to get set up to make pull requests!