### PR TITLE
Parameters: Allow specifying minimum slot number

### DIFF
--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -215,8 +215,11 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
       auto maxLevel = getMaxLevel();
       std::vector<double> logPrimes(maxLevel + 1, 45);  // all primes of 45 bits
 
-      auto schemeParam =
-          bgv::SchemeParam::getConcreteSchemeParam(logPrimes, plaintextModulus);
+      // pass option polyModDegree is actually the number of slots
+      // assuming slots = ringDim / 2 for 1-dim vector behavior
+      // TODO(#1402): use a proper name for BGV
+      auto schemeParam = bgv::SchemeParam::getConcreteSchemeParam(
+          logPrimes, plaintextModulus, polyModDegree);
 
       primes = schemeParam.getQi();
 

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -413,8 +413,10 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
       logPrimes.push_back(scalingModBits);
     }
 
-    auto schemeParam =
-        ckks::SchemeParam::getConcreteSchemeParam(logPrimes, scalingModBits);
+    // pass option polyModDegree is actually the number of slots
+    // TODO(#1402): use a proper name for CKKS
+    auto schemeParam = ckks::SchemeParam::getConcreteSchemeParam(
+        logPrimes, scalingModBits, polyModDegree);
     LLVM_DEBUG(llvm::dbgs() << "Concrete Scheme Param:\n"
                             << schemeParam << "\n");
 

--- a/lib/Parameters/BGV/Params.cpp
+++ b/lib/Parameters/BGV/Params.cpp
@@ -14,15 +14,20 @@ namespace heir {
 namespace bgv {
 
 SchemeParam SchemeParam::getConservativeSchemeParam(int level,
-                                                    int64_t plaintextModulus) {
-  return SchemeParam(RLWESchemeParam::getConservativeRLWESchemeParam(level),
-                     plaintextModulus);
+                                                    int64_t plaintextModulus,
+                                                    int slotNumber) {
+  // Use only half of the BGV slot number to make 1-dim vector.
+  return SchemeParam(
+      RLWESchemeParam::getConservativeRLWESchemeParam(level, 2 * slotNumber),
+      plaintextModulus);
 }
 
 SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
-                                                int64_t plaintextModulus) {
+                                                int64_t plaintextModulus,
+                                                int slotNumber) {
+  // Use only half of the BGV slot number to make 1-dim vector.
   return SchemeParam(RLWESchemeParam::getConcreteRLWESchemeParam(
-                         std::move(logqi), plaintextModulus),
+                         std::move(logqi), 2 * slotNumber, plaintextModulus),
                      plaintextModulus);
 }
 

--- a/lib/Parameters/BGV/Params.h
+++ b/lib/Parameters/BGV/Params.h
@@ -27,10 +27,12 @@ class SchemeParam : public RLWESchemeParam {
   void print(llvm::raw_ostream &os) const override;
 
   static SchemeParam getConservativeSchemeParam(int level,
-                                                int64_t plaintextModulus);
+                                                int64_t plaintextModulus,
+                                                int slotNumber);
 
   static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
-                                            int64_t plaintextModulus);
+                                            int64_t plaintextModulus,
+                                            int slotNumber);
 
   static SchemeParam getSchemeParamFromAttr(SchemeParamAttr attr);
 };

--- a/lib/Parameters/CKKS/Params.cpp
+++ b/lib/Parameters/CKKS/Params.cpp
@@ -12,10 +12,12 @@ namespace heir {
 namespace ckks {
 
 SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
-                                                int logDefaultScale) {
-  return SchemeParam(
-      RLWESchemeParam::getConcreteRLWESchemeParam(std::move(logqi)),
-      logDefaultScale);
+                                                int logDefaultScale,
+                                                int slotNumber) {
+  // CKKS slot number = ringDim / 2
+  return SchemeParam(RLWESchemeParam::getConcreteRLWESchemeParam(
+                         std::move(logqi), 2 * slotNumber),
+                     logDefaultScale);
 }
 
 void SchemeParam::print(llvm::raw_ostream &os) const {

--- a/lib/Parameters/CKKS/Params.h
+++ b/lib/Parameters/CKKS/Params.h
@@ -26,7 +26,8 @@ class SchemeParam : public RLWESchemeParam {
   void print(llvm::raw_ostream &os) const override;
 
   static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
-                                            int logDefaultScale);
+                                            int logDefaultScale,
+                                            int slotNumber);
 };
 
 }  // namespace ckks

