### PR TITLE
add support for `arith.extui`/`arith.extsi`

### DIFF
--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -12,6 +12,7 @@
 #include "lib/Dialect/BGV/IR/BGVOps.h"
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
@@ -265,6 +266,10 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
         SecretGenericOpCipherConversion<arith::AddIOp, bgv::AddOp>,
         SecretGenericOpCipherConversion<arith::SubIOp, bgv::SubOp>,
         SecretGenericOpCipherConversion<arith::MulIOp, bgv::MulOp>,
+        SecretGenericOpCipherConversion<arith::ExtUIOp,
+                                        lwe::ReinterpretApplicationDataOp>,
+        SecretGenericOpCipherConversion<arith::ExtSIOp,
+                                        lwe::ReinterpretApplicationDataOp>,
         SecretGenericOpRelinearizeConversion<bgv::RelinearizeOp>,
         SecretGenericOpModulusSwitchConversion<bgv::ModulusSwitchOp>,
         SecretGenericOpConversion<tensor::ExtractOp, bgv::ExtractOp>,

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -12,6 +12,7 @@
 #include "lib/Dialect/CKKS/IR/CKKSOps.h"
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
@@ -480,6 +481,10 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
         SecretGenericOpCipherConversion<arith::AddFOp, ckks::AddOp>,
         SecretGenericOpCipherConversion<arith::SubFOp, ckks::SubOp>,
         SecretGenericOpCipherConversion<arith::MulFOp, ckks::MulOp>,
+        SecretGenericOpCipherConversion<arith::ExtUIOp,
+                                        lwe::ReinterpretApplicationDataOp>,
+        SecretGenericOpCipherConversion<arith::ExtSIOp,
+                                        lwe::ReinterpretApplicationDataOp>,
         SecretGenericOpCipherConversion<tensor::EmptyOp, tensor::EmptyOp>,
         SecretGenericOpRelinearizeConversion<ckks::RelinearizeOp>,
         SecretGenericOpModulusSwitchConversion<ckks::RescaleOp>,


### PR DESCRIPTION
* Necessary step towards both #1520 and supporting ops such as `arith.select` which require one `i1` and one `i16`/`i32`/etc operand. 

Approach:
* Since the ptxt mod must already be selected large enough for the largest `i??` type appearing in the program to fit, the extension becomes a no-op under FHE.
* Whenever we see an extension operation in a `SecretTo<Scheme>` lowering, we emit a `lwe.reintrepret_application_data` op as it's "FHE op". 
* The OpenFHE emitter already had code to turn this op into a trivial assignment (e.g., `auto ct2 = ct;`), the lattigo backend has it's own non-parametrized ctxt type, so the op becomes a true no-op and is automagically removed.

marked as draft for now because:
* Depends on #1525
*  #1522 needs to be fixed (or at least worked-around for this specific case) before it'll work for `--mlir-to-bgv`.