### PR TITLE
Migrate to new AsmPrinter alias behavior

### DIFF
--- a/tests/Dialect/Arith/Conversions/ArithToModArith/arith-to-mod-arith.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToModArith/arith-to-mod-arith.mlir
@@ -1,7 +1,7 @@
 // RUN: heir-opt --arith-to-mod-arith --split-input-file %s | FileCheck %s --enable-var-scope
 
 // CHECK-LABEL: @test_lower_add
-// CHECK-SAME: (%[[LHS:.*]]: !Z2147483648_i33_, %[[RHS:.*]]: !Z2147483648_i33_) -> [[T:.*]] {
+// CHECK-SAME: (%[[LHS:.*]]: !Z2147483648_i33, %[[RHS:.*]]: !Z2147483648_i33) -> [[T:.*]] {
 func.func @test_lower_add(%lhs : i32, %rhs : i32) -> i32 {
   // CHECK: %[[ADD:.*]] = mod_arith.add %[[LHS]], %[[RHS]] : [[T]]
   // CHECK: return %[[ADD:.*]] : [[T]]
@@ -10,7 +10,7 @@ func.func @test_lower_add(%lhs : i32, %rhs : i32) -> i32 {
 }
 
 // CHECK-LABEL: @test_lower_add_vec
-// CHECK-SAME: (%[[LHS:.*]]: tensor<4x!Z2147483648_i33_>, %[[RHS:.*]]: tensor<4x!Z2147483648_i33_>) -> [[T:.*]] {
+// CHECK-SAME: (%[[LHS:.*]]: tensor<4x!Z2147483648_i33>, %[[RHS:.*]]: tensor<4x!Z2147483648_i33>) -> [[T:.*]] {
 func.func @test_lower_add_vec(%lhs : tensor<4xi32>, %rhs : tensor<4xi32>) -> tensor<4xi32> {
   // CHECK: %[[ADD:.*]] = mod_arith.add %[[LHS]], %[[RHS]] : [[T]]
   // CHECK: return %[[ADD:.*]] : [[T]]
@@ -75,7 +75,7 @@ func.func @test_arith_constant_no_convert_index(%arg : tensor<2xi32>) -> i32 {
 }
 
 // CHECK-LABEL: @test_memref_global
-// CHECK-SAME: (%[[ARG:.*]]: memref<1x1x!Z2147483648_i33_>) -> memref<1x1x!Z2147483648_i33_> {
+// CHECK-SAME: (%[[ARG:.*]]: memref<1x1x!Z2147483648_i33>) -> memref<1x1x!Z2147483648_i33> {
 module attributes {tf_saved_model.semantics} {
   memref.global "private" constant @__constant_16xi32_0 : memref<16xi32> = dense<[-729, 1954, 610, 0, 241, -471, -35, -867, 571, 581, 4260, 3943, 591, 0, -889, -5103]> {alignment = 64 : i64}
   memref.global "private" constant @__constant_16x1xi8 : memref<16x1xi8> = dense<[[-9], [-54], [57], [71], [104], [115], [98], [99], [64], [-26], [127], [25], [-82], [68], [95], [86]]> {alignment = 64 : i64}
@@ -90,7 +90,7 @@ module attributes {tf_saved_model.semantics} {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1xi32>
     %22 = memref.load %0[%c0, %c0] : memref<16x1xi8>
     %24 = memref.load %arg0[%c0, %c0] : memref<1x1xi32>
-  // CHECK: %[[ENC:.*]] = mod_arith.mod_switch %{{.*}}: !Z128_i9_ to !Z2147483648_i33_
+  // CHECK: %[[ENC:.*]] = mod_arith.mod_switch %{{.*}}: !Z128_i9 to !Z2147483648_i33
     %a24 = arith.extui %22 : i8 to i32
     %25 = arith.muli %24, %a24 : i32
     %26 = arith.addi %21, %25 : i32
@@ -101,7 +101,7 @@ module attributes {tf_saved_model.semantics} {
 }
 
 // CHECK-LABEL: @test_affine
-// CHECK-SAME: (%[[ARG:.*]]: memref<1x1x!Z128_i9_>) -> memref<1x1x!Z2147483648_i33_> {
+// CHECK-SAME: (%[[ARG:.*]]: memref<1x1x!Z128_i9>) -> memref<1x1x!Z2147483648_i33> {
 module attributes {tf_saved_model.semantics} {
   func.func @test_affine(%arg0: memref<1x1xi8>) -> memref<1x1xi32> {
     %c429_i32 = arith.constant 429 : i32
@@ -111,7 +111,7 @@ module attributes {tf_saved_model.semantics} {
     %c0 = arith.constant 0 : index
     %1 = arith.extsi %0 : i8 to i32
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1xi32>
-  // CHECK: %[[ENC:.*]] = mod_arith.mod_switch %{{.*}}: !Z128_i9_ to !Z2147483648_i33_
+  // CHECK: %[[ENC:.*]] = mod_arith.mod_switch %{{.*}}: !Z128_i9 to !Z2147483648_i33
     %25 = arith.muli %1, %c33 : i32
     %26 = arith.addi %c429_i32, %25 : i32
     affine.store %26, %alloc[0, 0] : memref<1x1xi32>

--- a/tests/Dialect/Arith/Conversions/ArithToModArith/user-modulus.mlir
+++ b/tests/Dialect/Arith/Conversions/ArithToModArith/user-modulus.mlir
@@ -1,9 +1,9 @@
 // RUN: heir-opt %s --arith-to-mod-arith=modulus=65537 | FileCheck %s
 
-// CHECK: !Z65537_i64_ = !mod_arith.int<65537 : i64>
+// CHECK: !Z65537_i64 = !mod_arith.int<65537 : i64>
 
 // CHECK-LABEL: @add
-// CHECK-SAME: (%[[ARG0:.*]]: tensor<8x!Z65537_i64_> {secret.secret}) -> tensor<8x!Z65537_i64_> {
+// CHECK-SAME: (%[[ARG0:.*]]: tensor<8x!Z65537_i64> {secret.secret}) -> tensor<8x!Z65537_i64> {
 func.func @add(%arg0 : tensor<8xi16> {secret.secret}) -> tensor<8xi16> {
     %0 = arith.addi %arg0, %arg0 : tensor<8xi16>
     return %0 : tensor<8xi16>

--- a/tests/Dialect/LWE/IR/alias.mlir
+++ b/tests/Dialect/LWE/IR/alias.mlir
@@ -20,9 +20,9 @@
 #ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
 #ciphertext_space_L0_D10_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb, size = 10>
 
-// CHECK: [[TY:!ct_L0_[0-9]*]]
+// CHECK: [[TY:!ct_L0[_0-9]*]]
 !ct = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
-// CHECK: [[TY1:!ct_L0_D10_[0-9]*]]
+// CHECK: [[TY1:!ct_L0_D10[_0-9]*]]
 !ct1 = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_D10_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
 // CHECK: @test_alias(%[[ARG0:.*]]: [[TY]], %[[ARG1:.*]]: [[TY1]]) -> [[TY]]

--- a/tests/Dialect/ModArith/IR/alias.mlir
+++ b/tests/Dialect/ModArith/IR/alias.mlir
@@ -1,10 +1,10 @@
 // RUN: heir-opt %s | FileCheck %s
 
-// CHECK: !Z17_i10_ = !mod_arith.int<17 : i10>
+// CHECK: !Z17_i10 = !mod_arith.int<17 : i10>
 !Zp = !mod_arith.int<17 : i10>
-// CHECK: !Z17_i32_ = !mod_arith.int<17 : i32>
+// CHECK: !Z17_i32 = !mod_arith.int<17 : i32>
 !Zp1 = !mod_arith.int<17 : i32>
-// CHECK: !Z65536_i32_ = !mod_arith.int<65536 : i32>
+// CHECK: !Z65536_i32 = !mod_arith.int<65536 : i32>
 !Zp2 = !mod_arith.int<65536 : i32>
 
 // CHECK-LABEL: @test_alias

--- a/tests/Dialect/ModArith/Transforms/find_mac.mlir
+++ b/tests/Dialect/ModArith/Transforms/find_mac.mlir
@@ -1,7 +1,7 @@
 // RUN: heir-opt --arith-to-mod-arith --mod-arith-to-mac %s | FileCheck %s --enable-var-scope
 
 // CHECK-LABEL: @double_mac
-// CHECK-SAME: (%[[ARG:.*]]: !Z32768_i17_) -> [[T:.*]] {
+// CHECK-SAME: (%[[ARG:.*]]: !Z32768_i17) -> [[T:.*]] {
 func.func @double_mac(%arg0: i16) -> i16 {
   %c1 = arith.constant 1: i16
   %c2 = arith.constant 2 : i16

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_intt.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_intt.mlir
@@ -72,7 +72,7 @@
 // CHECK:      %[[OUTPUT_ENC:.*]] = mod_arith.encapsulate %[[OUTPUT_VEC]] : [[INT_TYPE]] -> [[MOD_TYPE]]
 // CHECK:      %[[ORDERED_OUTPUT:.*]] = linalg.generic {indexing_maps = [#[[ID_MAP]], #[[ID_MAP]]], iterator_types = ["parallel"]}
 // CHECK-SAME:   ins(%[[REVERSE_BIT_ORDER_COEFFS]] : tensor<4xindex>) outs(%[[OUTPUT_ENC]] : [[MOD_TYPE]]) {
-// CHECK:       ^bb0(%[[REV_INDEX:.*]]: index, %[[OUT:.*]]: [[coeff_ty:!Z7681_i32_]]):
+// CHECK:       ^bb0(%[[REV_INDEX:.*]]: index, %[[OUT:.*]]: [[coeff_ty:!Z7681_i32]]):
 // CHECK:         %[[EXTRACTED:.*]] = tensor.extract %[[RES_INTT]][%[[REV_INDEX]]] : [[MOD_TYPE]]
 // CHECK:         linalg.yield %[[EXTRACTED]] : [[coeff_ty]]
 // CHECK:       } -> [[MOD_TYPE]]

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul.mlir
@@ -5,20 +5,20 @@
 #ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl_2048>
 !poly_ty = !polynomial.polynomial<ring=#ring>
 
-// CHECK: !Z65536_i32_ = !mod_arith.int<65536 : i32>
+// CHECK: !Z65536_i32 = !mod_arith.int<65536 : i32>
 // CHECK: #[[LHS_MAP:.*]] = affine_map<(d0, d1) -> (d0)>
 // CHECK: #[[RHS_MAP:.*]] = affine_map<(d0, d1) -> (d1)>
 // CHECK: #[[OUTPUT_MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1)>
 
-// CHECK: func.func @lower_poly_mul(%[[poly0:.*]]: [[INPUT_TENSOR_TY:tensor<1024x!Z65536_i32_>]], %[[poly1:.*]]: [[INPUT_TENSOR_TY]]) -> [[INPUT_TENSOR_TY]] {
+// CHECK: func.func @lower_poly_mul(%[[poly0:.*]]: [[INPUT_TENSOR_TY:tensor<1024x!Z65536_i32>]], %[[poly1:.*]]: [[INPUT_TENSOR_TY]]) -> [[INPUT_TENSOR_TY]] {
 // CHECK:      %[[NAIVE_POLYMUL_OUTPUT_STORAGE:.*]] = arith.constant dense<0> : [[NAIVE_POLYMUL_TENSOR_TY_STORAGE:tensor<2047xi32>]]
-// CHECK:      %[[NAIVE_POLYMUL_OUTPUT:.*]] = mod_arith.encapsulate %[[NAIVE_POLYMUL_OUTPUT_STORAGE]] : [[NAIVE_POLYMUL_TENSOR_TY_STORAGE]] -> [[NAIVE_POLYMUL_TENSOR_TY:tensor<2047x!Z65536_i32_>]]
+// CHECK:      %[[NAIVE_POLYMUL_OUTPUT:.*]] = mod_arith.encapsulate %[[NAIVE_POLYMUL_OUTPUT_STORAGE]] : [[NAIVE_POLYMUL_TENSOR_TY_STORAGE]] -> [[NAIVE_POLYMUL_TENSOR_TY:tensor<2047x!Z65536_i32>]]
 // CHECK:      %[[GENERIC_RESULT:.*]] = linalg.generic
 // CHECK-SAME:     indexing_maps = [#[[LHS_MAP]], #[[RHS_MAP]], #[[OUTPUT_MAP]]]
 // CHECK-SAME:     iterator_types = ["parallel", "parallel"]
 // CHECK-SAME:     ins(%[[generic_arg0:.*]], %[[generic_arg1:.*]] : [[INPUT_TENSOR_TY]], [[INPUT_TENSOR_TY]])
 // CHECK-SAME:     outs(%[[NAIVE_POLYMUL_OUTPUT]] : [[NAIVE_POLYMUL_TENSOR_TY]])
-// CHECK:     ^[[BB0:.*]](%[[LHS_IN:.*]]: [[COEFF_TY:!Z65536_i32_]], %[[RHS_IN:.*]]: [[COEFF_TY]], %[[OUT:.*]]: [[COEFF_TY]]):
+// CHECK:     ^[[BB0:.*]](%[[LHS_IN:.*]]: [[COEFF_TY:!Z65536_i32]], %[[RHS_IN:.*]]: [[COEFF_TY]], %[[OUT:.*]]: [[COEFF_TY]]):
 // CHECK:       %[[MULTED:.*]] = mod_arith.mul %[[LHS_IN]], %[[RHS_IN]]
 // CHECK:       %[[SUMMED:.*]] = mod_arith.add %[[MULTED]], %[[OUT]]
 // CHECK:       linalg.yield %[[SUMMED]]

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_ntt.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_ntt.mlir
@@ -25,7 +25,7 @@
 // CHECK:      %[[OUTPUT_ENC:.*]] = mod_arith.encapsulate %[[OUTPUT_VEC]] : [[INT_TYPE]] -> [[MOD_TYPE]]
 // CHECK:      %[[ORDERED_INPUT:.*]] = linalg.generic {indexing_maps = [#[[ID_MAP]], #[[ID_MAP]]], iterator_types = ["parallel"]}
 // CHECK-SAME:   ins(%[[REVERSE_BIT_ORDER_COEFFS]] : tensor<4xindex>) outs(%[[OUTPUT_ENC]] : [[MOD_TYPE]]) {
-// CHECK:       ^bb0(%[[REV_INDEX:.*]]: index, %[[OUT:.*]]: [[COEFF_TYPE:!Z7681_i32_]]):
+// CHECK:       ^bb0(%[[REV_INDEX:.*]]: index, %[[OUT:.*]]: [[COEFF_TYPE:!Z7681_i32]]):
 // CHECK:         %[[EXTRACTED:.*]] = tensor.extract %[[COEFFS_ENC]][%[[REV_INDEX]]] : [[MOD_TYPE]]
 // CHECK:         linalg.yield %[[EXTRACTED]] : [[COEFF_TYPE]]
 // CHECK:       } -> [[MOD_TYPE]]

--- a/tests/Dialect/Polynomial/IR/alias.mlir
+++ b/tests/Dialect/Polynomial/IR/alias.mlir
@@ -1,21 +1,21 @@
 // RUN: heir-opt %s | FileCheck %s
 
-// CHECK: !Z17_i32_ = !mod_arith.int<17 : i32>
+// CHECK: !Z17_i32 = !mod_arith.int<17 : i32>
 !Zp1 = !mod_arith.int<17 : i32>
-// CHECK: !Z65536_i32_ = !mod_arith.int<65536 : i32>
+// CHECK: !Z65536_i32 = !mod_arith.int<65536 : i32>
 !Zp2 = !mod_arith.int<65536 : i32>
 
 #ideal1 = #polynomial.int_polynomial<x**1024 + 1>
 #ideal2 = #polynomial.int_polynomial<x**2048 + 1>
 
-// CHECK: #ring_Z17_i32_1_x1024_ = #polynomial.ring<coefficientType = !Z17_i32_, polynomialModulus = <1 + x**1024>>
+// CHECK: #ring_Z17_i32_1_x1024 = #polynomial.ring<coefficientType = !Z17_i32, polynomialModulus = <1 + x**1024>>
 #ring1 = #polynomial.ring<coefficientType=!Zp1, polynomialModulus=#ideal1>
-// CHECK: #ring_Z65536_i32_1_x2048_ = #polynomial.ring<coefficientType = !Z65536_i32_, polynomialModulus = <1 + x**2048>>
+// CHECK: #ring_Z65536_i32_1_x2048 = #polynomial.ring<coefficientType = !Z65536_i32, polynomialModulus = <1 + x**2048>>
 #ring2 = #polynomial.ring<coefficientType=!Zp2, polynomialModulus=#ideal2>
 
-// CHECK: !poly = !polynomial.polynomial<ring = #ring_Z17_i32_1_x1024_>
+// CHECK: !poly = !polynomial.polynomial<ring = #ring_Z17_i32_1_x1024>
 !poly = !polynomial.polynomial<ring = #ring1>
-// CHECK: !poly1 = !polynomial.polynomial<ring = #ring_Z65536_i32_1_x2048_>
+// CHECK: !poly1 = !polynomial.polynomial<ring = #ring_Z65536_i32_1_x2048>
 !poly1 = !polynomial.polynomial<ring = #ring2>
 
 // CHECK-LABEL: @test_alias

--- a/tests/Dialect/RNS/IR/alias.mlir
+++ b/tests/Dialect/RNS/IR/alias.mlir
@@ -5,9 +5,9 @@
 !Zp2 = !mod_arith.int<65536 : i32>
 !Zp3 = !mod_arith.int<65537 : i32>
 
-// CHECK: !rns_L1_ = !rns.rns<!Z17_i32_, !Z65536_i32_>
+// CHECK: !rns_L1 = !rns.rns<!Z17_i32, !Z65536_i32>
 !rns = !rns.rns<!Zp1, !Zp2>
-// CHECK: !rns_L2_ = !rns.rns<!Z17_i32_, !Z65536_i32_, !Z65537_i32_>
+// CHECK: !rns_L2 = !rns.rns<!Z17_i32, !Z65536_i32, !Z65537_i32>
 !rns1 = !rns.rns<!Zp1, !Zp2, !Zp3>
 
 // CHECK-LABEL: @test_alias

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
@@ -2,7 +2,7 @@
 
 module {
 // CHECK-LABEL: func @hv_matmul
-// CHECK-SAME:    %[[ct:.*]]: !ct_L1_
+// CHECK-SAME:    %[[ct:.*]]: !ct_L1
 // CHECK:      %[[pt:.*]] = lwe.rlwe_encode
 // CHECK-NEXT: %[[ct2:.*]] = ckks.mul_plain %[[ct]], %[[pt]]
 // CHECK:      %[[pt3:.*]] = lwe.rlwe_encode


### PR DESCRIPTION
In the past when an alias is generated with a trailing digit, it is sanitized with a trailing underscore to avoid potential conflict with other auto-generated ids.

After https://github.com/llvm/llvm-project/pull/127993, such behavior is no longer present as AsmPrinter will record what has been generated and decide which one should append `_N` suffix.

Hope Integrate LLVM people find this PR as they may encounter test failure when bumping llvm commit.