--- a/lib/Parameters/RLWEParams.cpp
+++ b/lib/Parameters/RLWEParams.cpp
@@ -28,7 +28,8 @@ int computeDnum(int level) {
   return 1;
 }
 
-RLWESchemeParam RLWESchemeParam::getConservativeRLWESchemeParam(int level) {
+RLWESchemeParam RLWESchemeParam::getConservativeRLWESchemeParam(
+    int level, int slotNumber) {
   auto logModuli = 60;  // assume all 60 bit moduli
   auto dnum = computeDnum(level);
   std::vector<double> logqi(level + 1, logModuli);
@@ -37,7 +38,7 @@ RLWESchemeParam RLWESchemeParam::getConservativeRLWESchemeParam(int level) {
 
   auto totalQP = logModuli * (logqi.size() + logpi.size());
 
-  auto ringDim = computeRingDim(totalQP);
+  auto ringDim = computeRingDim(totalQP, slotNumber);
 
   return RLWESchemeParam(ringDim, level, logqi, dnum, logpi);
 }
@@ -78,7 +79,7 @@ int64_t findPrime(int qi, int ringDim,
 }
 
 RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
-    std::vector<double> logqi, int64_t plaintextModulus) {
+    std::vector<double> logqi, int slotNumber, int64_t plaintextModulus) {
   auto level = logqi.size() - 1;
   auto dnum = computeDnum(level);
 
@@ -98,7 +99,7 @@ RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
                  std::accumulate(logpi.begin(), logpi.end(), 0.0);
 
   // ringDim will change if newLogPQ is too large
-  auto ringDim = computeRingDim(logPQ);
+  auto ringDim = computeRingDim(logPQ, slotNumber);
   std::vector<int64_t> qiImpl;
   std::vector<int64_t> piImpl;
   bool redo = false;
@@ -127,7 +128,7 @@ RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
       newLogPQ += log2(prime);
     }
     // if generated primes are too large, increase ringDim
-    auto newRingDim = computeRingDim(newLogPQ);
+    auto newRingDim = computeRingDim(newLogPQ, slotNumber);
     if (newRingDim != ringDim) {
       ringDim = newRingDim;
       redo = true;

--- a/lib/Parameters/RLWEParams.h
+++ b/lib/Parameters/RLWEParams.h
@@ -80,12 +80,13 @@ class RLWESchemeParam {
     return os;
   }
 
-  static RLWESchemeParam getConservativeRLWESchemeParam(int level);
+  static RLWESchemeParam getConservativeRLWESchemeParam(int level,
+                                                        int minRingDim);
 
   // plaintext modulus for BGV
   // for CKKS this field is not used
   static RLWESchemeParam getConcreteRLWESchemeParam(
-      std::vector<double> logqi, int64_t plaintextModulus = 0);
+      std::vector<double> logqi, int minRingDim, int64_t plaintextModulus = 0);
 };
 
 // Parameter for each RLWE ciphertext SSA value.

--- a/lib/Parameters/RLWESecurityParams.cpp
+++ b/lib/Parameters/RLWESecurityParams.cpp
@@ -13,8 +13,11 @@ struct RLWESecurityParam rlweSecurityParam128BitClassic[] = {
     {1024, 26},   {2048, 53},   {4096, 106},   {8192, 214},
     {16384, 430}, {32768, 868}, {65536, 1747}, {131072, 3523}};
 
