### PR TITLE
enable (1-dim) dense `mod_arith.constant`

### DIFF
--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -91,8 +91,8 @@ def ModArith_ConstantOp : Op<ModArith_Dialect, "constant", [Pure]> {
     %0 = mod_arith.constant 123 : !mod_arith.int<65537:i32>
     ```
   }];
-  let arguments = (ins APIntAttr:$value);
-  let results = (outs ModArith_ModArithType:$output);
+  let arguments = (ins TypedAttrInterface:$value);
+  let results = (outs ModArithLike:$output);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }

--- a/tests/Dialect/ModArith/IR/invalid-ops.mlir
+++ b/tests/Dialect/ModArith/IR/invalid-ops.mlir
@@ -37,7 +37,7 @@ func.func @test_barrett_neg_mod_err(%arg : i8) -> i8 {
 // -----
 // CHECK-NOT @test_constant_bad_width
 func.func @test_constant_bad_width() {
-  // expected-error@+1 {{Constant value's bitwidth must be smaller than underlying type.}}
+  // expected-error@+1 {{value's bitwidth must not be larger than underlying type.}}
   %c = mod_arith.constant 512 : !mod_arith.int<17 : i8>
   return
 }

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -17,6 +17,16 @@ func.func @test_arith_syntax() {
 
   // CHECK: mod_arith.constant 12 : !mod_arith.int<17 : i10>
   %const123 = mod_arith.constant 12 : !Zp
+  // CHECK: mod_arith.constant 0 : !mod_arith.int<17 : i10>
+  %constZero = mod_arith.constant 0 : !Zp
+  // CHECK: mod_arith.constant -1 : !mod_arith.int<17 : i10>
+  %constNegative = mod_arith.constant -1 : !Zp
+  // CHECK: mod_arith.constant dense<[1, 2, 3, 4]> : tensor<4x!mod_arith.int<17 : i10>>
+  %constdense = mod_arith.constant dense<[1, 2, 3, 4]> : !Zp_vec
+  // CHECK: mod_arith.constant dense<[0, 2, 3, 4]> : tensor<4x!mod_arith.int<17 : i10>>
+  %constdenseZero = mod_arith.constant dense<[0, 2, 3, 4]> : !Zp_vec
+  // CHECK: mod_arith.constant dense<[-1, -2, -3, -4]> : tensor<4x!mod_arith.int<17 : i10>>
+  %constdenseNegative = mod_arith.constant dense<[-1, -2, -3, -4]> : !Zp_vec
 
   // CHECK-COUNT-6: mod_arith.encapsulate
   %e4 = mod_arith.encapsulate %c4 : i10 -> !Zp


### PR DESCRIPTION
* (Partially) fixes #1483 
* In addition to adding dense, this PR also fixes the `zero becomes i64` issue @ZenithalHourlyRate  spotted (See #1484)

I'm not very happy with or attached to the current implementation, so happy to hear improvement suggestions!

~~For some reason, I was set on avoiding a `dyn_cast` of the parsedType to get at the underlying type/bitwidth of `mod_arith.int` but I think that's the only reasonable way to do this. Right now, the attribute on the op might have any IntegerType, as long as its smaller than the underlying type of `mod_arith.int`, but that just seems like it'd cause annoying crashes down the line in folders/lowerings/etc, due to bitwidth-equality asserts being all over the place in MLIR.~~ 
Update: I tried this, and it actually causes MORE headaches to have them (need to) match, as we can't just grab an attribute of `arith.constant` and hand it off to `mod_arith.constant`, which is a pretty common use case.

~~Also, there's still the open question on how to enable multi-dim dense values: more re-inventing parsers, or accepting a 64-bit limit on dense values? (I know `polynomial`'s attributes already have a 64-bit limit, probably for similar reasons?)~~
While the `ArrayAttr` approach does parse mult-dim arrays, it doesn't let you access them in a helpful way, so both are probably equal amounts of effort. I think I'll leave adding multi-dim support for another time, as this "quick fix" is already spiraling out of control anyway. The "correct" solution is probably to expose more parsing stuff upstream anyway.
