### PR TITLE
LWE: allow mixed degree mul

### DIFF
--- a/lib/Dialect/LWE/IR/LWEOps.h
+++ b/lib/Dialect/LWE/IR/LWEOps.h
@@ -33,9 +33,6 @@ LogicalResult verifyMulOp(Op* op) {
   // verify dimension matches
   auto x = op->getLhs().getType();
   auto y = op->getRhs().getType();
-  if (x.getCiphertextSpace().getSize() != y.getCiphertextSpace().getSize()) {
-    return op->emitOpError() << "input dimensions do not match";
-  }
   auto out = op->getOutput().getType();
   if (out.getCiphertextSpace().getSize() !=
       y.getCiphertextSpace().getSize() + x.getCiphertextSpace().getSize() - 1) {
@@ -305,7 +302,7 @@ LogicalResult inferRelinearizeOpReturnTypes(
       ctx, x.getApplicationData(), x.getPlaintextSpace(),
       lwe::CiphertextSpaceAttr::get(ctx, x.getCiphertextSpace().getRing(),
                                     x.getCiphertextSpace().getEncryptionType(),
-                                    2),
+                                    adaptor.getToBasis().size()),
       x.getKey(), x.getModulusChain()));
   return success();
 }

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.cpp
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.cpp
@@ -20,6 +20,8 @@ namespace openfhe {
 // Op verifiers
 //===----------------------------------------------------------------------===//
 
+LogicalResult MulNoRelinOp::verify() { return lwe::verifyMulOp(this); }
+
 LogicalResult MakePackedPlaintextOp::verify() {
   auto enc = this->getPlaintext().getType().getPlaintextSpace().getEncoding();
   if (!llvm::isa<lwe::FullCRTPackingEncodingAttr>(enc)) {
@@ -50,6 +52,12 @@ LogicalResult SubOp::inferReturnTypes(
     MLIRContext *ctx, std::optional<Location>, SubOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   return lwe::inferAddOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
+LogicalResult MulNoRelinOp::inferReturnTypes(
+    MLIRContext *ctx, std::optional<Location>, MulNoRelinOp::Adaptor adaptor,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  return lwe::inferMulOpReturnTypes(ctx, adaptor, inferredReturnTypes);
 }
 
 }  // namespace openfhe

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -211,7 +211,7 @@ def SubPlainOp : Openfhe_Op<"sub_plain",[
 
 def MulOp : Openfhe_BinaryOp<"mul"> { let summary = "OpenFHE mul operation of two ciphertexts with relinearization."; }
 
-def MulNoRelinOp : Openfhe_Op<"mul_no_relin", [Pure, SameOperandsAndResultRings]> {
+def MulNoRelinOp : Openfhe_Op<"mul_no_relin", [Pure, SameOperandsAndResultRings, InferTypeOpAdaptor]> {
   let summary = "OpenFHE mul operation of two ciphertexts without relinearization.";
   let arguments = (ins
     Openfhe_CryptoContext:$cryptoContext,
@@ -219,6 +219,7 @@ def MulNoRelinOp : Openfhe_Op<"mul_no_relin", [Pure, SameOperandsAndResultRings]
     NewLWECiphertext:$rhs
   );
   let results = (outs NewLWECiphertext:$output);
+  let hasVerifier = 1;
 }
 
 def MulPlainOp : Openfhe_Op<"mul_plain",[

--- a/tests/Dialect/Openfhe/IR/ops.mlir
+++ b/tests/Dialect/Openfhe/IR/ops.mlir
@@ -23,12 +23,14 @@
 !ptf16 = !lwe.new_lwe_plaintext<application_data = <message_type = f16>, plaintext_space = #plaintext_space_f16>
 
 #ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L0_D3 = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb, size = 3>
 
 !pk = !openfhe.public_key
 !sk = !openfhe.private_key
 !ek = !openfhe.eval_key
 !cc = !openfhe.crypto_context
 !ct = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!ct_D3 = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_D3, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
 module {
   // CHECK-LABEL: func @test_make_packed_plaintext
@@ -125,7 +127,7 @@ module {
   func.func @test_mul_no_relin(%cc : !cc, %pt : !pt, %pk: !pk) {
     %c1 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
     %c2 = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct
-    %out = openfhe.mul_no_relin %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct
+    %out = openfhe.mul_no_relin %cc, %c1, %c2: (!cc, !ct, !ct) -> !ct_D3
     return
   }
 

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_add.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_add.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s --mlir-print-local-scope --secret-distribute-generic --secret-to-bgv=poly-mod-degree=8 | FileCheck %s
+
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [1152921504606994433, 1097729], P = [1152921504607191041], plaintextModulus = 65537>, scheme.bfv} {
+  func.func @mixed_add(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) -> !secret.secret<tensor<8xi16>> {
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<8xi16>>, !secret.secret<tensor<8xi16>>) attrs = {__argattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}, {mgmt.mgmt = #mgmt.mgmt<level = 1>}], __resattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}]} {
+    ^body(%input0: tensor<8xi16>, %input1: tensor<8xi16>):
+      // CHECK: bgv.mul
+      // CHECK-SAME: size = 3
+      %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3>} : tensor<8xi16>
+      // CHECK: bgv.add
+      // CHECK-SAME: size = 3
+      // CHECK-SAME: size = 3
+      %2 = arith.addi %1, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3>} : tensor<8xi16>
+      // CHECK: bgv.relinearize
+      // CHECK-SAME: from_basis = array<i32: 0, 1, 2>
+      %3 = mgmt.relinearize %2 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
+      secret.yield %3 : tensor<8xi16>
+    } -> !secret.secret<tensor<8xi16>>
+    return %0 : !secret.secret<tensor<8xi16>>
+  }
+}

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_mul.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_mul.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt %s --mlir-print-local-scope --secret-distribute-generic --secret-to-bgv=poly-mod-degree=8 | FileCheck %s
+
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [1152921504606994433, 17179967489], P = [1152921504607191041], plaintextModulus = 65537>, scheme.bfv} {
+  func.func @two_mul(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) -> !secret.secret<tensor<8xi16>> {
+    %0 = secret.generic ins(%arg0, %arg1 : !secret.secret<tensor<8xi16>>, !secret.secret<tensor<8xi16>>) attrs = {__argattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}, {mgmt.mgmt = #mgmt.mgmt<level = 1>}], __resattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}]} {
+    ^body(%input0: tensor<8xi16>, %input1: tensor<8xi16>):
+      // CHECK: bgv.mul
+      // CHECK-SAME: size = 3
+      %1 = arith.muli %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3>} : tensor<8xi16>
+      // CHECK: bgv.mul
+      // CHECK-SAME: size = 3
+      // CHECK-SAME: size = 4
+      %2 = arith.muli %1, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 4>} : tensor<8xi16>
+      // CHECK: bgv.relinearize
+      // CHECK-SAME: from_basis = array<i32: 0, 1, 2, 3>
+      %3 = mgmt.relinearize %2 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
+      secret.yield %3 : tensor<8xi16>
+    } -> !secret.secret<tensor<8xi16>>
+    return %0 : !secret.secret<tensor<8xi16>>
+  }
+}


### PR DESCRIPTION
Follow up of #1334, which does not remove the requirement inside verifier.

Note that bgv dialect itself should allow mixed-degree mul like `ct of size 3 * ct of size 2 = ct of size 4`. The reason we prevent it previously is that we need extra relinearization key for it (s^3 to s).

It should be determined by previous pass whether such multiplication should be allowed (like optimize-relinearization) instead of preventing it in bgv dialect.