### PR TITLE
ValidateNoise: select parameters more conservatively

### DIFF
--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -197,7 +197,12 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
         for (Value result : op->getResults()) {
           if (getLevelFromMgmtAttr(result) == 0) {
             auto bound = getBound(result);
-            firstModSize = std::max(firstModSize, 1 + int(ceil(bound)));
+            // the bound is from v_ms + v / q, where v / q is negligible
+            // so originally bound(v_ms) + 1 is enough
+            // after the parameter selection with smaller primes, we have
+            // v_ms \approx v / q so bound(2 * v_ms) approx bound(v_ms) + 0.5
+            // now we need bound(v_ms) + 1.5 or bound + 2 to ensure the noise
+            firstModSize = std::max(firstModSize, 2 + int(ceil(bound)));
           }
         }
         return WalkResult::advance();

--- a/tests/Regression/issue_1480.mlir
+++ b/tests/Regression/issue_1480.mlir
@@ -1,0 +1,11 @@
+// RUN: heir-opt %s --mlir-to-bgv | FileCheck %s
+
+// CHECK-LABEL: @func
+func.func @func(%x: i16 {secret.secret}, %y: i16 {secret.secret}) -> (i16) {
+    %0 = arith.addi %x, %y : i16
+    %1 = arith.subi %x, %y : i16
+    %2 = arith.muli %x, %y : i16
+    %3 = arith.muli %0, %1 : i16
+    %4 = arith.addi %3, %2 : i16
+    func.return %4 : i16
+}


### PR DESCRIPTION
Fixes #1480 

It is kind of a off-by-one bug.

Originally, we get the following trace

```
Conservative Scheme Param:
plaintextModulus: 65537
ringDim: 8192
level: 1
logqi: 60.00 60.00 
qi: 
dnum: 2
logpi: 60.00 
pi: 

// last two op
Noise Bound: 67.36 Budget: 51.64 Total: 119.00 for value: %7 = arith.addi %6, %4 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : i16 
Noise Bound: 22.51 Budget: 36.49 Total: 59.00 for value: %8 = mgmt.modreduce %7 {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16 

Gap logqi: 24 46 
Concrete Scheme Param:
plaintextModulus: 65537
ringDim: 8192
level: 1
logqi: 24.02 46.00 
qi: 16957441 70368744210433 
dnum: 2
logpi: 46.00 
pi: 70368744570881

// last two op
Noise Bound: 67.36 Budget: 1.66 Total: 69.02 for value: %7 = arith.addi %6, %4 {mgmt.mgmt = #mgmt.mgmt<level = 1>, noise.bound = "67.36"} : i16 
Noise Bound: 23.04 Budget: -0.03 Total: 23.02 for value: %8 = mgmt.modreduce %7 {mgmt.mgmt = #mgmt.mgmt<level = 0>, noise.bound = "22.51"} : i16
```

As we can see, the last noise increases as `67.36 - 46 = 21.3` which is similar to the added modulus switching error `22.5` so the noise estimation becomes larger.

We should make `v / q << v_ms` or at least a few bits less to make the former conservative estimation the same as the later agressive estimation.