### PR TITLE
Add canonicalization patterns and constant foldings for ModArith binary ops

### DIFF
--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -1,7 +1,7 @@
 # ModArith dialect
 
 load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
-load("@llvm-project//mlir:tblgen.bzl", "td_library")
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -19,6 +19,7 @@ cc_library(
         "ModArithTypes.h",
     ],
     deps = [
+        ":canonicalization_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":types_inc_gen",
@@ -33,6 +34,7 @@ cc_library(
 td_library(
     name = "td_files",
     srcs = [
+        "ModArithCanonicalization.td",
         "ModArithDialect.td",
         "ModArithOps.td",
         "ModArithTypes.td",
@@ -75,5 +77,21 @@ add_heir_dialect_library(
     td_file = "ModArithOps.td",
     deps = [
         ":td_files",
+    ],
+)
+
+gentbl_cc_library(
+    name = "canonicalization_inc_gen",
+    tbl_outs = [
+        (
+            ["-gen-rewriters"],
+            "ModArithCanonicalization.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ModArithCanonicalization.td",
+    deps = [
+        ":td_files",
+        "@llvm-project//mlir:ArithOpsTdFiles",
     ],
 )

--- a/lib/Dialect/ModArith/IR/ModArithCanonicalization.td
+++ b/lib/Dialect/ModArith/IR/ModArithCanonicalization.td
@@ -1,0 +1,280 @@
+#ifndef LIB_DIALECT_MODARITH_IR_MODARITHCANONICALIZATION_TD_
+#define LIB_DIALECT_MODARITH_IR_MODARITHCANONICALIZATION_TD_
+
+include "lib/Dialect/ModArith/IR/ModArithOps.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/PatternBase.td"
+
+def Equal : Constraint<CPred<"$0 == $1">>;
+
+def IsZero : Constraint<CPred<"dyn_cast<IntegerAttr>($0).getValue().isZero()">>;
+def IsOne : Constraint<CPred<"dyn_cast<IntegerAttr>($0).getValue() == APInt(dyn_cast<IntegerAttr>($0).getValue().getBitWidth(), 1, true)">>;
+
+def IsMinusOne : Constraint<CPred<"dyn_cast<IntegerAttr>($1).getValue().zextOrTrunc(dyn_cast<ModArithType>($0.getType()).getModulus().getValue().getBitWidth()) == dyn_cast<ModArithType>($0.getType()).getModulus().getValue() - APInt(dyn_cast<ModArithType>($0.getType()).getModulus().getValue().getBitWidth(), 1)">>;
+
+def CreateZeroConstant : NativeCodeCall<
+   "$_builder.create<ConstantOp>($0.getLoc(), dyn_cast<ModArithType>($0.getType()), IntegerAttr::get(dyn_cast<ModArithType>($0.getType()).getModulus().getType(), 0));">
+  ;
+
+// add x, 0 -> x
+def AddZero : Pat<
+  (ModArith_AddOp $lhs, (ModArith_ConstantOp $cst)),
+  (replaceWithValue $lhs),
+  [
+    (IsZero $cst),
+  ]
+>;
+
+// sub x, 0 -> x
+def SubZero : Pat<
+  (ModArith_SubOp $lhs, (ModArith_ConstantOp $cst)),
+  (replaceWithValue $lhs),
+  [
+    (IsZero $cst),
+  ]
+>;
+
+// mul x, 0 -> 0
+def MulZero : Pat<
+  (ModArith_MulOp $lhs, (ModArith_ConstantOp:$rhs $cst)),
+  (replaceWithValue $rhs),
+  [
+    (IsZero $cst),
+  ]
+>;
+
+// mul x, 1 -> x
+def MulOne : Pat<
+  (ModArith_MulOp $lhs, (ModArith_ConstantOp $cst)),
+  (replaceWithValue $lhs),
+  [
+    (IsOne $cst),
+  ]
+>;
+
+// add(add(x, c0), c1) -> add(x, c0 + c1)
+def AddAddConstant : Pat<
+  (ModArith_AddOp
+    (ModArith_AddOp
+      $x,
+      (ModArith_ConstantOp:$c0 $a)),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_AddOp
+    $x,
+    (ModArith_AddOp
+      $c0,
+      $c1)),
+  []
+>;
+
+// add (sub (x, c0), c1) -> add (x, c1 - c0)
+def AddSubConstantRHS : Pat<
+  (ModArith_AddOp
+    (ModArith_SubOp
+      $x,
+      (ModArith_ConstantOp:$c0 $a)),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_AddOp
+    $x,
+    (ModArith_SubOp
+      $c1,
+      $c0)),
+  []
+>;
+
+// add(sub(c0, x), c1) -> sub(c0 + c1, x)
+def AddSubConstantLHS : Pat<
+  (ModArith_AddOp
+    (ModArith_SubOp
+      (ModArith_ConstantOp:$c0 $a),
+      $x),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_SubOp
+    (ModArith_AddOp
+      $c0,
+      $c1),
+    $x),
+  []
+>;
+
+// add(x, mul(y, (modulus - 1))) -> sub(x, y)
+def AddMulNegativeOneRhs : Pat<
+  (ModArith_AddOp
+    $x,
+    (ModArith_MulOp
+      $y,
+      (ModArith_ConstantOp:$z $cst))),
+  (ModArith_SubOp
+    $x,
+    $y),
+  [
+    (IsMinusOne $z, $cst),
+  ]
+>;
+
+// add(mul(x, modulus - 1), y) -> sub(y, x)
+def AddMulNegativeOneLhs : Pat<
+  (ModArith_AddOp
+    (ModArith_MulOp
+      $x,
+      (ModArith_ConstantOp:$z $cst)),
+    $y),
+  (ModArith_SubOp
+    $y,
+    $x),
+  [
+    (IsMinusOne $z, $cst),
+  ]
+>;
+
+// sub(x, mul(y, (modulus - 1))) -> add(x, y)
+def SubMulNegativeOneRhs : Pat<
+  (ModArith_SubOp
+    $x,
+    (ModArith_MulOp
+      $y,
+      (ModArith_ConstantOp:$z $cst))),
+  (ModArith_AddOp
+    $x,
+    $y),
+  [
+    (IsMinusOne $z, $cst),
+  ]
+>;
+
+// sub(mul(x, modulus - 1), y) -> sub(0, add(x, y))
+def SubMulNegativeOneLhs : Pat<
+  (ModArith_SubOp
+    (ModArith_MulOp
+      $x,
+      (ModArith_ConstantOp:$z $cst)),
+    $y),
+  (ModArith_SubOp
+    (CreateZeroConstant $x),
+    (ModArith_AddOp
+      $x,
+      $y)),
+  [
+    (IsMinusOne $z, $cst),
+  ]
+>;
+
+// mul(mul(x, c0), c1) -> mul(x, c0 * c1)
+def MulMulConstant : Pat<
+  (ModArith_MulOp
+    (ModArith_MulOp
+      $x,
+      (ModArith_ConstantOp:$c0 $a)),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_MulOp
+    $x,
+    (ModArith_MulOp
+      $c0,
+      $c1)),
+  []
+>;
+
+// sub(add(x, c0), c1) -> add(x, c0 - c1)
+def SubRHSAddConstant : Pat<
+  (ModArith_SubOp
+    (ModArith_AddOp
+      $x,
+      (ModArith_ConstantOp:$c0 $a)),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_AddOp
+    $x,
+    (ModArith_SubOp
+      $c0,
+      $c1)),
+  []
+>;
+
+// sub(c1, add(x, c0)) -> sub(c1 - c0, x)
+def SubLHSAddConstant : Pat<
+  (ModArith_SubOp
+    (ModArith_ConstantOp:$c1 $a),
+    (ModArith_AddOp
+      $x,
+      (ModArith_ConstantOp:$c0 $b))),
+  (ModArith_SubOp
+    (ModArith_SubOp
+      $c1,
+      $c0),
+    $x),
+  []
+>;
+
+// sub(sub(x, c0), c1) -> sub(x, c0 + c1)
+def SubRHSSubConstantRHS : Pat<
+  (ModArith_SubOp
+    (ModArith_SubOp
+      $x,
+      (ModArith_ConstantOp:$c0 $a)),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_SubOp
+    $x,
+    (ModArith_AddOp
+      $c0,
+      $c1)),
+  []
+>;
+
+// sub(sub(c0, x), c1) -> sub(c0 - c1, x)
+def SubRHSSubConstantLHS : Pat<
+  (ModArith_SubOp
+    (ModArith_SubOp
+      (ModArith_ConstantOp:$c0 $a),
+      $x),
+    (ModArith_ConstantOp:$c1 $b)),
+  (ModArith_SubOp
+    (ModArith_SubOp
+      $c0,
+      $c1),
+    $x),
+  []
+>;
+
+// sub(c1, sub(x, c0)) -> sub(c0 + c1, x)
+def SubLHSSubConstantRHS : Pat<
+  (ModArith_SubOp
+    (ModArith_ConstantOp:$c1 $a),
+    (ModArith_SubOp
+      $x,
+      (ModArith_ConstantOp:$c0 $b))),
+  (ModArith_SubOp
+    (ModArith_AddOp
+      $c0,
+      $c1),
+    $x),
+  []
+>;
+
+// sub(c1, sub(c0, x)) -> add(x, c1 - c0)
+def SubLHSSubConstantLHS : Pat<
+  (ModArith_SubOp
+    (ModArith_ConstantOp:$c1 $a),
+    (ModArith_SubOp
+      (ModArith_ConstantOp:$c0 $b),
+      $x)),
+  (ModArith_AddOp
+    $x,
+    (ModArith_SubOp
+      $c1,
+      $c0)),
+  []
+>;
+
+// sub(sub(a, b), a) -> sub(0, b)
+def SubSubLHSRHSLHS : Pat<
+  (ModArith_SubOp
+    (ModArith_SubOp
+      $a,
+      $b),
+    $a),
+  (ModArith_SubOp
+    (CreateZeroConstant $a),
+    $b),
+  []
+>;
+
+#endif  // LIB_DIALECT_MODARITH_IR_MODARITHCANONICALIZATION_TD_

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
@@ -11,6 +12,7 @@
 #include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/OpImplementation.h"       // from @llvm-project
 #include "mlir/include/mlir/IR/OperationSupport.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/TypeUtilities.h"          // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
@@ -20,6 +22,7 @@
 #include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/CommonFolders.h"   // from @llvm-project
 // NOLINTEND(misc-include-cleaner)
 
 // Generated definitions
@@ -30,6 +33,8 @@
 
 #define GET_OP_CLASSES
 #include "lib/Dialect/ModArith/IR/ModArithOps.cpp.inc"
+
+#define DEBUG_TYPE "mod-arith"
 
 namespace mlir {
 namespace heir {
@@ -224,6 +229,167 @@ void ConstantOp::print(OpAsmPrinter &p) {
   p.printAttributeWithoutType(getValue());
   p << " : ";
   p.printType(getOutput().getType());
+}
+
+// constant(c0) -> c0 mod q
+OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
+  // Check if the value is an IntegerAttr
+  auto intAttr = dyn_cast_if_present<IntegerAttr>(adaptor.getValue());
+  if (!intAttr) return {};
+
+  auto modType = dyn_cast_if_present<ModArithType>(getType());
+  if (!modType) return {};
+
+  // Retrieve the modulus value and its bit width
+  APInt modulus = modType.getModulus().getValue();
+  unsigned modBitWidth = modulus.getBitWidth();
+
+  // Extract the actual integer values
+  APInt cst = intAttr.getValue();
+
+  // Adjust cst's bit width to match modulus if necessary
+  cst = cst.zextOrTrunc(modBitWidth);
+
+  // Fold the constant value
+  APInt foldedVal = cst.urem(modulus);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n";
+    llvm::dbgs() << "========================================\n";
+    llvm::dbgs() << "  Folding Operation: Constant\n";
+    llvm::dbgs() << "----------------------------------------\n";
+    llvm::dbgs() << "  Value   : " << cst << "\n";
+    llvm::dbgs() << "  Modulus : " << modulus << "\n";
+    llvm::dbgs() << "  Folded  : " << foldedVal << "\n";
+    llvm::dbgs() << "========================================\n";
+  });
+
+  // Create the result
+  auto elementType = modType.getModulus().getType();
+  return IntegerAttr::get(elementType, foldedVal);
+}
+
+/// Helper function to handle common folding logic for binary arithmetic
+/// operations.
+/// - `opName` is used for debug output.
+/// - `foldBinFn` defines how the actual binary operation (+, -, *) should be
+/// performed.
+template <typename FoldAdaptor, typename FoldBinFn>
+static OpFoldResult foldBinModOp(Operation *op, FoldAdaptor adaptor,
+                                 FoldBinFn &&foldBinFn,
+                                 llvm::StringRef opName) {
+  // Check if lhs and rhs are IntegerAttrs
+  auto lhs = dyn_cast_if_present<IntegerAttr>(adaptor.getLhs());
+  auto rhs = dyn_cast_if_present<IntegerAttr>(adaptor.getRhs());
+  if (!lhs || !rhs) return {};
+
+  auto modType = dyn_cast<ModArithType>(op->getResultTypes().front());
+  if (!modType) return {};
+
+  // Retrieve the modulus value and its bit width
+  APInt modulus = modType.getModulus().getValue();
+  unsigned modBitWidth = modulus.getBitWidth();
+
+  // Extract the actual integer values
+  APInt lhsVal = lhs.getValue();
+  APInt rhsVal = rhs.getValue();
+
+  // Adjust lhsVal and rhsVal bit widths to match modulus if necessary
+  lhsVal = lhsVal.zextOrTrunc(modBitWidth);
+  rhsVal = rhsVal.zextOrTrunc(modBitWidth);
+
+  // Perform the operation using the provided foldBinFn
+  APInt foldedVal = foldBinFn(lhsVal, rhsVal, modulus);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n";
+    llvm::dbgs() << "========================================\n";
+    llvm::dbgs() << "  Folding Operation: " << opName << "\n";
+    llvm::dbgs() << "----------------------------------------\n";
+    llvm::dbgs() << "  LHS     : " << lhsVal << "\n";
+    llvm::dbgs() << "  RHS     : " << rhsVal << "\n";
+    llvm::dbgs() << "  Modulus : " << modulus << "\n";
+    llvm::dbgs() << "  Folded  : " << foldedVal << "\n";
+    llvm::dbgs() << "========================================\n";
+  });
+
+  // Create the result
+  auto elementType = modType.getModulus().getType();
+  return IntegerAttr::get(elementType, foldedVal);
+}
+
+// add(c0, c1) -> (c0 + c1) mod q
+OpFoldResult AddOp::fold(FoldAdaptor adaptor) {
+  return foldBinModOp(
+      getOperation(), adaptor,
+      [](APInt lhs, APInt rhs, APInt modulus) {
+        APInt sum = lhs + rhs;
+        return sum.urem(modulus);
+      },
+      "Add");
+}
+
+// sub(c0, c1) -> (c0 - c1) mod q
+OpFoldResult SubOp::fold(FoldAdaptor adaptor) {
+  return foldBinModOp(
+      getOperation(), adaptor,
+      [](APInt lhs, APInt rhs, APInt modulus) {
+        APInt diff = lhs - rhs;
+        if (diff.isNegative()) {
+          diff += modulus;
+        }
+        return diff.urem(modulus);
+      },
+      "Sub");
+}
+
+// mul(c0, c1) -> (c0 * c1) mod q
+OpFoldResult MulOp::fold(FoldAdaptor adaptor) {
+  return foldBinModOp(
+      getOperation(), adaptor,
+      [](APInt lhs, APInt rhs, APInt modulus) {
+        APInt product = lhs * rhs;
+        return product.urem(modulus);
+      },
+      "Mul");
+}
+
+Operation *ModArithDialect::materializeConstant(OpBuilder &builder,
+                                                Attribute value, Type type,
+                                                Location loc) {
+  auto intAttr = dyn_cast_if_present<IntegerAttr>(value);
+  if (!intAttr) return nullptr;
+  auto modType = dyn_cast_if_present<ModArithType>(type);
+  if (!modType) return nullptr;
+  auto op = builder.create<mod_arith::ConstantOp>(loc, modType, intAttr);
+  return op.getOperation();
+}
+
+//===----------------------------------------------------------------------===//
+// TableGen'd canonicalization patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+#include "lib/Dialect/ModArith/IR/ModArithCanonicalization.cpp.inc"
+}  // namespace
+
+void AddOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                        MLIRContext *context) {
+  results.add<AddZero, AddAddConstant, AddSubConstantRHS, AddSubConstantLHS,
+              AddMulNegativeOneRhs, AddMulNegativeOneLhs>(context);
+}
+
+void SubOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                        MLIRContext *context) {
+  results.add<SubZero, SubMulNegativeOneRhs, SubMulNegativeOneLhs,
+              SubRHSAddConstant, SubLHSAddConstant, SubRHSSubConstantRHS,
+              SubRHSSubConstantLHS, SubLHSSubConstantRHS, SubLHSSubConstantLHS,
+              SubSubLHSRHSLHS>(context);
+}
+
+void MulOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                        MLIRContext *context) {
+  results.add<MulZero, MulOne, MulMulConstant>(context);
 }
 
 }  // namespace mod_arith

