### PR TITLE
Remove cfg=exec from bazel executable targets

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -937,7 +937,7 @@
     },
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "b5FkZYymLJqXrpFALT3yo4vmvkIJlCXRa+rRlrNfsi8=",
+        "bzlTransitiveDigest": "npnHl1jGdnSt5hglsMHC97vRzHsub5IeUUtFGwSXIyw=",
         "usagesDigest": "ogzJv1UVhgnb/xpM7ytUxAUUpEs+C8eyACas/3Xgl0A=",
         "recordedFileInputs": {
           "@@//frontend/requirements.txt": "af2cd992a762dabd7d9b4dc32667c9aecc82550f90aab96d637bed7496e14963",

--- a/tests/Examples/benchmark/benchmark.bzl
+++ b/tests/Examples/benchmark/benchmark.bzl
@@ -8,7 +8,10 @@ def executable_attr(label):
         default = Label(label),
         allow_single_file = True,
         executable = True,
-        cfg = "exec",
+        # commenting this out breaks cross-compilation, but this should not be a problem
+        # for developer builds
+        # cfg = "exec",
+        cfg = "target",
     )
 
 _LLC = "@llvm-project//llvm:llc"

--- a/tools/heir-opt.bzl
+++ b/tools/heir-opt.bzl
@@ -5,7 +5,10 @@ def executable_attr(label):
     return attr.label(
         default = Label(label),
         executable = True,
-        cfg = "exec",
+        # commenting this out breaks cross-compilation, but this should not be a problem
+        # for developer builds
+        # cfg = "exec",
+        cfg = "target",
     )
 
 _HEIR_OPT = "@heir//tools:heir-opt"

--- a/tools/heir-translate.bzl
+++ b/tools/heir-translate.bzl
@@ -6,7 +6,10 @@ def executable_attr(label):
         default = Label(label),
         allow_single_file = True,
         executable = True,
-        cfg = "exec",
+        # commenting this out breaks cross-compilation, but this should not be a problem
+        # for developer builds
+        # cfg = "exec",
+        cfg = "target",
     )
 
 _HEIR_TRANSLATE = "@heir//tools:heir-translate"


### PR DESCRIPTION
And update module lock file

Cf. https://github.com/google/heir/issues/847#issuecomment-2691438353

This reduces build time by ~40% in `-c fastbuild` mode, and 38% in `-c opt`.