### PR TITLE
Polynomial approximation patterns

### DIFF
--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
@@ -57,7 +57,7 @@ def Polynomial_FloatPolynomialAttr : Polynomial_Attr<"FloatPolynomial", "float_p
 }
 
 def Polynomial_TypedIntPolynomialAttr : Polynomial_Attr<
-    "TypedIntPolynomial", "typed_int_polynomial", [TypedAttrInterface]> {
+    "TypedIntPolynomial", "typed_int_polynomial"> {
   let summary = "a typed int_polynomial";
   let description = [{
     Example:
@@ -84,12 +84,12 @@ def Polynomial_TypedIntPolynomialAttr : Polynomial_Attr<
     }]>
   ];
   let extraClassDeclaration = [{
-    using ValueType = ::mlir::Attribute;
+    using ValueType = ::mlir::heir::polynomial::IntPolynomialAttr;
   }];
 }
 
 def Polynomial_TypedFloatPolynomialAttr : Polynomial_Attr<
-    "TypedFloatPolynomial", "typed_float_polynomial", [TypedAttrInterface]> {
+    "TypedFloatPolynomial", "typed_float_polynomial"> {
   let summary = "a typed float_polynomial";
   let description = [{
     Example:
@@ -116,7 +116,7 @@ def Polynomial_TypedFloatPolynomialAttr : Polynomial_Attr<
     }]>
   ];
   let extraClassDeclaration = [{
-    using ValueType = ::mlir::Attribute;
+    using ValueType = ::mlir::heir::polynomial::FloatPolynomialAttr;
   }];
 }
 

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.td
@@ -340,35 +340,35 @@ def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure]> {
   let hasVerifier = 1;
 }
 
