### PR TITLE
Openfhe: support type alias

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheTypes.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheTypes.td
@@ -20,6 +20,11 @@ class Openfhe_Type<string name, string typeMnemonic, list<Trait> traits = []>
     void getAsmName(::mlir::OpAsmSetNameFn setNameFn) const {
       setNameFn("}] # asmName # [{");
     }
+
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # asmName # [{";
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
   }];
 }
 

--- a/tests/Transforms/forward_insert_to_extract/forward_insert_to_extract.mlir
+++ b/tests/Transforms/forward_insert_to_extract/forward_insert_to_extract.mlir
@@ -18,7 +18,7 @@
 
 
 //  CHECK-LABEL: @successful_forwarding
-//  CHECK-SAME:  (%[[ARG0:.*]]: !openfhe.crypto_context,
+//  CHECK-SAME:  (%[[ARG0:.*]]: !cc,
 
 
 func.func @successful_forwarding(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: tensor<1x16x!ct>, %arg3: tensor<16xf64>, %arg4: tensor<16xf64>) -> tensor<1x16x!ct> {
@@ -61,7 +61,7 @@ func.func @successful_forwarding(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: ten
 
 //hits def == nullptr
 //  CHECK-LABEL: @forward_from_func_arg
-//  CHECK-SAME:  (%[[ARG0:.*]]: !openfhe.crypto_context,
+//  CHECK-SAME:  (%[[ARG0:.*]]: !cc,
 
 func.func @forward_from_func_arg(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: tensor<1x16x!ct>)-> !ct {
   // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
@@ -73,7 +73,7 @@ func.func @forward_from_func_arg(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: ten
 }
 
 //  CHECK-LABEL: @forwarding_with_an_insert_in_between
-//  CHECK-SAME:  (%[[ARG0:.*]]: !openfhe.crypto_context,
+//  CHECK-SAME:  (%[[ARG0:.*]]: !cc,
 
 func.func @forwarding_with_an_insert_in_between(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: tensor<1x16x!ct>, %arg3: tensor<16xf64> )-> !ct {
 
@@ -104,7 +104,7 @@ func.func @forwarding_with_an_insert_in_between(%arg0: !cc, %arg1: tensor<1x16x!
 }
 
 //  CHECK-LABEL: @forwarding_with_an_operation_in_between
-//  CHECK-SAME:  (%[[ARG0:.*]]: !openfhe.crypto_context,
+//  CHECK-SAME:  (%[[ARG0:.*]]: !cc,
 
 func.func @forwarding_with_an_operation_in_between(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: tensor<1x16x!ct>, %arg3: tensor<16xf64>, %arg4: i1 )-> !ct {
 
@@ -138,7 +138,7 @@ func.func @forwarding_with_an_operation_in_between(%arg0: !cc, %arg1: tensor<1x1
 
 
 //  CHECK-LABEL: @two_extracts_both_forwarded
-//  CHECK-SAME:  (%[[ARG0:.*]]: !openfhe.crypto_context,
+//  CHECK-SAME:  (%[[ARG0:.*]]: !cc,
 
 func.func @two_extracts_both_forwarded(%arg0: !cc, %arg1: tensor<1x16x!ct>, %arg2: tensor<1x16x!ct>, %arg3: tensor<16xf64>) -> !ct {
 


### PR DESCRIPTION
Similar to #1454

### Example

```mlir
!cc = !openfhe.crypto_context
!params = !openfhe.cc_params
!pk = !openfhe.public_key
!sk = !openfhe.private_key

  func.func @dot_product(%cc: !cc, %ct: !ct_L2_, %ct_0: !ct_L2_) -> !ct_L0_ {
    %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 1]> : tensor<8xi64>
    %ct_1 = openfhe.mul_no_relin %cc, %ct, %ct_0 : (!cc, !ct_L2_, !ct_L2_) -> !ct_L2_D3_
    %ct_2 = openfhe.relin %cc, %ct_1 : (!cc, !ct_L2_D3_) -> !ct_L2_
    %ct_3 = openfhe.rot %cc, %ct_2 {index = 4 : index} : (!cc, !ct_L2_) -> !ct_L2_
    %ct_4 = openfhe.add %cc, %ct_2, %ct_3 : (!cc, !ct_L2_, !ct_L2_) -> !ct_L2_
    %ct_5 = openfhe.rot %cc, %ct_4 {index = 2 : index} : (!cc, !ct_L2_) -> !ct_L2_
    %ct_6 = openfhe.add %cc, %ct_4, %ct_5 : (!cc, !ct_L2_, !ct_L2_) -> !ct_L2_
    %ct_7 = openfhe.rot %cc, %ct_6 {index = 1 : index} : (!cc, !ct_L2_) -> !ct_L2_
    %ct_8 = openfhe.add %cc, %ct_6, %ct_7 : (!cc, !ct_L2_, !ct_L2_) -> !ct_L2_
    %ct_9 = openfhe.mod_reduce %cc, %ct_8 : (!cc, !ct_L2_) -> !ct_L1_
    %pt = openfhe.make_packed_plaintext %cc, %cst : (!cc, tensor<8xi64>) -> !pt
    %ct_10 = openfhe.mul_plain %cc, %ct_9, %pt : (!cc, !ct_L1_, !pt) -> !ct_L1_
    %ct_11 = openfhe.rot %cc, %ct_10 {index = 7 : index} : (!cc, !ct_L1_) -> !ct_L1_
    %ct_12 = lwe.reinterpret_underlying_type %ct_11 : !ct_L1_ to !ct_L1_1
    %ct_13 = openfhe.mod_reduce %cc, %ct_12 : (!cc, !ct_L1_1) -> !ct_L0_
    return %ct_13 : !ct_L0_
  }
```