### PR TITLE
B/FV: implement secret-insert-mgmt pass

### DIFF
--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
@@ -111,7 +111,8 @@ static int getMaxLevel(Operation *top, DataFlowSolver *solver) {
   return maxLevel;
 }
 
-void annotateLevel(Operation *top, DataFlowSolver *solver) {
+/// baseLevel is for B/FV scheme, where all the analysis result would be 0
+void annotateLevel(Operation *top, DataFlowSolver *solver, int baseLevel) {
   auto maxLevel = getMaxLevel(top, solver);
 
   auto getIntegerAttr = [&](int level) {
@@ -121,7 +122,8 @@ void annotateLevel(Operation *top, DataFlowSolver *solver) {
   // use L to 0 instead of 0 to L
   auto getLevel = [&](Value value) {
     return maxLevel -
-           solver->lookupState<LevelLattice>(value)->getValue().getLevel();
+           solver->lookupState<LevelLattice>(value)->getValue().getLevel() +
+           baseLevel;
   };
 
   top->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -96,7 +96,8 @@ class LevelAnalysis
 
 LevelState::LevelType getLevelFromMgmtAttr(Value value);
 
-void annotateLevel(Operation *top, DataFlowSolver *solver);
+/// baseLevel is for B/FV scheme, where all the analysis result would be 0
+void annotateLevel(Operation *top, DataFlowSolver *solver, int baseLevel = 0);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Mgmt/Transforms/AnnotateMgmt.cpp
+++ b/lib/Dialect/Mgmt/Transforms/AnnotateMgmt.cpp
@@ -88,7 +88,7 @@ struct AnnotateMgmt : impl::AnnotateMgmtBase<AnnotateMgmt> {
       return;
     }
 
-    annotateLevel(getOperation(), &solver);
+    annotateLevel(getOperation(), &solver, baseLevel);
     annotateDimension(getOperation(), &solver);
     // combine level and dimension into MgmtAttr
     // also removes the level/dimension annotations

--- a/lib/Dialect/Mgmt/Transforms/Passes.td
+++ b/lib/Dialect/Mgmt/Transforms/Passes.td
@@ -10,6 +10,10 @@ def AnnotateMgmt : Pass<"annotate-mgmt"> {
   saving it into each op's attribute dictionary as mgmt.mgmt : <analysis results>
   }];
   let dependentDialects = ["mlir::heir::mgmt::MgmtDialect"];
+  let options = [
+    Option<"baseLevel", "base-level", "int",
+           /*default=*/"0", "Level to start counting from (used by B/FV)">,
+  ];
 }
 
 #endif  // LIB_DIALECT_MGMT_TRANSFORMS_PASSES_TD_

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
@@ -13,7 +13,6 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
-        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -17,7 +17,6 @@
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
-#include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Dialect/Secret/IR/SecretDialect.h"
@@ -184,13 +183,6 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     auto *module = getOperation();
-
-    // Helper for future lowerings that want to know what scheme was used
-    if (isBFV) {
-      moduleSetBFV(module);
-    } else {
-      moduleSetBGV(module);
-    }
 
     // used by LWE type
     int64_t plaintextModulus;

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.td
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.td
@@ -32,8 +32,6 @@ def SecretToBGV : Pass<"secret-to-bgv"> {
     Option<"polyModDegree", "poly-mod-degree", "int",
            /*default=*/"1024", "Default degree of the cyclotomic polynomial "
            "modulus to use for ciphertext space.">,
-    Option<"isBFV", "is-bfv", "bool",
-           /*default=*/"false", "Whether to use the BFV scheme instead of BGV.">,
   ];
 }
 

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/BUILD
@@ -13,7 +13,6 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
-        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -18,7 +18,6 @@
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
-#include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Dialect/Secret/IR/SecretDialect.h"
@@ -401,9 +400,6 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     auto *module = getOperation();
-
-    // Helper for future lowerings that want to know what scheme was used
-    moduleSetCKKS(module);
 
     // generate scheme parameters
     auto maxLevel = getMaxLevel();

--- a/lib/Transforms/OptimizeRelinearization/BUILD
+++ b/lib/Transforms/OptimizeRelinearization/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "@heir//lib/Analysis/DimensionAnalysis",
         "@heir//lib/Analysis/OptimizeRelinearizationAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/Transforms:AnnotateMgmt",
         "@heir//lib/Dialect/Secret/IR:Dialect",

--- a/lib/Transforms/SecretInsertMgmt/BUILD
+++ b/lib/Transforms/SecretInsertMgmt/BUILD
@@ -8,6 +8,7 @@ package(
 cc_library(
     name = "SecretInsertMgmt",
     srcs = [
+        "SecretInsertMgmtBFV.cpp",
         "SecretInsertMgmtBGV.cpp",
         "SecretInsertMgmtCKKS.cpp",
     ],
@@ -20,6 +21,7 @@ cc_library(
         "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/MulResultAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/Transforms",
         "@heir//lib/Dialect/Mgmt/Transforms:AnnotateMgmt",

--- a/lib/Transforms/SecretInsertMgmt/Passes.td
+++ b/lib/Transforms/SecretInsertMgmt/Passes.td
@@ -67,13 +67,57 @@ def SecretInsertMgmtBGV : Pass<"secret-insert-mgmt-bgv", "ModuleOp"> {
 
   let dependentDialects = [
     "mlir::heir::secret::SecretDialect",
-    "mlir::heir::mgmt::MgmtDialect",
-    "mlir::func::FuncDialect"
+    "mlir::heir::mgmt::MgmtDialect"
   ];
 
   let options = [
     Option<"includeFirstMul", "include-first-mul", "bool",
            /*default=*/"false", "Modulus switching right before the first multiplication (default to false)">
+  ];
+}
+
+def SecretInsertMgmtBFV : Pass<"secret-insert-mgmt-bfv", "ModuleOp"> {
+  let summary = "Place BFV ciphertext management operations";
+
+  let description = [{
+    This pass inserts relinearization operation for multiplication, and
+    compute the multiplicative depth, or the level information.
+
+    For most cases B/FV is instantiated with no mod reduce so it is not a leveled scheme.
+    However, for instantiating B/FV parameters it is often meaningful to know the multiplicative
+    depth of the circuit.
+
+    Example of multiplication+addition:
+    ```mlir
+    func.func @func(%arg0: !secret.secret<i16>, %arg1: !secret.secret<i16>) -> !secret.secret<i16> {
+      %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<i16>, !secret.secret<i16>) {
+      ^bb0(%arg2: i16, %arg3: i16):
+        %1 = arith.muli %arg2, %arg3 : i16
+        %2 = arith.addi %1, %arg3 : i16
+        secret.yield %2 : i16
+      } -> !secret.secret<i16>
+      return %0 : !secret.secret<i16>
+    }
+    ```
+
+    which get transformed to:
+    ```mlir
+    func.func @func(%arg0: !secret.secret<i16>, %arg1: !secret.secret<i16>) -> !secret.secret<i16> {
+      %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<i16>, !secret.secret<i16>) attrs = {arg0 = {mgmt.mgmt = #mgmt.mgmt<level = 1>}, arg1 = {mgmt.mgmt = #mgmt.mgmt<level = 1>}} {
+      ^body(%input0: i16, %input1: i16):
+        %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3>} : i16
+        %2 = mgmt.relinearize %1 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : i16
+        %3 = arith.addi %2, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : i16
+        secret.yield %3 : i16
+      } -> !secret.secret<i16>
+      return %0 : !secret.secret<i16>
+    }
+    ```
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::secret::SecretDialect",
+    "mlir::heir::mgmt::MgmtDialect"
   ];
 }
 
@@ -99,8 +143,7 @@ def SecretInsertMgmtCKKS : Pass<"secret-insert-mgmt-ckks", "ModuleOp"> {
 
   let dependentDialects = [
     "mlir::heir::secret::SecretDialect",
-    "mlir::heir::mgmt::MgmtDialect",
-    "mlir::func::FuncDialect"
+    "mlir::heir::mgmt::MgmtDialect"
   ];
 
   let options = [

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBFV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBFV.cpp
@@ -1,0 +1,69 @@
+#include <utility>
+
+#include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
+#include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Transforms/SecretInsertMgmt/Passes.h"
+#include "lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h"
+#include "mlir/include/mlir/Support/LLVM.h"       // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_SECRETINSERTMGMTBFV
+#include "lib/Transforms/SecretInsertMgmt/Passes.h.inc"
+
+struct SecretInsertMgmtBFV
+    : impl::SecretInsertMgmtBFVBase<SecretInsertMgmtBFV> {
+  using SecretInsertMgmtBFVBase::SecretInsertMgmtBFVBase;
+
+  void runOnOperation() override {
+    OpPassManager pipeline("builtin.module");
+    SecretInsertMgmtBGVOptions options;
+    options.includeFirstMul = false;
+    pipeline.addPass(createSecretInsertMgmtBGV(options));
+    (void)runPipeline(pipeline, getOperation());
+
+    // Helper for future lowerings that want to know what scheme was used.
+    // Should be called after the secret-insert-mgmt-bgv pass has been run.
+    moduleSetBFV(getOperation());
+
+    // inherit mulDepth information from BGV pass.
+    mgmt::MgmtAttr mgmtAttr = nullptr;
+    getOperation()->walk([&](secret::GenericOp op) {
+      for (auto i = 0; i != op->getBlock()->getNumArguments(); ++i) {
+        if ((mgmtAttr = dyn_cast<mgmt::MgmtAttr>(
+                 op.getArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName)))) {
+          break;
+        }
+      }
+    });
+
+    if (!mgmtAttr) {
+      getOperation()->emitError("No mgmt attribute found in the module");
+      return signalPassFailure();
+    }
+
+    // Remove mgmt::ModReduceOp
+    RewritePatternSet patterns(&getContext());
+    patterns.add<RemoveOp<mgmt::ModReduceOp>>(&getContext());
+    (void)walkAndApplyPatterns(getOperation(), std::move(patterns));
+
+    // annotate mgmt attribute with all levels set to mulDepth
+    auto level = mgmtAttr.getLevel();
+    OpPassManager annotateMgmtPipeline("builtin.module");
+    mgmt::AnnotateMgmtOptions annotateMgmtOptions;
+    annotateMgmtOptions.baseLevel = level;
+    annotateMgmtPipeline.addPass(mgmt::createAnnotateMgmt(annotateMgmtOptions));
+    (void)runPipeline(annotateMgmtPipeline, getOperation());
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
@@ -5,17 +5,15 @@
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
 #include "lib/Dialect/Mgmt/Transforms/Passes.h"
+#include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h"
-#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/Iterators.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"             // from @llvm-project
 #include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
@@ -33,6 +31,9 @@ struct SecretInsertMgmtBGV
   using SecretInsertMgmtBGVBase::SecretInsertMgmtBGVBase;
 
   void runOnOperation() override {
+    // Helper for future lowerings that want to know what scheme was used
+    moduleSetBGV(getOperation());
+
     DataFlowSolver solver;
     solver.load<dataflow::DeadCodeAnalysis>();
     solver.load<dataflow::SparseConstantPropagation>();

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
@@ -8,6 +8,7 @@
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
 #include "lib/Dialect/Mgmt/Transforms/Passes.h"
+#include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h"
@@ -18,15 +19,12 @@
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"        // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"             // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/Iterators.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"             // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
 #include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
 #include "mlir/include/mlir/Transforms/Passes.h"           // from @llvm-project
@@ -101,6 +99,9 @@ struct SecretInsertMgmtCKKS
   using SecretInsertMgmtCKKSBase::SecretInsertMgmtCKKSBase;
 
   void runOnOperation() override {
+    // Helper for future lowerings that want to know what scheme was used
+    moduleSetCKKS(getOperation());
+
     DataFlowSolver solver;
     solver.load<dataflow::DeadCodeAnalysis>();
     solver.load<dataflow::SparseConstantPropagation>();

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.cpp
@@ -143,6 +143,14 @@ LogicalResult ModReduceBefore<Op>::matchAndRewrite(
 }
 
 template <typename Op>
+LogicalResult RemoveOp<Op>::matchAndRewrite(Op op,
+                                            PatternRewriter &rewriter) const {
+  rewriter.replaceAllUsesWith(op->getResult(0), op->getOperand(0));
+  rewriter.eraseOp(op);
+  return success();
+}
+
+template <typename Op>
 LogicalResult BootstrapWaterLine<Op>::matchAndRewrite(
     Op op, PatternRewriter &rewriter) const {
   auto levelLattice = solver->lookupState<LevelLattice>(op->getResult(0));
@@ -188,6 +196,9 @@ template struct ModReduceBefore<secret::YieldOp>;
 // isMul = false
 template struct ModReduceBefore<arith::AddIOp>;
 template struct ModReduceBefore<arith::SubIOp>;
+
+// for B/FV
+template struct RemoveOp<mgmt::ModReduceOp>;
 
 // for CKKS
 template struct MultRelinearize<arith::MulFOp>;

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h
@@ -50,6 +50,20 @@ struct ModReduceBefore : public OpRewritePattern<Op> {
   DataFlowSolver *solver;
 };
 
+template <typename Op>
+struct RemoveOp : public OpRewritePattern<Op> {
+  using OpRewritePattern<Op>::OpRewritePattern;
+
+  RemoveOp(MLIRContext *context)
+      : OpRewritePattern<Op>(context, /*benefit=*/1) {}
+
+  LogicalResult matchAndRewrite(Op op,
+                                PatternRewriter &rewriter) const override;
+
+ private:
+  Operation *top;
+};
+
 // when reached a certain depth (water line), bootstrap
 template <typename Op>
 struct BootstrapWaterLine : public OpRewritePattern<Op> {


### PR DESCRIPTION
Related to #1419, depending on #1456.

This PR is standalone as the solution in #1456 _just works_. This pass is for making LWE type look valid.

B/FV parameter generation is another topic. In #1456 B/FV just reuses the parameter from BGV, however we can not guarantee the parameter generated is good, so should fallback to default generation for B/FV in `secret-to-bgv` instead of relying on `validate-noise`.

### TODO

* [x] move `moduleSetBFV` earlier (to here)
* [x] Make the `annotate-mgmt` call inside `optimize-relinearization` aware of B/FV style mgmt based on `moduleIsBFV`.
