### PR TITLE
ModArith: support some folding method for add

### DIFF
--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -12,6 +12,7 @@ cc_library(
     name = "Dialect",
     srcs = [
         "ModArithDialect.cpp",
+        "ModArithOps.cpp",
     ],
     hdrs = [
         "ModArithDialect.h",

--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -1,0 +1,36 @@
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
+
+namespace mlir {
+namespace heir {
+namespace mod_arith {
+
+//===----------------------------------------------------------------------===//
+// AddIOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) { return getValueAttr(); }
+
+// copied from ArithOps.cpp
+OpFoldResult AddOp::fold(FoldAdaptor adaptor) {
+  // addi(x, 0) -> x
+  if (auto integerAttr =
+          mlir::dyn_cast_or_null<IntegerAttr>(adaptor.getRhs())) {
+    if (integerAttr.getValue() == 0) return getLhs();
+  }
+
+  // addi(subi(a, b), b) -> a
+  if (auto sub = getLhs().getDefiningOp<SubOp>())
+    if (getRhs() == sub.getRhs()) return sub.getLhs();
+
+  // addi(b, subi(a, b)) -> a
+  if (auto sub = getRhs().getDefiningOp<SubOp>())
+    if (getLhs() == sub.getRhs()) return sub.getLhs();
+
+  // TODO(#1216): fold constant a + b
+  // See ArithOps.td for detail
+  return {};
+}
+
+}  // namespace mod_arith
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -82,7 +82,7 @@ def ModArith_ModSwitchOp : ModArith_Op<"mod_switch", [Pure, SameOperandsAndResul
   let assemblyFormat = "$input attr-dict `:` type($input) `to` type($output)";
 }
 
-def ModArith_ConstantOp : Op<ModArith_Dialect, "constant", [Pure]> {
+def ModArith_ConstantOp : Op<ModArith_Dialect, "constant", [ConstantLike, Pure]> {
   let summary = "Define a constant value via an attribute.";
   let description = [{
     Example:
@@ -95,6 +95,7 @@ def ModArith_ConstantOp : Op<ModArith_Dialect, "constant", [Pure]> {
   let results = (outs ModArith_ModArithType:$output);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 
@@ -139,6 +140,8 @@ def ModArith_AddOp : ModArith_BinaryOp<"add", [Commutative]> {
     Unless otherwise specified, the operation assumes both inputs are canonical
     representatives and guarantees the output being canonical representative.
   }];
+
+  let hasFolder = 1;
 }
 
 def ModArith_SubOp : ModArith_BinaryOp<"sub"> {

--- a/tests/Dialect/ModArith/IR/folders.mlir
+++ b/tests/Dialect/ModArith/IR/folders.mlir
@@ -1,0 +1,38 @@
+// RUN: heir-opt --apply-folders --split-input-file %s | FileCheck %s
+
+!Zp = !mod_arith.int<255 : i32>
+
+// CHECK-LABEL: @test_add_zero
+// CHECK-SAME: (%[[ARG0:.*]]: !
+func.func @test_add_zero(%arg0 : !Zp) -> !Zp {
+  // CHECK: return %[[ARG0]]
+  %c0 = mod_arith.constant 0 : !Zp
+  %add = mod_arith.add %arg0, %c0 : !Zp
+  return %add : !Zp
+}
+
+// -----
+
+!Zp = !mod_arith.int<255 : i32>
+
+// CHECK-LABEL: @test_add_sub_a_b_b
+// CHECK-SAME: (%[[A:.*]]: ![[type:.*]], %[[B:.*]]: ![[type]])
+func.func @test_add_sub_a_b_b(%a : !Zp, %b : !Zp) -> !Zp {
+  // CHECK: return %[[A:.*]]
+  %sub = mod_arith.sub %a, %b : !Zp
+  %add = mod_arith.add %sub, %b : !Zp
+  return %add : !Zp
+}
+
+// -----
+
+!Zp = !mod_arith.int<255 : i32>
+
+// CHECK-LABEL: @test_add_b_sub_a_b
+// CHECK-SAME: (%[[A:.*]]: ![[type:.*]], %[[B:.*]]: ![[type]])
+func.func @test_add_b_sub_a_b(%a : !Zp, %b : !Zp) -> !Zp {
+  // CHECK: return %[[A:.*]]
+  %sub = mod_arith.sub %a, %b : !Zp
+  %add = mod_arith.add %b, %sub : !Zp
+  return %add : !Zp
+}


### PR DESCRIPTION
Splitted from #1470 

Folders copied from ArithOps.cpp of MLIR

Should be rebased after #1484 is in.