### PR TITLE
Implementation of mono bounds for noise analysis

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BGV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BGV/BUILD
@@ -13,6 +13,7 @@ cc_library(
     deps = [
         ":NoiseByBoundCoeffModel",
         ":NoiseByVarianceCoeffModel",
+        ":NoiseCanEmbModel",
         "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/DimensionAnalysis",
         "@heir//lib/Analysis/LevelAnalysis",
@@ -38,6 +39,20 @@ cc_library(
     ],
     hdrs = [
         "NoiseByBoundCoeffModel.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/NoiseAnalysis:Noise",
+        "@heir//lib/Parameters/BGV:Params",
+    ],
+)
+
+cc_library(
+    name = "NoiseCanEmbModel",
+    srcs = [
+        "NoiseCanEmbModel.cpp",
+    ],
+    hdrs = [
+        "NoiseCanEmbModel.h",
     ],
     deps = [
         "@heir//lib/Analysis/NoiseAnalysis:Noise",

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.cpp
@@ -1,0 +1,284 @@
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <iomanip>
+#include <ios>
+#include <numeric>
+#include <sstream>
+#include <string>
+
+namespace mlir {
+namespace heir {
+namespace bgv {
+// the formulae below are mainly taken from MMLGA22
+// "Finding and Evaluating Parameters for BGV"
+// https://eprint.iacr.org/2022/706
+
+template <bool P>
+using Model = NoiseCanEmbModel<P>;
+
+template <bool P>
+double Model<P>::toLogBound(const LocalParamType &param,
+                            const StateType &noise) {
+  auto cm = getRingExpansionFactor(param);
+  // ||a|| <= c_m * ||a||^{can}
+  return log(cm * noise.getValue()) / log(2);
+}
+
+template <bool P>
+double Model<P>::toLogBudget(const LocalParamType &param,
+                             const StateType &noise) {
+  return toLogTotal(param) - toLogBound(param, noise);
+}
+
+template <bool P>
+double Model<P>::toLogTotal(const LocalParamType &param) {
+  double total = 0;
+  auto logqi = param.getSchemeParam()->getLogqi();
+  for (auto i = 0; i <= param.getCurrentLevel(); ++i) {
+    total += logqi[i];
+  }
+  return total - 1.0;
+}
+
+template <bool P>
+std::string Model<P>::toLogBoundString(const LocalParamType &param,
+                                       const StateType &noise) {
+  auto logBound = toLogBound(param, noise);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logBound;
+  return stream.str();
+}
+
+template <bool P>
+std::string Model<P>::toLogBudgetString(const LocalParamType &param,
+                                        const StateType &noise) {
+  auto logBudget = toLogBudget(param, noise);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logBudget;
+  return stream.str();
+}
+
+template <bool P>
+std::string Model<P>::toLogTotalString(const LocalParamType &param) {
+  auto logTotal = toLogTotal(param);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logTotal;
+  return stream.str();
+}
+
+template <bool P>
+double Model<P>::getVarianceErr(const LocalParamType &param) {
+  auto std0 = param.getSchemeParam()->getStd0();
+  return std0 * std0;
+}
+
+template <bool P>
+double Model<P>::getVarianceKey(const LocalParamType &param) {
+  // assume UNIFORM_TERNARY
+  return 2.0 / 3.0;
+}
+
+template <bool P>
+double Model<P>::getRingExpansionFactor(const LocalParamType &param) {
+  auto N = param.getSchemeParam()->getRingDim();
+  // Assert that N is a power of 2
+  assert((N > 0) && ((N & (N - 1)) == 0) && "N must be a power of 2");
+  // In power-of-two rings c_m = 1
+  return 1.;
+}
+
+template <bool P>
+double Model<P>::getAssuranceFactor(const LocalParamType &param) {
+  // probability that a exceeds its standard deviation by more than a factor of
+  // D is roughly erfc(D) with erfc(6) = 2^-55, erfc(5) = 2^-40, erfc(4.5) =
+  // 2^-32
+  return 6.;
+}
+
+template <bool P>
+double Model<P>::getBScale(const LocalParamType &param) {
+  auto varianceKey = getVarianceKey(param);
+  auto t = param.getSchemeParam()->getPlaintextModulus();
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // B_scale = D * t * sqrt(phi(m)/12 * (1 + phi(m) * V_key)
+  double innerTerm = (phi / 12.) * (1 + phi * varianceKey);
+  return d * t * sqrt(innerTerm);
+}
+
+template <bool P>
+double Model<P>::getBKs(const LocalParamType &param) {
+  auto varianceError = getVarianceErr(param);
+  auto t = param.getSchemeParam()->getPlaintextModulus();
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // B_ks = D * t * phi(m) * sqrt(V_err / 12)
+  return d * t * phi * sqrt(varianceError / 12.);
+}
+
+template <bool P>
+double Model<P>::getPhi(const LocalParamType &param) {
+  return param.getSchemeParam()->getRingDim();
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalEncryptPk(
+    const LocalParamType &param) {
+  auto varianceError = getVarianceErr(param);
+  // uniform ternary
+  auto varianceKey = getVarianceKey(param);
+  auto t = param.getSchemeParam()->getPlaintextModulus();
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // public key (-as + t * e, a)
+  // public key encryption (-aus + t(u * e + e_0) + m, au + e_1)
+  // ||m + t * (u * e + e_1 * s + e_0)||
+  // <= D * t * sqrt(phi(m) * (1/12 + 2 * phi(m) * V_err * V_key + V_err))
+  double innerTerm =
+      phi * (1. / 12. + 2. * phi * varianceError * varianceKey + varianceKey);
+  double fresh = d * t * sqrt(innerTerm);
+  return StateType::of(fresh);
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalEncryptSk(
+    const LocalParamType &param) {
+  auto varianceError = getVarianceErr(param);
+  auto t = param.getSchemeParam()->getPlaintextModulus();
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // secret key s
+  // secret key encryption (-as + m + t * e, a)
+  // ||m + t * e|| <= D * t * sqrt(phi(m) * (1/12 + V_err))
+  double innerTerm = phi * (1. / 12. + varianceError);
+  double fresh = d * t * sqrt(innerTerm);
+  return StateType::of(fresh);
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalEncrypt(
+    const LocalParamType &param) {
+  // P stands for public key encryption
+  if constexpr (P) {
+    return evalEncryptPk(param);
+  } else {
+    return evalEncryptSk(param);
+  }
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalConstant(
+    const LocalParamType &param) {
+  auto t = param.getSchemeParam()->getPlaintextModulus();
+  auto phi = getPhi(param);
+
+  // noise part of the plaintext in a pt-ct multiplication
+  // v_const <= t * sqrt(phi(m) / 12)
+  return StateType::of(t * sqrt(phi / 12.0));
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalAdd(const StateType &lhs,
+                                               const StateType &rhs) {
+  // v_add <= v_0 + v_1
+  return StateType::of(lhs.getValue() + rhs.getValue());
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalMul(
+    const LocalParamType &resultParam, const StateType &lhs,
+    const StateType &rhs) {
+  // v_mul <= v_0 * v_1
+  return StateType::of(lhs.getValue() * rhs.getValue());
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalModReduce(
+    const LocalParamType &inputParam, const StateType &input) {
+  auto currentLogqi =
+      inputParam.getSchemeParam()->getLogqi()[inputParam.getCurrentLevel()];
+  double modulus = pow(2.0, currentLogqi);
+
+  // modulus switching is essentially a scaling operation
+  // so the original error is scaled by the modulus
+  // ||v_scaled|| = ||v_input|| / modulus
+  auto scaled = input.getValue() / modulus;
+  // in the meantime, it will introduce a rounding error
+  // (tau_0, tau_1) to (ct_0, ct_1)
+  // ||tau_0 + tau_1 * s|| <= D * t * sqrt(phi(m)/12 * (1 + phi(m) * V_key) =
+  // B_scale
+  // ||v_ms|| <= ||v_scaled|| + B_scale
+  double bScale = getBScale(inputParam);
+  return StateType::of(scaled + bScale);
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalRelinearizeHYBRID(
+    const LocalParamType &inputParam, const StateType &input) {
+  // for v_input, after modup and moddown, it remains the same (with rounding).
+  // We only need to consider the error from key switching key
+  // and rounding error during moddown.
+  // Check section 3.2 of MMLGA22 for more details.
+  auto dnum = inputParam.getSchemeParam()->getDnum();
+
+  auto currentLevel = inputParam.getCurrentLevel();
+  auto logpi = inputParam.getSchemeParam()->getLogpi();
+
+  // TODO: prod of Pi() if Pi() is available instead of logPi()
+  auto pi = inputParam.getSchemeParam()->getPi();
+  double prodPi;
+  double maxPi;
+  size_t k;
+  if (pi.size() == 0) {
+    // values of pi are not set in schemeParam, so we use this
+    std::vector<double> moduliPi(logpi.size());
+    std::transform(logpi.begin(), logpi.end(), moduliPi.begin(),
+                   [](double value) { return pow(2.0, value); });
+    maxPi = *std::max_element(moduliPi.begin(), moduliPi.end());
+    prodPi = std::accumulate(moduliPi.begin(), moduliPi.end(), 1.,
+                             std::multiplies<double>());
+    k = moduliPi.size();
+  } else {
+    // if real values of pi are set, we use those
+    maxPi = *std::max_element(pi.begin(), pi.end());
+    prodPi =
+        std::accumulate(pi.begin(), pi.end(), 1., std::multiplies<double>());
+    k = pi.size();
+  }
+
+  // v_ks = v + sqrt(dnum * (currentLevel + 1)) * p_l^(ceil(currentLevel / dnum)
+  // * B_ks / P + sqrt(k) * B_scale
+  double bKs = getBKs(inputParam);
+  auto pPower = ceil(static_cast<double>(currentLevel) / dnum);
+  auto noiseKs = sqrt(dnum * (currentLevel + 1)) *
+                 pow(static_cast<double>(maxPi), static_cast<double>(pPower)) *
+                 bKs / prodPi;
+  double bScale = getBScale(inputParam);
+  auto noiseScale = sqrt(k) * bScale;
+
+  return StateType::of(input.getValue() + noiseKs + noiseScale);
+}
+
+template <bool P>
+typename Model<P>::StateType Model<P>::evalRelinearize(
+    const LocalParamType &inputParam, const StateType &input) {
+  // assume HYBRID
+  // if we further introduce BV to SchemeParam we can have alternative
+  // implementation.
+  return evalRelinearizeHYBRID(inputParam, input);
+}
+
+// instantiate template class
+template class NoiseCanEmbModel<false>;
+template class NoiseCanEmbModel<true>;
+
+}  // namespace bgv
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h
@@ -1,0 +1,74 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_BGV_NOISECANEMBMODEL_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_BGV_NOISECANEMBMODEL_H_
+
+#include <cassert>
+#include <string>
+
+#include "lib/Analysis/NoiseAnalysis/Noise.h"
+#include "lib/Parameters/BGV/Params.h"
+
+namespace mlir {
+namespace heir {
+namespace bgv {
+
+// canonical embedding noise model from MMLGA22
+// see https://eprint.iacr.org/2022/706
+// use template here just for the sake of code reuse
+// P for public key
+template <bool P>
+class NoiseCanEmbModel {
+ public:
+  // for MMLGA22, NoiseState stores the bound ||m + t * e||^{can} for error e.
+  using StateType = NoiseState;
+  using SchemeParamType = bgv::SchemeParam;
+  using LocalParamType = bgv::LocalParam;
+
+ private:
+  static double getVarianceErr(const LocalParamType &param);
+  static double getVarianceKey(const LocalParamType &param);
+  static double getBScale(const LocalParamType &param);
+  static double getBKs(const LocalParamType &param);
+  static double getAssuranceFactor(const LocalParamType &param);
+  static double getPhi(const LocalParamType &param);
+  static double getRingExpansionFactor(const LocalParamType &param);
+
+  static StateType evalEncryptPk(const LocalParamType &param);
+  static StateType evalEncryptSk(const LocalParamType &param);
+  static StateType evalRelinearizeHYBRID(const LocalParamType &inputParam,
+                                         const StateType &input);
+
+ public:
+  static StateType evalEncrypt(const LocalParamType &param);
+  static StateType evalConstant(const LocalParamType &param);
+  static StateType evalAdd(const StateType &lhs, const StateType &rhs);
+  static StateType evalMul(const LocalParamType &resultParam,
+                           const StateType &lhs, const StateType &rhs);
+  static StateType evalRelinearize(const LocalParamType &inputParam,
+                                   const StateType &input);
+  static StateType evalModReduce(const LocalParamType &inputParam,
+                                 const StateType &input);
+
+  // logTotal: log(Ql / 2)
+  // logBound: bound on ||m + t * e|| predicted by the model
+  // logBudget: logTotal - logBound
+  // as ||m + t * e|| < Ql / 2 for correct decryption
+  static double toLogBound(const LocalParamType &param, const StateType &noise);
+  static std::string toLogBoundString(const LocalParamType &param,
+                                      const StateType &noise);
+  static double toLogBudget(const LocalParamType &param,
+                            const StateType &noise);
+  static std::string toLogBudgetString(const LocalParamType &param,
+                                       const StateType &noise);
+  static double toLogTotal(const LocalParamType &param);
+  static std::string toLogTotalString(const LocalParamType &param);
+};
+
+// user-facing typedefs
+using NoiseCanEmbPkModel = NoiseCanEmbModel<true>;
+using NoiseCanEmbSkModel = NoiseCanEmbModel<false>;
+
+}  // namespace bgv
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_BGV_NOISECANEMBMODEL_H_

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCoeffModelAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCoeffModelAnalysis.cpp
@@ -4,6 +4,7 @@
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
@@ -216,6 +217,10 @@ template class NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCasePkModel>;
 template class NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCasePkModel>;
 template class NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCaseSkModel>;
 template class NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCaseSkModel>;
+
+// for mono bounds
+template class NoiseAnalysis<bgv::NoiseCanEmbPkModel>;
+template class NoiseAnalysis<bgv::NoiseCanEmbSkModel>;
 
 // for by variance
 template class NoiseAnalysis<bgv::NoiseByVarianceCoeffPkModel>;

--- a/lib/Transforms/GenerateParam/BUILD
+++ b/lib/Transforms/GenerateParam/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/CKKS/IR:Dialect",

--- a/lib/Transforms/GenerateParam/GenerateParam.td
+++ b/lib/Transforms/GenerateParam/GenerateParam.td
@@ -8,10 +8,11 @@ def GenerateParamBGV : Pass<"generate-param-bgv"> {
   let description = [{
     The pass generates the BGV scheme parameter using a given noise model.
 
-    There are three noise models available:
+    There are four noise models available:
     - `bgv-noise-by-bound-coeff-average-case{-pk,-sk}`
     - `bgv-noise-by-bound-coeff-worst-case{-pk,-sk}`
     - `bgv-noise-by-variance-coeff{-pk,-sk}`
+    - `bgv-noise-mono{-pk,-sk}`
 
     The `-pk`/`-sk` suffixes assume the input ciphertexts are
     encrypted using the public/secret key.
@@ -26,6 +27,11 @@ def GenerateParamBGV : Pass<"generate-param-bgv"> {
     of the coefficient embedding of the ciphertexts. This gives a more accurate
     noise estimate, but it may give underestimates in some cases. See the paper
     for more details.
+
+    The last model is taken from MMLGA22. It uses the canonical embedding to
+    bound the critical quantity of a ciphertext that defines whether c can be
+    decrypted correctly. According to the authors they achieve more accurate and
+    better bounds than KPZ21. See the paper for more details.
 
     This pass relies on the presence of the `mgmt` dialect ops to model
     relinearize/modreduce, and it relies on `mgmt.mgmt` attribute to determine

--- a/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
@@ -2,6 +2,7 @@
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
@@ -210,6 +211,10 @@ struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
       run<NoiseAnalysis<bgv::NoiseByVarianceCoeffPkModel>>();
     } else if (model == "bgv-noise-by-variance-coeff-sk") {
       run<NoiseAnalysis<bgv::NoiseByVarianceCoeffSkModel>>();
+    } else if (model == "bgv-noise-mono-pk") {
+      run<NoiseAnalysis<bgv::NoiseCanEmbPkModel>>();
+    } else if (model == "bgv-noise-mono-sk") {
+      run<NoiseAnalysis<bgv::NoiseCanEmbSkModel>>();
     } else {
       getOperation()->emitWarning() << "Unknown noise model.\n";
       generateFallbackParam();

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:MgmtOps",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -10,6 +10,7 @@
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
@@ -206,6 +207,10 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
       run<NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCaseSkModel>>();
     } else if (model == "bfv-noise-by-bound-coeff-average-case-sk") {
       run<NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseSkModel>>();
+    } else if (model == "bgv-noise-mono-pk") {
+      run<NoiseAnalysis<bgv::NoiseCanEmbPkModel>>();
+    } else if (model == "bgv-noise-mono-sk") {
+      run<NoiseAnalysis<bgv::NoiseCanEmbSkModel>>();
     } else {
       getOperation()->emitOpError() << "Unknown noise model.\n";
       signalPassFailure();

--- a/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/BUILD
+++ b/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/BUILD
@@ -1,0 +1,33 @@
+# See README.md for setup required to run these tests
+
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+# This is a Google-internal hack to avoid issues with automated tooling that
+# expects very specific go package layout with respect to build targets.
+# @unused
+glaze_ignore = [
+    "dot_product_8_debug.go",
+]
+
+heir_lattigo_lib(
+    name = "dot_product_8_debug",
+    extra_srcs = ["dot_product_8_debug.go"],
+    go_library_name = "dotproduct8debug",
+    heir_opt_flags = [
+        "--mlir-to-bgv=ciphertext-degree=8 noise-model=bgv-noise-mono-pk annotate-noise-bound=true",
+        "--scheme-to-lattigo=insert-debug-handler-calls=true",
+    ],
+    mlir_src = "dot_product_8.mlir",
+)
+
+# For Google-internal reasons we must separate the go_test rules from the macro
+# above.
+
+go_test(
+    name = "dotproduct8debug_test",
+    srcs = ["dot_product_8_debug_handler_test.go"],
+    embed = [":dotproduct8debug"],
+)

--- a/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/dot_product_8.mlir
+++ b/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/dot_product_8.mlir
@@ -1,0 +1,1 @@
+../../../common/dot_product_8.mlir

--- a/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/dot_product_8_debug.go
+++ b/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/dot_product_8_debug.go
@@ -1,0 +1,68 @@
+// Package dotproduct8debug is a debug handler callback for the compiled lattigo code.
+package dotproduct8debug
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/tuneinsight/lattigo/v6/core/rlwe"
+	"github.com/tuneinsight/lattigo/v6/schemes/bgv"
+)
+
+func __heir_debug(evaluator *bgv.Evaluator, param bgv.Parameters, encoder *bgv.Encoder, decryptor *rlwe.Decryptor, ct *rlwe.Ciphertext, debugAttrMap map[string]string) {
+	// print op
+	isBlockArgument := debugAttrMap["asm.is_block_arg"]
+	if isBlockArgument == "1" {
+		fmt.Println("Input")
+	} else {
+		fmt.Println(debugAttrMap["asm.op_name"])
+	}
+
+	// print the decryption result
+	messageSizeStr := debugAttrMap["message.size"]
+	messageSize, err := strconv.Atoi(messageSizeStr)
+	if err != nil {
+		panic(err)
+	}
+	value := make([]int64, messageSize)
+	pt := decryptor.DecryptNew(ct)
+	encoder.Decode(pt, value)
+	fmt.Printf("  %v\n", value)
+
+	// print the noise
+
+	// get a new pt with no noise
+	// in Lattigo, Decrypt won't mod T
+	// Decode will mod T so we Decode then Encode
+	valueFull := make([]int64, ct.N())
+	encoder.Decode(pt, valueFull)
+	// set the level and scale of the plaintext
+	ptNoNoise := bgv.NewPlaintext(param, ct.Level())
+	ptNoNoise.Scale = ct.Scale
+	encoder.Encode(valueFull, ptNoNoise)
+
+	// subtract the message from the ciphertext
+	vec, _ := evaluator.SubNew(ct, ptNoNoise)
+	// get infty norm of the noise
+	_, _, max := rlwe.Norm(vec, decryptor)
+	// get logQi for current level
+	total := 0
+	for i := 0; i <= ct.LevelQ(); i++ {
+		total += param.LogQi()[i]
+	}
+	// t * e for BGV
+	fmt.Printf("  Noise: %.2f Total: %d\n", max+param.LogT(), total)
+
+	// print the predicted bound by analysis
+	noiseBoundStr, ok := debugAttrMap["noise.bound"]
+	if ok {
+		noiseBound, err := strconv.ParseFloat(noiseBoundStr, 64)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("  Noise Bound: %.2f Gap: %.2f\n", noiseBound, noiseBound-(max+param.LogT()))
+		if noiseBound < max+param.LogT() {
+			panic("Noise Bound Exceeded")
+		}
+	}
+}

--- a/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/dot_product_8_debug_handler_test.go
+++ b/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/dot_product_8_debug_handler_test.go
@@ -1,0 +1,26 @@
+package dotproduct8debug
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := dot_product__configure()
+
+	// Vector of plaintext values
+	arg0 := []int16{1, 2, 3, 4, 5, 6, 7, 8}
+	arg1 := []int16{2, 3, 4, 5, 6, 7, 8, 9}
+
+	expected := int16(240)
+
+	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
+
+	resultCt := dot_product(evaluator, params, ecd, dec, ct0, ct1)
+
+	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}


### PR DESCRIPTION
This PR adds the noise model introduced by [Mono et al](https://eprint.iacr.org/2022/706) for BGV to the noise analysis framework.

This noise analysis gives better bounds, when the actual primes `q` are available instead of only using the bit-size of the primes. When the primes are not available the bit-size is used to calculate the bounds.

**Example**

The noise model can be used with this command:
`bazel run //tools:heir-opt -- --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --generate-param-bgv=model=bgv-noise-mono-pk $PWD/tests/Examples/openfhe/bgv/dot_product_8/dot_product_8.mlir --validate-noise=model=bgv-noise-mono-pk --debug --debug-only=secret-insert-mgmt-bgv --debug-only=NoiseAnalysis --debug-only=BGVNoise`

Producing this output:
```Propagating 49.47 to <block argument> of type 'tensor<8xi16>' at index: 0
Propagating 49.47 to <block argument> of type 'tensor<8xi16>' at index: 1
Propagating 82.94 to %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 2, dimension = 3>} : tensor<8xi16>
Propagating 82.94 to %2 = mgmt.relinearize %1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 82.94 to %3 = tensor_ext.rotate %2, %c4 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
Propagating 83.94 to %4 = arith.addi %2, %3 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 83.94 to %5 = tensor_ext.rotate %4, %c2 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
Propagating 84.94 to %6 = arith.addi %4, %5 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 84.94 to %7 = tensor_ext.rotate %6, %c1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
Propagating 85.94 to %8 = arith.addi %6, %7 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 45.50 to %9 = mgmt.modreduce %8 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
Propagating 66.21 to %extracted = tensor.extract %9[%c7] {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
Propagating 45.50 to %10 = mgmt.modreduce %extracted {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16
Propagating 48.47 to <block argument> of type 'tensor<8xi16>' at index: 0
Propagating 48.47 to <block argument> of type 'tensor<8xi16>' at index: 1
Propagating 80.94 to %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 2, dimension = 3>} : tensor<8xi16>
Propagating 80.94 to %2 = mgmt.relinearize %1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 80.94 to %3 = tensor_ext.rotate %2, %c4 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
Propagating 81.94 to %4 = arith.addi %2, %3 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 81.94 to %5 = tensor_ext.rotate %4, %c2 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
Propagating 82.94 to %6 = arith.addi %4, %5 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 82.94 to %7 = tensor_ext.rotate %6, %c1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
Propagating 83.94 to %8 = arith.addi %6, %7 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
Propagating 44.73 to %9 = mgmt.modreduce %8 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
Propagating 64.93 to %extracted = tensor.extract %9[%c7] {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
Propagating 44.90 to %10 = mgmt.modreduce %extracted {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16
module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [281474977349633, 4423681, 4398047051777], P = [281474977595393, 281474978185217], plaintextModulus = 65537>, scheme.bgv} {
  func.func @dot_product(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) -> !secret.secret<i16> {
    %c1 = arith.constant 1 : index
    %c2 = arith.constant 2 : index
    %c4 = arith.constant 4 : index
    %c7 = arith.constant 7 : index
    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<8xi16>>, !secret.secret<tensor<8xi16>>) attrs = {__argattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 2>}, {mgmt.mgmt = #mgmt.mgmt<level = 2>}], __resattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 0>}]} {
    ^body(%input0: tensor<8xi16>, %input1: tensor<8xi16>):
      %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 2, dimension = 3>} : tensor<8xi16>
      %2 = mgmt.relinearize %1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %3 = tensor_ext.rotate %2, %c4 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
      %4 = arith.addi %2, %3 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %5 = tensor_ext.rotate %4, %c2 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
      %6 = arith.addi %4, %5 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %7 = tensor_ext.rotate %6, %c1 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>, index
      %8 = arith.addi %6, %7 {mgmt.mgmt = #mgmt.mgmt<level = 2>} : tensor<8xi16>
      %9 = mgmt.modreduce %8 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
      %extracted = tensor.extract %9[%c7] {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
      %10 = mgmt.modreduce %extracted {mgmt.mgmt = #mgmt.mgmt<level = 0>} : i16
      secret.yield %10 : i16
    } -> !secret.secret<i16>
    return %0 : !secret.secret<i16>
  }
}
```