### PR TITLE
Split parameter generation into standalone pass

### DIFF
--- a/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
@@ -20,7 +20,6 @@ cc_library(
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
-        "@heir//lib/Parameters/BGV:Params",
         "@heir//lib/Utils",
         "@heir//lib/Utils:ConversionUtils",
         "@heir//lib/Utils/Polynomial",

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/BUILD
@@ -22,7 +22,6 @@ cc_library(
         "@heir//lib/Dialect/RNS/IR:RNSTypes",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
-        "@heir//lib/Parameters/CKKS:Params",
         "@heir//lib/Utils",
         "@heir//lib/Utils:ConversionUtils",
         "@heir//lib/Utils/Polynomial",

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.td
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.td
@@ -33,12 +33,6 @@ def SecretToCKKS : Pass<"secret-to-ckks"> {
     Option<"polyModDegree", "poly-mod-degree", "int",
            /*default=*/"1024", "Default degree of the cyclotomic polynomial "
            "modulus to use for ciphertext space.">,
-    Option<"firstModBits", "first-mod-bits", "int",
-           /*default=*/"55", "Default number of bits of the first prime "
-           "coefficient modulus to use for the ciphertext space.">,
-    Option<"scalingModBits", "scaling-mod-bits", "int",
-           /*default=*/"45", "Default number of bits of the scaling prime "
-           "coefficient modulus to use for the ciphertext space.">,
   ];
 }
 

--- a/lib/Parameters/CKKS/BUILD
+++ b/lib/Parameters/CKKS/BUILD
@@ -8,6 +8,7 @@ cc_library(
     srcs = ["Params.cpp"],
     hdrs = ["Params.h"],
     deps = [
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Parameters:RLWEParams",
         "@llvm-project//llvm:Support",
     ],

--- a/lib/Parameters/CKKS/Params.cpp
+++ b/lib/Parameters/CKKS/Params.cpp
@@ -20,6 +20,31 @@ SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
                      logDefaultScale);
 }
 
