### PR TITLE
Update todo.yaml to fix permissions

### DIFF
--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
     - name: todo-backlinks


### PR DESCRIPTION
According to https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#update-an-issue-comment we also need a pull-request: write to update comments on an issue