### PR TITLE
BGV: split bgv.rotate into rotate_cols/rows variants

### DIFF
--- a/lib/Dialect/BGV/Conversions/BGVToLWE/BGVToLWE.cpp
+++ b/lib/Dialect/BGV/Conversions/BGVToLWE/BGVToLWE.cpp
@@ -24,7 +24,7 @@ struct BGVToLWE : public impl::BGVToLWEBase<BGVToLWE> {
     RewritePatternSet patterns(context);
     patterns.add<Convert<AddOp, lwe::RAddOp>, Convert<SubOp, lwe::RSubOp>,
                  Convert<NegateOp, lwe::RNegateOp>, Convert<MulOp, lwe::RMulOp>,
-                 lwe::ConvertExtract<ExtractOp, MulPlainOp, RotateOp> >(
+                 lwe::ConvertExtract<ExtractOp, MulPlainOp, RotateColumnsOp> >(
         context);
     walkAndApplyPatterns(module, std::move(patterns));
   }

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -41,7 +41,9 @@ void BGVDialect::initialize() {
 
 LogicalResult MulOp::verify() { return verifyMulOp(this); }
 
-LogicalResult RotateOp::verify() { return verifyRotateOp(this); }
+LogicalResult RotateColumnsOp::verify() { return verifyRotateOp(this); }
+
+LogicalResult RotateRowsOp::verify() { return verifyRotateOp(this); }
 
 LogicalResult RelinearizeOp::verify() { return verifyRelinearizeOp(this); }
 

--- a/lib/Dialect/BGV/IR/BGVOps.td
+++ b/lib/Dialect/BGV/IR/BGVOps.td
@@ -91,8 +91,44 @@ def BGV_MulPlainOp : BGV_CiphertextPlaintextOp<"mul_plain"> {
   let summary = "Multiplication operation between ciphertext-plaintext.";
 }
 
-def BGV_RotateOp : BGV_Op<"rotate", [Pure, AllTypesMatch<["input", "output"]>]> {
-  let summary = "Rotate the coefficients of the ciphertext using a Galois automorphism.";
+def BGV_RotateColumnsOp : BGV_Op<"rotate_cols", [Pure, AllTypesMatch<["input", "output"]>]> {
+  let summary = "Rotate the columns of the coefficients of the ciphertext using a Galois automorphism.";
+
+  let description = [{
+    This operation rotates the columns of the coefficients of the ciphertext using a
+    Galois automorphism.
+
+    Often BGV scheme is instantiated with a ring of the form `Z_q[X]/(X^N + 1)` and
+    plaintext modulus `t` where `N` is a power of 2 and `t` is a prime number. In
+    this case, the plaintext slots can be viewed as a `2 x N/2` matrix where
+    `N/2` is the number of columns and `2` is the number of rows.
+  }];
+
+  let arguments = (ins
+    NewLWECiphertext:$input,
+    Builtin_IntegerAttr:$offset
+  );
+
+  let results = (outs
+    NewLWECiphertext:$output
+  );
+
+  let hasVerifier = 1;
+  let assemblyFormat = "operands attr-dict `:` qualified(type($input))" ;
+}
+
+def BGV_RotateRowsOp : BGV_Op<"rotate_rows", [Pure, AllTypesMatch<["input", "output"]>]> {
+  let summary = "Rotate the rows of the coefficients of the ciphertext using a Galois automorphism.";
+
+  let description = [{
+    This operation rotates the rows of the coefficients of the ciphertext using a
+    Galois automorphism.
+
+    Often BGV scheme is instantiated with a ring of the form `Z_q[X]/(X^N + 1)` and
+    plaintext modulus `t` where `N` is a power of 2 and `t` is a prime number. In
+    this case, the plaintext slots can be viewed as a `2 x N/2` matrix where
+    `N/2` is the number of columns and `2` is the number of rows.
+  }];
 
   let arguments = (ins
     NewLWECiphertext:$input,

--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -440,9 +440,8 @@ using ConvertBGVModulusSwitchOp =
     ConvertRlweUnaryOp<lattigo::BGVEvaluatorType, bgv::ModulusSwitchOp,
                        lattigo::BGVRescaleNewOp>;
 
-// TODO(#1186): figure out generic rotating using BGVRotateColumns/RowsOp
-using ConvertBGVRotateOp =
-    ConvertRlweRotateOp<lattigo::BGVEvaluatorType, bgv::RotateOp,
+using ConvertBGVRotateColumnsOp =
+    ConvertRlweRotateOp<lattigo::BGVEvaluatorType, bgv::RotateColumnsOp,
                         lattigo::BGVRotateColumnsNewOp>;
 
 using ConvertBGVEncryptOp =
@@ -678,9 +677,10 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
       patterns
           .add<ConvertBGVAddOp, ConvertBGVSubOp, ConvertBGVMulOp,
                ConvertBGVAddPlainOp, ConvertBGVSubPlainOp, ConvertBGVMulPlainOp,
-               ConvertBGVRelinOp, ConvertBGVModulusSwitchOp, ConvertBGVRotateOp,
-               ConvertBGVEncryptOp, ConvertBGVDecryptOp, ConvertBGVEncodeOp,
-               ConvertBGVDecodeOp>(typeConverter, context);
+               ConvertBGVRelinOp, ConvertBGVModulusSwitchOp,
+               ConvertBGVRotateColumnsOp, ConvertBGVEncryptOp,
+               ConvertBGVDecryptOp, ConvertBGVEncodeOp, ConvertBGVDecodeOp>(
+              typeConverter, context);
     }
     if (moduleIsCKKS(module)) {
       patterns.add<ConvertCKKSAddOp, ConvertCKKSSubOp, ConvertCKKSMulOp,

--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -406,7 +406,7 @@ struct LWEToOpenfhe : public impl::LWEToOpenfheBase<LWEToOpenfhe> {
         ConvertCiphertextPlaintextOp<ckks::MulPlainOp, openfhe::MulPlainOp>,
 
         // Rotate
-        ConvertRotateOp<bgv::RotateOp, openfhe::RotOp>,
+        ConvertRotateOp<bgv::RotateColumnsOp, openfhe::RotOp>,
         ConvertRotateOp<ckks::RotateOp, openfhe::RotOp>,
         // Relin
         ConvertRelinOp<bgv::RelinearizeOp, openfhe::RelinOp>,

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -303,7 +303,7 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
         SecretGenericOpRelinearizeConversion<bgv::RelinearizeOp>,
         SecretGenericOpModulusSwitchConversion<bgv::ModulusSwitchOp>,
         SecretGenericOpConversion<tensor::ExtractOp, bgv::ExtractOp>,
-        SecretGenericOpRotateConversion<bgv::RotateOp>,
+        SecretGenericOpRotateConversion<bgv::RotateColumnsOp>,
         SecretGenericOpCipherPlainConversion<arith::AddIOp, bgv::AddPlainOp>,
         SecretGenericOpCipherPlainConversion<arith::SubIOp, bgv::SubPlainOp>,
         SecretGenericOpCipherPlainConversion<arith::MulIOp, bgv::MulPlainOp>>(

--- a/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
@@ -43,7 +43,7 @@ module attributes {scheme.bgv} {
     // CHECK: %[[rescale:.*]] = lattigo.bgv.rescale_new [[C]], %[[relin]] : ([[S]], [[T]]) -> [[T]]
     %rescale = bgv.modulus_switch %relin {to_ring = #ring_rns_L0_1_x1024_} : !ct -> !ct2
     // CHECK: %[[rot:.*]] = lattigo.bgv.rotate_columns_new [[C]], %[[rescale]] {offset = 1 : i64} : ([[S]], [[T]]) -> [[T]]
-    %rot = bgv.rotate %rescale { offset = 1 } : !ct2
+    %rot = bgv.rotate_cols %rescale { offset = 1 } : !ct2
     return
   }
 }

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/bgv_to_openfhe.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/bgv_to_openfhe.mlir
@@ -46,7 +46,7 @@ module {
     %mul = bgv.mul %x, %y  : (!ct, !ct) -> !ct_D3
     // CHECK: %[[v5:.*]] = openfhe.rot [[C]], %[[x5:.*]] {index = 4 : i64}
     // CHECK-SAME: ([[S]], [[T]]) -> [[T]]
-    %rot = bgv.rotate %x { offset = 4 } : !ct
+    %rot = bgv.rotate_cols %x { offset = 4 } : !ct
     return %negate, %add, %sub, %mul, %rot : !ct, !ct, !ct, !ct_D3, !ct
   }
 

--- a/tests/Dialect/BGV/IR/ops.mlir
+++ b/tests/Dialect/BGV/IR/ops.mlir
@@ -61,7 +61,7 @@ module {
   // CHECK-LABEL: @test_rotate_extract
   func.func @test_rotate_extract(%arg3: !ct_tensor) -> !ct_scalar {
     %c0 = arith.constant 0 : index
-    %add = bgv.rotate %arg3 { offset = 1 } : !ct_tensor
+    %add = bgv.rotate_cols %arg3 { offset = 1 } : !ct_tensor
     %ext = bgv.extract %add, %c0 : (!ct_tensor, index) -> !ct_scalar
     // CHECK: message_type = i16
     // CHECK: ring = <coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>, !mod_arith.int<1032955396097 : i64>>, polynomialModulus = <1 + x**1024>>

--- a/tests/Dialect/BGV/IR/verifier.mlir
+++ b/tests/Dialect/BGV/IR/verifier.mlir
@@ -20,7 +20,7 @@
 
 func.func @test_input_dimension_error(%input: !ct) {
   // expected-error@+1 {{x.dim == 2 does not hold}}
-  %out = bgv.rotate  %input { offset = 4 }  : !ct
+  %out = bgv.rotate_cols  %input { offset = 4 }  : !ct
   return
 }
 

--- a/tests/Dialect/LWE/Transforms/add_client_interface.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface.mlir
@@ -24,15 +24,15 @@
 
 func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
   %c31 = arith.constant 31 : index
-  %0 = bgv.rotate %arg0 { offset = 16 } : !in_ty
+  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
   %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate %1 { offset = 8 } : !in_ty
+  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
   %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate %3 { offset = 4 } : !in_ty
+  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
   %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate %5 { offset = 2 } : !in_ty
+  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
   %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate %7 { offset = 1 } : !in_ty
+  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
   %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
   %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
   return %10 : !out_ty

--- a/tests/Dialect/LWE/Transforms/add_client_interface_private_func.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface_private_func.mlir
@@ -26,15 +26,15 @@ func.func private @external_func(!out_ty) -> !out_ty
 
 func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
   %c31 = arith.constant 31 : index
-  %0 = bgv.rotate %arg0 { offset = 16 } : !in_ty
+  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
   %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate %1 { offset = 8 } : !in_ty
+  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
   %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate %3 { offset = 4 } : !in_ty
+  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
   %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate %5 { offset = 2 } : !in_ty
+  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
   %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate %7 { offset = 1 } : !in_ty
+  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
   %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
   %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
   %11 = func.call @external_func(%10) : (!out_ty) -> !out_ty

--- a/tests/Dialect/LWE/Transforms/add_client_interface_public_key.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface_public_key.mlir
@@ -24,15 +24,15 @@
 
 func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
   %c31 = arith.constant 31 : index
-  %0 = bgv.rotate %arg0 { offset = 16 } : !in_ty
+  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
   %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate %1 { offset = 8 } : !in_ty
+  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
   %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate %3 { offset = 4 } : !in_ty
+  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
   %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate %5 { offset = 2 } : !in_ty
+  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
   %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate %7 { offset = 1 } : !in_ty
+  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
   %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
   %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
   return %10 : !out_ty

--- a/tests/Dialect/LWE/Transforms/add_client_interface_split.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface_split.mlir
@@ -26,11 +26,11 @@ func.func @dot_product(%arg0: !in_ty, %arg1: !in_ty) -> (!out_ty, !out_ty) {
   %c7 = arith.constant 7 : index
   %0 = bgv.mul %arg0, %arg1 : (!in_ty, !in_ty) -> !mul_ty
   %1 = bgv.relinearize %0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !mul_ty -> !in_ty
-  %2 = bgv.rotate %1 { offset = 4 } : !in_ty
+  %2 = bgv.rotate_cols %1 { offset = 4 } : !in_ty
   %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate %3 { offset = 2 } : !in_ty
+  %4 = bgv.rotate_cols %3 { offset = 2 } : !in_ty
   %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate %5 { offset = 1 } : !in_ty
+  %6 = bgv.rotate_cols %5 { offset = 1 } : !in_ty
   %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
   %8 = bgv.extract %7, %c7 : (!in_ty, index) -> !out_ty
   return %8, %8 : !out_ty, !out_ty

--- a/tests/Dialect/LWE/Transforms/add_debug_port.mlir
+++ b/tests/Dialect/LWE/Transforms/add_debug_port.mlir
@@ -24,15 +24,15 @@
 
 func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
   %c31 = arith.constant 31 : index
-  %0 = bgv.rotate %arg0 { offset = 16 } : !in_ty
+  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
   %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate %1 { offset = 8 } : !in_ty
+  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
   %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate %3 { offset = 4 } : !in_ty
+  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
   %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate %5 { offset = 2 } : !in_ty
+  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
   %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate %7 { offset = 1 } : !in_ty
+  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
   %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
   %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
   return %10 : !out_ty


### PR DESCRIPTION
Fixes #1186 and #1450