--- a/lib/Dialect/ModArith/IR/ModArithDialect.td
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.td
@@ -12,6 +12,7 @@ def ModArith_Dialect : Dialect {
 
   let cppNamespace = "::mlir::heir::mod_arith";
   let useDefaultTypePrinterParser = 1;
+  let hasConstantMaterializer = 1;
 
   let dependentDialects = [
     "arith::ArithDialect",

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -82,7 +82,8 @@ def ModArith_ModSwitchOp : ModArith_Op<"mod_switch", [Pure, SameOperandsAndResul
   let assemblyFormat = "$input attr-dict `:` type($input) `to` type($output)";
 }
 
-def ModArith_ConstantOp : Op<ModArith_Dialect, "constant", [Pure]> {
+def ModArith_ConstantOp : Op<ModArith_Dialect, "constant",
+    [Pure, ConstantLike]> {
   let summary = "Define a constant value via an attribute.";
   let description = [{
     Example:
@@ -95,6 +96,8 @@ def ModArith_ConstantOp : Op<ModArith_Dialect, "constant", [Pure]> {
   let results = (outs ModArithLike:$output);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+  let hasFolder = 1;
+
 }
 
 
@@ -139,6 +142,8 @@ def ModArith_AddOp : ModArith_BinaryOp<"add", [Commutative]> {
     Unless otherwise specified, the operation assumes both inputs are canonical
     representatives and guarantees the output being canonical representative.
   }];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def ModArith_SubOp : ModArith_BinaryOp<"sub"> {
@@ -149,6 +154,8 @@ def ModArith_SubOp : ModArith_BinaryOp<"sub"> {
     Unless otherwise specified, the operation assumes both inputs are canonical
     representatives and guarantees the output being canonical representative.
   }];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def ModArith_MulOp : ModArith_BinaryOp<"mul", [Commutative]> {
@@ -159,6 +166,8 @@ def ModArith_MulOp : ModArith_BinaryOp<"mul", [Commutative]> {
     Unless otherwise specified, the operation assumes both inputs are canonical
     representatives and guarantees the output being canonical representative.
   }];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def ModArith_MacOp : ModArith_Op<"mac", [SameOperandsAndResultType, Pure, ElementwiseMappable]> {

--- a/tests/Dialect/ModArith/IR/canonicalization.mlir
+++ b/tests/Dialect/ModArith/IR/canonicalization.mlir
@@ -1,0 +1,241 @@
+// RUN: heir-opt -canonicalize %s | FileCheck %s
+
+!Zp = !mod_arith.int<42 : i64>
+
+// CHECK-LABEL: @test_add_fold
+// CHECK: () -> [[T:.*]] {
+func.func @test_add_fold() -> !Zp {
+  // CHECK: %[[RESULT:.+]] = mod_arith.constant 18 : [[T]]
+  %e1 = mod_arith.constant 12 : !Zp
+  %e2 = mod_arith.constant 34 : !Zp
+  %add = mod_arith.add %e1, %e2 : !Zp
+  %e3 = mod_arith.constant 56 : !Zp
+  %add2 = mod_arith.add %add, %e3 : !Zp
+  // CHECK: return %[[RESULT]] : [[T]]
+  return %add2 : !Zp
+}
+
+// CHECK-LABEL: @test_sub_fold
+// CHECK: () -> [[T:.*]] {
+func.func @test_sub_fold() -> !Zp {
+  // CHECK: %[[RESULT:.+]] = mod_arith.constant 6 : [[T]]
+  %e1 = mod_arith.constant 12 : !Zp
+  %e2 = mod_arith.constant 34 : !Zp
+  %sub = mod_arith.sub %e1, %e2 : !Zp
+  %e3 = mod_arith.constant 56 : !Zp
+  %sub2 = mod_arith.sub %sub, %e3 : !Zp
+  // CHECK: return %[[RESULT]] : [[T]]
+  return %sub2 : !Zp
+}
+
+// CHECK-LABEL: @test_mul_fold
+// CHECK: () -> [[T:.*]] {
+func.func @test_mul_fold() -> !Zp {
+  // CHECK: %[[RESULT:.+]] = mod_arith.constant 0 : [[T]]
+  %e1 = mod_arith.constant 12 : !Zp
+  %e2 = mod_arith.constant 34 : !Zp
+  %mul = mod_arith.mul %e1, %e2 : !Zp
+  %e3 = mod_arith.constant 56 : !Zp
+  %mul2 = mod_arith.mul %mul, %e3 : !Zp
+  return %mul2 : !Zp
+}
+
+// CHECK-LABEL: @test_add_zero_rhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_add_zero_rhs(%x: !Zp) -> !Zp {
+  %zero = mod_arith.constant 0 : !Zp
+  %add = mod_arith.add %x, %zero : !Zp
+  // CHECK: return %[[arg0]] : [[T]]
+  return %add : !Zp
+}
+
+// CHECK-LABEL: @test_add_zero_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_add_zero_lhs(%x: !Zp) -> !Zp {
+  %zero = mod_arith.constant 0 : !Zp
+  %add = mod_arith.add %zero, %x : !Zp
+  // CHECK: return %[[arg0]] : [[T]]
+  return %add : !Zp
+}
+
+// CHECK-LABEL: @test_sub_zero
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_sub_zero(%x: !Zp) -> !Zp {
+  %zero = mod_arith.constant 0 : !Zp
+  %sub = mod_arith.sub %x, %zero : !Zp
+  // CHECK: return %[[arg0]] : [[T]]
+  return %sub : !Zp
+}
+
+// CHECK-LABEL: @test_mul_zero_rhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_mul_zero_rhs(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+  %zero = mod_arith.constant 0 : !Zp
+  %mul = mod_arith.mul %x, %zero : !Zp
+  // CHECK: return %[[res0]] : [[T]]
+  return %mul : !Zp
+}
+
+// CHECK-LABEL: @test_mul_zero_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_mul_zero_lhs(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+  %zero = mod_arith.constant 0 : !Zp
+  %mul = mod_arith.mul %zero, %x : !Zp
+  // CHECK: return %[[res0]] : [[T]]
+  return %mul : !Zp
+}
+
+// CHECK-LABEL: @test_mul_one_rhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_mul_one_rhs(%x: !Zp) -> !Zp {
+  %one = mod_arith.constant 1 : !Zp
+  %mul = mod_arith.mul %x, %one : !Zp
+  // CHECK: return %[[arg0]] : [[T]]
+  return %mul : !Zp
+}
+
+// CHECK-LABEL: @test_mul_one_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_mul_one_lhs(%x: !Zp) -> !Zp {
+  %one = mod_arith.constant 1 : !Zp
+  %mul = mod_arith.mul %one, %x : !Zp
+  // CHECK: return %[[arg0]] : [[T]]
+  return %mul : !Zp
+}
+
+// CHECK-LABEL: @test_add_add_const
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_add_add_const(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 4 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[res0]] : [[T]]
+  %c0 = mod_arith.constant 12 : !Zp
+  %c1 = mod_arith.constant 34 : !Zp
+  %add = mod_arith.add %x, %c0 : !Zp
+  %add2 = mod_arith.add %add, %c1 : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %add2 : !Zp
+}
+
+// CHECK-LABEL: @test_add_sub_const_rhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_add_sub_const_rhs(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 22 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[res0]] : [[T]]
+  %c0 = mod_arith.constant 12 : !Zp
+  %c1 = mod_arith.constant 34 : !Zp
+  %sub = mod_arith.sub %x, %c0 : !Zp
+  %add = mod_arith.add %sub, %c1 : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %add : !Zp
+}
+
+// CHECK-LABEL: @test_add_sub_const_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_add_sub_const_lhs(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 4 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.sub %[[res0]], %[[arg0]] : [[T]]
+  %c0 = mod_arith.constant 12 : !Zp
+  %c1 = mod_arith.constant 34 : !Zp
+  %sub = mod_arith.sub %c0, %x : !Zp
+  %add = mod_arith.add %sub, %c1 : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %add : !Zp
+}
+
+// CHECK-LABEL: @test_add_mul_neg_one_rhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+func.func @test_add_mul_neg_one_rhs(%x: !Zp, %y: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.sub %[[arg0]], %[[arg1]] : [[T]]
+  %neg_one = mod_arith.constant 41 : !Zp
+  %mul = mod_arith.mul %y, %neg_one : !Zp
+  %add = mod_arith.add %x, %mul : !Zp
+  // CHECK: return %[[res0]] : [[T]]
+  return %add : !Zp
+}
+
+// CHECK-LABEL: @test_add_mul_neg_one_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+func.func @test_add_mul_neg_one_lhs(%x: !Zp, %y: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.sub %[[arg1]], %[[arg0]] : [[T]]
+  %neg_one = mod_arith.constant 41 : !Zp
+  %mul = mod_arith.mul %neg_one, %x : !Zp
+  %add = mod_arith.add %mul, %y : !Zp
+  // CHECK: return %[[res0]] : [[T]]
+  return %add : !Zp
+}
+
+// CHECK-LABEL: @test_sub_mul_neg_one_rhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+func.func @test_sub_mul_neg_one_rhs(%x: !Zp, %y: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.add %[[arg0]], %[[arg1]] : [[T]]
+  %neg_one = mod_arith.constant 41 : !Zp
+  %mul = mod_arith.mul %y, %neg_one : !Zp
+  %sub = mod_arith.sub %x, %mul : !Zp
+  // CHECK: return %[[res0]] : [[T]]
+  return %sub : !Zp
+}
+
+// CHECK-LABEL: @test_sub_mul_neg_one_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+func.func @test_sub_mul_neg_one_lhs(%x: !Zp, %y: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[arg1]] : [[T]]
+  // CHECK: %[[res2:.+]] = mod_arith.sub %[[res0]], %[[res1]] : [[T]]
+  %neg_one = mod_arith.constant 41 : !Zp
+  %mul = mod_arith.mul %x, %neg_one : !Zp
+  %sub = mod_arith.sub %mul, %y : !Zp
+  // CHECK: return %[[res2]] : [[T]]
+  return %sub : !Zp
+}
+
+// CHECK-LABEL: @test_mul_mul_const
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_mul_mul_const(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 30 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.mul %[[arg0]], %[[res0]] : [[T]]
+  %c0 = mod_arith.constant 12 : !Zp
+  %c1 = mod_arith.constant 34 : !Zp
+  %mul = mod_arith.mul %x, %c0 : !Zp
+  %mul2 = mod_arith.mul %mul, %c1 : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %mul2 : !Zp
+}
+
+// CHECK-LABEL: @test_sub_rhs_add_const
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_sub_rhs_add_const(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 20 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[res0]] : [[T]]
+  %c0 = mod_arith.constant 12 : !Zp
+  %c1 = mod_arith.constant 34 : !Zp
+  %add = mod_arith.add %x, %c0 : !Zp
+  %sub = mod_arith.sub %add, %c1 : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %sub : !Zp
+}
+
+// CHECK-LABEL: @test_sub_lhs_add_const
+// CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+func.func @test_sub_lhs_add_const(%x: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 22 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.sub %[[res0]], %[[arg0]] : [[T]]
+  %c0 = mod_arith.constant 12 : !Zp
+  %c1 = mod_arith.constant 34 : !Zp
+  %add = mod_arith.add %x, %c0 : !Zp
+  %sub = mod_arith.sub %c1, %add : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %sub : !Zp
+}
+
+// CHECK-LABEL: @test_sub_sub_lhs_rhs_lhs
+// CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+func.func @test_sub_sub_lhs_rhs_lhs(%a: !Zp, %b: !Zp) -> !Zp {
+  // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+  // CHECK: %[[res1:.+]] = mod_arith.sub %[[res0]], %[[arg1]] : [[T]]
+  %sub = mod_arith.sub %a, %b : !Zp
+  %sub2 = mod_arith.sub %sub, %a : !Zp
+  // CHECK: return %[[res1]] : [[T]]
+  return %sub2 : !Zp
+}


### PR DESCRIPTION
This implements parts of #1216, focusing on binary arithmetic operations.
- Added constant folding
  - Assumes that all inputs and outputs of operations follow the canonical representation.
- Added canonicalization patterns
  - Most of these patterns are ported from [arith canonicalization patterns](https://github.com/llvm/llvm-project/blob/main/mlir/test/Dialect/Arith/canonicalize.mlir).
- Added corresponding tests
  - TODO? : I’m exploring the possibility of using the lean-mlir project for translation validation of these manually written tests. (related to #817)