### PR TITLE
Lattigo: support type alias

### DIFF
--- a/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWETypes.td
@@ -49,6 +49,9 @@ def Lattigo_RLWEGaloisKey : Lattigo_RLWEType<"GaloisKey", "galois_key"> {
   let parameters = (ins Builtin_IntegerAttr:$galoisElement);
   let assemblyFormat = "`<` struct(params) `>`";
   let asmName = "gk";
+  let aliasSuffix = [{
+    os << "_g" << getGaloisElement().getValue().getSExtValue();
+  }];
 }
 
 def Lattigo_RLWEEvaluationKeySet : Lattigo_RLWEType<"EvaluationKeySet", "evaluation_key_set"> {
@@ -65,6 +68,13 @@ def Lattigo_RLWEEncryptor : Lattigo_RLWEType<"Encryptor", "encryptor"> {
   let parameters = (ins "bool":$publicKey);
   let assemblyFormat = "`<` struct(params) `>`";
   let asmName = "encryptor";
+  let aliasSuffix = [{
+    if (getPublicKey()) {
+      os<< "_pk";
+    } else {
+      os<< "_sk";
+    }
+  }];
 }
 
 def Lattigo_RLWEDecryptor : Lattigo_RLWEType<"Decryptor", "decryptor"> {

--- a/lib/Dialect/Lattigo/IR/LattigoTypes.td
+++ b/lib/Dialect/Lattigo/IR/LattigoTypes.td
@@ -15,10 +15,17 @@ class Lattigo_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 
   string asmName = ?;
+  string aliasSuffix = "";
   let extraClassDeclaration = [{
     // OpAsmTypeInterface method
     void getAsmName(::mlir::OpAsmSetNameFn setNameFn) const {
       setNameFn("}] # asmName # [{");
+    }
+
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # asmName # [{";
+      }] # aliasSuffix # [{
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
     }
   }];
 }


### PR DESCRIPTION
For convenience just use asmName as aliasName.

### Example

```mlir
!ct = !lattigo.rlwe.ciphertext
!decryptor = !lattigo.rlwe.decryptor
!ekset = !lattigo.rlwe.evaluation_key_set
!encoder = !lattigo.bgv.encoder
!encryptor_pk = !lattigo.rlwe.encryptor<publicKey = true>
!evaluator = !lattigo.bgv.evaluator
!gk_g12589_ = !lattigo.rlwe.galois_key<galoisElement = 12589 : i64>
!gk_g25_ = !lattigo.rlwe.galois_key<galoisElement = 25 : i64>
!gk_g5_ = !lattigo.rlwe.galois_key<galoisElement = 5 : i64>
!gk_g625_ = !lattigo.rlwe.galois_key<galoisElement = 625 : i64>
!kgen = !lattigo.rlwe.key_generator
!param = !lattigo.bgv.parameter
!pk = !lattigo.rlwe.public_key
!pt = !lattigo.rlwe.plaintext
!rk = !lattigo.rlwe.relinearization_key
!sk = !lattigo.rlwe.secret_key

  func.func @dot_product(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %ct: !ct, %ct_0: !ct) -> !ct attributes {mgmt.openfhe_params = #mgmt.openfhe_params<evalAddCount = 8, keySwitchCount = 15>} {
    %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 1]> : tensor<8xi16>
    %ct_1 = lattigo.bgv.mul %evaluator, %ct, %ct_0 : (!evaluator, !ct, !ct) -> !ct
    %ct_2 = lattigo.bgv.relinearize %evaluator, %ct_1 : (!evaluator, !ct) -> !ct
    %ct_3 = lattigo.bgv.rotate_columns %evaluator, %ct_2 {offset = 4 : index} : (!evaluator, !ct) -> !ct
    %ct_4 = lattigo.bgv.add %evaluator, %ct_2, %ct_3 : (!evaluator, !ct, !ct) -> !ct
    %ct_5 = lattigo.bgv.rotate_columns %evaluator, %ct_4 {offset = 2 : index} : (!evaluator, !ct) -> !ct
    %ct_6 = lattigo.bgv.add %evaluator, %ct_4, %ct_5 : (!evaluator, !ct, !ct) -> !ct
    %ct_7 = lattigo.bgv.rotate_columns %evaluator, %ct_6 {offset = 1 : index} : (!evaluator, !ct) -> !ct
    %ct_8 = lattigo.bgv.add %evaluator, %ct_6, %ct_7 : (!evaluator, !ct, !ct) -> !ct
    %ct_9 = lattigo.bgv.rescale %evaluator, %ct_8 : (!evaluator, !ct) -> !ct
    %pt = lattigo.bgv.new_plaintext %param : (!param) -> !pt
    %pt_10 = lattigo.bgv.encode %encoder, %cst, %pt : (!encoder, tensor<8xi16>, !pt) -> !pt
    %ct_11 = lattigo.bgv.mul %evaluator, %ct_9, %pt_10 : (!evaluator, !ct, !pt) -> !ct
    %ct_12 = lattigo.bgv.rotate_columns %evaluator, %ct_11 {offset = 7 : index} : (!evaluator, !ct) -> !ct
    %ct_13 = lattigo.bgv.rescale %evaluator, %ct_12 : (!evaluator, !ct) -> !ct
    return %ct_13 : !ct
  }

```