### PR TITLE
lattigo-alloc-to-inplace: greedily use availible storage as inplace output

### DIFF
--- a/lib/Dialect/Lattigo/Transforms/AllocToInplace.cpp
+++ b/lib/Dialect/Lattigo/Transforms/AllocToInplace.cpp
@@ -3,98 +3,225 @@
 #include <utility>
 
 #include "lib/Dialect/Lattigo/IR/LattigoOps.h"
-#include "mlir/include/mlir/Analysis/Liveness.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/MLIRContext.h"     // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"    // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"       // from @llvm-project
-#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "lib/Utils/Tablegen/InplaceOpInterface.h"
+#include "mlir/include/mlir/Analysis/Liveness.h"        // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace lattigo {
 
+// There are two types of Value in the IR:
+// 1. Storage: the actual memory allocated for the value
+// 2. Referring Value: the value that refers to the storage (e.g., the
+// returned SSA of an inplace operation)
+//
+// This class is similar to Disjoint-set data structure.
+// Each Storage is the root, and all Referring Values are in its set.
+//
+// At the beginning StorageInfo should be initialized based on current relation
+// in program.
+//
+// During rewriting, when we find available Storage for an AllocOp, we replace
+// it with an InplaceOp and update the StorageInfo by merging the Storage of the
+// AllocOp to the available Storage.
+//
+// This allows a mix of AllocOp and InplaceOp in input IR for the pass.
+class StorageInfo {
+ public:
+  StorageInfo() = default;
+
+  void addStorage(Value value) {
+    if (mlir::isa<RLWECiphertextType>(value.getType())) {
+      storageToReferringValues[value] = {};
+    }
+  }
+
+  void addReferringValue(Value storage, Value value) {
+    storageToReferringValues[storage].push_back(value);
+  }
+
+ private:
+  // maintenance should be called internally
+  void removeStorage(Value value) { storageToReferringValues.erase(value); }
+
+  void mergeStorage(Value from, Value to) {
+    storageToReferringValues[to].reserve(storageToReferringValues[to].size() +
+                                         storageToReferringValues[from].size());
+    storageToReferringValues[to].insert(storageToReferringValues[to].end(),
+                                        storageToReferringValues[from].begin(),
+                                        storageToReferringValues[from].end());
+    removeStorage(from);
+  }
+
+ public:
+  // User API
+  Value getStorageFromValue(Value value) const {
+    for (auto &[storage, values] : storageToReferringValues) {
+      if (value == storage) {
+        return storage;
+      }
+      for (auto referringValue : values) {
+        if (value == referringValue) {
+          return storage;
+        }
+      }
+    }
+    return Value();
+  }
+
+  // Greedily use the first storage.
+  //
+  // This greedy policy is optimal in terms of memory usage in that
+  // 1. All dead values for this operation are dead for later operations so
+  // they are equivalent, which means the first dead value is enough.
+  // 2. If we decide not to use inplace for this operation, but allocate a new
+  // value, in the hope that later operation can benefit from the reserved value
+  // of this decision. Later operation actually can always allocate a new value
+  // so the memory usage is not affected by this operation's local decision.
+  //
+  // However, this might not be optimal in terms of cache-friendliness for
+  // various accelerators. One basic optimization is to use the dead value that
+  // is closest to the current operation in the block. But as we do not have the
+  // information of the memory layout, we do not implement this optimization.
+  Value getAvailableStorage(Operation *op, Liveness *liveness) const {
+    Value availableStorage;
+    for (auto &[storage, values] : storageToReferringValues) {
+      // storage and all referring values are dead
+      if (std::all_of(
+              values.begin(), values.end(),
+              [&](Value value) { return liveness->isDeadAfter(value, op); }) &&
+          liveness->isDeadAfter(storage, op)) {
+        availableStorage = storage;
+        break;
+      }
+    }
+    return availableStorage;
+  }
+
+  void replaceAllocWithInplace(Operation *oldOp, Operation *newOp,
+                               Value storage) {
+    // add newly created referring value
+    for (auto result : newOp->getResults()) {
+      addReferringValue(storage, result);
+    }
+    // remove storage of old op
+    for (auto result : oldOp->getResults()) {
+      mergeStorage(result, storage);
+    }
+  }
+
+ private:
+  DenseMap<Value, SmallVector<Value>> storageToReferringValues;
+};
+
 template <typename BinOp, typename InplaceOp>
 struct ConvertBinOp : public OpRewritePattern<BinOp> {
   using OpRewritePattern<BinOp>::OpRewritePattern;
 
-  ConvertBinOp(mlir::MLIRContext *context, Liveness *liveness)
-      : OpRewritePattern<BinOp>(context), liveness(liveness) {}
+  ConvertBinOp(mlir::MLIRContext *context, Liveness *liveness,
+               DenseMap<Block *, StorageInfo> *blockToStorageInfo)
+      : OpRewritePattern<BinOp>(context),
+        liveness(liveness),
+        blockToStorageInfo(blockToStorageInfo) {}
 
   LogicalResult matchAndRewrite(BinOp op,
                                 PatternRewriter &rewriter) const override {
-    // operand 0 is evaluator
-    auto lhs = op.getOperand(1);
-    if (!liveness->isDeadAfter(lhs, op)) {
+    auto &storageInfo = (*blockToStorageInfo)[op->getBlock()];
+    auto storage = storageInfo.getAvailableStorage(op, liveness);
+    if (!storage) {
       return failure();
     }
 
-    // InplaceOp has the form: output = InplaceOp(evaluator, lhs, rhs, inplace)
-    // where inplace is the actual output but for SSA form we need to return a
-    // new value
-    rewriter.replaceOpWithNewOp<InplaceOp>(op, op.getOperand(1).getType(),
-                                           op.getOperand(0), op.getOperand(1),
-                                           op.getOperand(2), op.getOperand(1));
+    // InplaceOp has the form: output = InplaceOp(evaluator, lhs, rhs,
+    // inplace) where inplace is the actual output but for SSA form we need to
+    // return a new value
+    auto inplaceOp = rewriter.replaceOpWithNewOp<InplaceOp>(
+        op, op.getOperand(1).getType(), op.getOperand(0), op.getOperand(1),
+        op.getOperand(2), storage);
+
+    // update storage info
+    storageInfo.replaceAllocWithInplace(op, inplaceOp, storage);
     return success();
   }
 
  private:
   Liveness *liveness;
+  DenseMap<Block *, StorageInfo> *blockToStorageInfo;
 };
 
 template <typename UnaryOp, typename InplaceOp>
 struct ConvertUnaryOp : public OpRewritePattern<UnaryOp> {
   using OpRewritePattern<UnaryOp>::OpRewritePattern;
 
-  ConvertUnaryOp(mlir::MLIRContext *context, Liveness *liveness)
-      : OpRewritePattern<UnaryOp>(context), liveness(liveness) {}
+  ConvertUnaryOp(mlir::MLIRContext *context, Liveness *liveness,
+                 DenseMap<Block *, StorageInfo> *blockToStorageInfo)
+      : OpRewritePattern<UnaryOp>(context),
+        liveness(liveness),
+        blockToStorageInfo(blockToStorageInfo) {}
 
   LogicalResult matchAndRewrite(UnaryOp op,
                                 PatternRewriter &rewriter) const override {
-    // operand 0 is evaluator
-    auto lhs = op.getOperand(1);
-    if (!liveness->isDeadAfter(lhs, op)) {
+    auto &storageInfo = (*blockToStorageInfo)[op->getBlock()];
+    auto storage = storageInfo.getAvailableStorage(op, liveness);
+    if (!storage) {
       return failure();
     }
 
     // InplaceOp has the form: output = InplaceOp(evaluator, lhs, inplace)
     // where inplace is the actual output but for SSA form we need to return a
     // new value
-    rewriter.replaceOpWithNewOp<InplaceOp>(op, op.getOperand(1).getType(),
-                                           op.getOperand(0), op.getOperand(1),
-                                           op.getOperand(1));
+    auto inplaceOp = rewriter.replaceOpWithNewOp<InplaceOp>(
+        op, op.getOperand(1).getType(), op.getOperand(0), op.getOperand(1),
+        storage);
+
+    // update storage info
+    storageInfo.replaceAllocWithInplace(op, inplaceOp, storage);
     return success();
   }
 
  private:
   Liveness *liveness;
+  DenseMap<Block *, StorageInfo> *blockToStorageInfo;
 };
 
 template <typename RotateOp, typename InplaceOp>
 struct ConvertRotateOp : public OpRewritePattern<RotateOp> {
   using OpRewritePattern<RotateOp>::OpRewritePattern;
 
-  ConvertRotateOp(mlir::MLIRContext *context, Liveness *liveness)
-      : OpRewritePattern<RotateOp>(context), liveness(liveness) {}
+  ConvertRotateOp(mlir::MLIRContext *context, Liveness *liveness,
+                  DenseMap<Block *, StorageInfo> *blockToStorageInfo)
+      : OpRewritePattern<RotateOp>(context),
+        liveness(liveness),
+        blockToStorageInfo(blockToStorageInfo) {}
 
   LogicalResult matchAndRewrite(RotateOp op,
                                 PatternRewriter &rewriter) const override {
-    // operand 0 is evaluator
-    auto lhs = op.getOperand(1);
-    if (!liveness->isDeadAfter(lhs, op)) {
+    auto &storageInfo = (*blockToStorageInfo)[op->getBlock()];
+    auto storage = storageInfo.getAvailableStorage(op, liveness);
+    if (!storage) {
       return failure();
     }
 
     // InplaceOp has the form: output = InplaceOp(evaluator, lhs, inplace)
     // {offset} where inplace is the actual output but for SSA form we need to
     // return a new value
-    rewriter.replaceOpWithNewOp<InplaceOp>(op, op.getOperand(1).getType(),
-                                           op.getOperand(0), op.getOperand(1),
-                                           op.getOperand(1), op.getOffset());
+    auto inplaceOp = rewriter.replaceOpWithNewOp<InplaceOp>(
+        op, op.getOperand(1).getType(), op.getOperand(0), op.getOperand(1),
+        storage, op.getOffset());
+
+    // update storage info
+    storageInfo.replaceAllocWithInplace(op, inplaceOp, storage);
     return success();
   }
 
  private:
   Liveness *liveness;
+  DenseMap<Block *, StorageInfo> *blockToStorageInfo;
 };
 
 #define GEN_PASS_DEF_ALLOCTOINPLACE
@@ -109,6 +236,41 @@ struct AllocToInplace : impl::AllocToInplaceBase<AllocToInplace> {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
 
+    DenseMap<Block *, StorageInfo> blockToStorageInfo;
+    // Initialize each func block's storage
+    getOperation()->walk([&](func::FuncOp funcOp) {
+      if (funcOp.isDeclaration()) {
+        return;
+      }
+      for (auto &block : funcOp.getBody().getBlocks()) {
+        auto &storageInfo = blockToStorageInfo[&block];
+        // arguments are storages
+        for (auto arg : block.getArguments()) {
+          storageInfo.addStorage(arg);
+        }
+        block.walk<WalkOrder::PreOrder>([&](Operation *op) {
+          // inplace op will not allocate new memory, it produces referring
+          // values
+          if (auto inplaceOpInterface =
+                  mlir::dyn_cast<InplaceOpInterface>(op)) {
+            auto inplaceOperand =
+                op->getOperand(inplaceOpInterface.getInplaceOperandIndex());
+            auto storage = storageInfo.getStorageFromValue(inplaceOperand);
+            if (storage) {
+              for (auto result : op->getResults()) {
+                storageInfo.addReferringValue(storage, result);
+              }
+            }
+          } else {
+            // alloc op results are storages
+            for (auto result : op->getResults()) {
+              storageInfo.addStorage(result);
+            }
+          }
+        });
+      }
+    });
+
     patterns.add<
         ConvertBinOp<lattigo::BGVAddNewOp, lattigo::BGVAddOp>,
         ConvertBinOp<lattigo::BGVSubNewOp, lattigo::BGVSubOp>,
@@ -116,9 +278,11 @@ struct AllocToInplace : impl::AllocToInplaceBase<AllocToInplace> {
         ConvertUnaryOp<lattigo::BGVRelinearizeNewOp, lattigo::BGVRelinearizeOp>,
         ConvertUnaryOp<lattigo::BGVRescaleNewOp, lattigo::BGVRescaleOp>,
         ConvertRotateOp<lattigo::BGVRotateColumnsNewOp,
-                        lattigo::BGVRotateColumnsOp> >(context, &liveness);
+                        lattigo::BGVRotateColumnsOp>>(context, &liveness,
+                                                      &blockToStorageInfo);
 
-    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+    // The greedy policy relies on the order of processing the operations.
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };
 

--- a/lib/Dialect/Lattigo/Transforms/BUILD
+++ b/lib/Dialect/Lattigo/Transforms/BUILD
@@ -23,7 +23,10 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
+        "@heir//lib/Utils/Tablegen:InplaceOpInterface",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",

--- a/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_dot_product.mlir
+++ b/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_dot_product.mlir
@@ -1,0 +1,27 @@
+// RUN: heir-opt --lattigo-alloc-to-inplace %s | FileCheck %s
+
+// CHECK-LABEL: func.func @dot_product
+func.func @dot_product(%evaluator: !lattigo.bgv.evaluator, %param: !lattigo.bgv.parameter, %encoder: !lattigo.bgv.encoder, %ct: !lattigo.rlwe.ciphertext, %ct_0: !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext attributes {mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>} {
+  // no new allocation found as the two ciphertexts in function argument are enough to store the imtermediate results
+  // CHECK-NOT: _new
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  %c7 = arith.constant 7 : index
+  %ct_1 = lattigo.bgv.mul_new %evaluator, %ct, %ct_0 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_2 = lattigo.bgv.relinearize_new %evaluator, %ct_1 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_3 = lattigo.bgv.rotate_columns_new %evaluator, %ct_2 {offset = 4 : index} : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_4 = lattigo.bgv.add_new %evaluator, %ct_2, %ct_3 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_5 = lattigo.bgv.rotate_columns_new %evaluator, %ct_4 {offset = 2 : index} : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_6 = lattigo.bgv.add_new %evaluator, %ct_4, %ct_5 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_7 = lattigo.bgv.rotate_columns_new %evaluator, %ct_6 {offset = 1 : index} : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_8 = lattigo.bgv.add_new %evaluator, %ct_6, %ct_7 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_9 = lattigo.bgv.rescale_new %evaluator, %ct_8 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 1]> : tensor<8xi16>
+  %pt = lattigo.bgv.new_plaintext %param : (!lattigo.bgv.parameter) -> !lattigo.rlwe.plaintext
+  %pt_10 = lattigo.bgv.encode %encoder, %cst, %pt : (!lattigo.bgv.encoder, tensor<8xi16>, !lattigo.rlwe.plaintext) -> !lattigo.rlwe.plaintext
+  %ct_11 = lattigo.bgv.mul_new %evaluator, %ct_9, %pt_10 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext, !lattigo.rlwe.plaintext) -> !lattigo.rlwe.ciphertext
+  %ct_12 = lattigo.bgv.rotate_columns_new %evaluator, %ct_11 {offset = 7 : index} : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  %ct_13 = lattigo.bgv.rescale_new %evaluator, %ct_12 : (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+  return %ct_13 : !lattigo.rlwe.ciphertext
+}

--- a/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_mixed_alloc_inplace.mlir
+++ b/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_mixed_alloc_inplace.mlir
@@ -1,0 +1,22 @@
+// RUN: heir-opt --lattigo-alloc-to-inplace %s | FileCheck %s
+
+// alloc-to-place should work with input with mixed AllocOp and InplaceOp
+
+!ct = !lattigo.rlwe.ciphertext
+!encoder = !lattigo.bgv.encoder
+!evaluator = !lattigo.bgv.evaluator
+!param = !lattigo.bgv.parameter
+!pt = !lattigo.rlwe.plaintext
+
+// CHECK-LABEL: func.func @add
+func.func @add(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %ct: !ct) -> !ct {
+  // no new allocation found
+  // CHECK-NOT: _new
+  %ct_0 = lattigo.bgv.add %evaluator, %ct, %ct, %ct : (!evaluator, !ct, !ct, !ct) -> !ct
+  %ct_1 = lattigo.bgv.add_new %evaluator, %ct_0, %ct_0 : (!evaluator, !ct, !ct) -> !ct
+  %ct_2 = lattigo.bgv.add %evaluator, %ct_1, %ct_1, %ct_1 : (!evaluator, !ct, !ct, !ct) -> !ct
+  %ct_3 = lattigo.bgv.add_new %evaluator, %ct_2, %ct_2 : (!evaluator, !ct, !ct) -> !ct
+  %ct_4 = lattigo.bgv.add %evaluator, %ct_3, %ct_3, %ct_3 : (!evaluator, !ct, !ct, !ct) -> !ct
+  %ct_5 = lattigo.bgv.add_new %evaluator, %ct_4, %ct_4 : (!evaluator, !ct, !ct) -> !ct
+  return %ct_5 : !ct
+}

--- a/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_multi_func.mlir
+++ b/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_multi_func.mlir
@@ -1,0 +1,62 @@
+// RUN: heir-opt --lattigo-alloc-to-inplace %s | FileCheck %s
+
+// alloc-to-place should work with multiple functions
+
+!ct = !lattigo.rlwe.ciphertext
+!encoder = !lattigo.bgv.encoder
+!evaluator = !lattigo.bgv.evaluator
+!param = !lattigo.bgv.parameter
+!pt = !lattigo.rlwe.plaintext
+
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [33832961, 34062337, 281474977349633], P = [281474977595393, 281474978185217], plaintextModulus = 65537>, scheme.bgv} {
+  // CHECK-LABEL: func.func @dot_product
+  func.func @dot_product(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %ct: !ct, %ct_0: !ct) -> !ct attributes {mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>} {
+    // no new allocation found as the two ciphertexts in function argument are enough to store the imtermediate results
+    // CHECK-NOT: _new
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %c7 = arith.constant 7 : index
+    %ct_1 = lattigo.bgv.mul_new %evaluator, %ct, %ct_0 : (!evaluator, !ct, !ct) -> !ct
+    %ct_2 = lattigo.bgv.relinearize_new %evaluator, %ct_1 : (!evaluator, !ct) -> !ct
+    %ct_3 = lattigo.bgv.rotate_columns_new %evaluator, %ct_2 {offset = 4 : index} : (!evaluator, !ct) -> !ct
+    %ct_4 = lattigo.bgv.add_new %evaluator, %ct_2, %ct_3 : (!evaluator, !ct, !ct) -> !ct
+    %ct_5 = lattigo.bgv.rotate_columns_new %evaluator, %ct_4 {offset = 2 : index} : (!evaluator, !ct) -> !ct
+    %ct_6 = lattigo.bgv.add_new %evaluator, %ct_4, %ct_5 : (!evaluator, !ct, !ct) -> !ct
+    %ct_7 = lattigo.bgv.rotate_columns_new %evaluator, %ct_6 {offset = 1 : index} : (!evaluator, !ct) -> !ct
+    %ct_8 = lattigo.bgv.add_new %evaluator, %ct_6, %ct_7 : (!evaluator, !ct, !ct) -> !ct
+    %ct_9 = lattigo.bgv.rescale_new %evaluator, %ct_8 : (!evaluator, !ct) -> !ct
+    %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 1]> : tensor<8xi16>
+    %pt = lattigo.bgv.new_plaintext %param : (!param) -> !pt
+    %pt_10 = lattigo.bgv.encode %encoder, %cst, %pt : (!encoder, tensor<8xi16>, !pt) -> !pt
+    %ct_11 = lattigo.bgv.mul_new %evaluator, %ct_9, %pt_10 : (!evaluator, !ct, !pt) -> !ct
+    %ct_12 = lattigo.bgv.rotate_columns_new %evaluator, %ct_11 {offset = 7 : index} : (!evaluator, !ct) -> !ct
+    %ct_13 = lattigo.bgv.rescale_new %evaluator, %ct_12 : (!evaluator, !ct) -> !ct
+    return %ct_13 : !ct
+  }
+  // CHECK-LABEL: func.func @dot_product23
+  func.func @dot_product23(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %ct: !ct, %ct_0: !ct) -> !ct attributes {mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>} {
+    // no new allocation found as the two ciphertexts in function argument are enough to store the imtermediate results
+    // CHECK-NOT: _new
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %c7 = arith.constant 7 : index
+    %ct_1 = lattigo.bgv.mul_new %evaluator, %ct, %ct_0 : (!evaluator, !ct, !ct) -> !ct
+    %ct_2 = lattigo.bgv.relinearize_new %evaluator, %ct_1 : (!evaluator, !ct) -> !ct
+    %ct_3 = lattigo.bgv.rotate_columns_new %evaluator, %ct_2 {offset = 4 : index} : (!evaluator, !ct) -> !ct
+    %ct_4 = lattigo.bgv.add_new %evaluator, %ct_2, %ct_3 : (!evaluator, !ct, !ct) -> !ct
+    %ct_5 = lattigo.bgv.rotate_columns_new %evaluator, %ct_4 {offset = 2 : index} : (!evaluator, !ct) -> !ct
+    %ct_6 = lattigo.bgv.add_new %evaluator, %ct_4, %ct_5 : (!evaluator, !ct, !ct) -> !ct
+    %ct_7 = lattigo.bgv.rotate_columns_new %evaluator, %ct_6 {offset = 1 : index} : (!evaluator, !ct) -> !ct
+    %ct_8 = lattigo.bgv.add_new %evaluator, %ct_6, %ct_7 : (!evaluator, !ct, !ct) -> !ct
+    %ct_9 = lattigo.bgv.rescale_new %evaluator, %ct_8 : (!evaluator, !ct) -> !ct
+    %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 1]> : tensor<8xi16>
+    %pt = lattigo.bgv.new_plaintext %param : (!param) -> !pt
+    %pt_10 = lattigo.bgv.encode %encoder, %cst, %pt : (!encoder, tensor<8xi16>, !pt) -> !pt
+    %ct_11 = lattigo.bgv.mul_new %evaluator, %ct_9, %pt_10 : (!evaluator, !ct, !pt) -> !ct
+    %ct_12 = lattigo.bgv.rotate_columns_new %evaluator, %ct_11 {offset = 7 : index} : (!evaluator, !ct) -> !ct
+    %ct_13 = lattigo.bgv.rescale_new %evaluator, %ct_12 : (!evaluator, !ct) -> !ct
+    return %ct_13 : !ct
+  }
+}


### PR DESCRIPTION
See https://github.com/google/heir/pull/1407#discussion_r1962686905

This optimization extends the alloc-to-inplace pass to use available storage (dead value after this operation) instead of judging only whether one of its operand is dead. This further reduces the memory usage.

Detailed explanation of the optimization could be found in the code comments.

Marked as draft as waiting for #1407 to merge.