### PR TITLE
Initial support of B/FV via reusing BGV

### DIFF
--- a/lib/Dialect/BGV/IR/BGVDialect.td
+++ b/lib/Dialect/BGV/IR/BGVDialect.td
@@ -10,7 +10,14 @@ def BGV_Dialect : Dialect {
   let name = "bgv";
 
   let description = [{
-    The BGV dialect defines the types and operations of the BGV cryptosystem.
+    The BGV dialect defines the types and operations of the BGV and B/FV cryptosystem.
+
+    Due to similarity with the BFV scheme, BGV dialect also represents the B/FV scheme.
+
+    The semantics of bgv dialect operations are determined by the `scheme.bgv` or `scheme.bfv`
+    annotation at the module level.
+
+    In B/FV mode, bgv.modulus_switch is an no-op.
   }];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -569,7 +569,7 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
     auto gateByBGVModuleAttr =
         [&](const OpPredicate &inputPredicate) -> OpPredicate {
       return [module, inputPredicate](Operation *op) {
-        return moduleIsBGV(module) && inputPredicate(op);
+        return moduleIsBGVOrBFV(module) && inputPredicate(op);
       };
     };
 
@@ -638,7 +638,7 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
     patterns.add<AddEvaluatorArg>(context, evaluators);
     patterns.add<ConvertFuncCallOp>(context, evaluators);
 
-    if (moduleIsBGV(module)) {
+    if (moduleIsBGVOrBFV(module)) {
       patterns
           .add<ConvertBGVAddOp, ConvertBGVSubOp, ConvertBGVMulOp,
                ConvertBGVAddPlainOp, ConvertBGVSubPlainOp, ConvertBGVMulPlainOp,

--- a/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
@@ -82,10 +82,14 @@ def Lattigo_BGVNewEvaluatorOp : Lattigo_BGVOp<"new_evaluator"> {
 
     To support operations that require evaluation keys,
     the optional evaluation key set should be provided.
+
+    The scaleInvariant flag is used to indicate whether the evaluator is for B/FV or BGV.
+    If it is set to true, the evaluator will evaluate operations in B/FV style.
   }];
   let arguments = (ins
     Lattigo_BGVParameter:$params,
-    Optional<Lattigo_RLWEEvaluationKeySet>:$evaluationKeySet
+    Optional<Lattigo_RLWEEvaluationKeySet>:$evaluationKeySet,
+    DefaultValuedAttr<BoolAttr, "false">:$scaleInvariant
   );
   let results = (outs Lattigo_BGVEvaluator:$evaluator);
 }

--- a/lib/Dialect/ModuleAttributes.cpp
+++ b/lib/Dialect/ModuleAttributes.cpp
@@ -9,6 +9,14 @@ bool moduleIsBGV(Operation *moduleOp) {
   return moduleOp->getAttrOfType<mlir::UnitAttr>(kBGVSchemeAttrName) != nullptr;
 }
 
+bool moduleIsBFV(Operation *moduleOp) {
+  return moduleOp->getAttrOfType<mlir::UnitAttr>(kBFVSchemeAttrName) != nullptr;
+}
+
+bool moduleIsBGVOrBFV(Operation *moduleOp) {
+  return moduleIsBGV(moduleOp) || moduleIsBFV(moduleOp);
+}
+
 bool moduleIsCKKS(Operation *moduleOp) {
   return moduleOp->getAttrOfType<mlir::UnitAttr>(kCKKSSchemeAttrName) !=
          nullptr;
@@ -17,6 +25,37 @@ bool moduleIsCKKS(Operation *moduleOp) {
 bool moduleIsCGGI(Operation *moduleOp) {
   return moduleOp->getAttrOfType<mlir::UnitAttr>(kCGGISchemeAttrName) !=
          nullptr;
+}
+
+void moduleClearScheme(Operation *moduleOp) {
+  moduleOp->removeAttr(kBGVSchemeAttrName);
+  moduleOp->removeAttr(kBFVSchemeAttrName);
+  moduleOp->removeAttr(kCKKSSchemeAttrName);
+  moduleOp->removeAttr(kCGGISchemeAttrName);
+}
+
+void moduleSetBGV(Operation *moduleOp) {
+  moduleClearScheme(moduleOp);
+  moduleOp->setAttr(kBGVSchemeAttrName,
+                    mlir::UnitAttr::get(moduleOp->getContext()));
+}
+
+void moduleSetBFV(Operation *moduleOp) {
+  moduleClearScheme(moduleOp);
+  moduleOp->setAttr(kBFVSchemeAttrName,
+                    mlir::UnitAttr::get(moduleOp->getContext()));
+}
+
+void moduleSetCKKS(Operation *moduleOp) {
+  moduleClearScheme(moduleOp);
+  moduleOp->setAttr(kCKKSSchemeAttrName,
+                    mlir::UnitAttr::get(moduleOp->getContext()));
+}
+
+void moduleSetCGGI(Operation *moduleOp) {
+  moduleClearScheme(moduleOp);
+  moduleOp->setAttr(kCGGISchemeAttrName,
+                    mlir::UnitAttr::get(moduleOp->getContext()));
 }
 
 }  // namespace heir

--- a/lib/Dialect/ModuleAttributes.h
+++ b/lib/Dialect/ModuleAttributes.h
@@ -10,14 +10,24 @@ namespace mlir {
 namespace heir {
 
 constexpr const static ::llvm::StringLiteral kBGVSchemeAttrName = "scheme.bgv";
+constexpr const static ::llvm::StringLiteral kBFVSchemeAttrName = "scheme.bfv";
 constexpr const static ::llvm::StringLiteral kCKKSSchemeAttrName =
     "scheme.ckks";
 constexpr const static ::llvm::StringLiteral kCGGISchemeAttrName =
     "scheme.cggi";
 
 bool moduleIsBGV(Operation *moduleOp);
+bool moduleIsBFV(Operation *moduleOp);
+bool moduleIsBGVOrBFV(Operation *moduleOp);
 bool moduleIsCKKS(Operation *moduleOp);
 bool moduleIsCGGI(Operation *moduleOp);
+
+void moduleClearScheme(Operation *moduleOp);
+
+void moduleSetBGV(Operation *moduleOp);
+void moduleSetBFV(Operation *moduleOp);
+void moduleSetCKKS(Operation *moduleOp);
+void moduleSetCGGI(Operation *moduleOp);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -186,7 +186,11 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
     auto *module = getOperation();
 
     // Helper for future lowerings that want to know what scheme was used
-    module->setAttr(kBGVSchemeAttrName, UnitAttr::get(context));
+    if (isBFV) {
+      moduleSetBFV(module);
+    } else {
+      moduleSetBGV(module);
+    }
 
     // used by LWE type
     int64_t plaintextModulus;

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.td
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.td
@@ -32,6 +32,8 @@ def SecretToBGV : Pass<"secret-to-bgv"> {
     Option<"polyModDegree", "poly-mod-degree", "int",
            /*default=*/"1024", "Default degree of the cyclotomic polynomial "
            "modulus to use for ciphertext space.">,
+    Option<"isBFV", "is-bfv", "bool",
+           /*default=*/"false", "Whether to use the BFV scheme instead of BGV.">,
   ];
 }
 

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -403,7 +403,7 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
     auto *module = getOperation();
 
     // Helper for future lowerings that want to know what scheme was used
-    module->setAttr(kCKKSSchemeAttrName, UnitAttr::get(context));
+    moduleSetCKKS(module);
 
     // generate scheme parameters
     auto maxLevel = getMaxLevel();

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -13,7 +13,7 @@
 namespace mlir::heir {
 
 // RLWE scheme selector
-enum RLWEScheme { ckksScheme, bgvScheme };
+enum RLWEScheme { ckksScheme, bgvScheme, bfvScheme };
 
 struct SimdVectorizerOptions
     : public PassPipelineOptions<SimdVectorizerOptions> {

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -89,7 +89,7 @@ LogicalResult LattigoEmitter::translate(Operation &op) {
 LogicalResult LattigoEmitter::printOperation(ModuleOp moduleOp) {
   os << "package " << packageName << "\n";
 
-  if (moduleIsBGV(moduleOp)) {
+  if (moduleIsBGVOrBFV(moduleOp)) {
     os << kModulePreludeBGVTemplate;
   } else if (moduleIsCKKS(moduleOp)) {
     os << kModulePreludeCKKSTemplate;
@@ -348,7 +348,13 @@ LogicalResult LattigoEmitter::printOperation(BGVNewEvaluatorOp op) {
     // no evaluation key set, use empty Value for 'nil'
     operands.push_back(Value());
   }
-  return printNewMethod(op.getResult(), operands, "bgv.NewEvaluator", false);
+  os << getName(op.getResult());
+  os << " := bgv.NewEvaluator(";
+  os << getCommaSeparatedNames(operands);
+  os << ", ";
+  os << (op.getScaleInvariant() ? "true" : "false");
+  os << ")\n";
+  return success();
 }
 
 LogicalResult LattigoEmitter::printOperation(BGVNewPlaintextOp op) {

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -31,7 +31,6 @@
 #include "mlir/include/mlir/IR/Types.h"                  // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
 #include "mlir/include/mlir/IR/ValueRange.h"             // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
 
@@ -114,9 +113,11 @@ LogicalResult OpenFhePkeEmitter::translate(Operation &op) {
 
 LogicalResult OpenFhePkeEmitter::printOperation(ModuleOp moduleOp) {
   OpenfheScheme scheme;
-  if (moduleOp->getAttr(kBGVSchemeAttrName)) {
+  if (moduleIsBGV(moduleOp)) {
     scheme = OpenfheScheme::BGV;
-  } else if (moduleOp->getAttr(kCKKSSchemeAttrName)) {
+  } else if (moduleIsBFV(moduleOp)) {
+    scheme = OpenfheScheme::BFV;
+  } else if (moduleIsCKKS(moduleOp)) {
     scheme = OpenfheScheme::CKKS;
   } else {
     return emitError(moduleOp.getLoc(), "Missing scheme attribute on module");

--- a/lib/Target/OpenFhePke/OpenFhePkeHeaderEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeHeaderEmitter.cpp
@@ -8,13 +8,11 @@
 #include "llvm/include/llvm/Support/FormatVariadic.h"   // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/Types.h"                 // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
 #include "mlir/include/mlir/IR/ValueRange.h"            // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"    // from @llvm-project
 
@@ -47,9 +45,11 @@ LogicalResult OpenFhePkeHeaderEmitter::translate(Operation &op) {
 
 LogicalResult OpenFhePkeHeaderEmitter::printOperation(ModuleOp moduleOp) {
   OpenfheScheme scheme;
-  if (moduleOp->getAttr(kBGVSchemeAttrName)) {
+  if (moduleIsBGV(moduleOp)) {
     scheme = OpenfheScheme::BGV;
-  } else if (moduleOp->getAttr(kCKKSSchemeAttrName)) {
+  } else if (moduleIsBFV(moduleOp)) {
+    scheme = OpenfheScheme::BFV;
+  } else if (moduleIsCKKS(moduleOp)) {
     scheme = OpenfheScheme::CKKS;
   } else {
     return emitError(moduleOp.getLoc(), "Missing scheme attribute on module");

--- a/lib/Target/OpenFhePke/OpenFheUtils.cpp
+++ b/lib/Target/OpenFhePke/OpenFheUtils.cpp
@@ -29,7 +29,9 @@ std::string getModulePrelude(OpenfheScheme scheme,
                     : kInstallationRelativeOpenfheImport;
   auto prelude = std::string(
       llvm::formatv(kModulePreludeTemplate.data(),
-                    scheme == OpenfheScheme::CKKS ? "CKKS" : "BGV"));
+                    scheme == OpenfheScheme::CKKS
+                        ? "CKKS"
+                        : (scheme == OpenfheScheme::BGV ? "BGV" : "BFV")));
   return std::string(import) + prelude;
 }
 

--- a/lib/Target/OpenFhePke/OpenFheUtils.h
+++ b/lib/Target/OpenFhePke/OpenFheUtils.h
@@ -12,7 +12,7 @@ namespace mlir {
 namespace heir {
 namespace openfhe {
 
-enum class OpenfheScheme { BGV, CKKS };
+enum class OpenfheScheme { BGV, BFV, CKKS };
 
 // OpenFHE's installation process moves headers around in the install directory,
 // as well as changing the import paths from the development repository. This

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -68,7 +68,7 @@ module attributes {scheme.bgv} {
   // CHECK: [[enc:[^, ].*]] := rlwe.NewEncryptor([[param]], [[pk]])
   // CHECK: [[encSk:[^, ].*]] := rlwe.NewEncryptor([[param]], [[sk]])
   // CHECK: [[dec:[^, ].*]] := rlwe.NewDecryptor([[param]], [[sk]])
-  // CHECK: [[eval:[^, ].*]] := bgv.NewEvaluator([[param]], [[evalKeySet]])
+  // CHECK: [[eval:[^, ].*]] := bgv.NewEvaluator([[param]], [[evalKeySet]], false)
   // CHECK: [[value1:[^, ].*]] := []int64
   // CHECK: [[value2:[^, ].*]] := []int64
   // CHECK: [[pt1:[^, ].*]] := bgv.NewPlaintext([[param]], [[param]].MaxLevel())
@@ -161,7 +161,7 @@ module attributes {scheme.bgv} {
 !evaluator = !lattigo.bgv.evaluator
 
 // CHECK-LABEL: test_new_evaluator_no_key_set
-// CHECK: bgv.NewEvaluator([[params:[^, ].*]], nil)
+// CHECK: bgv.NewEvaluator([[params:[^, ].*]], nil, false)
 module attributes {scheme.bgv} {
   func.func @test_new_evaluator_no_key_set(%params : !params) -> (!evaluator) {
     %evaluator = lattigo.bgv.new_evaluator %params : (!params) -> !evaluator

--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -85,6 +85,18 @@ heir_lattigo_lib(
     mlir_src = "roberts_cross_64x64.mlir",
 )
 
+# B/FV
+
+heir_lattigo_lib(
+    name = "dot_product_8_bfv",
+    go_library_name = "dotproduct8bfv",
+    heir_opt_flags = [
+        "--mlir-to-bfv=ciphertext-degree=8",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "dot_product_8.mlir",
+)
+
 # CKKS
 
 heir_lattigo_lib(
@@ -137,6 +149,14 @@ go_test(
     name = "robertscross_test",
     srcs = ["roberts_cross_test.go"],
     embed = [":robertscross"],
+)
+
+# B/FV
+
+go_test(
+    name = "dotproduct8bfv_test",
+    srcs = ["dot_product_8_bfv_test.go"],
+    embed = [":dotproduct8bfv"],
 )
 
 # CKKS

--- a/tests/Examples/lattigo/dot_product_8_bfv_test.go
+++ b/tests/Examples/lattigo/dot_product_8_bfv_test.go
@@ -1,0 +1,26 @@
+package dotproduct8bfv
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := dot_product__configure()
+
+	// Vector of plaintext values
+	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8}
+	arg1 := []int16{2, 3, 4, 5, 6, 7, 8, 9}
+
+	expected := int16(240)
+
+	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
+
+	resultCt := dot_product(evaluator, params, ecd, ct0, ct1)
+
+	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tests/Examples/openfhe/BUILD
+++ b/tests/Examples/openfhe/BUILD
@@ -94,6 +94,20 @@ openfhe_end_to_end_test(
     test_src = "roberts_cross_test.cpp",
 )
 
+# B/FV
+
+openfhe_end_to_end_test(
+    name = "dot_product_8_bfv_test",
+    generated_lib_header = "dot_product_8_bfv_lib.h",
+    heir_opt_flags = [
+        "--mlir-to-bfv=ciphertext-degree=8",
+        "--scheme-to-openfhe",
+    ],
+    mlir_src = "dot_product_8.mlir",
+    tags = ["notap"],
+    test_src = "dot_product_8_bfv_test.cpp",
+)
+
 # CKKS
 
 openfhe_end_to_end_test(

--- a/tests/Examples/openfhe/dot_product_8_bfv_test.cpp
+++ b/tests/Examples/openfhe/dot_product_8_bfv_test.cpp
@@ -1,0 +1,40 @@
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/dot_product_8_bfv_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(DotProduct8Test, RunTest) {
+  auto cryptoContext = dot_product__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      dot_product__configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<int16_t> arg0 = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<int16_t> arg1 = {2, 3, 4, 5, 6, 7, 8, 9};
+  int64_t expected = 240;
+
+  auto arg0Encrypted =
+      dot_product__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg1Encrypted =
+      dot_product__encrypt__arg1(cryptoContext, arg1, publicKey);
+  auto outputEncrypted =
+      dot_product(cryptoContext, arg0Encrypted, arg1Encrypted);
+  auto actual =
+      dot_product__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -354,6 +354,12 @@ int main(int argc, char **argv) {
       mlirToRLWEPipelineBuilder(mlir::heir::RLWEScheme::bgvScheme));
 
   PassPipelineRegistration<mlir::heir::MlirToRLWEPipelineOptions>(
+      "mlir-to-bfv",
+      "Convert a func using standard MLIR dialects to FHE using "
+      "BFV.",
+      mlirToRLWEPipelineBuilder(mlir::heir::RLWEScheme::bfvScheme));
+
+  PassPipelineRegistration<mlir::heir::MlirToRLWEPipelineOptions>(
       "mlir-to-ckks",
       "Convert a func using standard MLIR dialects to FHE using "
       "CKKS.",


### PR DESCRIPTION
Addresses #1419

As B/FV operation is highly similar to BGV, to make the pipeline work with minimum effort we can reuse BGV to represent B/FV.

One exception is that `bgv.modulus_switch` is not available for B/FV (most libraries does not implement the leveled version). Happily the two backends we have, when configured in B/FV mode, just ignores the compiler-issued modulus switching instruction.

  * Lattigo implements it as no-op
  * Openfhe, when in FIXEDMANUAL mode, throws exception. In other cases just no-op.

The side effect is that in `LWE` IR, we will see the level decreasing but in the backend it is not decreasing. This should be resolved by a future `secret-insert-mgmt-bfv` pass.
  
I think the time we want to separate B/FV from BGV is when we want to model/implement the multiplication technique of B/FV.