### PR TITLE
rename `lwe.reinterpret_underlying_type` to `lwe.reinterpret_application_data`

### DIFF
--- a/docs/content/en/docs/getting_started.md
+++ b/docs/content/en/docs/getting_started.md
@@ -206,7 +206,7 @@ module {
     %9 = openfhe.make_packed_plaintext %arg0, %cst : (!openfhe.crypto_context, tensor<8xi64>) -> !rlwe_pt_L1_
     %10 = openfhe.mul_plain %arg0, %8, %9 : (!openfhe.crypto_context, !rlwe_ct_L1_, !rlwe_pt_L1_) -> !rlwe_ct_L1_
     %11 = openfhe.rot %arg0, %10 {index = 7 : index} : (!openfhe.crypto_context, !rlwe_ct_L1_) -> !rlwe_ct_L1_
-    %12 = lwe.reinterpret_underlying_type %11 : !rlwe_ct_L1_ to !rlwe_ct_L1_1
+    %12 = lwe.reinterpret_application_data %11 : !rlwe_ct_L1_ to !rlwe_ct_L1_1
     %13 = openfhe.mod_reduce %arg0, %12 : (!openfhe.crypto_context, !rlwe_ct_L1_1) -> !rlwe_ct_L0_
     return %13 : !rlwe_ct_L0_
   }

