### PR TITLE
heir-vectorizer: support mod arith input

### DIFF
--- a/lib/Analysis/RotationAnalysis/BUILD
+++ b/lib/Analysis/RotationAnalysis/BUILD
@@ -9,6 +9,7 @@ cc_library(
     srcs = ["RotationAnalysis.cpp"],
     hdrs = ["RotationAnalysis.h"],
     deps = [
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.cpp
+++ b/lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.cpp
@@ -33,47 +33,57 @@ namespace arith {
 #define GEN_PASS_DEF_ARITHTOMODARITH
 #include "lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.h.inc"
 
-static mod_arith::ModArithType convertArithType(Type type) {
-  auto modulusBitSize = (int64_t)type.getIntOrFloatBitWidth();
-  auto modulus = (1L << (modulusBitSize - 1L));
-  auto newType = mlir::IntegerType::get(type.getContext(), modulusBitSize + 1);
+static mod_arith::ModArithType convertArithType(Type type, int64_t modulus) {
+  Type newType;
+  if (modulus == 0) {
+    auto modulusBitSize = (int64_t)type.getIntOrFloatBitWidth();
+    modulus = (1L << (modulusBitSize - 1L));
+    newType = mlir::IntegerType::get(type.getContext(), modulusBitSize + 1);
+  } else {
+    auto modulusBitSize = 64;
+    newType = mlir::IntegerType::get(type.getContext(), modulusBitSize);
+  }
 
   return mod_arith::ModArithType::get(type.getContext(),
                                       mlir::IntegerAttr::get(newType, modulus));
 }
 
-static Type convertArithLikeType(ShapedType type) {
+static Type convertArithLikeType(ShapedType type, int64_t modulus) {
   if (auto arithType = llvm::dyn_cast<IntegerType>(type.getElementType())) {
-    return type.cloneWith(type.getShape(), convertArithType(arithType));
+    return type.cloneWith(type.getShape(),
+                          convertArithType(arithType, modulus));
   }
   return type;
 }
 
-static Value buildLoadOps(OpBuilder &builder, Type resultTypes,
-                          ValueRange inputs, Location loc) {
-  assert(inputs.size() == 1);
-  auto loadOp = inputs[0].getDefiningOp<memref::LoadOp>();
+static auto buildLoadOps(int64_t modulus) {
+  return [=](OpBuilder &builder, Type resultTypes, ValueRange inputs,
+             Location loc) -> Value {
+    assert(inputs.size() == 1);
+    auto loadOp = inputs[0].getDefiningOp<memref::LoadOp>();
 
-  if (!loadOp) return {};
+    if (!loadOp) return {};
 
-  auto *globaMemReflOp = loadOp.getMemRef().getDefiningOp();
+    auto *globaMemReflOp = loadOp.getMemRef().getDefiningOp();
 
-  if (!globaMemReflOp) return {};
+    if (!globaMemReflOp) return {};
 
-  return builder.create<mod_arith::EncapsulateOp>(
-      loc, convertArithType(loadOp.getType()), loadOp.getResult());
+    return builder.create<mod_arith::EncapsulateOp>(
+        loc, convertArithType(loadOp.getType(), modulus), loadOp.getResult());
+  };
 }
 
 class ArithToModArithTypeConverter : public TypeConverter {
  public:
-  ArithToModArithTypeConverter(MLIRContext *ctx) {
+  ArithToModArithTypeConverter(MLIRContext *ctx, int64_t modulus) {
     addConversion([](Type type) { return type; });
-    addConversion([](IntegerType type) -> mod_arith::ModArithType {
-      return convertArithType(type);
+    addConversion([=](IntegerType type) -> mod_arith::ModArithType {
+      return convertArithType(type, modulus);
     });
-    addConversion(
-        [](ShapedType type) -> Type { return convertArithLikeType(type); });
-    addTargetMaterialization(buildLoadOps);
+    addConversion([=](ShapedType type) -> Type {
+      return convertArithLikeType(type, modulus);
+    });
+    addTargetMaterialization(buildLoadOps(modulus));
   }
 };
 
@@ -92,8 +102,13 @@ struct ConvertConstant : public OpConversionPattern<mlir::arith::ConstantOp> {
       return failure();
     }
 
+    auto convertedType = typeConverter->convertType(op.getType());
+    if (convertedType == op.getType()) {
+      return failure();
+    }
+
     auto result = b.create<mod_arith::ConstantOp>(mod_arith::ModArithAttr::get(
-        convertArithType(op.getType()),
+        cast<mod_arith::ModArithType>(convertedType),
         cast<IntegerAttr>(op.getValue()).getValue().getSExtValue()));
 
     rewriter.replaceOp(op, result);
@@ -113,7 +128,7 @@ struct ConvertExtSI : public OpConversionPattern<mlir::arith::ExtSIOp> {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
     auto result = b.create<mod_arith::ModSwitchOp>(
-        op.getLoc(), convertArithType(op.getType()), adaptor.getIn());
+        op.getLoc(), typeConverter->convertType(op.getType()), adaptor.getIn());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -131,7 +146,7 @@ struct ConvertExtUI : public OpConversionPattern<mlir::arith::ExtUIOp> {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
     auto result = b.create<mod_arith::ModSwitchOp>(
-        op.getLoc(), convertArithType(op.getType()), adaptor.getIn());
+        op.getLoc(), typeConverter->convertType(op.getType()), adaptor.getIn());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -158,8 +173,8 @@ struct ConvertLoadOp : public OpConversionPattern<mlir::memref::LoadOp> {
     }
 
     auto result = rewriter.create<memref::LoadOp>(
-        op.getLoc(), convertArithType(op.getType()), adaptor.getOperands()[0],
-        op.getIndices());
+        op.getLoc(), typeConverter->convertType(op.getType()),
+        adaptor.getOperands()[0], op.getIndices());
 
     rewriter.replaceOp(op, result);
     return success();
@@ -175,7 +190,7 @@ struct ArithToModArith : impl::ArithToModArithBase<ArithToModArith> {
 void ArithToModArith::runOnOperation() {
   MLIRContext *context = &getContext();
   ModuleOp module = getOperation();
-  ArithToModArithTypeConverter typeConverter(context);
+  ArithToModArithTypeConverter typeConverter(context, modulus);
 
   ConversionTarget target(*context);
   target.addLegalDialect<mod_arith::ModArithDialect>();
@@ -184,6 +199,11 @@ void ArithToModArith::runOnOperation() {
   target.addDynamicallyLegalOp<mlir::arith::ConstantOp>(
       [](mlir::arith::ConstantOp op) {
         return isa<IndexType>(op.getValue().getType());
+      });
+  target.addDynamicallyLegalOp<mlir::arith::AddIOp, mlir::arith::SubIOp,
+                               mlir::arith::MulIOp, mlir::arith::RemUIOp>(
+      [](Operation *op) {
+        return isa<IndexType>(op->getOperand(0).getType());
       });
 
   target.addDynamicallyLegalOp<memref::LoadOp>([&](Operation *op) {
@@ -205,10 +225,13 @@ void ArithToModArith::runOnOperation() {
   target.addDynamicallyLegalOp<
       memref::AllocOp, memref::DeallocOp, memref::StoreOp, memref::SubViewOp,
       memref::CopyOp, tensor::FromElementsOp, tensor::ExtractOp,
-      affine::AffineStoreOp, affine::AffineLoadOp>([&](Operation *op) {
-    return typeConverter.isLegal(op->getOperandTypes()) &&
-           typeConverter.isLegal(op->getResultTypes());
-  });
+      tensor::ExtractSliceOp, tensor::InsertOp, tensor::ExpandShapeOp,
+      tensor::ConcatOp, affine::AffineStoreOp, affine::AffineLoadOp,
+      affine::AffineForOp, affine::AffineYieldOp, tensor_ext::RotateOp>(
+      [&](Operation *op) {
+        return typeConverter.isLegal(op->getOperandTypes()) &&
+               typeConverter.isLegal(op->getResultTypes());
+      });
 
   RewritePatternSet patterns(context);
   patterns
@@ -219,8 +242,12 @@ void ArithToModArith::runOnOperation() {
            ConvertAny<memref::AllocOp>, ConvertAny<memref::DeallocOp>,
            ConvertAny<memref::StoreOp>, ConvertAny<memref::SubViewOp>,
            ConvertAny<memref::CopyOp>, ConvertAny<tensor::FromElementsOp>,
-           ConvertAny<tensor::ExtractOp>, ConvertAny<affine::AffineStoreOp>,
-           ConvertAny<affine::AffineLoadOp>>(typeConverter, context);
+           ConvertAny<tensor::ExtractOp>, ConvertAny<tensor::ExtractSliceOp>,
+           ConvertAny<tensor::InsertOp>, ConvertAny<tensor::ExpandShapeOp>,
+           ConvertAny<tensor::ConcatOp>, ConvertAny<affine::AffineStoreOp>,
+           ConvertAny<affine::AffineLoadOp>, ConvertAny<affine::AffineForOp>,
+           ConvertAny<affine::AffineYieldOp>, ConvertAny<tensor_ext::RotateOp>>(
+          typeConverter, context);
 
   addStructuralConversionPatterns(typeConverter, patterns, target);
 

--- a/lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.td
+++ b/lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.td
@@ -24,6 +24,12 @@ def ArithToModArith : Pass<"arith-to-mod-arith", "ModuleOp"> {
     "mlir::arith::ArithDialect",
     "mlir::heir::mod_arith::ModArithDialect",
   ];
+
+  let options = [
+    Option<"modulus", "modulus", "int64_t",
+           /*default=*/"0", "Modulus to use for the mod-arith dialect."
+           " If not specified, the pass will use the natural modulus for that integer type">,
+  ];
 }
 
 #endif  // LIB_DIALECT_MODARITH_CONVERSIONS_ARITHTOMODARITH_ARITHTOMODARITH_TD_

--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -12,6 +12,7 @@ cc_library(
     name = "Dialect",
     srcs = [
         "ModArithDialect.cpp",
+        "ModArithOps.cpp",
     ],
     hdrs = [
         "ModArithAttributes.h",

--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -1,0 +1,36 @@
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
+
+namespace mlir {
+namespace heir {
+namespace mod_arith {
+
+//===----------------------------------------------------------------------===//
+// AddIOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) { return getValue(); }
+
+// copied from ArithOps.cpp
+OpFoldResult AddOp::fold(FoldAdaptor adaptor) {
+  // addi(x, 0) -> x
+  if (auto modArithAttr =
+          mlir::dyn_cast_or_null<ModArithAttr>(adaptor.getRhs())) {
+    if (modArithAttr.getValue().getValue() == 0) return getLhs();
+  }
+
+  // addi(subi(a, b), b) -> a
+  if (auto sub = getLhs().getDefiningOp<SubOp>())
+    if (getRhs() == sub.getRhs()) return sub.getLhs();
+
+  // addi(b, subi(a, b)) -> a
+  if (auto sub = getRhs().getDefiningOp<SubOp>())
+    if (getLhs() == sub.getRhs()) return sub.getLhs();
+
+  // TODO(#1216): fold constant a + b
+  // See ArithOps.td for detail
+  return {};
+}
+
+}  // namespace mod_arith
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -84,7 +84,7 @@ def ModArith_ModSwitchOp : ModArith_Op<"mod_switch", [Pure, SameOperandsAndResul
 }
 
 def ModArith_ConstantOp : Op<ModArith_Dialect, "constant",
-    [Pure, InferTypeOpAdaptor]> {
+    [ConstantLike, Pure, InferTypeOpAdaptor]> {
   let summary = "Define a constant value via an attribute.";
   let description = [{
     Example:
@@ -96,6 +96,7 @@ def ModArith_ConstantOp : Op<ModArith_Dialect, "constant",
   let arguments = (ins ModArith_ModArithAttr:$value);
   let results = (outs ModArith_ModArithType:$output);
   let hasCustomAssemblyFormat = 1;
+  let hasFolder = 1;
 
   let builders = [
     OpBuilder<(ins "::mlir::heir::mod_arith::ModArithType":$ty, "int64_t":$value), [{
@@ -132,7 +133,11 @@ def ModArith_ReduceOp : ModArith_Op<"reduce", [Pure, ElementwiseMappable, SameOp
 
 class ModArith_BinaryOp<string mnemonic, list<Trait> traits = []> :
     ModArith_Op<mnemonic, traits # [SameOperandsAndResultType, Pure, ElementwiseMappable]>,
-    Arguments<(ins ModArithLike:$lhs, ModArithLike:$rhs)>,
+    Arguments<(ins ModArithLike:$lhs, ModArithLike:$rhs,
+      // This is only for making mod arith op looks like arith op in various DRR.
+      DefaultValuedAttr<
+        BoolAttr,
+        "0">:$overflowFlags)>,
     Results<(outs ModArithLike:$output)> {
   let hasVerifier = 1;
   let assemblyFormat ="operands attr-dict `:` type($output)";
@@ -146,6 +151,8 @@ def ModArith_AddOp : ModArith_BinaryOp<"add", [Commutative]> {
     Unless otherwise specified, the operation assumes both inputs are canonical
     representatives and guarantees the output being canonical representative.
   }];
+
+  let hasFolder = 1;
 }
 
 def ModArith_SubOp : ModArith_BinaryOp<"sub"> {

--- a/lib/Dialect/TensorExt/IR/BUILD
+++ b/lib/Dialect/TensorExt/IR/BUILD
@@ -44,6 +44,7 @@ cc_library(
         ":canonicalize_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Utils:AffineMapUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
@@ -117,6 +118,7 @@ gentbl_cc_library(
     deps = [
         ":ops_inc_gen",
         ":td_files",
+        "@heir//lib/Dialect/ModArith/IR:td_files",
         "@llvm-project//mlir:ArithOpsTdFiles",
         "@llvm-project//mlir:TensorOpsTdFiles",
     ],

--- a/lib/Dialect/TensorExt/IR/TensorExtCanonicalization.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtCanonicalization.td
@@ -3,6 +3,7 @@
 
 include "TensorExtOps.td"
 include "lib/Utils/DRR/Utils.td"
+include "lib/Dialect/ModArith/IR/ModArithOps.td"
 include "mlir/Dialect/Arith/IR/ArithOps.td"
 include "mlir/Dialect/Tensor/IR/TensorOps.td"
 include "mlir/IR/PatternBase.td"
@@ -70,7 +71,7 @@ def RotatePlusExtractToIndexedExtract : Pat<
     (MakeSingleResultVariadic (Arith_AddIOp $shift, $index, DefOverflow)))
 >;
 
-foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
+foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, ModArith_AddOp, ModArith_SubOp, ModArith_MulOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
   // Rotating two tensors by the same amount can be converted to a single
   // post-rotation. This can result in eliminating either the rotation (because
   // it can be combined with a later rotation) or the arith op itself, if it is

--- a/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Utils/AffineMapUtils.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"             // from @llvm-project
 #include "llvm/include/llvm/ADT/SmallVectorExtras.h"     // from @llvm-project

--- a/lib/Dialect/TensorExt/Transforms/BUILD
+++ b/lib/Dialect/TensorExt/Transforms/BUILD
@@ -31,6 +31,7 @@ cc_library(
         ":insert_rotate_inc_gen",
         ":pass_inc_gen",
         "@heir//lib/Analysis/TargetSlotAnalysis",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:canonicalize_inc_gen",
         "@llvm-project//llvm:Support",
@@ -73,6 +74,7 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Analysis/RotationAnalysis",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@llvm-project//llvm:Support",
@@ -162,6 +164,7 @@ gentbl_cc_library(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "InsertRotate.td",
     deps = [
+        "@heir//lib/Dialect/ModArith/IR:td_files",
         "@heir//lib/Dialect/TensorExt/IR:ops_inc_gen",
         "@heir//lib/Dialect/TensorExt/IR:td_files",
         "@heir//lib/Utils/DRR",

--- a/lib/Dialect/TensorExt/Transforms/InsertRotate.h
+++ b/lib/Dialect/TensorExt/Transforms/InsertRotate.h
@@ -1,6 +1,7 @@
 #ifndef LIB_DIALECT_TENSOREXT_TRANSFORMS_INSERTROTATE_H_
 #define LIB_DIALECT_TENSOREXT_TRANSFORMS_INSERTROTATE_H_
 
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project

--- a/lib/Dialect/TensorExt/Transforms/InsertRotate.td
+++ b/lib/Dialect/TensorExt/Transforms/InsertRotate.td
@@ -3,6 +3,7 @@
 
 include "lib/Utils/DRR/Utils.td"
 include "lib/Dialect/TensorExt/IR/TensorExtOps.td"
+include "lib/Dialect/ModArith/IR/ModArithOps.td"
 include "mlir/Dialect/Arith/IR/ArithOps.td"
 include "mlir/Dialect/Tensor/IR/TensorOps.td"
 include "mlir/IR/CommonTypeConstraints.td"
@@ -26,7 +27,7 @@ def CreateSplatOp : NativeCodeCall<
 
 // Match an arith op that extracts scalar values from one or more tensors, and
 // replace it with rotations to align slots and apply the same op in SIMD.
-foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
+foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, ModArith_AddOp, ModArith_SubOp, ModArith_MulOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
   def InsertRotations_TwoTensorArgs_#ArithOp : Pattern<
     (ArithOp:$arithOp
       (Tensor_ExtractOp $t1, (variadic $i1)),
@@ -91,8 +92,8 @@ foreach ArithOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, Arith_AddFOp, Arith
 // TODO(#514): handle OuterOp with two different InnerOps on the LHS and RHS
 // TODO(#579): determine if these patterns are still necessary after the
 // target slot analysis was improved.
-foreach InnerOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
-  foreach OuterOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
+foreach InnerOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, ModArith_AddOp, ModArith_SubOp, ModArith_MulOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
+  foreach OuterOp = [Arith_AddIOp, Arith_SubIOp, Arith_MulIOp, ModArith_AddOp, ModArith_SubOp, ModArith_MulOp, Arith_AddFOp, Arith_SubFOp, Arith_MulFOp] in {
     // Left associated grouping handles (add (add (rotate t1 i1) (rotate t2 i2)) (rotate t3 i3))
     def AlignRotations_LeftAssociated_Inner_#InnerOp#_Outer_#OuterOp : Pattern<
       (OuterOp

--- a/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
+++ b/lib/Dialect/TensorExt/Transforms/RotateAndReduce.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "lib/Analysis/RotationAnalysis/RotationAnalysis.h"
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "llvm/include/llvm/ADT/DenseSet.h"    // from @llvm-project
@@ -114,6 +115,14 @@ struct RotateAndReduce : impl::RotateAndReduceBase<RotateAndReduce> {
                     .Case<arith::MulIOp>([&](auto arithOp) {
                       tryReplaceRotations<arith::MulIOp>(arithOp, reduction,
                                                          extraction);
+                    })
+                    .Case<mod_arith::AddOp>([&](auto arithOp) {
+                      tryReplaceRotations<mod_arith::AddOp>(arithOp, reduction,
+                                                            extraction);
+                    })
+                    .Case<mod_arith::MulOp>([&](auto arithOp) {
+                      tryReplaceRotations<mod_arith::MulOp>(arithOp, reduction,
+                                                            extraction);
                     })
                     .Case<arith::AddFOp>([&](auto arithOp) {
                       tryReplaceRotations<arith::AddFOp>(arithOp, reduction,

--- a/tests/Dialect/Arith/Conversions/ArithToModArith/user-modulus.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToModArith/user-modulus.mlir
@@ -1,0 +1,10 @@
+// RUN: heir-opt %s --arith-to-mod-arith=modulus=65537 | FileCheck %s
+
+// CHECK: !Z65537_i64_ = !mod_arith.int<65537 : i64>
+
+// CHECK-LABEL: @add
+// CHECK-SAME: (%[[ARG0:.*]]: tensor<8x!Z65537_i64_> {secret.secret}) -> tensor<8x!Z65537_i64_> {
+func.func @add(%arg0 : tensor<8xi16> {secret.secret}) -> tensor<8xi16> {
+    %0 = arith.addi %arg0, %arg0 : tensor<8xi16>
+    return %0 : tensor<8xi16>
+}

--- a/tests/Transforms/heir_simd_vectorizer/box_blur_4x4.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/box_blur_4x4.mlir
@@ -1,6 +1,9 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// RUN: heir-opt --arith-to-mod-arith --secretize --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
 module  {
   // CHECK-LABEL: @box_blur
   // CHECK-NOT: tensor.extract

--- a/tests/Transforms/heir_simd_vectorizer/dot_product_8.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/dot_product_8.mlir
@@ -1,6 +1,9 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// RUN: heir-opt --arith-to-mod-arith --secretize --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
 // CHECK-LABEL: func @dot_product
 // CHECK-COUNT-3: tensor_ext.rotate
 // CHECK-NOT: tensor_ext.rotate

--- a/tests/Transforms/heir_simd_vectorizer/gx_kernel_64x64.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/gx_kernel_64x64.mlir
@@ -3,6 +3,9 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// TODO(#1483): support constant tensor for mod_arith.constant
+// run this for --arith-to-mod-arith as well
+
 // CHECK-LABEL: @gx_kernel
 // CHECK: secret.generic
 // CHECK-COUNT-6: tensor_ext.rotate

--- a/tests/Transforms/heir_simd_vectorizer/gx_kernel_8x8.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/gx_kernel_8x8.mlir
@@ -1,6 +1,9 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// TODO(#1483): support constant tensor for mod_arith.constant
+// run this for --arith-to-mod-arith as well
+
 // CHECK-LABEL: @gx_kernel
 // CHECK: secret.generic
 // CHECK-COUNT-6: tensor_ext.rotate

--- a/tests/Transforms/heir_simd_vectorizer/hamming_distance.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/hamming_distance.mlir
@@ -1,14 +1,21 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
-// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ARITH
+
+// RUN: heir-opt --arith-to-mod-arith --secretize --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-MOD-ARITH
 
 // CHECK-LABEL: @hamming
 // CHECK: secret.generic
-// CHECK: arith.subi
-// CHECK-NEXT: arith.muli
+// CHECK-ARITH: arith.subi
+// CHECK-MOD-ARITH: mod_arith.sub
+// CHECK-ARITH-NEXT: arith.muli
+// CHECK-MOD-ARITH-NEXT: mod_arith.mul
 // CHECK-NEXT: tensor_ext.rotate
-// CHECK-NEXT: arith.addi
+// CHECK-ARITH-NEXT: arith.addi
+// CHECK-MOD-ARITH-NEXT: mod_arith.add
 // CHECK-NEXT: tensor_ext.rotate
-// CHECK-NEXT: arith.addi
+// CHECK-ARITH-NEXT: arith.addi
+// CHECK-MOD-ARITH-NEXT: mod_arith.add
 // CHECK-NEXT: tensor.extract
 // CHECK-NEXT: secret.yield
 

--- a/tests/Transforms/heir_simd_vectorizer/linear_polynomial_64.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/linear_polynomial_64.mlir
@@ -3,6 +3,9 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// RUN: heir-opt --arith-to-mod-arith --secretize --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
 // CHECK-LABEL: @linear_polynomial
 // CHECK: secret.generic
 // CHECK-NOT: tensor_ext.rotate

--- a/tests/Transforms/heir_simd_vectorizer/quadratic_polynomial.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/quadratic_polynomial.mlir
@@ -3,6 +3,9 @@
 // RUN: heir-opt --secretize --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// RUN: heir-opt --arith-to-mod-arith --secretize --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
 // CHECK-LABEL: @quadratic_polynomial
 // CHECK: secret.generic
 // CHECK-NOT: tensor_ext.rotate

--- a/tests/Transforms/heir_simd_vectorizer/simple_sum.mlir
+++ b/tests/Transforms/heir_simd_vectorizer/simple_sum.mlir
@@ -2,6 +2,10 @@
 // RUN:   --wrap-generic --canonicalize --cse \
 // RUN:   --heir-simd-vectorizer %s | FileCheck %s
 
+// RUN: heir-opt --arith-to-mod-arith --secretize \
+// RUN:   --wrap-generic --canonicalize --cse \
+// RUN:   --heir-simd-vectorizer %s | FileCheck %s
+
 // Sum all entries of a tensor into a single scalar
 // CHECK-LABEL: @simple_sum
 // CHECK: secret.generic


### PR DESCRIPTION
In an effort to make the _ciphertext semantic cleartext backend_, which should support execution in Zt, the plaintext modulus ring, we may transform the input from `i16` to `mod_arith<ptm>`, which could be done by the existing `--arith-to-mod-arith` with small modification.

Note that `--arith-to-mod-arith` should happen before `--wrap-generic` as it seems designed to be so.

Meanwhile, the heir-vectorizer is unaware of mod_arith type so no simd optimization will happen if we apply `--mlir-to-secret-arithmetic`. This PR is meant for making various passes in heir-vectorizer understand mod arith type and produce the same circuit for `i16` input and `mod_arith` input.

### Current status

* `insert-rotation` works after adding DRR rules
* `cse` following `insert-rotation` seems to ignore some optimization chance (i.e. no clean up as expected). Might be resolved by #1216?
* `rotate-and-reduce` does not work
* `arith-to-mod-arith` should support custom modulus in pass options.

### Side note

We may also just cheat through the heir-vectorizer by the following pipeline. However, `forget-secrets` then `secretize` will lose information on argument secretness. E.g. plaintext func argument will be secret now.

```bash
# first make i16 input transformed to the wanted circuit
# then use arith-to-mod-arith to convert type
--mlir-to-secret-arithmetic --secret-forget-secrets \
--secretize --arith-to-mod-arith --wrap-generic
```