### PR TITLE
B/FV: Lattigo: Add debug func impl for noise

### DIFF
--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -97,6 +97,17 @@ heir_lattigo_lib(
     mlir_src = "dot_product_8.mlir",
 )
 
+heir_lattigo_lib(
+    name = "dot_product_8_bfv_debug",
+    extra_srcs = ["dot_product_8_bfv_debug.go"],
+    go_library_name = "dotproduct8bfvdebug",
+    heir_opt_flags = [
+        "--mlir-to-bfv=ciphertext-degree=8",
+        "--scheme-to-lattigo=insert-debug-handler-calls=true",
+    ],
+    mlir_src = "dot_product_8.mlir",
+)
+
 # CKKS
 
 heir_lattigo_lib(
@@ -157,6 +168,12 @@ go_test(
     name = "dotproduct8bfv_test",
     srcs = ["dot_product_8_bfv_test.go"],
     embed = [":dotproduct8bfv"],
+)
+
+go_test(
+    name = "dotproduct8bfvdebug_test",
+    srcs = ["dot_product_8_bfv_debug_handler_test.go"],
+    embed = [":dotproduct8bfvdebug"],
 )
 
 # CKKS

--- a/tests/Examples/lattigo/dot_product_8_bfv_debug.go
+++ b/tests/Examples/lattigo/dot_product_8_bfv_debug.go
@@ -1,0 +1,54 @@
+// Package dotproduct8debug is a debug handler callback for the compiled lattigo code.
+package dotproduct8bfvdebug
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/tuneinsight/lattigo/v6/core/rlwe"
+	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
+)
+
+func __heir_debug(evaluator *bgv.Evaluator, param bgv.Parameters, encoder *bgv.Encoder, decryptor *rlwe.Decryptor, ct *rlwe.Ciphertext, debugAttrMap map[string]string) {
+	// print op
+	isBlockArgument := debugAttrMap["asm.is_block_arg"]
+	if isBlockArgument == "1" {
+		fmt.Println("Input")
+	} else {
+		fmt.Println(debugAttrMap["asm.op_name"])
+	}
+
+	// print the decryption result
+	messageSizeStr := debugAttrMap["message.size"]
+	messageSize, err := strconv.Atoi(messageSizeStr)
+	if err != nil {
+		panic(err)
+	}
+	value := make([]int64, messageSize)
+	pt := decryptor.DecryptNew(ct)
+	encoder.Decode(pt, value)
+	fmt.Printf("  %v\n", value)
+
+	// print the noise
+
+	// get a new pt with no noise
+	// in Lattigo, Decrypt won't mod T
+	// Decode will mod T so we Decode then Encode
+	valueFull := make([]int64, ct.N())
+	encoder.Decode(pt, valueFull)
+	// set the level and scale of the plaintext
+	ptNoNoise := bgv.NewPlaintext(param, ct.Level())
+	ptNoNoise.Scale = ct.Scale
+	encoder.Encode(valueFull, ptNoNoise)
+
+	// subtract the message from the ciphertext
+	vec, _ := evaluator.SubNew(ct, ptNoNoise)
+	// get infty norm of the noise
+	_, _, max := rlwe.Norm(vec, decryptor)
+	// get logQi for current level
+	total := 0
+	for i := 0; i <= ct.LevelQ(); i++ {
+		total += param.LogQi()[i]
+	}
+	fmt.Printf("  Noise: %.2f Total: %d\n", max, total)
+}

--- a/tests/Examples/lattigo/dot_product_8_bfv_debug_handler_test.go
+++ b/tests/Examples/lattigo/dot_product_8_bfv_debug_handler_test.go
@@ -1,0 +1,26 @@
+package dotproduct8bfvdebug
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := dot_product__configure()
+
+	// Vector of plaintext values
+	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8}
+	arg1 := []int16{2, 3, 4, 5, 6, 7, 8, 9}
+
+	expected := int16(240)
+
+	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
+
+	resultCt := dot_product(evaluator, params, ecd, dec, ct0, ct1)
+
+	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}


### PR DESCRIPTION
Mirror of #1467

debug output

```
Input
  [1 2 3 4 5 6 7 8]
  Noise: 6.38 Total: 96
Input
  [2 3 4 5 6 7 8 9]
  Noise: 6.34 Total: 96
lattigo.bgv.mul
  [2 6 12 20 30 42 56 72]
  Noise: 34.25 Total: 96
lattigo.bgv.relinearize
  [2 6 12 20 30 42 56 72]
  Noise: 34.25 Total: 96
lattigo.bgv.rotate_columns
  [30 42 56 72 2 6 12 20]
  Noise: 34.25 Total: 96
lattigo.bgv.add
  [32 48 68 92 32 48 68 92]
  Noise: 34.70 Total: 96
lattigo.bgv.rotate_columns
  [68 92 32 48 68 92 32 48]
  Noise: 34.70 Total: 96
lattigo.bgv.add
  [100 140 100 140 100 140 100 140]
  Noise: 35.32 Total: 96
lattigo.bgv.rotate_columns
  [140 100 140 100 140 100 140 100]
  Noise: 35.32 Total: 96
lattigo.bgv.add
  [240 240 240 240 240 240 240 240]
  Noise: 35.71 Total: 96
lattigo.bgv.rescale
  [240 240 240 240 240 240 240 240]
  Noise: 35.71 Total: 96
lattigo.bgv.mul
  [0 0 0 0 0 0 0 240]
  Noise: 53.37 Total: 96
lattigo.bgv.rotate_columns
  [240 0 0 0 0 0 0 0]
  Noise: 53.37 Total: 96
lattigo.bgv.rotate_columns
  [240 0 0 0 0 0 0 0]
  Noise: 53.37 Total: 96
lattigo.bgv.rescale
  [240 0 0 0 0 0 0 0]
  Noise: 53.37 Total: 96
```