--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -387,7 +387,7 @@ struct ConvertRlweDecodeOp : public OpConversionPattern<DecodeOp> {
     auto decodeOp = rewriter.create<LattigoDecodeOp>(
         op.getLoc(), outputTensorType, evaluator, adaptor.getInput(), alloc);
 
-    // TODO(#1174): the sin of lwe.reinterpret_underlying_type
+    // TODO(#1174): the sin of lwe.reinterpret_application_data
     if (isScalar) {
       SmallVector<Value, 1> indices;
       auto index = rewriter.create<arith::ConstantOp>(op.getLoc(),
@@ -403,12 +403,12 @@ struct ConvertRlweDecodeOp : public OpConversionPattern<DecodeOp> {
   }
 };
 
-struct ConvertLWEReinterpretUnderlyingType
-    : public OpConversionPattern<lwe::ReinterpretUnderlyingTypeOp> {
+struct ConvertLWEReinterpretApplicationData
+    : public OpConversionPattern<lwe::ReinterpretApplicationDataOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
-      lwe::ReinterpretUnderlyingTypeOp op, OpAdaptor adaptor,
+      lwe::ReinterpretApplicationDataOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     // erase reinterpret underlying
     rewriter.replaceOp(op, adaptor.getOperands()[0].getDefiningOp());
@@ -553,7 +553,7 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
     target
         .addIllegalOp<lwe::RLWEEncryptOp, lwe::RLWEDecryptOp, lwe::RLWEEncodeOp,
                       lwe::RLWEDecodeOp, lwe::RAddOp, lwe::RSubOp, lwe::RMulOp,
-                      lwe::ReinterpretUnderlyingTypeOp>();
+                      lwe::ReinterpretApplicationDataOp>();
 
     RewritePatternSet patterns(context);
     addStructuralConversionPatterns(typeConverter, patterns, target);
@@ -694,7 +694,7 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
                                                              context);
     }
     // Misc
-    patterns.add<ConvertLWEReinterpretUnderlyingType>(typeConverter, context);
+    patterns.add<ConvertLWEReinterpretApplicationData>(typeConverter, context);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       return signalPassFailure();

--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -332,7 +332,7 @@ struct LWEToOpenfhe : public impl::LWEToOpenfheBase<LWEToOpenfhe> {
     target.addIllegalDialect<ckks::CKKSDialect>();
     target.addIllegalDialect<lwe::LWEDialect>();
     // We can keep the following ops, which the emitter can handle directly
-    target.addLegalOp<lwe::ReinterpretUnderlyingTypeOp, lwe::RLWEDecodeOp>();
+    target.addLegalOp<lwe::ReinterpretApplicationDataOp, lwe::RLWEDecodeOp>();
 
     RewritePatternSet patterns(context);
     addStructuralConversionPatterns(typeConverter, patterns, target);

--- a/lib/Dialect/LWE/IR/LWEDialect.cpp
+++ b/lib/Dialect/LWE/IR/LWEDialect.cpp
@@ -180,7 +180,7 @@ LogicalResult TrivialEncryptOp::verify() {
   return success();
 }
 
-LogicalResult ReinterpretUnderlyingTypeOp::verify() {
+LogicalResult ReinterpretApplicationDataOp::verify() {
   auto inputType = getInput().getType();
   auto outputType = getOutput().getType();
   if (inputType.getPlaintextSpace() != outputType.getPlaintextSpace() ||

--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -264,12 +264,13 @@ def LWE_RLWEDecryptOp : LWE_Op<"rlwe_decrypt", [
   let results = (outs NewLWEPlaintext:$output);
 }
 
-def ReinterpretUnderlyingTypeOp : LWE_Op<"reinterpret_underlying_type", []> {
+def ReinterpretApplicationDataOp : LWE_Op<"reinterpret_application_data", []> {
   let summary = "A placeholder cast from one ciphertext type to another";
   let description = [{
-    The `cast` op is thus used to translate `underlying_type` between
-    ciphertexts in particular situations , such as when lowering to an API that
-    does not keep track of types for you.
+    The `cast` op is thus used to translate application data (e.g., `message_type`)
+    between ciphertexts in particular situations, such as when the bitwidth of the
+    message type changes, but this change is not observed in the plaintext space,
+    or when lowering to an API that does not keep track of types.
   }];
 
   let arguments = (ins NewLWECiphertext:$input);

--- a/lib/Dialect/LWE/IR/LWEPatterns.h
+++ b/lib/Dialect/LWE/IR/LWEPatterns.h
@@ -91,7 +91,7 @@ struct ConvertExtract : public OpRewritePattern<ExtractOp> {
     // It might make sense to move this op to the add-client-interface pass,
     // but it also seems like a backend implementation detail, and not part
     // of RLWE schemes generally.
-    auto recast = b.create<lwe::ReinterpretUnderlyingTypeOp>(
+    auto recast = b.create<lwe::ReinterpretApplicationDataOp>(
                        op.getOutput().getType(), rotated.getResult())
                       .getResult();
     rewriter.replaceOp(op, recast);

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -190,7 +190,7 @@ LogicalResult OpenFhePkeEmitter::translate(Operation &op) {
                 tensor::ExtractSliceOp, tensor::SplatOp>(
               [&](auto op) { return printOperation(op); })
           // LWE ops
-          .Case<lwe::RLWEDecodeOp, lwe::ReinterpretUnderlyingTypeOp>(
+          .Case<lwe::RLWEDecodeOp, lwe::ReinterpretApplicationDataOp>(
               [&](auto op) { return printOperation(op); })
           // OpenFHE ops
           .Case<AddOp, AddPlainOp, SubOp, SubPlainOp, MulNoRelinOp, MulOp,
@@ -799,7 +799,7 @@ LogicalResult OpenFhePkeEmitter::printOperation(tensor::SplatOp op) {
 }
 
 LogicalResult OpenFhePkeEmitter::printOperation(
-    lwe::ReinterpretUnderlyingTypeOp op) {
+    lwe::ReinterpretApplicationDataOp op) {
   emitAutoAssignPrefix(op.getResult());
   os << variableNames->getNameForValue(op.getInput()) << ";\n";
   return success();

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -70,7 +70,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::func::ReturnOp op);
   LogicalResult printOperation(::mlir::heir::lwe::RLWEDecodeOp op);
   LogicalResult printOperation(
-      ::mlir::heir::lwe::ReinterpretUnderlyingTypeOp op);
+      ::mlir::heir::lwe::ReinterpretApplicationDataOp op);
   LogicalResult printOperation(AddOp op);
   LogicalResult printOperation(AddPlainOp op);
   LogicalResult printOperation(AutomorphOp op);

--- a/scripts/jupyter/HEIR Play.ipynb
+++ b/scripts/jupyter/HEIR Play.ipynb
@@ -255,7 +255,7 @@
         "  %15 = lwe.rlwe_encode %cst {encoding = #eval_encoding, ring = #ring2} : tensor\u003c32xi16\u003e -\u003e !tensor_pt_ty\n",
         "  %16 = openfhe.mul_plain %arg0, %14, %15 : (!openfhe.crypto_context, !tensor_ct_ty, !tensor_pt_ty) -\u003e !tensor_ct_ty\n",
         "  %18 = openfhe.rot %arg0, %16 { index = 31 } : (!openfhe.crypto_context, !tensor_ct_ty) -\u003e !tensor_ct_ty\n",
-        "  %19 = lwe.reinterpret_underlying_type %18 : !tensor_ct_ty to !scalar_ct_ty\n",
+        "  %19 = lwe.reinterpret_application_data %18 : !tensor_ct_ty to !scalar_ct_ty\n",
         "  return %19 : !scalar_ct_ty\n",
         "}\n",
         "func.func @simple_sum__encrypt(%arg0: !openfhe.crypto_context, %arg1: tensor\u003c32xi16\u003e, %arg2: !openfhe.public_key) -\u003e !tensor_ct_ty {\n",

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/extract.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/extract.mlir
@@ -27,7 +27,7 @@ func.func @test_lower_extract(%arg0: !ty1) -> !ty2 {
   // CHECK: openfhe.make_packed_plaintext
   // CHECK: openfhe.mul_plain
   // CHECK: openfhe.rot
-  // CHECK: lwe.reinterpret_underlying_type
+  // CHECK: lwe.reinterpret_application_data
   // CHECK: return
   %c4 = arith.constant 4 : index
   %0 = bgv.extract %arg0, %c4 : (!ty1, index) -> !ty2

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/extract.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/extract.mlir
@@ -27,7 +27,7 @@ func.func @test_lower_extract(%arg0: !ty1) -> !ty2 {
   // CHECK: openfhe.make_ckks_packed_plaintext
   // CHECK: openfhe.mul_plain
   // CHECK: openfhe.rot
-  // CHECK: lwe.reinterpret_underlying_type
+  // CHECK: lwe.reinterpret_application_data
   // CHECK: return
   %c4 = arith.constant 4 : index
   %0 = ckks.extract %arg0, %c4 : (!ty1, index) -> !ty2

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -120,7 +120,7 @@ module attributes {scheme.ckks} {
     %15 = openfhe.make_packed_plaintext %arg0, %cst : (!openfhe.crypto_context, tensor<32xi16>) -> !tensor_pt_ty
     %16 = openfhe.mul_plain %arg0, %14, %15 : (!openfhe.crypto_context, !tensor_ct_ty, !tensor_pt_ty) -> !tensor_ct_ty
     %18 = openfhe.rot %arg0, %16 { index = 31 } : (!openfhe.crypto_context, !tensor_ct_ty) -> !tensor_ct_ty
-    %19 = lwe.reinterpret_underlying_type %18 : !tensor_ct_ty to !scalar_ct_ty
+    %19 = lwe.reinterpret_application_data %18 : !tensor_ct_ty to !scalar_ct_ty
     return %19 : !scalar_ct_ty
   }
   func.func @simple_sum__encrypt(%arg0: !openfhe.crypto_context, %arg1: tensor<32xi16>, %arg2: !openfhe.public_key) -> !tensor_ct_ty {

--- a/tests/Dialect/Openfhe/Emitters/emit_pybind.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_pybind.mlir
@@ -73,7 +73,7 @@ func.func @simple_sum(%arg0: !openfhe.crypto_context, %arg1: !tensor_ct_ty) -> !
   %15 = openfhe.make_packed_plaintext %arg0, %cst : (!openfhe.crypto_context, tensor<32xi16>) -> !tensor_pt_ty
   %16 = openfhe.mul_plain %arg0, %14, %15 : (!openfhe.crypto_context, !tensor_ct_ty, !tensor_pt_ty) -> !tensor_ct_ty
   %18 = openfhe.rot %arg0, %16 { index = 31 } : (!openfhe.crypto_context, !tensor_ct_ty) -> !tensor_ct_ty
-  %19 = lwe.reinterpret_underlying_type %18 : !tensor_ct_ty to !scalar_ct_ty
+  %19 = lwe.reinterpret_application_data %18 : !tensor_ct_ty to !scalar_ct_ty
   return %19 : !scalar_ct_ty
 }
 func.func @simple_sum__encrypt(%arg0: !openfhe.crypto_context, %arg1: tensor<32xi16>, %arg2: !openfhe.public_key) -> !tensor_ct_ty {

--- a/tests/Dialect/Openfhe/Transforms/configure_crypto_context.mlir
+++ b/tests/Dialect/Openfhe/Transforms/configure_crypto_context.mlir
@@ -36,7 +36,7 @@ func.func @simple_sum(%arg0: !openfhe.crypto_context, %arg1: !ct_L1_) -> !ct_L0_
   %10 = openfhe.make_packed_plaintext %arg0, %cst : (!openfhe.crypto_context, tensor<32xi64>) -> !pt
   %11 = openfhe.mul_plain %arg0, %9, %10 : (!openfhe.crypto_context, !ct_L1_, !pt) -> !ct_L1_
   %12 = openfhe.rot %arg0, %11 {index = 31 : index} : (!openfhe.crypto_context, !ct_L1_) -> !ct_L1_
-  %13 = lwe.reinterpret_underlying_type %12 : !ct_L1_ to !ct_L1_1
+  %13 = lwe.reinterpret_application_data %12 : !ct_L1_ to !ct_L1_1
   %14 = openfhe.mod_reduce %arg0, %13 : (!openfhe.crypto_context, !ct_L1_1) -> !ct_L0_
   return %14 : !ct_L0_
 }


### PR DESCRIPTION
Inspired by a discussion in #1523: with the new LWE types, the ctxt type no longer has an `underlying_type` and instead has `application_data` (I originally assumed `message_type` and suggested that rename, but that's actually "inside" application data). This simply renames the op to match.