### PR TITLE
Support cleartext execution mode

### DIFF
--- a/lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.cpp
+++ b/lib/Dialect/LinAlg/Conversions/LinalgToTensorExt/LinalgToTensorExt.cpp
@@ -277,6 +277,9 @@ class ReplicatedTensorTypeConverter : public TypeConverter {
     addConversion([](Type type) { return type; });
 
     addConversion([this](RankedTensorType type) -> Type {
+      if (type.getShape().size() == 1) {
+        return type;
+      }
       // Assuming 2-d operations only
       if (type.getShape()[0] == 1) {
         return RankedTensorType::get({1, this->maxTilingSize},

--- a/lib/Dialect/Secret/IR/SecretOps.td
+++ b/lib/Dialect/Secret/IR/SecretOps.td
@@ -59,7 +59,7 @@ def Secret_ConcealOp : Secret_Op<"conceal", [Pure]> {
 
   let arguments = (ins AnyType:$cleartext);
   let results = (outs Secret:$output);
-  let assemblyFormat = "$cleartext attr-dict `:` type($cleartext) `->` type($output)";
+  let assemblyFormat = "$cleartext attr-dict `:` qualified(type($cleartext)) `->` qualified(type($output))";
 
   let builders = [
     // Builder to infer output type from the input type
@@ -84,7 +84,7 @@ def Secret_RevealOp : Secret_Op<"reveal", [Pure]> {
 
   let arguments = (ins Secret:$input);
   let results = (outs AnyType:$cleartext);
-  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($cleartext)";
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` qualified(type($cleartext))";
 
   let builders = [
     // Builder to infer output type from the input type

--- a/lib/Dialect/Secret/Transforms/DistributeGeneric.cpp
+++ b/lib/Dialect/Secret/Transforms/DistributeGeneric.cpp
@@ -616,6 +616,9 @@ void moveMgmtAttrAnnotationToFuncArgument(Operation *top) {
   // some unused func secret type arg should also be annotated with mgmt attr,
   // inferred from other used arg
   top->walk([&](func::FuncOp funcOp) {
+    if (funcOp.isDeclaration()) {
+      return;
+    }
     Attribute firstMgmtAttr;
     for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
       firstMgmtAttr = funcOp.getArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName);

--- a/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/BUILD
+++ b/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/BUILD
@@ -1,0 +1,27 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "TensorExtToTensor",
+    srcs = ["TensorExtToTensor.cpp"],
+    hdrs = ["TensorExtToTensor.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Utils:ConversionUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    header_filename = "TensorExtToTensor.h.inc",
+    pass_name = "TensorExtToTensor",
+    td_file = "TensorExtToTensor.td",
+)

--- a/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.cpp
+++ b/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.cpp
@@ -1,0 +1,100 @@
+#include "lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h"
+
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "lib/Utils/ConversionUtils.h"
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir::heir::tensor_ext {
+
+#define GEN_PASS_DEF_TENSOREXTTOTENSOR
+#include "lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h.inc"
+
+struct ConvertRotateOp : public OpRewritePattern<RotateOp> {
+  ConvertRotateOp(mlir::MLIRContext *context)
+      : OpRewritePattern<RotateOp>(context) {}
+
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(RotateOp op,
+                                PatternRewriter &rewriter) const override {
+    auto shift = op.getShift();
+    auto constantOp =
+        dyn_cast_or_null<arith::ConstantOp>(shift.getDefiningOp());
+    if (!constantOp) {
+      return failure();
+    }
+
+    auto shiftValue = cast<IntegerAttr>(constantOp.getValue()).getInt();
+    auto tensorShape =
+        cast<RankedTensorType>(op.getTensor().getType()).getShape();
+
+    // only support 1D tensors
+    // TODO(#924): Currently RotateOp only supports rotating a 1-D vector, or a
+    // vector with only one non-unit dimension that is treated as the major
+    // dimension.
+    if (tensorShape.size() != 1) {
+      return failure();
+    }
+
+    auto tensorSize = tensorShape[0];
+    if (shiftValue < 0) {
+      shiftValue += tensorSize;
+    }
+
+    auto tensorElementType = getElementTypeOrSelf(op.getTensor().getType());
+    auto leftTensorType =
+        RankedTensorType::get({shiftValue}, tensorElementType);
+    auto rightTensorType =
+        RankedTensorType::get({tensorSize - shiftValue}, tensorElementType);
+
+    auto left = rewriter.create<tensor::ExtractSliceOp>(
+        op.getLoc(), leftTensorType, op.getTensor(), ArrayRef<Value>{},
+        ArrayRef<Value>{}, ArrayRef<Value>{},
+        /*offsets=*/ArrayRef<int64_t>{0},
+        /*sizes=*/ArrayRef{shiftValue}, /*strides=*/ArrayRef<int64_t>{1});
+    auto right = rewriter.create<tensor::ExtractSliceOp>(
+        op.getLoc(), rightTensorType, op.getTensor(), ArrayRef<Value>{},
+        ArrayRef<Value>{}, ArrayRef<Value>{},
+        /*offsets=*/ArrayRef{shiftValue},
+        /*sizes=*/ArrayRef{tensorSize - shiftValue},
+        /*strides=*/ArrayRef<int64_t>{1});
+    // for tensor.concat to lower we need to use
+    // transform.apply_patterns.tensor.decompose_concat which is quite painful
+    // auto concat = rewriter.create<tensor::ConcatOp>(
+    //    op.getLoc(), /*dim=*/0,
+    //    ValueRange{right.getResult(), left.getResult()});
+    auto empty = rewriter.create<tensor::EmptyOp>(op.getLoc(), tensorShape,
+                                                  tensorElementType);
+    auto insertLeftToRight = rewriter.create<tensor::InsertSliceOp>(
+        op.getLoc(), left.getResult(), empty, ArrayRef<Value>{},
+        ArrayRef<Value>{}, ArrayRef<Value>{},
+        /*offsets=*/ArrayRef<int64_t>{tensorSize - shiftValue},
+        /*sizes=*/ArrayRef{shiftValue}, /*strides=*/ArrayRef<int64_t>{1});
+    auto insertRightToLeft = rewriter.create<tensor::InsertSliceOp>(
+        op.getLoc(), right.getResult(), insertLeftToRight, ArrayRef<Value>{},
+        ArrayRef<Value>{}, ArrayRef<Value>{},
+        /*offsets=*/ArrayRef<int64_t>{0},
+        /*sizes=*/ArrayRef{tensorSize - shiftValue},
+        /*strides=*/ArrayRef<int64_t>{1});
+
+    rewriter.replaceAllOpUsesWith(op, insertRightToLeft.getResult());
+    return success();
+  }
+};
+
+struct TensorExtToTensor
+    : public impl::TensorExtToTensorBase<TensorExtToTensor> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertRotateOp>(context);
+
+    (void)walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace mlir::heir::tensor_ext

--- a/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h
+++ b/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h
@@ -1,0 +1,16 @@
+#ifndef LIB_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_H_
+#define LIB_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir::heir::tensor_ext {
+
+#define GEN_PASS_DECL
+#include "lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h.inc"
+
+}  // namespace mlir::heir::tensor_ext
+
+#endif  // LIB_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_H_

--- a/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.td
+++ b/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.td
@@ -1,0 +1,22 @@
+#ifndef LIB_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TD_
+#define LIB_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def TensorExtToTensor : Pass<"tensor-ext-to-tensor"> {
+  let summary = "Lower `tensor_ext` to `tensor` dialect.";
+  let description = [{
+    This pass lowers the `tensor_ext` dialect to the `tensor` dialect.
+
+    This pass is intended to be used for testing purpose where the
+    secret arithmetic IR containing `tensor_ext` dialect is lowered
+    to the IR containing `tensor` dialect, which could be further
+    lowered to the LLVM dialect.
+  }];
+  let dependentDialects = [
+    "mlir::heir::tensor_ext::TensorExtDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_TENSOREXT_CONVERSIONS_TENSOREXTTOTENSOR_TENSOREXTTOTENSOR_TD_

--- a/lib/Transforms/Secretize/WrapGeneric.cpp
+++ b/lib/Transforms/Secretize/WrapGeneric.cpp
@@ -61,8 +61,11 @@ struct WrapWithGeneric : public OpRewritePattern<func::FuncOp> {
         op.getResultTypes(),
         [](Type t) -> Type { return secret::SecretType::get(t); }));
 
-    op.setFunctionType(
-        FunctionType::get(getContext(), {newInputs}, {newOutputs}));
+    // modification to function type should go through the rewriter
+    rewriter.modifyOpInPlace(op, [&] {
+      op.setFunctionType(
+          FunctionType::get(getContext(), {newInputs}, {newOutputs}));
+    });
 
     // Externally defined functions have no body
     if (op.isDeclaration()) {
@@ -103,8 +106,65 @@ struct WrapWithGeneric : public OpRewritePattern<func::FuncOp> {
   }
 };
 
+struct ConvertFuncCall : public OpRewritePattern<func::CallOp> {
+  ConvertFuncCall(mlir::MLIRContext *context, Operation *top)
+      : mlir::OpRewritePattern<func::CallOp>(context), top(top) {}
+
+  LogicalResult matchAndRewrite(func::CallOp op,
+                                PatternRewriter &rewriter) const override {
+    auto module = mlir::cast<ModuleOp>(top);
+    auto callee = module.lookupSymbol<func::FuncOp>(op.getCallee());
+    if (callee.isDeclaration()) {
+      return success();
+    }
+
+    SmallVector<Value> newOperands;
+    auto funcResultTypes = llvm::to_vector(callee.getResultTypes());
+
+    for (auto i = 0; i != op->getNumOperands(); ++i) {
+      auto operand = op.getOperand(i);
+      auto funcArgType = callee.getArgumentTypes()[i];
+      if (mlir::isa<secret::SecretType>(funcArgType)) {
+        auto newOperand =
+            rewriter.create<secret::ConcealOp>(op.getLoc(), operand);
+        newOperands.push_back(newOperand.getResult());
+      } else {
+        newOperands.push_back(operand);
+      }
+    }
+
+    auto newOp = rewriter.create<func::CallOp>(op->getLoc(), op.getCallee(),
+                                               funcResultTypes, newOperands);
+    newOp->setAttrs(op->getAttrs());
+
+    for (auto i = 0; i != newOp->getNumResults(); ++i) {
+      auto result = op.getResult(i);
+      auto newResult = newOp.getResult(i);
+      if (mlir::isa<secret::SecretType>(newResult.getType())) {
+        newResult = rewriter.create<secret::RevealOp>(op.getLoc(), newResult);
+      }
+      rewriter.replaceAllUsesWith(result, newResult);
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+ private:
+  Operation *top;
+};
+
 struct WrapGeneric : impl::WrapGenericBase<WrapGeneric> {
   using WrapGenericBase::WrapGenericBase;
+
+  void detectSecretGeneric() {
+    bool hasSecretGeneric = false;
+    getOperation().walk([&](secret::GenericOp op) { hasSecretGeneric = true; });
+    if (!hasSecretGeneric) {
+      getOperation().emitWarning(
+          "No secret found in the module. Did you forget to annotate "
+          "{secret.secret} to the function arguments?");
+    }
+  }
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
@@ -112,6 +172,14 @@ struct WrapGeneric : impl::WrapGenericBase<WrapGeneric> {
     mlir::RewritePatternSet patterns(context);
     patterns.add<WrapWithGeneric>(context);
     (void)walkAndApplyPatterns(getOperation(), std::move(patterns));
+
+    // func.call should be converted after callee func type updated
+    mlir::RewritePatternSet patterns2(context);
+    patterns2.add<ConvertFuncCall>(context, getOperation());
+    (void)walkAndApplyPatterns(getOperation(), std::move(patterns2));
+
+    // warn if no secret.generic found
+    detectSecretGeneric();
   }
 };
 

--- a/tests/Dialect/Secret/Transforms/wrap_generic/sub_call.mlir
+++ b/tests/Dialect/Secret/Transforms/wrap_generic/sub_call.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s --wrap-generic | FileCheck %s
+
+// CHECK-LABEL: @pointwise
+// CHECK-SAME: (%[[ARG0:.*]]: !secret.secret<tensor<8xi16>>) -> !secret.secret<tensor<8xi16>>
+func.func @pointwise(%arg0: tensor<8xi16> {secret.secret}) -> tensor<8xi16> {
+  // CHECK: secret.generic
+  return %arg0 : tensor<8xi16>
+}
+
+// CHECK-LABEL: @dot_product
+// CHECK-SAME: (%[[ARG0:.*]]: !secret.secret<tensor<8xi16>>, %[[ARG1:.*]]: tensor<8xi16>) -> !secret.secret<i16>
+func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16>) -> i16 {
+  // CHECK: secret.generic
+  // CHECK:   secret.conceal
+  // CHECK:   call
+  // CHECK:   secret.reveal
+  %pointwise = call @pointwise(%arg0) : (tensor<8xi16>) -> tensor<8xi16>
+  %c0 = arith.constant 0 : index
+  %0 = tensor.extract %pointwise[%c0] : tensor<8xi16>
+  return %0 : i16
+}

--- a/tests/Dialect/Secret/Transforms/wrap_generic/test_call.mlir
+++ b/tests/Dialect/Secret/Transforms/wrap_generic/test_call.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s --wrap-generic | FileCheck %s
+
+// CHECK-LABEL: @dot_product
+// CHECK-SAME: (%[[ARG0:.*]]: !secret.secret<tensor<8xi16>>, %[[ARG1:.*]]: tensor<8xi16>) -> !secret.secret<i16>
+func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16>) -> i16 {
+  // CHECK: secret.generic
+  %c0 = arith.constant 0 : index
+  %0 = tensor.extract %arg0[%c0] : tensor<8xi16>
+  return %0 : i16
+}
+
+// CHECK-LABEL: @test_dot_product
+// CHECK-SAME: %[[ARG0:.*]]: tensor<8xi16>, %[[ARG1:.*]]: tensor<8xi16>
+func.func @test_dot_product(%arg0: tensor<8xi16>, %arg1: tensor<8xi16>) {
+  // CHECK: %[[v0:.*]] = secret.conceal %[[ARG0]]
+  // CHECK: %[[v1:.*]] = call @dot_product(%[[v0]], %[[ARG1]])
+  // CHECK: %[[v2:.*]] = secret.reveal %[[v1]]
+  // CHECK: return
+  %res = func.call @dot_product(%arg0, %arg1) : (tensor<8xi16>, tensor<8xi16>) -> i16
+  return
+}

--- a/tests/Examples/cleartext/BUILD
+++ b/tests/Examples/cleartext/BUILD
@@ -1,0 +1,24 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = [
+        ":dot_product_8_test",
+        "@heir//tests:test_utilities",
+        "@llvm-project//clang",
+        "@llvm-project//llvm:llc",
+        "@llvm-project//mlir:mlir-translate",
+    ],
+    default_tags = [
+        "notap",
+    ],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)
+
+cc_library(
+    name = "dot_product_8_test",
+    srcs = ["dot_product_8_test.c"],
+)

--- a/tests/Examples/cleartext/dot_product_8.mlir
+++ b/tests/Examples/cleartext/dot_product_8.mlir
@@ -1,0 +1,18 @@
+// RUN: heir-opt %s --mlir-to-secret-arithmetic --tensor-ext-to-tensor --secret-forget-secrets --heir-polynomial-to-llvm \
+// RUN:   | mlir-translate --mlir-to-llvmir | llc -filetype=obj > %t
+// RUN: clang %S/libdot_product_8_test.a %t -o a.out
+// RUN: ./a.out | FileCheck %s
+
+// CHECK: Test passed
+func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16> {secret.secret}) -> i16 {
+  %c0 = arith.constant 0 : index
+  %c0_si16 = arith.constant 0 : i16
+  %0 = affine.for %arg2 = 0 to 8 iter_args(%iter = %c0_si16) -> (i16) {
+    %1 = tensor.extract %arg0[%arg2] : tensor<8xi16>
+    %2 = tensor.extract %arg1[%arg2] : tensor<8xi16>
+    %3 = arith.muli %1, %2 : i16
+    %4 = arith.addi %iter, %3 : i16
+    affine.yield %4 : i16
+  }
+  return %0 : i16
+}

--- a/tests/Examples/cleartext/dot_product_8_test.c
+++ b/tests/Examples/cleartext/dot_product_8_test.c
@@ -1,0 +1,29 @@
+#include <stdint.h>
+#include <stdio.h>
+
+// This is the function we want to call from LLVM
+int16_t dot_product(
+    /* arg 0*/
+    int16_t *allocated, int16_t *aligned, int64_t offset, int64_t size,
+    int64_t stride,
+    /* arg 1*/
+    int16_t *allocated_2, int16_t *aligned_2, int64_t offset_2, int64_t size_2,
+    int64_t stride_2);
+
+int main() {
+  int16_t arg0[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  int16_t arg1[8] = {2, 3, 4, 5, 6, 7, 8, 9};
+  int16_t expected = 240;
+
+  int16_t res = dot_product(
+      /* arg 0*/
+      arg0, arg0, 0, 8, 1,
+      /* arg 1*/
+      arg1, arg1, 0, 8, 1);
+
+  if (res == expected) {
+    printf("Test passed\n");
+  } else {
+    printf("Test failed %d != %d\n", res, expected);
+  }
+}

--- a/tests/Regression/issue_1086_reduced.mlir
+++ b/tests/Regression/issue_1086_reduced.mlir
@@ -28,7 +28,7 @@ func.func @sum(%arg0: !secret.secret<memref<2xi3>>) -> !secret.secret<i3> {
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %c0_i3 = arith.constant 0 : i3
-  %0 = secret.conceal %c0_i3 : i3 -> <i3>
+  %0 = secret.conceal %c0_i3 : i3 -> !secret.secret<i3>
   %1 = affine.for %arg1 = 0 to 2 iter_args(%arg2 = %0) -> (!secret.secret<i3>) {
     %2 = secret.cast %arg0 : !secret.secret<memref<2xi3>> to !secret.secret<memref<6xi1>>
     %3 = secret.generic ins(%2 : !secret.secret<memref<6xi1>>) {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -88,6 +88,7 @@ cc_binary(
         "@heir//lib/Dialect/Secret/Transforms:BufferizableOpInterface",
         "@heir//lib/Dialect/Secret/Transforms:DistributeGeneric",
         "@heir//lib/Dialect/TOSA/Conversions/TosaToSecretArith",
+        "@heir//lib/Dialect/TensorExt/Conversions/TensorExtToTensor",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/Transforms",
         "@heir//lib/Dialect/TensorExt/Transforms:CollapseInsertionChains",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -45,6 +45,7 @@
 #include "lib/Dialect/Secret/Transforms/BufferizableOpInterfaceImpl.h"
 #include "lib/Dialect/Secret/Transforms/Passes.h"
 #include "lib/Dialect/TOSA/Conversions/TosaToSecretArith/TosaToSecretArith.h"
+#include "lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "lib/Dialect/TensorExt/Transforms/Passes.h"
 #include "lib/Dialect/TfheRust/IR/TfheRustDialect.h"
@@ -299,6 +300,7 @@ int main(int argc, char **argv) {
   lwe::registerLWEToPolynomialPasses();
   ::mlir::heir::linalg::registerLinalgToTensorExtPasses();
   ::mlir::heir::polynomial::registerPolynomialToModArithPasses();
+  tensor_ext::registerTensorExtToTensorPasses();
   registerCGGIToJaxitePasses();
   registerCGGIToTfheRustPasses();
   registerCGGIToTfheRustBoolPasses();


### PR DESCRIPTION
With the discussion on _ciphertext semantic cleartext execution_, it might be preferable to lower the secret arithmetic IR to LLVM and execute them in mlir-runner to inspect the execution result.

There should be two versions of cleartext execution, one with the original type (i16, f16) and one with the FHE underlying type (e.g. `mod_arith<65537>`, f64?)

This PR implements the lowering for tensor_ext.rotate to tensor dialect, and with that we can lower to LLVM using `heir-polynoimal-to-llvm`.

```bash
--mlir-to-secret-arithmetic --tensor-ext-to-tensor --secret-forget-secrets --cse
# on dot_product_8.mlir
``` 

The trouble is that, for the test file `dot_product_8_test.mlir`, we can not run

```bash
--mlir-to-secret-arithmetic --tensor-ext-to-tensor --secret-forget-secrets --cse --heir-polynomial-to-llvm
```

As we are facing these two problems

* printMemrefI32 is external function, which runs into segfault somewhere
* in `test` body we have `call @dot_product`. However, for `--wrap-generic` the signature of `dot_product` will change and func.call will fail validation.