-def Polynomial_EvalOp : Polynomial_Op<"eval", [AllTypesMatch<["value", "output"]>]> {
-    let summary = "Evaluate a static polynomial attribute at a given SSA value.";
-    let description = [{
-        Evaluates the result of a polynomial specified as a static attribute at
-        a given SSA value. The result represents the evaluation of the
-        polynomial at the input value and produces a corresponding scalar
-        value.
+def Polynomial_EvalOp : Polynomial_Op<"eval", [AllTypesMatch<["value", "output"]>, ElementwiseMappable]> {
+  let summary = "Evaluate a static polynomial attribute at a given SSA value.";
+  let description = [{
+      Evaluates the result of a polynomial specified as a static attribute at
+      a given SSA value. The result represents the evaluation of the
+      polynomial at the input value and produces a corresponding scalar
+      value.
 
-        Example:
+      Example:
 
-        ```mlir
-        !poly_ty = !polynomial.polynomial<ring=<coefficientType=i32>>
-        #poly = #polynomial.typed_int_polynomial<1 + x + x**2> : !poly_ty
-        %x = arith.constant 5 : i32
-        %result = polynomial.eval #poly, %x : i32
-        ```
+      ```mlir
+      !poly_ty = !polynomial.polynomial<ring=<coefficientType=i32>>
+      #poly = #polynomial.typed_int_polynomial<1 + x + x**2> : !poly_ty
+      %x = arith.constant 5 : i32
+      %result = polynomial.eval #poly, %x : i32
+      ```
 
-        The coefficient type of the polynomial does not necessarily need to be
-        the same as the scalar input type. For example, one may evaluate a
-        square matrix in a polynomial, because the scalar-matrix operation is
-        well-defined. It is the responsibility of the lowering to determine
-        if the input is compatible with the polynomial coefficient type.
-    }];
-    let arguments = (ins
-        Polynomial_AnyTypedPolynomialAttr: $polynomial,
-        AnyType: $value
-    );
-    let results = (outs AnyType:$output);
-    let assemblyFormat = "$polynomial `,` $value attr-dict `:` type($value)";
+      The coefficient type of the polynomial does not necessarily need to be
+      the same as the scalar input type. For example, one may evaluate a
+      square matrix in a polynomial, because the scalar-matrix operation is
+      well-defined. It is the responsibility of the lowering to determine
+      if the input is compatible with the polynomial coefficient type.
+  }];
+  let arguments = (ins
+      Polynomial_AnyTypedPolynomialAttr: $polynomial,
+      AnyType: $value
+  );
+  let results = (outs AnyType:$output);
+  let assemblyFormat = "$polynomial `,` $value attr-dict `:` type($value)";
 }
 
 

--- a/lib/Transforms/PolynomialApproximation/BUILD
+++ b/lib/Transforms/PolynomialApproximation/BUILD
@@ -1,0 +1,28 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "PolynomialApproximation",
+    srcs = ["PolynomialApproximation.cpp"],
+    hdrs = ["PolynomialApproximation.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@heir//lib/Utils/Approximation:CaratheodoryFejer",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MathDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "PolynomialApproximation",
+    td_file = "PolynomialApproximation.td",
+)

--- a/lib/Transforms/PolynomialApproximation/PolynomialApproximation.cpp
+++ b/lib/Transforms/PolynomialApproximation/PolynomialApproximation.cpp
@@ -1,0 +1,211 @@
+#include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h"
+
+#include <cmath>
+
+#include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
+#include "lib/Utils/Approximation/CaratheodoryFejer.h"
+#include "llvm/include/llvm/ADT/APFloat.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Math/IR/Math.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_POLYNOMIALAPPROXIMATION
+#include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h.inc"
+
+static constexpr int64_t defaultDegree = 5;
+static constexpr double defaultDomainLower = -1.0;
+static constexpr double defaultDomainUpper = 1.0;
+
+using polynomial::EvalOp;
+using polynomial::FloatPolynomial;
+using polynomial::PolynomialType;
+using polynomial::RingAttr;
+using polynomial::TypedFloatPolynomialAttr;
+
+APFloat absf(const APFloat &x) {
+  return APFloat(std::abs(x.convertToDouble()));
+}
+APFloat acos(const APFloat &x) {
+  return APFloat(std::acos(x.convertToDouble()));
+}
+APFloat acosh(const APFloat &x) {
+  return APFloat(std::acosh(x.convertToDouble()));
+}
+APFloat asin(const APFloat &x) {
+  return APFloat(std::asin(x.convertToDouble()));
+}
+APFloat asinh(const APFloat &x) {
+  return APFloat(std::asinh(x.convertToDouble()));
+}
+APFloat atan(const APFloat &x) {
+  return APFloat(std::atan(x.convertToDouble()));
+}
+APFloat atanh(const APFloat &x) {
+  return APFloat(std::atanh(x.convertToDouble()));
+}
+APFloat cbrt(const APFloat &x) {
+  return APFloat(std::cbrt(x.convertToDouble()));
+}
+APFloat ceil(const APFloat &x) {
+  return APFloat(std::ceil(x.convertToDouble()));
+}
+APFloat cos(const APFloat &x) { return APFloat(std::cos(x.convertToDouble())); }
+APFloat cosh(const APFloat &x) {
+  return APFloat(std::cosh(x.convertToDouble()));
+}
+APFloat erf(const APFloat &x) { return APFloat(std::erf(x.convertToDouble())); }
+APFloat erfc(const APFloat &x) {
+  return APFloat(std::erfc(x.convertToDouble()));
+}
+APFloat exp(const APFloat &x) { return APFloat(std::exp(x.convertToDouble())); }
+APFloat exp2(const APFloat &x) {
+  return APFloat(std::exp2(x.convertToDouble()));
+}
+APFloat expm1(const APFloat &x) {
+  return APFloat(std::expm1(x.convertToDouble()));
+}
+APFloat floor(const APFloat &x) {
+  return APFloat(std::floor(x.convertToDouble()));
+}
+APFloat log(const APFloat &x) { return APFloat(std::log(x.convertToDouble())); }
+APFloat log10(const APFloat &x) {
+  return APFloat(std::log10(x.convertToDouble()));
+}
+APFloat log1p(const APFloat &x) {
+  return APFloat(std::log1p(x.convertToDouble()));
+}
+APFloat log2(const APFloat &x) {
+  return APFloat(std::log2(x.convertToDouble()));
+}
+APFloat round(const APFloat &x) {
+  return APFloat(std::round(x.convertToDouble()));
+}
+APFloat roundeven(const APFloat &x) {
+  return APFloat(roundevenf(x.convertToDouble()));
+}
+APFloat rsqrt(const APFloat &x) {
+  return APFloat(1.0 / std::sqrt(x.convertToDouble()));
+}
+APFloat sin(const APFloat &x) { return APFloat(std::sin(x.convertToDouble())); }
+APFloat sinh(const APFloat &x) {
+  return APFloat(std::sinh(x.convertToDouble()));
+}
+APFloat sqrt(const APFloat &x) {
+  return APFloat(std::sqrt(x.convertToDouble()));
+}
+APFloat tan(const APFloat &x) { return APFloat(std::tan(x.convertToDouble())); }
+APFloat tanh(const APFloat &x) {
+  return APFloat(std::tanh(x.convertToDouble()));
+}
+APFloat trunc(const APFloat &x) {
+  return APFloat(std::trunc(x.convertToDouble()));
+}
+
+template <typename OpTy>
+struct ConvertUnaryOp : public OpRewritePattern<OpTy> {
+  ConvertUnaryOp(mlir::MLIRContext *context,
+                 const std::function<APFloat(APFloat)> &cppFunc)
+      : OpRewritePattern<OpTy>(context, /*benefit=*/1), cppFunc(cppFunc) {}
+
+ public:
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    IntegerAttr degreeAttr = op->hasAttr("degree")
+                                 ? cast<IntegerAttr>(op->getAttr("degree"))
+                                 : rewriter.getI32IntegerAttr(defaultDegree);
+    FloatAttr domainLowerAttr =
+        op->hasAttr("domain_lower")
+            ? cast<FloatAttr>(op->getAttr("domain_lower"))
+            : rewriter.getF64FloatAttr(defaultDomainLower);
+    FloatAttr domainUpperAttr =
+        op->hasAttr("domain_upper")
+            ? cast<FloatAttr>(op->getAttr("domain_upper"))
+            : rewriter.getF64FloatAttr(defaultDomainUpper);
+    FloatPolynomial poly = approximation::caratheodoryFejerApproximation(
+        exp, degreeAttr.getInt(), domainLowerAttr.getValue().convertToDouble(),
+        domainUpperAttr.getValue().convertToDouble());
+    PolynomialType polyType =
+        PolynomialType::get(ctx, RingAttr::get(Float64Type::get(ctx)));
+    TypedFloatPolynomialAttr polyAttr =
+        TypedFloatPolynomialAttr::get(polyType, poly);
+    rewriter.replaceOpWithNewOp<EvalOp>(op, polyAttr, op.getOperand());
+    return success();
+  }
+
+ private:
+  std::function<APFloat(APFloat)> cppFunc;
+};
+
+struct PolynomialApproximation
+    : impl::PolynomialApproximationBase<PolynomialApproximation> {
+  using PolynomialApproximationBase::PolynomialApproximationBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    // Math unary ops
+    patterns.add<ConvertUnaryOp<math::AbsFOp>>(context, absf);
+    patterns.add<ConvertUnaryOp<math::AcosOp>>(context, acos);
+    patterns.add<ConvertUnaryOp<math::AcoshOp>>(context, acosh);
+    patterns.add<ConvertUnaryOp<math::AsinOp>>(context, asin);
+    patterns.add<ConvertUnaryOp<math::AsinhOp>>(context, asinh);
+    patterns.add<ConvertUnaryOp<math::AtanOp>>(context, atan);
+    patterns.add<ConvertUnaryOp<math::AtanhOp>>(context, atanh);
+    patterns.add<ConvertUnaryOp<math::CbrtOp>>(context, cbrt);
+    patterns.add<ConvertUnaryOp<math::CeilOp>>(context, ceil);
+    patterns.add<ConvertUnaryOp<math::CosOp>>(context, cos);
+    patterns.add<ConvertUnaryOp<math::CoshOp>>(context, cosh);
+    patterns.add<ConvertUnaryOp<math::ErfOp>>(context, erf);
+    patterns.add<ConvertUnaryOp<math::ErfcOp>>(context, erfc);
+    patterns.add<ConvertUnaryOp<math::ExpOp>>(context, exp);
+    patterns.add<ConvertUnaryOp<math::Exp2Op>>(context, exp2);
+    patterns.add<ConvertUnaryOp<math::ExpM1Op>>(context, expm1);
+    patterns.add<ConvertUnaryOp<math::FloorOp>>(context, floor);
+    patterns.add<ConvertUnaryOp<math::LogOp>>(context, log);
+    patterns.add<ConvertUnaryOp<math::Log10Op>>(context, log10);
+    patterns.add<ConvertUnaryOp<math::Log1pOp>>(context, log1p);
+    patterns.add<ConvertUnaryOp<math::Log2Op>>(context, log2);
+    patterns.add<ConvertUnaryOp<math::RoundOp>>(context, round);
+    patterns.add<ConvertUnaryOp<math::RoundEvenOp>>(context, roundeven);
+    patterns.add<ConvertUnaryOp<math::RsqrtOp>>(context, rsqrt);
+    patterns.add<ConvertUnaryOp<math::SinOp>>(context, sin);
+    patterns.add<ConvertUnaryOp<math::SinhOp>>(context, sinh);
+    patterns.add<ConvertUnaryOp<math::SqrtOp>>(context, sqrt);
+    patterns.add<ConvertUnaryOp<math::TanOp>>(context, tan);
+    patterns.add<ConvertUnaryOp<math::TanhOp>>(context, tanh);
+    patterns.add<ConvertUnaryOp<math::TruncOp>>(context, trunc);
+
+    // Unsupported math dialect unary ops:
+    // math::AbsIOp
+    // math::CtlzOp
+    // math::CtpopOp
+    // math::CttzOp
+    // math::IsfiniteOp
+    // math::IsinfOp
+    // math::IsnanOp
+    // math::IsnormalOp
+
+    // TODO(#1487): support these ops when all but one operand is constant
+    // Math binary ops (when one argument is statically constant)
+    // patterns.add<ConvertUnaryOp<math::Atan2Op>>(context, atan2);
+    // patterns.add<ConvertUnaryOp<math::CopySignOp>>(context, copysign);
+    // patterns.add<ConvertBinaryOp<math::FpowiOp>>(context, fpowi);
+    // patterns.add<ConvertBinaryOp<math::IpowiOp>>(context, ipowi);
+    // patterns.add<ConvertBinaryOp<math::PowfOp>>(context, powf);
+
+    // Math ternary ops
+    // patterns.add<ConvertUnaryOp<math::FmaOp>>(context, fma);
+
+    // TODO (#1221): Investigate whether folding (default: on) can be skipped
+    // here.
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/PolynomialApproximation/PolynomialApproximation.h
+++ b/lib/Transforms/PolynomialApproximation/PolynomialApproximation.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_POLYNOMIALAPPROXIMATION_POLYNOMIALAPPROXIMATION_H_
+#define LIB_TRANSFORMS_POLYNOMIALAPPROXIMATION_POLYNOMIALAPPROXIMATION_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_POLYNOMIALAPPROXIMATION_POLYNOMIALAPPROXIMATION_H_

--- a/lib/Transforms/PolynomialApproximation/PolynomialApproximation.td
+++ b/lib/Transforms/PolynomialApproximation/PolynomialApproximation.td
@@ -1,0 +1,77 @@
+#ifndef LIB_TRANSFORMS_POLYNOMIALAPPROXIMATION_POLYNOMIALAPPROXIMATION_TD_
+#define LIB_TRANSFORMS_POLYNOMIALAPPROXIMATION_POLYNOMIALAPPROXIMATION_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def PolynomialApproximation : Pass<"polynomial-approximation"> {
+  let summary = "Approximate ops by polynomials";
+  let description = [{
+    This pass replaces certain operations that are incompatible
+    with the FHE computational model with polynomial approximations.
+
+    The pass applies to the following ops in the `math` dialect:
+
+
+    - `absf`
+    - `acos`
+    - `acosh`
+    - `asin`
+    - `asinh`
+    - `atan`
+    - `atanh`
+    - `cbrt`
+    - `ceil`
+    - `cos`
+    - `cosh`
+    - `erf`
+    - `erfc`
+    - `exp`
+    - `exp2`
+    - `expm1`
+    - `floor`
+    - `log`
+    - `log10`
+    - `log1p`
+    - `log2`
+    - `round`
+    - `roundeven`
+    - `rsqrt`
+    - `sin`
+    - `sinh`
+    - `sqrt`
+    - `tan`
+    - `tanh`
+    - `trunc`
+
+    These ops are replaced with `polynomial.eval` ops with a static polynomial
+    attribute.
+
+    Examples:
+
+    ```mlir
+    %0 = math.exp %x {
+          degree = 3 : i32,
+          domain_lower = -1.0 : f64,
+          domain_upper = 1.0 : f64
+      } : f32
+    ```
+
+    is converted to
+
+    ```mlir
+    #ring_f64_ = #polynomial.ring<coefficientType = f64>
+    !poly = !polynomial.polynomial<ring = #ring_f64_>
+    %0 = polynomial.eval
+           #polynomial<typed_float_polynomial <
+             0.99458116404270657
+           + 0.99565537253615788x
+           + 0.54297028147256321x**2
+           + 0.17954582110873779x**3> : !poly>, %arg0 : f32
+    ```
+  }];
+  let dependentDialects = [
+    "mlir::heir::polynomial::PolynomialDialect"
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_POLYNOMIALAPPROXIMATION_POLYNOMIALAPPROXIMATION_TD_

--- a/tests/Transforms/polynomial_approximation/BUILD
+++ b/tests/Transforms/polynomial_approximation/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/polynomial_approximation/poylnomial_approximation.mlir
+++ b/tests/Transforms/polynomial_approximation/poylnomial_approximation.mlir
@@ -1,0 +1,17 @@
+// RUN: heir-opt --polynomial-approximation %s | FileCheck %s
+
+// CHECK-LABEL: @test_exp
+func.func @test_exp(%x: f32) -> f32 {
+  // CHECK: polynomial.eval
+  // CHECK-SAME: 0.99458116404270657 + 0.99565537253615788x + 0.54297028147256321x**2 + 0.17954582110873779x**3
+  %0 = math.exp %x {degree = 3 : i32, domain_lower = -1.0 : f64, domain_upper = 1.0 : f64} : f32
+  return %0 : f32
+}
+
+// CHECK-LABEL: @test_sin_default_params
+func.func @test_sin_default_params(%x: f32) -> f32 {
+  // CHECK: polynomial.eval
+  // CHECK-SAME: x**5
+  %0 = math.sin %x : f32
+  return %0 : f32
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -116,6 +116,7 @@ cc_binary(
         "@heir//lib/Transforms/MemrefToArith:MemrefToArithRegistration",
         "@heir//lib/Transforms/OperationBalancer",
         "@heir//lib/Transforms/OptimizeRelinearization",
+        "@heir//lib/Transforms/PolynomialApproximation",
         "@heir//lib/Transforms/SecretInsertMgmt",
         "@heir//lib/Transforms/Secretize",
         "@heir//lib/Transforms/StraightLineVectorizer",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -67,6 +67,7 @@
 #include "lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.h"
 #include "lib/Transforms/OperationBalancer/OperationBalancer.h"
 #include "lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.h"
+#include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/Secretize/Passes.h"
 #include "lib/Transforms/StraightLineVectorizer/StraightLineVectorizer.h"
@@ -256,6 +257,7 @@ int main(int argc, char **argv) {
   registerUnusedMemRefPasses();
   registerValidateNoisePasses();
   registerOptimizeRelinearizationPasses();
+  registerPolynomialApproximationPasses();
   registerLayoutPropagationPasses();
   registerLinalgCanonicalizationsPasses();
   registerTensorToScalarsPasses();


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/1217


This PR adds polynomial approximation patterns for all unary `math` dialect ops that operate on floats, e.g., `math.exp`. These should all be elementwise mappable, so extent to tensors<f32> and similar for use in the secret+tensor_ext_layer.

The pass supports extracting the desired degree/interval of approximation from the op attributes, and otherwise uses a default [-1, 1] degree 5 approximation.

What's missing:

- Smarter error handling (e.g., someone asks for an approximation of an op outside its domain)
- Binary/ternary math ops, when all but one argument is statically known (filed a TODO) 
- Patterns that match on higher level math ops, e.g., stablehlo.relu lowers to something like `linalg.map { arith.maximumf }`