### PR TITLE
frontend: add support for multiple iter_args and complex control flow

### DIFF
--- a/frontend/heir/pipeline.py
+++ b/frontend/heir/pipeline.py
@@ -53,7 +53,9 @@ def run_pipeline(
     numba_signature = ""
     secret_args = ""
     try:
-      numba_signature, secret_args = parse_annotations(function.__annotations__)
+      numba_signature, secret_args, rettype = parse_annotations(
+          function.__annotations__
+      )
     except Exception as e:
       print(
           Fore.RED
@@ -89,6 +91,14 @@ def run_pipeline(
           f" signature {numba_signature} with {type(e).__name__}: {e}"
       )
       raise
+
+    # If a result type was annotated, compare with numba
+    if rettype is not None and debug:
+      if rettype != restype:
+        print(
+            "HEIR Debug: Warning: user provided return type does not match"
+            f" numba inference, expected {restype}, got {rettype}"
+        )
 
     # Emit Textual IR
     mlir_textual = TextualMlirEmitter(

--- a/frontend/loop_test.py
+++ b/frontend/loop_test.py
@@ -10,12 +10,14 @@ class EndToEndTest(absltest.TestCase):
 
     @compile()
     def loopa(a: Secret[I64]):
-      result = a
+      result1 = a
+      result2 = 0
       lb = 1
       ub = 5
       for _ in range(lb, ub):
-        result = result + result
-      return result
+        result1 = result1 + result1
+        result2 = result2 + 1
+      return result1
 
     self.assertEqual(32, loopa(2))
 


### PR DESCRIPTION
* adds loops with > 1 init_arg
* adds support for loops with complex control flow (including nested loops - which are just now blocked on an upstream MLIR verification issue #1412)
* adds a few more binary ops
* fixes a bug in type inference when return type is specified