-int computeRingDim(int logPQ) {
+int computeRingDim(int logPQ, int minRingDim) {
   for (auto &param : rlweSecurityParam128BitClassic) {
+    if (param.ringDim < minRingDim) {
+      continue;
+    }
     if (param.logMaxQ >= logPQ) {
       return param.ringDim;
     }

--- a/lib/Parameters/RLWESecurityParams.h
+++ b/lib/Parameters/RLWESecurityParams.h
@@ -12,7 +12,7 @@ struct RLWESecurityParam {
 };
 
 // compute ringDim given logPQ under 128-bit classic security
-int computeRingDim(int logPQ);
+int computeRingDim(int logPQ, int minRingDim);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -161,6 +161,7 @@ void mlirToRLWEPipeline(OpPassManager &pm,
       auto validateNoiseOptions = ValidateNoiseOptions{};
       validateNoiseOptions.model = options.noiseModel;
       validateNoiseOptions.plaintextModulus = options.plaintextModulus;
+      validateNoiseOptions.slotNumber = options.ciphertextDegree;
       pm.addPass(createValidateNoise(validateNoiseOptions));
       break;
     }

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -224,7 +224,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
 
     auto concreteSchemeParam =
         NoiseAnalysis::SchemeParamType::getConcreteSchemeParam(
-            qiSize, schemeParam.getPlaintextModulus());
+            qiSize, schemeParam.getPlaintextModulus(), slotNumber);
 
     LLVM_DEBUG(llvm::dbgs() << "Concrete Scheme Param:\n"
                             << concreteSchemeParam << "\n");
@@ -260,7 +260,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
     // plaintext modulus from command line option
     auto schemeParam =
         NoiseAnalysis::SchemeParamType::getConservativeSchemeParam(
-            maxLevel, plaintextModulus);
+            maxLevel, plaintextModulus, slotNumber);
 
     LLVM_DEBUG(llvm::dbgs() << "Conservative Scheme Param:\n"
                             << schemeParam << "\n");

--- a/lib/Transforms/ValidateNoise/ValidateNoise.td
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.td
@@ -50,6 +50,8 @@ def ValidateNoise : Pass<"validate-noise"> {
            /*default=*/"", "Noise model to validate against.">,
     Option<"plaintextModulus", "plaintext-modulus", "int64_t",
            /*default=*/"65537", "Plaintext modulus.">,
+    Option<"slotNumber", "slot-number", "int",
+           /*default=*/"0", "Minimum number of slots for parameter generation.">,
   ];
 }
 

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -69,7 +69,7 @@ heir_lattigo_lib(
     name = "box_blur",
     go_library_name = "boxblur",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=4295294977",
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=786433",
         "--scheme-to-lattigo",
     ],
     mlir_src = "box_blur_64x64.mlir",
@@ -144,7 +144,6 @@ go_test(
     embed = [":dotproduct8debug"],
 )
 
-# happens to have logN = 13
 go_test(
     name = "robertscross_test",
     srcs = ["roberts_cross_test.go"],

--- a/tests/Examples/lattigo/box_blur_test.go
+++ b/tests/Examples/lattigo/box_blur_test.go
@@ -5,11 +5,6 @@ import (
 )
 
 func TestBinops(t *testing.T) {
-	// TODO(#1186): re-enable this test
-	// Disabled now for logN = 12 in parameter generation
-	// which does not satisfy the requirement of logN >= 13
-	// for 4096 input size
-	t.Skip("Disabled because the parameters generated are too small.")
 	evaluator, params, ecd, enc, dec := box_blur__configure()
 
 	input := make([]int16, 4096)


### PR DESCRIPTION
Fixes #1440

Now for lattigo, boxblur uses the ptm of 786433 and roberts cross uses the ptm of 536903681, which is the same as those used in openfhe tests.

Seems that during computation the number in slots do can exceed 65537 so these ptm are required. Have not inspected the intermediate values during computation though. Not sure if #1441 is necessary or not.

Indeed we need a plaintext execution result from the secret-arithmetic IR (both in Z and Zp) to determine whether the execution is correct given a plaintext modulus, or the incorrectness is from the ciphertext side (i.e. scheme parameter). Ref to #1266