### PR TITLE
CountAnalysis: do not emit error on arith.constant

### DIFF
--- a/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.cpp
+++ b/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.cpp
@@ -111,10 +111,10 @@ LogicalResult CountAnalysis::visitOperation(
       })
       .Default(
           [&](auto &op) {
-            if (!mlir::isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp>(op)) {
+            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                           arith::ExtFOp>(op)) {
               op.emitError()
-                  << "Unsupported operation for count analysis encountered: "
-                  << op;
+                  << "Unsupported operation for count analysis encountered.";
             }
 
             // condition on result secretness

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCoeffModelAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCoeffModelAnalysis.cpp
@@ -173,10 +173,10 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
             return success();
           })
           .Default([&](auto &op) {
-            if (!mlir::isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp>(op)) {
+            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                           arith::ExtFOp>(op)) {
               op.emitError()
-                  << "Unsupported operation for noise analysis encountered: "
-                  << op;
+                  << "Unsupported operation for noise analysis encountered.";
             }
 
             // condition on result secretness


### PR DESCRIPTION
After #1524 when running test I would observe

```
<unknown>:0: error: Unsupported operation for count analysis encountered: %5 = "arith.constant"() <{value = 31 : index}> : () -> index
<unknown>:0: note: see current operation: %5 = "arith.constant"() <{value = 31 : index}> : () -> index
```

This fixes such emitting.