### PR TITLE
set permissions on todo backlinks workflow

### DIFF
--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
     - name: todo-backlinks


### PR DESCRIPTION
I think something changed with org-wide default permissions for runners, so this should override that with explicit permissions for this action.

Maybe fixes https://github.com/google/heir/issues/1488 ? Hard to tell