+SchemeParam SchemeParam::getSchemeParamFromAttr(SchemeParamAttr attr) {
+  auto logN = attr.getLogN();
+  auto ringDim = pow(2, logN);
+  auto Q = attr.getQ();
+  auto P = attr.getP();
+  auto logDefaultScale = attr.getLogDefaultScale();
+  std::vector<int64_t> qiImpl;
+  std::vector<int64_t> piImpl;
+  std::vector<double> logqi;
+  std::vector<double> logpi;
+  for (auto qi : Q.asArrayRef()) {
+    qiImpl.push_back(qi);
+    logqi.push_back(log2(qi));
+  }
+  for (auto pi : P.asArrayRef()) {
+    piImpl.push_back(pi);
+    logpi.push_back(log2(pi));
+  }
+  auto level = logqi.size() - 1;
+  auto dnum = ceil(static_cast<double>(qiImpl.size()) / piImpl.size());
+  return SchemeParam(
+      RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi, piImpl),
+      logDefaultScale);
+}
+
 void SchemeParam::print(llvm::raw_ostream &os) const {
   os << "logDefaultScale: " << logDefaultScale << "\n";
   RLWESchemeParam::print(os);

--- a/lib/Parameters/CKKS/Params.h
+++ b/lib/Parameters/CKKS/Params.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
 #include "lib/Parameters/RLWEParams.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 
@@ -28,6 +29,8 @@ class SchemeParam : public RLWESchemeParam {
   static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
                                             int logDefaultScale,
                                             int slotNumber);
+
+  static SchemeParam getSchemeParamFromAttr(SchemeParamAttr attr);
 };
 
 }  // namespace ckks

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -51,9 +51,21 @@ struct MlirToRLWEPipelineOptions : public SimdVectorizerOptions {
   PassOptions::Option<std::string> noiseModel{
       *this, "noise-model",
       llvm::cl::desc("Noise model to use during parameter generation, see "
-                     "--validate-noise pass options for available models"
-                     "(default to bgv-noise-by-bound-coeff-average-case-pk)"),
-      llvm::cl::init("bgv-noise-by-bound-coeff-average-case-pk")};
+                     "--generate-param pass options for available models"),
+      llvm::cl::init("")};
+  PassOptions::Option<bool> annotateNoiseBound{
+      *this, "annotate-noise-bound",
+      llvm::cl::desc("If true, the noise predicted by noise model is annotated "
+                     "in the IR."),
+      llvm::cl::init(false)};
+  PassOptions::Option<int> firstModBits{
+      *this, "first-mod-bits",
+      llvm::cl::desc("The number of bits in the first modulus for CKKS"),
+      llvm::cl::init(55)};
+  PassOptions::Option<int> scalingModBits{
+      *this, "scaling-mod-bits",
+      llvm::cl::desc("The number of bits in the scaling modulus for CKKS"),
+      llvm::cl::init(45)};
 };
 
 struct BackendOptions : public PassPipelineOptions<BackendOptions> {

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -108,6 +108,7 @@ cc_library(
         "@heir//lib/Dialect/TensorExt/Transforms:RotateAndReduce",
         "@heir//lib/Transforms/ApplyFolders",
         "@heir//lib/Transforms/FullLoopUnroll",
+        "@heir//lib/Transforms/GenerateParam",
         "@heir//lib/Transforms/LinalgCanonicalizations",
         "@heir//lib/Transforms/MemrefToArith:MemrefToArithRegistration",
         "@heir//lib/Transforms/OperationBalancer",

--- a/lib/Transforms/GenerateParam/BUILD
+++ b/lib/Transforms/GenerateParam/BUILD
@@ -1,0 +1,45 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "GenerateParam",
+    srcs = [
+        "GenerateParamBFV.cpp",
+        "GenerateParamBGV.cpp",
+        "GenerateParamCKKS.cpp",
+    ],
+    hdrs = ["GenerateParam.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/DimensionAnalysis",
+        "@heir//lib/Analysis/LevelAnalysis",
+        "@heir//lib/Analysis/NoiseAnalysis",
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/Mgmt/IR:MgmtOps",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Parameters/BGV:Params",
+        "@heir//lib/Parameters/CKKS:Params",
+        "@heir//lib/Transforms/ValidateNoise",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "GenerateParam",
+    td_file = "GenerateParam.td",
+)

--- a/lib/Transforms/GenerateParam/GenerateParam.h
+++ b/lib/Transforms/GenerateParam/GenerateParam.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_GENERATEPARAM_GENERATEPARAM_H_
+#define LIB_TRANSFORMS_GENERATEPARAM_GENERATEPARAM_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/GenerateParam/GenerateParam.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/GenerateParam/GenerateParam.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_GENERATEPARAM_GENERATEPARAM_H_

--- a/lib/Transforms/GenerateParam/GenerateParam.td
+++ b/lib/Transforms/GenerateParam/GenerateParam.td
@@ -1,0 +1,191 @@
+#ifndef LIB_TRANSFORMS_GENERATEPARAM_GENERATEPARAM_TD_
+#define LIB_TRANSFORMS_GENERATEPARAM_GENERATEPARAM_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def GenerateParamBGV : Pass<"generate-param-bgv"> {
+  let summary = "Generate BGV Scheme Parameter using a given noise model";
+  let description = [{
+    The pass generates the BGV scheme parameter using a given noise model.
+
+    There are three noise models available:
+    - `bgv-noise-by-bound-coeff-average-case{-pk,-sk}`
+    - `bgv-noise-by-bound-coeff-worst-case{-pk,-sk}`
+    - `bgv-noise-by-variance-coeff{-pk,-sk}`
+
+    The `-pk`/`-sk` suffixes assume the input ciphertexts are
+    encrypted using the public/secret key.
+
+    The first two models are taken from KPZ21, and they work by bounding
+    the coefficient embedding of the ciphertexts. The difference
+    of the two models is expansion factor used for multiplication
+    of the coefficients, the first being `2\sqrt{N}` and the second
+    being `N`.
+
+    The third model is taken from MP24. It works by tracking the variance
+    of the coefficient embedding of the ciphertexts. This gives a more accurate
+    noise estimate, but it may give underestimates in some cases. See the paper
+    for more details.
+
+    This pass relies on the presence of the `mgmt` dialect ops to model
+    relinearize/modreduce, and it relies on `mgmt.mgmt` attribute to determine
+    the ciphertext level/dimension. These ops and attributes can be added by
+    a pass like `--secret-insert-mgmt-bgv` and `--annotate-mgmt`.
+
+    User can provide custom scheme parameters by annotating bgv::SchemeParamAttr
+    at the module level.
+
+    Example:
+
+    ```mlir
+    module {
+      func.func @add(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {
+        %0 = secret.generic ins(%arg0 : !secret.secret<i16>) attrs = {arg0 = {mgmt.mgmt = #mgmt.mgmt<level = 0>}} {
+        ^body(%input0: i16):
+          %1 = arith.addi %input0, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16
+          secret.yield %1 : i16
+        } -> !secret.secret<i16>
+        return %0 : !secret.secret<i16>
+      }
+    }
+    ```
+
+    After applying the pass, the module will be updated with the scheme parameters:
+
+    ```mlir
+    module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 12, Q = [4294991873], P = [4295049217], plaintextModulus = 65537>} {
+      func.func @add(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {
+        // same as above
+      }
+    }
+    ```
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::bgv::BGVDialect",
+  ];
+
+  let options = [
+    Option<"model", "model", "std::string",
+           /*default=*/"\"bgv-noise-by-bound-coeff-average-case-pk\"", "Noise model to validate against.">,
+    Option<"plaintextModulus", "plaintext-modulus", "int64_t",
+           /*default=*/"65537", "Plaintext modulus.">,
+    Option<"slotNumber", "slot-number", "int",
+           /*default=*/"0", "Minimum number of slots for parameter generation.">,
+  ];
+}
+
+def GenerateParamBFV : Pass<"generate-param-bfv"> {
+  let summary = "Generate BFV Scheme Parameter";
+  let description = [{
+    The pass generates the BFV scheme parameter.
+
+    This pass get the multiplicative depth from the IR and generates the
+    moduli chain of that long consisting of 60 bits primes.
+
+    This pass relies on the presence of the `mgmt` dialect ops to model
+    relinearize/modreduce, and it relies on `mgmt.mgmt` attribute to determine
+    the ciphertext level/dimension. These ops and attributes can be added by
+    a pass like `--secret-insert-mgmt-bgv` and `--annotate-mgmt`.
+
+    User can provide custom scheme parameters by annotating bgv::SchemeParamAttr
+    at the module level. Note that we reuse bgv::SchemeParamAttr for BFV.
+
+    Example:
+
+    ```mlir
+    module {
+      func.func @add(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {
+        %0 = secret.generic ins(%arg0 : !secret.secret<i16>) attrs = {arg0 = {mgmt.mgmt = #mgmt.mgmt<level = 0>}} {
+        ^body(%input0: i16):
+          %1 = arith.addi %input0, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16
+          secret.yield %1 : i16
+        } -> !secret.secret<i16>
+        return %0 : !secret.secret<i16>
+      }
+    }
+    ```
+
+    After applying the pass, the module will be updated with the scheme parameters:
+
+    ```mlir
+    module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 12, Q = [1152921504606994433], P = [1152921504607191041], plaintextModulus = 65537>} {
+      func.func @add(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {
+        // same as above
+      }
+    }
+    ```
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::bgv::BGVDialect",
+  ];
+
+  let options = [
+    Option<"slotNumber", "slot-number", "int",
+           /*default=*/"0", "Minimum number of slots for parameter generation.">,
+    Option<"plaintextModulus", "plaintext-modulus", "int64_t",
+           /*default=*/"65537", "Plaintext modulus.">,
+  ];
+}
+
+def GenerateParamCKKS : Pass<"generate-param-ckks"> {
+  let summary = "Generate CKKS Scheme Parameter";
+  let description = [{
+    The pass generates the CKKS scheme parameter.
+
+    The pass asks the user to provide the number of bits for the first modulus
+    and scaling modulus. The default values are 55 and 45, respectively.
+    Then the pass generates the moduli chain using the provided values.
+
+    This pass relies on the presence of the `mgmt` dialect ops to model
+    relinearize/modreduce, and it relies on `mgmt.mgmt` attribute to determine
+    the ciphertext level/dimension. These ops and attributes can be added by
+    a pass like `--secret-insert-mgmt-<scheme>` and `--annotate-mgmt`.
+
+    User can provide custom scheme parameters by annotating bgv::SchemeParamAttr
+    at the module level.
+
+    Example:
+
+    ```mlir
+    module {
+      func.func @add(%arg0: !secret.secret<f16>) -> !secret.secret<f16> {
+        %0 = secret.generic ins(%arg0 : !secret.secret<f16>) attrs = {arg0 = {mgmt.mgmt = #mgmt.mgmt<level = 0>}} {
+        ^body(%input0: f16):
+          %1 = arith.addf %input0, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 0>} : f16
+          secret.yield %1 : f16
+        } -> !secret.secret<f16>
+        return %0 : !secret.secret<f16>
+      }
+    }
+    ```
+
+    After applying the pass, the module will be updated with the scheme parameters:
+
+    ```mlir
+    module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797019389953], P = [36028797019488257], logDefaultScale = 45>} {
+      func.func @add(%arg0: !secret.secret<f16>) -> !secret.secret<f16> {
+        // same as above
+      }
+    }
+    ```
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::ckks::CKKSDialect",
+  ];
+
+  let options = [
+    Option<"slotNumber", "slot-number", "int",
+           /*default=*/"0", "Minimum number of slots for parameter generation.">,
+    Option<"firstModBits", "first-mod-bits", "int",
+           /*default=*/"55", "Default number of bits of the first prime "
+           "coefficient modulus to use for the ciphertext space.">,
+    Option<"scalingModBits", "scaling-mod-bits", "int",
+           /*default=*/"45", "Default number of bits of the scaling prime "
+           "coefficient modulus to use for the ciphertext space.">,
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_GENERATEPARAM_GENERATEPARAM_TD_

--- a/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
@@ -1,0 +1,78 @@
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Dialect/BGV/IR/BGVAttributes.h"
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Parameters/BGV/Params.h"
+#include "lib/Transforms/GenerateParam/GenerateParam.h"
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"        // from @llvm-project
+
+#define DEBUG_TYPE "GenerateParamBFV"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_GENERATEPARAMBFV
+#include "lib/Transforms/GenerateParam/GenerateParam.h.inc"
+
+struct GenerateParamBFV : impl::GenerateParamBFVBase<GenerateParamBFV> {
+  using GenerateParamBFVBase::GenerateParamBFVBase;
+
+  // assume only one main func
+  // also assume max level at entry
+  // also assume first genericOp arg is secret
+  int getMaxLevel() {
+    int maxLevel = 0;
+    getOperation()->walk([&](func::FuncOp funcOp) {
+      funcOp->walk([&](secret::GenericOp genericOp) {
+        if (genericOp.getBody()->getNumArguments() > 0) {
+          maxLevel = getLevelFromMgmtAttr(genericOp.getBody()->getArgument(0));
+        }
+      });
+    });
+    return maxLevel;
+  }
+
+  void annotateSchemeParam(const bgv::SchemeParam &schemeParam) {
+    getOperation()->setAttr(
+        bgv::BGVDialect::kSchemeParamAttrName,
+        bgv::SchemeParamAttr::get(
+            &getContext(), log2(schemeParam.getRingDim()),
+
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getQi())),
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getPi())),
+            schemeParam.getPlaintextModulus()));
+  }
+
+  void generateFallbackParam() {
+    // generate fallback scheme parameters
+    auto maxLevel = getMaxLevel();
+    std::vector<double> logPrimes(maxLevel + 1, 60);  // all primes of 60 bits
+
+    auto schemeParam = bgv::SchemeParam::getConcreteSchemeParam(
+        logPrimes, plaintextModulus, slotNumber);
+
+    annotateSchemeParam(schemeParam);
+  }
+
+  void runOnOperation() override {
+    if (auto schemeParamAttr =
+            getOperation()->getAttrOfType<bgv::SchemeParamAttr>(
+                bgv::BGVDialect::kSchemeParamAttrName)) {
+      getOperation()->emitRemark()
+          << "Scheme parameters already exist. Skipping generation.\n";
+      return;
+    }
+
+    generateFallbackParam();
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
@@ -1,0 +1,221 @@
+#include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/BGV/IR/BGVAttributes.h"
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Transforms/GenerateParam/GenerateParam.h"
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"           // from @llvm-project
+
+#define DEBUG_TYPE "GenerateParamBGV"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_GENERATEPARAMBGV
+#include "lib/Transforms/GenerateParam/GenerateParam.h.inc"
+
+struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
+  using GenerateParamBGVBase::GenerateParamBGVBase;
+
+  // assume only one main func
+  // also assume max level at entry
+  // also assume first genericOp arg is secret
+  int getMaxLevel() {
+    int maxLevel = 0;
+    getOperation()->walk([&](func::FuncOp funcOp) {
+      funcOp->walk([&](secret::GenericOp genericOp) {
+        if (genericOp.getBody()->getNumArguments() > 0) {
+          maxLevel = getLevelFromMgmtAttr(genericOp.getBody()->getArgument(0));
+        }
+      });
+    });
+    return maxLevel;
+  }
+
+  template <typename NoiseAnalysis>
+  typename NoiseAnalysis::SchemeParamType generateParamByGap(
+      DataFlowSolver *solver,
+      const typename NoiseAnalysis::SchemeParamType &schemeParam) {
+    using NoiseModel = typename NoiseAnalysis::NoiseModel;
+    using NoiseLatticeType = typename NoiseAnalysis::LatticeType;
+    using LocalParamType = typename NoiseAnalysis::LocalParamType;
+
+    // for level i, the biggest gap observed.
+    std::map<int, double> levelToGap;
+
+    auto updateLevelToGap = [&](int level, double gap) {
+      if (levelToGap.count(level) == 0) {
+        levelToGap[level] = gap;
+      } else {
+        levelToGap[level] = std::max(levelToGap.at(level), gap);
+      }
+    };
+
+    auto getLocalParam = [&](Value value) {
+      auto level = getLevelFromMgmtAttr(value);
+      auto dimension = getDimensionFromMgmtAttr(value);
+      return LocalParamType(&schemeParam, level, dimension);
+    };
+
+    auto getBound = [&](Value value) {
+      auto localParam = getLocalParam(value);
+      auto noiseLattice = solver->lookupState<NoiseLatticeType>(value);
+      return NoiseModel::toLogBound(localParam, noiseLattice->getValue());
+    };
+
+    auto firstModSize = 0;
+
+    getOperation()->walk([&](secret::GenericOp genericOp) {
+      // gaps caused by mod reduce
+      genericOp.getBody()->walk([&](mgmt::ModReduceOp op) {
+        auto operandBound = getBound(op.getOperand());
+        auto resultBound = getBound(op.getResult());
+        // the gap between the operand and result
+        updateLevelToGap(getLevelFromMgmtAttr(op.getOperand()),
+                         operandBound - resultBound);
+        return WalkResult::advance();
+      });
+
+      // find the max noise for the first level
+      genericOp.getBody()->walk([&](Operation *op) {
+        for (Value result : op->getResults()) {
+          if (getLevelFromMgmtAttr(result) == 0) {
+            auto bound = getBound(result);
+            // the bound is from v_ms + v / q, where v / q is negligible
+            // so originally bound(v_ms) + 1 is enough
+            // after the parameter selection with smaller primes, we have
+            // v_ms \approx v / q so bound(2 * v_ms) approx bound(v_ms) + 0.5
+            // now we need bound(v_ms) + 1.5 or bound + 2 to ensure the noise
+            firstModSize = std::max(firstModSize, 2 + int(ceil(bound)));
+          }
+        }
+        return WalkResult::advance();
+      });
+    });
+
+    auto maxLevel = levelToGap.size() + 1;
+    auto qiSize = std::vector<double>(maxLevel, 0);
+    qiSize[0] = firstModSize;
+
+    for (auto &[level, gap] : levelToGap) {
+      // the prime size should be larger than the gap to ensure after mod reduce
+      // the noise is still within the bound
+      qiSize[level] = 1 + int(ceil(gap));
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "Gap logqi: ";
+      for (auto size : qiSize) {
+        llvm::dbgs() << static_cast<int>(size) << " ";
+      }
+      llvm::dbgs() << "\n";
+    });
+
+    auto concreteSchemeParam =
+        NoiseAnalysis::SchemeParamType::getConcreteSchemeParam(
+            qiSize, schemeParam.getPlaintextModulus(), slotNumber);
+
+    return concreteSchemeParam;
+  }
+
+  void annotateSchemeParam(const bgv::SchemeParam &schemeParam) {
+    getOperation()->setAttr(
+        bgv::BGVDialect::kSchemeParamAttrName,
+        bgv::SchemeParamAttr::get(
+            &getContext(), log2(schemeParam.getRingDim()),
+
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getQi())),
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getPi())),
+            schemeParam.getPlaintextModulus()));
+  }
+
+  template <typename NoiseAnalysis>
+  void run() {
+    int maxLevel = getMaxLevel();
+
+    // plaintext modulus from command line option
+    auto schemeParam =
+        NoiseAnalysis::SchemeParamType::getConservativeSchemeParam(
+            maxLevel, plaintextModulus, slotNumber);
+
+    LLVM_DEBUG(llvm::dbgs() << "Conservative Scheme Param:\n"
+                            << schemeParam << "\n");
+
+    DataFlowSolver solver;
+    solver.load<dataflow::DeadCodeAnalysis>();
+    solver.load<dataflow::SparseConstantPropagation>();
+    // NoiseAnalysis depends on SecretnessAnalysis
+    solver.load<SecretnessAnalysis>();
+    solver.load<NoiseAnalysis>(schemeParam);
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+    }
+
+    // use previous analysis result to generate concrete scheme param
+    auto concreteSchemeParam =
+        generateParamByGap<NoiseAnalysis>(&solver, schemeParam);
+
+    LLVM_DEBUG(llvm::dbgs() << "Concrete Scheme Param:\n"
+                            << concreteSchemeParam << "\n");
+
+    annotateSchemeParam(concreteSchemeParam);
+  }
+
+  void generateFallbackParam() {
+    // generate fallback scheme parameters
+    auto maxLevel = getMaxLevel();
+    std::vector<double> logPrimes(maxLevel + 1, 45);  // all primes of 45 bits
+
+    auto schemeParam = bgv::SchemeParam::getConcreteSchemeParam(
+        logPrimes, plaintextModulus, slotNumber);
+
+    annotateSchemeParam(schemeParam);
+  }
+
+  void runOnOperation() override {
+    if (auto schemeParamAttr =
+            getOperation()->getAttrOfType<bgv::SchemeParamAttr>(
+                bgv::BGVDialect::kSchemeParamAttrName)) {
+      getOperation()->emitRemark()
+          << "Scheme parameters already exist. Skipping generation.\n";
+      return;
+    }
+
+    if (model == "bgv-noise-by-bound-coeff-worst-case-pk") {
+      run<NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCasePkModel>>();
+    } else if (model == "bgv-noise-by-bound-coeff-average-case-pk") {
+      run<NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCasePkModel>>();
+    } else if (model == "bgv-noise-by-bound-coeff-worst-case-sk") {
+      run<NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCaseSkModel>>();
+    } else if (model == "bgv-noise-by-bound-coeff-average-case-sk") {
+      run<NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCaseSkModel>>();
+    } else if (model == "bgv-noise-by-variance-coeff-pk") {
+      run<NoiseAnalysis<bgv::NoiseByVarianceCoeffPkModel>>();
+    } else if (model == "bgv-noise-by-variance-coeff-sk") {
+      run<NoiseAnalysis<bgv::NoiseByVarianceCoeffSkModel>>();
+    } else {
+      getOperation()->emitWarning() << "Unknown noise model.\n";
+      generateFallbackParam();
+    }
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
@@ -1,0 +1,84 @@
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Parameters/CKKS/Params.h"
+#include "lib/Transforms/GenerateParam/GenerateParam.h"
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"        // from @llvm-project
+
+#define DEBUG_TYPE "GenerateParamCKKS"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_GENERATEPARAMCKKS
+#include "lib/Transforms/GenerateParam/GenerateParam.h.inc"
+
+struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
+  using GenerateParamCKKSBase::GenerateParamCKKSBase;
+
+  // assume only one main func
+  // also assume max level at entry
+  // also assume first genericOp arg is secret
+  int getMaxLevel() {
+    int maxLevel = 0;
+    getOperation()->walk([&](func::FuncOp funcOp) {
+      funcOp->walk([&](secret::GenericOp genericOp) {
+        if (genericOp.getBody()->getNumArguments() > 0) {
+          maxLevel = getLevelFromMgmtAttr(genericOp.getBody()->getArgument(0));
+        }
+      });
+    });
+    return maxLevel;
+  }
+
+  void runOnOperation() override {
+    auto maxLevel = getMaxLevel();
+
+    if (auto schemeParamAttr =
+            getOperation()->getAttrOfType<ckks::SchemeParamAttr>(
+                ckks::CKKSDialect::kSchemeParamAttrName)) {
+      getOperation()->emitRemark()
+          << "Scheme parameters already exist. Skipping generation.\n";
+
+      // TODO: put this in validate-noise once CKKS noise model is in
+      auto schemeParam =
+          ckks::SchemeParam::getSchemeParamFromAttr(schemeParamAttr);
+      if (schemeParam.getLevel() < maxLevel) {
+        getOperation()->emitOpError()
+            << "The level in the scheme param is smaller than the max level.\n";
+        signalPassFailure();
+        return;
+      }
+      return;
+    }
+
+    // generate scheme parameters
+    std::vector<double> logPrimes(maxLevel + 1, scalingModBits);
+    logPrimes[0] = firstModBits;
+
+    auto schemeParam = ckks::SchemeParam::getConcreteSchemeParam(
+        logPrimes, scalingModBits, slotNumber);
+
+    LLVM_DEBUG(llvm::dbgs() << "Scheme Param:\n" << schemeParam << "\n");
+
+    // annotate ckks::SchemeParamAttr to ModuleOp
+    getOperation()->setAttr(
+        ckks::CKKSDialect::kSchemeParamAttrName,
+        ckks::SchemeParamAttr::get(
+            &getContext(), log2(schemeParam.getRingDim()),
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getQi())),
+            DenseI64ArrayAttr::get(&getContext(),
+                                   ArrayRef(schemeParam.getPi())),
+            schemeParam.getLogDefaultScale()));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/ValidateNoise/ValidateNoise.td
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.td
@@ -8,30 +8,12 @@ def ValidateNoise : Pass<"validate-noise"> {
   let description = [{
     This pass validates the noise of the HE circuit against a given noise model.
 
-    Currently the pass works for BGV scheme, and there are two noise models
-    available: "bgv-noise-by-bound-coeff-average-case{-pk,-sk}",
-    "bgv-noise-by-bound-coeff-worst-case{-pk,-sk}" and
-    "bgv-noise-by-variance-coeff{-pk,-sk}".
+    The pass expects the scheme parameters to be annotated in the IR. Usually
+    this is done by the `generate-param-<scheme>` passes.
 
-    The first two models are taken from KPZ21, and they work by bounding
-    the coefficient embedding of the ciphertexts. The difference
-    of the two models is expansion factor used for multiplication
-    of the coefficients, the first being `2\sqrt{N}` and the second
-    being `N`. The `-pk`/`-sk` suffixes assume the input ciphertexts are
-    encrypted using the public/secret key.
+    For available noise models, see `generate-param-<scheme>` passes.
 
-    The third model is taken from MP24. It works by tracking the variance
-    of the coefficient embedding of the ciphertexts. This gives a more accurate
-    noise estimate, but it may give underestimates in some cases. See the paper
-    for more details.
-
-    This pass is experimental. The result should be observed using
-    --debug-only=ValidateNoise.
-
-    This pass relies on the presence of the `mgmt` dialect ops to model
-    relinearize/modreduce, and it relies on `mgmt.mgmt` attribute to determine
-    the ciphertext level/dimension. These ops and attributes can be added by
-    a pass like `--secret-insert-mgmt-<scheme>` and `--annotate-mgmt`.
+    The result should be observed using --debug-only=ValidateNoise.
 
     Example
     ```bash
@@ -47,11 +29,9 @@ def ValidateNoise : Pass<"validate-noise"> {
 
   let options = [
     Option<"model", "model", "std::string",
-           /*default=*/"", "Noise model to validate against.">,
-    Option<"plaintextModulus", "plaintext-modulus", "int64_t",
-           /*default=*/"65537", "Plaintext modulus.">,
-    Option<"slotNumber", "slot-number", "int",
-           /*default=*/"0", "Minimum number of slots for parameter generation.">,
+           /*default=*/"\"bgv-noise-by-bound-coeff-average-case-pk\"", "Noise model to validate against.">,
+    Option<"annotateNoiseBound", "annotate-noise-bound", "bool",
+           /*default=*/"false", "Annotate the noise bound to the IR.">,
   ];
 }
 

--- a/tests/Dialect/CKKS/IR/ops.mlir
+++ b/tests/Dialect/CKKS/IR/ops.mlir
@@ -35,7 +35,7 @@
 !ct_scalar = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
 
 // CHECK: module
-module {
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   // CHECK-LABEL: @test_multiply
   func.func @test_multiply(%arg0 : !ct, %arg1: !ct) -> !ct {
     %add = ckks.add %arg0, %arg1 : (!ct, !ct) -> !ct

--- a/tests/Dialect/Openfhe/Transforms/configure_crypto_context_complex.mlir
+++ b/tests/Dialect/Openfhe/Transforms/configure_crypto_context_complex.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --secretize --wrap-generic --cse --canonicalize --secret-insert-mgmt-bgv --secret-distribute-generic --secret-to-bgv=poly-mod-degree=32 --bgv-to-lwe --lwe-to-openfhe --openfhe-configure-crypto-context=entry-function=complex_func %s | FileCheck %s
+// RUN: heir-opt --secretize --wrap-generic --cse --canonicalize --secret-insert-mgmt-bgv --generate-param-bgv --secret-distribute-generic --secret-to-bgv=poly-mod-degree=32 --bgv-to-lwe --lwe-to-openfhe --openfhe-configure-crypto-context=entry-function=complex_func %s | FileCheck %s
 
 !ty = tensor<32xi16>
 

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/ciphertext_plaintext.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/ciphertext_plaintext.mlir
@@ -4,7 +4,7 @@
 
 #mgmt = #mgmt.mgmt<level = 0, dimension = 2>
 
-module {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
   // CHECK-LABEL: func @test_add_plain
   // CHECK-SAME: %[[arg0:.*]]: !lwe.new_lwe_ciphertext
   // CHECK-SAME: %[[arg1:.*]]: tensor<1024xi1>

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/hamming_distance_1024.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/hamming_distance_1024.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --secret-insert-mgmt-bgv=include-first-mul=false --secret-distribute-generic --secret-to-bgv %s | FileCheck %s
+// RUN: heir-opt --secret-insert-mgmt-bgv=include-first-mul=false --generate-param-bgv --secret-distribute-generic --secret-to-bgv %s | FileCheck %s
 
 // CHECK-LABEL: @hamming
 // CHECK: bgv.sub

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/invalid.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/invalid.mlir
@@ -2,7 +2,7 @@
 
 // Tests invalid secret types
 
-module {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
   // expected-error@below {{expected batched secret types to be tensors with dimension matching ring parameter}}
   func.func @test_invalid_dimension(%arg0 : !secret.secret<tensor<1000xi1>>) -> (!secret.secret<tensor<1000xi1>>) {
     return %arg0 : !secret.secret<tensor<1000xi1>>
@@ -11,7 +11,9 @@ module {
 
 // -----
 
-// CHECK: test_valid_dimension
-func.func @test_valid_dimension(%arg0 : !secret.secret<tensor<1024xi1>>) -> (!secret.secret<tensor<1024xi1>>) {
-  return %arg0 : !secret.secret<tensor<1024xi1>>
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
+  // CHECK: test_valid_dimension
+  func.func @test_valid_dimension(%arg0 : !secret.secret<tensor<1024xi1>>) -> (!secret.secret<tensor<1024xi1>>) {
+    return %arg0 : !secret.secret<tensor<1024xi1>>
+  }
 }

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/ops.mlir
@@ -4,7 +4,7 @@
 #mgmt = #mgmt.mgmt<level = 0, dimension = 2>
 #mgmt1 = #mgmt.mgmt<level = 0, dimension = 3>
 
-module {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
   // CHECK-LABEL: func @test_arith_ops
   func.func @test_arith_ops(%arg0 : !eui1 {mgmt.mgmt = #mgmt}, %arg1 : !eui1 {mgmt.mgmt = #mgmt}, %arg2 : !eui1 {mgmt.mgmt = #mgmt}) -> (!eui1) {
     %0 = secret.generic ins(%arg0, %arg1 :  !eui1, !eui1) attrs = {mgmt.mgmt = #mgmt} {

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/preserve_attr.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/preserve_attr.mlir
@@ -4,7 +4,7 @@
 #mgmt = #mgmt.mgmt<level = 0, dimension = 2>
 #mgmt1 = #mgmt.mgmt<level = 0, dimension = 3>
 
-module {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
   // CHECK-LABEL: func @test_preserve_attr
   func.func @test_preserve_attr(%arg0 : !eui1 {mgmt.mgmt = #mgmt}, %arg1 : !eui1 {mgmt.mgmt = #mgmt}, %arg2 : !eui1 {mgmt.mgmt = #mgmt}) -> (!eui1) {
     %0 = secret.generic ins(%arg0, %arg1 :  !eui1, !eui1) attrs = {mgmt.mgmt = #mgmt} {

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/type_error.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/type_error.mlir
@@ -4,7 +4,7 @@
 //
 //   heir-opt --mlir-print-ir-before-all --mlir-to-bgv='ciphertext-degree=8' --scheme-to-openfhe='entry-function=dot_product' tests/Examples/openfhe/dot_product_8f.mlir
 
-module {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
   func.func @dot_product(%arg0: !secret.secret<tensor<8xf16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}, %arg1: !secret.secret<tensor<8xf16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}) -> !secret.secret<tensor<8xf16>> {
     %cst = arith.constant dense<9.997550e-02> : tensor<8xf16>
     // expected-error@below {{Floating point types are not supported in BGV. Maybe you meant to use a CKKS pipeline like --mlir-to-ckks?}}

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/ciphertext_plaintext.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/ciphertext_plaintext.mlir
@@ -5,7 +5,7 @@
 
 #mgmt = #mgmt.mgmt<level = 0, dimension = 2>
 
-module {
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   // CHECK-LABEL: func @test_addi_plain
   // CHECK-SAME: %[[arg0:.*]]: !lwe.new_lwe_ciphertext
   // CHECK-SAME: %[[arg1:.*]]: tensor<1024xi1>

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/hamming_distance_1024.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/hamming_distance_1024.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --secret-insert-mgmt-ckks=include-first-mul=false --secret-distribute-generic --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --secret-insert-mgmt-ckks=include-first-mul=false --generate-param-ckks --secret-distribute-generic --secret-to-ckks %s | FileCheck %s
 
 // CHECK-LABEL: @hamming
 // CHECK: ckks.sub

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/invalid.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/invalid.mlir
@@ -3,7 +3,7 @@
 // Tests invalid secret types
 
 // expected-warning@below {{expected secret types to be tensors with dimension matching ring parameter, pass will not pack tensors into ciphertext SIMD slots}}
-module {
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   func.func @test_invalid_dimension(%arg0 : !secret.secret<tensor<1000xi1>>) -> (!secret.secret<tensor<1000xi1>>) {
     return %arg0 : !secret.secret<tensor<1000xi1>>
   }
@@ -11,9 +11,11 @@ module {
 
 // -----
 
-// CHECK: test_valid_dimension
-func.func @test_valid_dimension(%arg0 : !secret.secret<tensor<1024xi1>>) -> (!secret.secret<tensor<1024xi1>>) {
-  return %arg0 : !secret.secret<tensor<1024xi1>>
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
+  // CHECK: test_valid_dimension
+  func.func @test_valid_dimension(%arg0 : !secret.secret<tensor<1024xi1>>) -> (!secret.secret<tensor<1024xi1>>) {
+    return %arg0 : !secret.secret<tensor<1024xi1>>
+  }
 }
 
 // -----
@@ -22,7 +24,7 @@ func.func @test_valid_dimension(%arg0 : !secret.secret<tensor<1024xi1>>) -> (!se
 // lowering must implement a loop of add operations on each element.
 
 // expected-warning@below {{expected secret types to be tensors with dimension matching ring parameter, pass will not pack tensors into ciphertext SIMD slots}}
-module {
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   func.func @test_add_tensor_not_packed(%arg0 : !secret.secret<tensor<1023xf32>>) -> (!secret.secret<tensor<1023xf32>>) {
     // expected-error@below {{failed to legalize}}
     %0 = secret.generic ins(%arg0 :  !secret.secret<tensor<1023xf32>>) {
@@ -39,7 +41,7 @@ module {
 
 // Currently we don't support lowering adds on tensor.insert on into slots of a single ciphertext.
 
-module {
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   func.func @test_tensor_insert_slot(%arg0 : !secret.secret<tensor<1024xf32>> {mgmt.mgmt = #mgmt}, %arg1 : !secret.secret<f32> {mgmt.mgmt = #mgmt}) -> (!secret.secret<tensor<1024xf32>>) {
     %c0 = arith.constant 0 : index
     // expected-error@below {{failed to legalize}}

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --secret-insert-mgmt-ckks=include-first-mul=false --secret-distribute-generic --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --secret-insert-mgmt-ckks=include-first-mul=false --generate-param-ckks --secret-distribute-generic --secret-to-ckks %s | FileCheck %s
 
 module {
 // CHECK-LABEL: func @hv_matmul

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/matmul_unrolled.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/matmul_unrolled.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-print-local-scope --secretize --wrap-generic --full-loop-unroll --secret-insert-mgmt-ckks=include-first-mul=false --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --secretize --wrap-generic --full-loop-unroll --secret-insert-mgmt-ckks=include-first-mul=false --generate-param-ckks --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
 
 module {
   // CHECK-LABEL: func @main

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
@@ -6,7 +6,7 @@
 #mgmt = #mgmt.mgmt<level = 0, dimension = 2>
 #mgmt1 = #mgmt.mgmt<level = 0, dimension = 3>
 
-module {
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   // CHECK-LABEL: func @test_arith_ops
   func.func @test_arith_ops(%arg0 : !eui1 {mgmt.mgmt = #mgmt}, %arg1 : !eui1 {mgmt.mgmt = #mgmt}, %arg2 : !eui1 {mgmt.mgmt = #mgmt}) -> (!eui1) {
     %0 = secret.generic ins(%arg0, %arg1 :  !eui1, !eui1) attrs = {mgmt.mgmt = #mgmt} {

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/type_converter.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/type_converter.mlir
@@ -1,7 +1,7 @@
 // Tests that the type converter handles both converting tensors to SIMD slots
 // if aligned, or to tensors of ciphertext.
 
-// RUN: heir-opt --mlir-print-local-scope --secret-insert-mgmt-ckks=include-first-mul=false --secret-distribute-generic --canonicalize --secret-to-ckks --split-input-file %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --secret-insert-mgmt-ckks=include-first-mul=false --generate-param-ckks --secret-distribute-generic --canonicalize --secret-to-ckks --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: func @test_arg_packed
 // CHECK-SAME: %[[arg0:.*]]: !lwe.new_lwe_ciphertext<{{.*}}message_type = tensor<1024xf32>{{.*}}>

--- a/tests/Regression/issue_1406.mlir
+++ b/tests/Regression/issue_1406.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --secret-distribute-generic --secret-to-bgv | FileCheck %s
+// RUN: heir-opt %s --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --generate-param-bgv --secret-distribute-generic --secret-to-bgv | FileCheck %s
 
 // CHECK-NOT: !secret.secret<i16>
 func.func @add(%arg0 : i16 {secret.secret}, %arg1 : i16 {secret.secret}) -> i16 {

--- a/tests/Transforms/validate_noise/validate_noise_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_fail.mlir
@@ -1,19 +1,19 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise="model=bgv-noise-by-bound-coeff-worst-case-pk plaintext-modulus=4295294977" --verify-diagnostics %s
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise="model=bgv-noise-by-bound-coeff-worst-case-pk" --verify-diagnostics %s
 
 // This is only for testing whether validate-noise would fail, but
 // not for testing the noise model.
 // This failing example is handcrafted to fail the noise validation
 // using the following conditions:
 //   + plaintext modulus is large
-//   + modulus is 60bit
+//   + modulus is 45 bits
 //   + consecutive multiplications
 //   + using worst-case noise model
-//   + When plaintext modulus is large, modulus of 60 bit is not enough
+//   + When plaintext modulus is large, modulus of 45 bits is not enough
 // Note that if any condition changed the test may fail and changes
 // to this file are expected
 
 // expected-error@below {{'builtin.module' op Noise validation failed.}}
-module {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113, 35184376184833], P = [35184376545281, 35184376578049], plaintextModulus = 4295294977>} {
   func.func @dot_product(%arg0: i16 {secret.secret}) -> i16 {
     %0 = arith.muli %arg0, %arg0 : i16
     %1 = arith.muli %0, %0 : i16

--- a/tests/Transforms/validate_noise/validate_noise_pass.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_pass.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise=model=bgv-noise-by-bound-coeff-average-case-pk %s | FileCheck %s
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --generate-param-bgv --validate-noise=model=bgv-noise-by-bound-coeff-average-case-pk %s | FileCheck %s
 
 // CHECK-LABEL: @dot_product
 func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16> {secret.secret}) -> i16 {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -111,6 +111,7 @@ cc_binary(
         "@heir//lib/Transforms/ForwardInsertToExtract",
         "@heir//lib/Transforms/ForwardStoreToLoad",
         "@heir//lib/Transforms/FullLoopUnroll",
+        "@heir//lib/Transforms/GenerateParam",
         "@heir//lib/Transforms/LayoutPropagation",
         "@heir//lib/Transforms/LinalgCanonicalizations",
         "@heir//lib/Transforms/MemrefToArith:ExpandCopy",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -64,6 +64,7 @@
 #include "lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.h"
 #include "lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.h"
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
+#include "lib/Transforms/GenerateParam/GenerateParam.h"
 #include "lib/Transforms/LayoutPropagation/LayoutPropagation.h"
 #include "lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.h"
 #include "lib/Transforms/OperationBalancer/OperationBalancer.h"
@@ -251,6 +252,7 @@ int main(int argc, char **argv) {
   registerApplyFoldersPasses();
   registerForwardInsertToExtractPasses();
   registerForwardStoreToLoadPasses();
+  registerGenerateParamPasses();
   registerOperationBalancerPasses();
   registerStraightLineVectorizerPasses();
   registerUnusedMemRefPasses();


### PR DESCRIPTION
Parameter generation process in `validate-noise` is no longer adaquate and deserves a standalone pass.

This also adds a default parameter generation process for BFV that generates all 60bit moduli chain, whose length is just the multiplicative depth. Further noise model for BFV could refine such process.

Now `secret-to-<scheme>` requires a explicit scheme param attr for proper lowering to LWE type.