### PR TITLE
NoiseAnalysis: refactor to use options from SchemeParam

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h
@@ -14,8 +14,8 @@ namespace bfv {
 // coefficient embedding noise model
 // both average-case (from HPS19/KPZ21) and worst-case
 // use template here just for the sake of code reuse
-// W for worst-case, P for public key
-template <bool W, bool P>
+// W for worst-case
+template <bool W>
 class NoiseByBoundCoeffModel {
  public:
   // for KPZ21, NoiseState stores the bound ||e|| for error e.
@@ -58,11 +58,8 @@ class NoiseByBoundCoeffModel {
 };
 
 // user-facing typedefs
-using NoiseByBoundCoeffAverageCasePkModel = NoiseByBoundCoeffModel<false, true>;
-using NoiseByBoundCoeffWorstCasePkModel = NoiseByBoundCoeffModel<true, true>;
-using NoiseByBoundCoeffAverageCaseSkModel =
-    NoiseByBoundCoeffModel<false, false>;
-using NoiseByBoundCoeffWorstCaseSkModel = NoiseByBoundCoeffModel<true, false>;
+using NoiseByBoundCoeffAverageCaseModel = NoiseByBoundCoeffModel<false>;
+using NoiseByBoundCoeffWorstCaseModel = NoiseByBoundCoeffModel<true>;
 
 }  // namespace bfv
 }  // namespace heir

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseCoeffModelAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseCoeffModelAnalysis.cpp
@@ -210,10 +210,8 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
 }
 
 // template instantiation
-template class NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCasePkModel>;
-template class NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCasePkModel>;
-template class NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseSkModel>;
-template class NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCaseSkModel>;
+template class NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseModel>;
+template class NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCaseModel>;
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BGV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BGV/BUILD
@@ -4,9 +4,9 @@ package(
 )
 
 cc_library(
-    name = "NoiseCoeffModelAnalysis",
+    name = "NoiseAnalysis",
     srcs = [
-        "NoiseCoeffModelAnalysis.cpp",
+        "NoiseAnalysis.cpp",
     ],
     hdrs = [
     ],

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
@@ -1,3 +1,5 @@
+#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+
 #include <functional>
 
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
@@ -5,7 +7,6 @@
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
-#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
@@ -213,18 +214,14 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
 }
 
 // template instantiation
-template class NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCasePkModel>;
-template class NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCasePkModel>;
-template class NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCaseSkModel>;
-template class NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCaseSkModel>;
+template class NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCaseModel>;
+template class NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCaseModel>;
 
 // for mono bounds
-template class NoiseAnalysis<bgv::NoiseCanEmbPkModel>;
-template class NoiseAnalysis<bgv::NoiseCanEmbSkModel>;
+template class NoiseAnalysis<bgv::NoiseCanEmbModel>;
 
 // for by variance
-template class NoiseAnalysis<bgv::NoiseByVarianceCoeffPkModel>;
-template class NoiseAnalysis<bgv::NoiseByVarianceCoeffSkModel>;
+template class NoiseAnalysis<bgv::NoiseByVarianceCoeffModel>;
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.cpp
@@ -16,26 +16,26 @@ namespace bgv {
 // "Revisiting Homomorphic Encryption Schemes for Finite Fields"
 // https://ia.cr/2021/204
 
-template <bool W, bool P>
-using Model = NoiseByBoundCoeffModel<W, P>;
+template <bool W>
+using Model = NoiseByBoundCoeffModel<W>;
 
-template <bool W, bool P>
-double Model<W, P>::toLogBound(const LocalParamType &param,
-                               const StateType &noise) {
+template <bool W>
+double Model<W>::toLogBound(const LocalParamType &param,
+                            const StateType &noise) {
   auto t = param.getSchemeParam()->getPlaintextModulus();
   // StateType only stores e in (m + t * e), so when we want to print the bound
   // we need to multiply t back
   return log2(t * noise.getValue());
 }
 
-template <bool W, bool P>
-double Model<W, P>::toLogBudget(const LocalParamType &param,
-                                const StateType &noise) {
+template <bool W>
+double Model<W>::toLogBudget(const LocalParamType &param,
+                             const StateType &noise) {
   return toLogTotal(param) - toLogBound(param, noise);
 }
 
-template <bool W, bool P>
-double Model<W, P>::toLogTotal(const LocalParamType &param) {
+template <bool W>
+double Model<W>::toLogTotal(const LocalParamType &param) {
   double total = 0;
   auto logqi = param.getSchemeParam()->getLogqi();
   for (auto i = 0; i <= param.getCurrentLevel(); ++i) {
@@ -44,34 +44,34 @@ double Model<W, P>::toLogTotal(const LocalParamType &param) {
   return total - 1.0;
 }
 
-template <bool W, bool P>
-std::string Model<W, P>::toLogBoundString(const LocalParamType &param,
-                                          const StateType &noise) {
+template <bool W>
+std::string Model<W>::toLogBoundString(const LocalParamType &param,
+                                       const StateType &noise) {
   auto logBound = toLogBound(param, noise);
   std::stringstream stream;
   stream << std::fixed << std::setprecision(2) << logBound;
   return stream.str();
 }
 
-template <bool W, bool P>
-std::string Model<W, P>::toLogBudgetString(const LocalParamType &param,
-                                           const StateType &noise) {
+template <bool W>
+std::string Model<W>::toLogBudgetString(const LocalParamType &param,
+                                        const StateType &noise) {
   auto logBudget = toLogBudget(param, noise);
   std::stringstream stream;
   stream << std::fixed << std::setprecision(2) << logBudget;
   return stream.str();
 }
 
-template <bool W, bool P>
-std::string Model<W, P>::toLogTotalString(const LocalParamType &param) {
+template <bool W>
+std::string Model<W>::toLogTotalString(const LocalParamType &param) {
   auto logTotal = toLogTotal(param);
   std::stringstream stream;
   stream << std::fixed << std::setprecision(2) << logTotal;
   return stream.str();
 }
 
-template <bool W, bool P>
-double Model<W, P>::getExpansionFactor(const LocalParamType &param) {
+template <bool W>
+double Model<W>::getExpansionFactor(const LocalParamType &param) {
   auto n = param.getSchemeParam()->getRingDim();
   if constexpr (W) {
     // worst-case
@@ -85,8 +85,8 @@ double Model<W, P>::getExpansionFactor(const LocalParamType &param) {
   }
 }
 
-template <bool W, bool P>
-double Model<W, P>::getBoundErr(const LocalParamType &param) {
+template <bool W>
+double Model<W>::getBoundErr(const LocalParamType &param) {
   auto std0 = param.getSchemeParam()->getStd0();
   // probability of larger than 6 * std0 is less than 2^{-30}
   auto assurance = 6;
@@ -94,15 +94,15 @@ double Model<W, P>::getBoundErr(const LocalParamType &param) {
   return boundErr;
 }
 
-template <bool W, bool P>
-double Model<W, P>::getBoundKey(const LocalParamType &param) {
+template <bool W>
+double Model<W>::getBoundKey(const LocalParamType &param) {
   // assume UNIFORM_TERNARY
   auto boundKey = 1.0;
   return boundKey;
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalEncryptPk(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalEncryptPk(
     const LocalParamType &param) {
   auto boundErr = getBoundErr(param);
   auto boundKey = getBoundKey(param);
@@ -116,8 +116,8 @@ typename Model<W, P>::StateType Model<W, P>::evalEncryptPk(
   return StateType::of(fresh);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalEncryptSk(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalEncryptSk(
     const LocalParamType &param) {
   auto boundErr = getBoundErr(param);
 
@@ -128,36 +128,42 @@ typename Model<W, P>::StateType Model<W, P>::evalEncryptSk(
   return StateType::of(fresh);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalEncrypt(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalEncrypt(
     const LocalParamType &param) {
-  // P stands for public key encryption
-  if constexpr (P) {
-    return evalEncryptPk(param);
-  } else {
-    return evalEncryptSk(param);
+  auto usePublicKey = param.getSchemeParam()->getUsePublicKey();
+  auto isEncryptionTechniqueExtended =
+      param.getSchemeParam()->isEncryptionTechniqueExtended();
+  if (isEncryptionTechniqueExtended) {
+    // for extended encryption technique, namely encrypt at Qp then mod reduce
+    // back to Q, the noise is modreduce(encrypt)
+    return evalModReduce(param, evalEncryptPk(param));
   }
+  if (usePublicKey) {
+    return evalEncryptPk(param);
+  }
+  return evalEncryptSk(param);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalConstant(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalConstant(
     const LocalParamType &param) {
   // constant is m + t * 0
   // v_constant = 0
   return StateType::of(0);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalAdd(const StateType &lhs,
-                                                     const StateType &rhs) {
+template <bool W>
+typename Model<W>::StateType Model<W>::evalAdd(const StateType &lhs,
+                                               const StateType &rhs) {
   // m_0 + tv_0 + m_1 + tv_1 <= [m_0 + m_1]_t + t(v_0 + v_1 + u)
   // v_add = v_0 + v_1 + u
   // where ||u|| <= 1
   return StateType::of(lhs.getValue() + rhs.getValue() + 1);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalMul(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalMul(
     const LocalParamType &resultParam, const StateType &lhs,
     const StateType &rhs) {
   auto t = resultParam.getSchemeParam()->getPlaintextModulus();
@@ -175,8 +181,8 @@ typename Model<W, P>::StateType Model<W, P>::evalMul(
                         rhs.getValue() + 1));
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalModReduce(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalModReduce(
     const LocalParamType &inputParam, const StateType &input) {
   // for cv > 2 the rounding error term is different!
   // like (tau_0, tau_1, tau_2) and the error becomes
@@ -199,12 +205,13 @@ typename Model<W, P>::StateType Model<W, P>::evalModReduce(
   // (tau_0, tau_1) to the (ct_0, ct_1) where ||tau_i|| < t / 2
   // so ||tau_0 + tau_1 * s|| <= t / 2 (1 + delta ||s||)
   // ||v_added|| <= (1 + delta * Bkey) / 2
-  auto added = (1.0 + expansionFactor * boundKey) / 2;
+  // (1.0 + expansionFactor * boundKey) will give underestimation.
+  auto added = 1.0 + expansionFactor * boundKey;
   return StateType::of(scaled + added);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalRelinearizeHYBRID(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalRelinearizeHYBRID(
     const LocalParamType &inputParam, const StateType &input) {
   // for v_input, after modup and moddown, it remains the same (with rounding).
   // We only need to consider the error from key switching key
@@ -252,8 +259,8 @@ typename Model<W, P>::StateType Model<W, P>::evalRelinearizeHYBRID(
   return StateType::of(input.getValue() + scaled + added);
 }
 
-template <bool W, bool P>
-typename Model<W, P>::StateType Model<W, P>::evalRelinearize(
+template <bool W>
+typename Model<W>::StateType Model<W>::evalRelinearize(
     const LocalParamType &inputParam, const StateType &input) {
   // assume HYBRID
   // if we further introduce BV to SchemeParam we can have alternative
@@ -262,10 +269,8 @@ typename Model<W, P>::StateType Model<W, P>::evalRelinearize(
 }
 
 // instantiate template class
-template class NoiseByBoundCoeffModel<false, true>;
-template class NoiseByBoundCoeffModel<true, true>;
-template class NoiseByBoundCoeffModel<false, false>;
-template class NoiseByBoundCoeffModel<true, false>;
+template class NoiseByBoundCoeffModel<false>;
+template class NoiseByBoundCoeffModel<true>;
 
 }  // namespace bgv
 }  // namespace heir

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h
@@ -14,8 +14,8 @@ namespace bgv {
 // coefficient embedding noise model
 // both average-case (from HPS19/KPZ21) and worst-case
 // use template here just for the sake of code reuse
-// W for worst-case, P for public key
-template <bool W, bool P>
+// W for worst-case
+template <bool W>
 class NoiseByBoundCoeffModel {
  public:
   // for KPZ21, NoiseState stores the bound ||e|| for error e
@@ -61,11 +61,8 @@ class NoiseByBoundCoeffModel {
 };
 
 // user-facing typedefs
-using NoiseByBoundCoeffAverageCasePkModel = NoiseByBoundCoeffModel<false, true>;
-using NoiseByBoundCoeffWorstCasePkModel = NoiseByBoundCoeffModel<true, true>;
-using NoiseByBoundCoeffAverageCaseSkModel =
-    NoiseByBoundCoeffModel<false, false>;
-using NoiseByBoundCoeffWorstCaseSkModel = NoiseByBoundCoeffModel<true, false>;
+using NoiseByBoundCoeffAverageCaseModel = NoiseByBoundCoeffModel<false>;
+using NoiseByBoundCoeffWorstCaseModel = NoiseByBoundCoeffModel<true>;
 
 }  // namespace bgv
 }  // namespace heir

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h
@@ -12,9 +12,6 @@ namespace heir {
 namespace bgv {
 
 // coefficient embedding noise model using variance
-// use template here just for the sake of code reuse
-// P for public key
-template <bool P>
 class NoiseByVarianceCoeffModel {
  public:
   // for MP24, NoiseState stores the variance var for the one coefficient of
@@ -61,10 +58,6 @@ class NoiseByVarianceCoeffModel {
   static double toLogTotal(const LocalParamType &param);
   static std::string toLogTotalString(const LocalParamType &param);
 };
-
-// user-facing typedefs
-using NoiseByVarianceCoeffPkModel = NoiseByVarianceCoeffModel<true>;
-using NoiseByVarianceCoeffSkModel = NoiseByVarianceCoeffModel<false>;
 
 }  // namespace bgv
 }  // namespace heir

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h
@@ -13,9 +13,6 @@ namespace bgv {
 
 // canonical embedding noise model from MMLGA22
 // see https://eprint.iacr.org/2022/706
-// use template here just for the sake of code reuse
-// P for public key
-template <bool P>
 class NoiseCanEmbModel {
  public:
   // for MMLGA22, NoiseState stores the bound ||m + t * e||^{can} for error e.
@@ -62,10 +59,6 @@ class NoiseCanEmbModel {
   static double toLogTotal(const LocalParamType &param);
   static std::string toLogTotalString(const LocalParamType &param);
 };
-
-// user-facing typedefs
-using NoiseCanEmbPkModel = NoiseCanEmbModel<true>;
-using NoiseCanEmbSkModel = NoiseCanEmbModel<false>;
 
 }  // namespace bgv
 }  // namespace heir

--- a/lib/Dialect/BGV/IR/BGVAttributes.h
+++ b/lib/Dialect/BGV/IR/BGVAttributes.h
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_BGV_IR_BGVATTRIBUTES_H_
 
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/BGV/IR/BGVEnums.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/BGV/IR/BGVAttributes.h.inc"

--- a/lib/Dialect/BGV/IR/BGVAttributes.td
+++ b/lib/Dialect/BGV/IR/BGVAttributes.td
@@ -3,6 +3,7 @@
 
 include "BGVDialect.td"
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/OpBase.td"
@@ -29,7 +30,9 @@ def BGV_SchemeParam
       "int":$logN,
       "DenseI64ArrayAttr":$Q,
       "DenseI64ArrayAttr":$P,
-      "int64_t":$plaintextModulus
+      "int64_t":$plaintextModulus,
+      DefaultValuedParameter<"BGVEncryptionType", "BGVEncryptionType::pk">:$encryptionType,
+      DefaultValuedParameter<"BGVEncryptionTechnique", "BGVEncryptionTechnique::standard">:$encryptionTechnique
     );
 }
 

--- a/lib/Dialect/BGV/IR/BGVDialect.cpp
+++ b/lib/Dialect/BGV/IR/BGVDialect.cpp
@@ -4,12 +4,14 @@
 #include <optional>
 
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
+#include "lib/Dialect/BGV/IR/BGVEnums.h"
 #include "lib/Dialect/BGV/IR/BGVOps.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
 // IWYU pragma: end_keep
 
 // Generated definitions
 #include "lib/Dialect/BGV/IR/BGVDialect.cpp.inc"
+#include "lib/Dialect/BGV/IR/BGVEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/BGV/IR/BGVAttributes.cpp.inc"
 #define GET_OP_CLASSES

--- a/lib/Dialect/BGV/IR/BGVEnums.h
+++ b/lib/Dialect/BGV/IR/BGVEnums.h
@@ -1,0 +1,9 @@
+#ifndef LIB_DIALECT_BGV_IR_BGVENUMS_H_
+#define LIB_DIALECT_BGV_IR_BGVENUMS_H_
+
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
+
+// Guard against clang-format
+#include "lib/Dialect/BGV/IR/BGVEnums.h.inc"
+
+#endif  // LIB_DIALECT_BGV_IR_BGVENUMS_H_

--- a/lib/Dialect/BGV/IR/BGVEnums.td
+++ b/lib/Dialect/BGV/IR/BGVEnums.td
@@ -1,0 +1,20 @@
+#ifndef LIB_DIALECT_BGV_IR_BGVENUMS_TD_
+#define LIB_DIALECT_BGV_IR_BGVENUMS_TD_
+
+include "mlir/IR/EnumAttr.td"
+
+def BGV_EncryptionTypeEnum : I32EnumAttr<"BGVEncryptionType", "An enum attribute representing an encryption method", [
+  I32EnumAttrCase<"pk", 0>,
+  I32EnumAttrCase<"sk", 1>
+]> {
+    let cppNamespace = "::mlir::heir::bgv";
+}
+
+def BGV_EncryptionTechniqueEnum : I32EnumAttr<"BGVEncryptionTechnique", "An enum attribute representing an encryption technique", [
+  I32EnumAttrCase<"standard", 0>,
+  I32EnumAttrCase<"extended", 1>
+]> {
+    let cppNamespace = "::mlir::heir::bgv";
+}
+
+#endif  // LIB_DIALECT_BGV_IR_BGVENUMS_TD_

--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -17,11 +17,13 @@ cc_library(
     hdrs = [
         "BGVAttributes.h",
         "BGVDialect.h",
+        "BGVEnums.h",
         "BGVOps.h",
     ],
     deps = [
         ":attributes_inc_gen",
         ":dialect_inc_gen",
+        ":enums_inc_gen",
         ":ops_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@llvm-project//llvm:Support",
@@ -36,6 +38,7 @@ td_library(
     srcs = [
         "BGVAttributes.td",
         "BGVDialect.td",
+        "BGVEnums.td",
         "BGVOps.td",
     ],
     deps = [
@@ -71,6 +74,16 @@ add_heir_dialect_library(
     dialect = "BGV",
     kind = "attribute",
     td_file = "BGVAttributes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "BGV",
+    kind = "enum",
+    td_file = "BGVEnums.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/CKKS/IR/BUILD
+++ b/lib/Dialect/CKKS/IR/BUILD
@@ -17,11 +17,13 @@ cc_library(
     hdrs = [
         "CKKSAttributes.h",
         "CKKSDialect.h",
+        "CKKSEnums.h",
         "CKKSOps.h",
     ],
     deps = [
         ":attributes_inc_gen",
         ":dialect_inc_gen",
+        ":enums_inc_gen",
         ":ops_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@llvm-project//llvm:Support",
@@ -34,7 +36,9 @@ cc_library(
 td_library(
     name = "td_files",
     srcs = [
+        "CKKSAttributes.td",
         "CKKSDialect.td",
+        "CKKSEnums.td",
         "CKKSOps.td",
     ],
     deps = [
@@ -70,6 +74,16 @@ add_heir_dialect_library(
     dialect = "CKKS",
     kind = "attribute",
     td_file = "CKKSAttributes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "CKKS",
+    kind = "enum",
+    td_file = "CKKSEnums.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/CKKS/IR/CKKSAttributes.h
+++ b/lib/Dialect/CKKS/IR/CKKSAttributes.h
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_CKKS_IR_CKKSATTRIBUTES_H_
 
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSEnums.h"
 
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/CKKS/IR/CKKSAttributes.h.inc"

--- a/lib/Dialect/CKKS/IR/CKKSAttributes.td
+++ b/lib/Dialect/CKKS/IR/CKKSAttributes.td
@@ -29,7 +29,8 @@ def CKKS_SchemeParam
       "int":$logN,
       "DenseI64ArrayAttr":$Q,
       "DenseI64ArrayAttr":$P,
-      "int":$logDefaultScale
+      "int":$logDefaultScale,
+      DefaultValuedParameter<"CKKSEncryptionType", "CKKSEncryptionType::pk">:$encryptionType
     );
 }
 

--- a/lib/Dialect/CKKS/IR/CKKSDialect.cpp
+++ b/lib/Dialect/CKKS/IR/CKKSDialect.cpp
@@ -1,6 +1,7 @@
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 
 #include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSEnums.h"
 #include "lib/Dialect/CKKS/IR/CKKSOps.h"
 
 // IWYU pragma: begin_keep
@@ -9,6 +10,7 @@
 
 // Generated definitions
 #include "lib/Dialect/CKKS/IR/CKKSDialect.cpp.inc"
+#include "lib/Dialect/CKKS/IR/CKKSEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/CKKS/IR/CKKSAttributes.cpp.inc"
 #define GET_OP_CLASSES

--- a/lib/Dialect/CKKS/IR/CKKSEnums.h
+++ b/lib/Dialect/CKKS/IR/CKKSEnums.h
@@ -1,0 +1,9 @@
+#ifndef LIB_DIALECT_CKKS_IR_CKKSENUMS_H_
+#define LIB_DIALECT_CKKS_IR_CKKSENUMS_H_
+
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+
+// Guard against clang-format
+#include "lib/Dialect/CKKS/IR/CKKSEnums.h.inc"
+
+#endif  // LIB_DIALECT_CKKS_IR_CKKSENUMS_H_

--- a/lib/Dialect/CKKS/IR/CKKSEnums.td
+++ b/lib/Dialect/CKKS/IR/CKKSEnums.td
@@ -1,0 +1,13 @@
+#ifndef LIB_DIALECT_CKKS_IR_CKKSENUMS_TD_
+#define LIB_DIALECT_CKKS_IR_CKKSENUMS_TD_
+
+include "mlir/IR/EnumAttr.td"
+
+def CKKS_EncryptionTypeEnum : I32EnumAttr<"CKKSEncryptionType", "An enum attribute representing an encryption method", [
+  I32EnumAttrCase<"pk", 0>,
+  I32EnumAttrCase<"sk", 1>
+]> {
+    let cppNamespace = "::mlir::heir::ckks";
+}
+
+#endif  // LIB_DIALECT_CKKS_IR_CKKSENUMS_TD_

--- a/lib/Dialect/LWE/Transforms/BUILD
+++ b/lib/Dialect/LWE/Transforms/BUILD
@@ -27,6 +27,9 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@llvm-project//llvm:Support",

--- a/lib/Dialect/LWE/Transforms/Passes.td
+++ b/lib/Dialect/LWE/Transforms/Passes.td
@@ -14,10 +14,6 @@ def AddClientInterface : Pass<"lwe-add-client-interface"> {
   must be encoded as a tensor).
   }];
   let dependentDialects = ["mlir::heir::lwe::LWEDialect"];
-  let options = [
-    Option<"usePublicKey", "use-public-key", "bool", /*default=*/"false",
-           "If true, generate a client interface that uses a public key for encryption.">,
-  ];
 }
 
 def AddDebugPort : Pass<"lwe-add-debug-port"> {

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -82,7 +82,8 @@ def GenParamsOp : Openfhe_Op<"gen_params"> {
     I64Attr:$plainMod,
     BoolAttr:$insecure,
     I64Attr:$evalAddCount,
-    I64Attr:$keySwitchCount
+    I64Attr:$keySwitchCount,
+    BoolAttr:$encryptionTechniqueExtended
   );
   let results = (outs Openfhe_CCParams:$params);
 }

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -26,6 +26,7 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",

--- a/lib/Parameters/BGV/Params.cpp
+++ b/lib/Parameters/BGV/Params.cpp
@@ -14,22 +14,23 @@ namespace mlir {
 namespace heir {
 namespace bgv {
 
-SchemeParam SchemeParam::getConservativeSchemeParam(int level,
-                                                    int64_t plaintextModulus,
-                                                    int slotNumber) {
+SchemeParam SchemeParam::getConservativeSchemeParam(
+    int level, int64_t plaintextModulus, int slotNumber, bool usePublicKey,
+    bool encryptionTechniqueExtended) {
   // Use only half of the BGV slot number to make 1-dim vector.
-  return SchemeParam(
-      RLWESchemeParam::getConservativeRLWESchemeParam(level, 2 * slotNumber),
-      plaintextModulus);
+  return SchemeParam(RLWESchemeParam::getConservativeRLWESchemeParam(
+                         level, 2 * slotNumber, usePublicKey),
+                     plaintextModulus, encryptionTechniqueExtended);
 }
 
-SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
-                                                int64_t plaintextModulus,
-                                                int slotNumber) {
+SchemeParam SchemeParam::getConcreteSchemeParam(
+    std::vector<double> logqi, int64_t plaintextModulus, int slotNumber,
+    bool usePublicKey, bool encryptionTechniqueExtended) {
   // Use only half of the BGV slot number to make 1-dim vector.
-  return SchemeParam(RLWESchemeParam::getConcreteRLWESchemeParam(
-                         std::move(logqi), 2 * slotNumber, plaintextModulus),
-                     plaintextModulus);
+  return SchemeParam(
+      RLWESchemeParam::getConcreteRLWESchemeParam(
+          std::move(logqi), 2 * slotNumber, usePublicKey, plaintextModulus),
+      plaintextModulus, encryptionTechniqueExtended);
 }
 
 SchemeParam SchemeParam::getSchemeParamFromAttr(SchemeParamAttr attr) {
@@ -52,9 +53,12 @@ SchemeParam SchemeParam::getSchemeParamFromAttr(SchemeParamAttr attr) {
   }
   auto level = logqi.size() - 1;
   auto dnum = ceil(static_cast<double>(qiImpl.size()) / piImpl.size());
-  return SchemeParam(
-      RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi, piImpl),
-      plaintextModulus);
+  auto usePublicKey = attr.getEncryptionType() == BGVEncryptionType::pk;
+  auto encryptionTechniqueExtended =
+      attr.getEncryptionTechnique() == BGVEncryptionTechnique::extended;
+  return SchemeParam(RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi,
+                                     piImpl, usePublicKey),
+                     plaintextModulus, encryptionTechniqueExtended);
 }
 
 void SchemeParam::print(llvm::raw_ostream &os) const {

--- a/lib/Parameters/BGV/Params.h
+++ b/lib/Parameters/BGV/Params.h
@@ -15,24 +15,37 @@ namespace bgv {
 // Parameter for BGV scheme at ModuleOp level
 class SchemeParam : public RLWESchemeParam {
  public:
-  SchemeParam(const RLWESchemeParam &rlweSchemeParam, int64_t plaintextModulus)
-      : RLWESchemeParam(rlweSchemeParam), plaintextModulus(plaintextModulus) {}
+  SchemeParam(const RLWESchemeParam &rlweSchemeParam, int64_t plaintextModulus,
+              bool encryptionTechniqueExtended)
+      : RLWESchemeParam(rlweSchemeParam),
+        plaintextModulus(plaintextModulus),
+        encryptionTechniqueExtended(encryptionTechniqueExtended) {}
 
  private:
   // the plaintext modulus for BGV
   int64_t plaintextModulus;
 
+  // the encryption technique used.
+  // if true, use extended encryption technique.
+  // which means encrypt at Qp then mod reduce to Q.
+  // this has the benefit of smaller encryption noise.
+  bool encryptionTechniqueExtended;
+
  public:
   int64_t getPlaintextModulus() const { return plaintextModulus; }
+  bool isEncryptionTechniqueExtended() const {
+    return encryptionTechniqueExtended;
+  }
   void print(llvm::raw_ostream &os) const override;
 
-  static SchemeParam getConservativeSchemeParam(int level,
-                                                int64_t plaintextModulus,
-                                                int slotNumber);
+  static SchemeParam getConservativeSchemeParam(
+      int level, int64_t plaintextModulus, int slotNumber, bool usePublicKey,
+      bool encryptionTechniqueExtended);
 
   static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
                                             int64_t plaintextModulus,
-                                            int slotNumber);
+                                            int slotNumber, bool usePublicKey,
+                                            bool encryptionTechniqueExtended);
 
   static SchemeParam getSchemeParamFromAttr(SchemeParamAttr attr);
 };

--- a/lib/Parameters/CKKS/Params.cpp
+++ b/lib/Parameters/CKKS/Params.cpp
@@ -13,10 +13,11 @@ namespace ckks {
 
 SchemeParam SchemeParam::getConcreteSchemeParam(std::vector<double> logqi,
                                                 int logDefaultScale,
-                                                int slotNumber) {
+                                                int slotNumber,
+                                                bool usePublicKey) {
   // CKKS slot number = ringDim / 2
   return SchemeParam(RLWESchemeParam::getConcreteRLWESchemeParam(
-                         std::move(logqi), 2 * slotNumber),
+                         std::move(logqi), 2 * slotNumber, usePublicKey),
                      logDefaultScale);
 }
 
@@ -40,9 +41,10 @@ SchemeParam SchemeParam::getSchemeParamFromAttr(SchemeParamAttr attr) {
   }
   auto level = logqi.size() - 1;
   auto dnum = ceil(static_cast<double>(qiImpl.size()) / piImpl.size());
-  return SchemeParam(
-      RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi, piImpl),
-      logDefaultScale);
+  auto usePublicKey = attr.getEncryptionType() == CKKSEncryptionType::pk;
+  return SchemeParam(RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi,
+                                     piImpl, usePublicKey),
+                     logDefaultScale);
 }
 
 void SchemeParam::print(llvm::raw_ostream &os) const {

--- a/lib/Parameters/CKKS/Params.h
+++ b/lib/Parameters/CKKS/Params.h
@@ -27,8 +27,8 @@ class SchemeParam : public RLWESchemeParam {
   void print(llvm::raw_ostream &os) const override;
 
   static SchemeParam getConcreteSchemeParam(std::vector<double> logqi,
-                                            int logDefaultScale,
-                                            int slotNumber);
+                                            int logDefaultScale, int slotNumber,
+                                            bool usePublicKey);
 
   static SchemeParam getSchemeParamFromAttr(SchemeParamAttr attr);
 };

--- a/lib/Parameters/RLWEParams.cpp
+++ b/lib/Parameters/RLWEParams.cpp
@@ -29,7 +29,7 @@ int computeDnum(int level) {
 }
 
 RLWESchemeParam RLWESchemeParam::getConservativeRLWESchemeParam(
-    int level, int slotNumber) {
+    int level, int slotNumber, bool usePublicKey) {
   auto logModuli = 60;  // assume all 60 bit moduli
   auto dnum = computeDnum(level);
   std::vector<double> logqi(level + 1, logModuli);
@@ -40,7 +40,7 @@ RLWESchemeParam RLWESchemeParam::getConservativeRLWESchemeParam(
 
   auto ringDim = computeRingDim(totalQP, slotNumber);
 
-  return RLWESchemeParam(ringDim, level, logqi, dnum, logpi);
+  return RLWESchemeParam(ringDim, level, logqi, dnum, logpi, usePublicKey);
 }
 
 int64_t findPrime(int qi, int ringDim,
@@ -79,7 +79,8 @@ int64_t findPrime(int qi, int ringDim,
 }
 
 RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
-    std::vector<double> logqi, int slotNumber, int64_t plaintextModulus) {
+    std::vector<double> logqi, int slotNumber, bool usePublicKey,
+    int64_t plaintextModulus) {
   auto level = logqi.size() - 1;
   auto dnum = computeDnum(level);
 
@@ -145,7 +146,8 @@ RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
     logpi.push_back(log2(pi));
   }
 
-  return RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi, piImpl);
+  return RLWESchemeParam(ringDim, level, logqi, qiImpl, dnum, logpi, piImpl,
+                         usePublicKey);
 }
 
 void RLWESchemeParam::print(llvm::raw_ostream &os) const {
@@ -178,6 +180,7 @@ void RLWESchemeParam::print(llvm::raw_ostream &os) const {
     os << pi << " ";
   }
   os << "\n";
+  os << "usePublicKey: " << usePublicKey << "\n";
 }
 
 }  // namespace heir

--- a/lib/Parameters/RLWEParams.h
+++ b/lib/Parameters/RLWEParams.h
@@ -13,24 +13,26 @@ namespace heir {
 class RLWESchemeParam {
  public:
   RLWESchemeParam(int ringDim, int level, const std::vector<double> &logqi,
-                  int dnum, const std::vector<double> &logpi)
+                  int dnum, const std::vector<double> &logpi, bool usePublicKey)
       : ringDim(ringDim),
         level(level),
         logqi(logqi),
         dnum(dnum),
-        logpi(logpi) {}
+        logpi(logpi),
+        usePublicKey(usePublicKey) {}
 
   RLWESchemeParam(int ringDim, int level, const std::vector<double> &logqi,
                   const std::vector<int64_t> &qi, int dnum,
                   const std::vector<double> &logpi,
-                  const std::vector<int64_t> &pi)
+                  const std::vector<int64_t> &pi, bool usePublicKey)
       : ringDim(ringDim),
         level(level),
         logqi(logqi),
         qi(qi),
         dnum(dnum),
         logpi(logpi),
-        pi(pi) {}
+        pi(pi),
+        usePublicKey(usePublicKey) {}
 
   virtual ~RLWESchemeParam() = default;
 
@@ -62,6 +64,9 @@ class RLWESchemeParam {
   // special modulus
   std::vector<int64_t> pi;
 
+  // whether to use public key
+  bool usePublicKey;
+
  public:
   int getRingDim() const { return ringDim; }
   int getLevel() const { return level; }
@@ -71,6 +76,7 @@ class RLWESchemeParam {
   const std::vector<double> &getLogpi() const { return logpi; }
   const std::vector<int64_t> &getPi() const { return pi; }
   double getStd0() const { return std0; }
+  bool getUsePublicKey() const { return usePublicKey; }
 
   virtual void print(llvm::raw_ostream &os) const;
 
@@ -81,12 +87,14 @@ class RLWESchemeParam {
   }
 
   static RLWESchemeParam getConservativeRLWESchemeParam(int level,
-                                                        int minRingDim);
+                                                        int minRingDim,
+                                                        bool usePublicKey);
 
   // plaintext modulus for BGV
   // for CKKS this field is not used
   static RLWESchemeParam getConcreteRLWESchemeParam(
-      std::vector<double> logqi, int minRingDim, int64_t plaintextModulus = 0);
+      std::vector<double> logqi, int minRingDim, bool usePublicKey,
+      int64_t plaintextModulus = 0);
 };
 
 // Parameter for each RLWE ciphertext SSA value.

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -199,6 +199,9 @@ void mlirToRLWEPipeline(OpPassManager &pm,
       }
       generateParamOptions.plaintextModulus = options.plaintextModulus;
       generateParamOptions.slotNumber = options.ciphertextDegree;
+      generateParamOptions.usePublicKey = options.usePublicKey;
+      generateParamOptions.encryptionTechniqueExtended =
+          options.encryptionTechniqueExtended;
       pm.addPass(createGenerateParamBGV(generateParamOptions));
 
       auto validateNoiseOptions = ValidateNoiseOptions{};
@@ -215,6 +218,9 @@ void mlirToRLWEPipeline(OpPassManager &pm,
       generateParamOptions.modBits = options.bfvModBits;
       generateParamOptions.plaintextModulus = options.plaintextModulus;
       generateParamOptions.slotNumber = options.ciphertextDegree;
+      generateParamOptions.usePublicKey = options.usePublicKey;
+      generateParamOptions.encryptionTechniqueExtended =
+          options.encryptionTechniqueExtended;
       pm.addPass(createGenerateParamBFV(generateParamOptions));
 
       auto validateNoiseOptions = ValidateNoiseOptions{};
@@ -228,6 +234,7 @@ void mlirToRLWEPipeline(OpPassManager &pm,
       generateParamOptions.firstModBits = options.firstModBits;
       generateParamOptions.scalingModBits = options.scalingModBits;
       generateParamOptions.slotNumber = options.ciphertextDegree;
+      generateParamOptions.usePublicKey = options.usePublicKey;
       pm.addPass(createGenerateParamCKKS(generateParamOptions));
       break;
     }
@@ -267,9 +274,7 @@ void mlirToRLWEPipeline(OpPassManager &pm,
   }
 
   // Add client interface (helper functions)
-  auto addClientInterfaceOptions = lwe::AddClientInterfaceOptions{};
-  addClientInterfaceOptions.usePublicKey = options.usePublicKey;
-  pm.addPass(lwe::createAddClientInterface(addClientInterfaceOptions));
+  pm.addPass(lwe::createAddClientInterface());
 
   // TODO (#1145): This should also generate keygen/param gen functions,
   // which can then be lowered to backend specific stuff later.

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -36,9 +36,13 @@ struct MlirToRLWEPipelineOptions : public SimdVectorizerOptions {
       llvm::cl::init(1024)};
   PassOptions::Option<bool> usePublicKey{
       *this, "use-public-key",
-      llvm::cl::desc("If true, generate a client interface that uses a public "
-                     "key for encryption."),
+      llvm::cl::desc("If true, use public key encryption (default to true)"),
       llvm::cl::init(true)};
+  PassOptions::Option<bool> encryptionTechniqueExtended{
+      *this, "encryption-technique-extended",
+      llvm::cl::desc("If true, use extended encryption technique (default to "
+                     "false)"),
+      llvm::cl::init(false)};
   PassOptions::Option<bool> modulusSwitchBeforeFirstMul{
       *this, "modulus-switch-before-first-mul",
       llvm::cl::desc("Modulus switching right before the first multiplication "

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -1091,6 +1091,10 @@ LogicalResult OpenFhePkeEmitter::printOperation(GenParamsOp op) {
   // B/FV defaults to BV, to match HEIR parameter generation we need to
   // set it to HYBRID. Other schemes defaults to HYBRID.
   os << paramsName << ".SetKeySwitchTechnique(HYBRID);\n";
+  // For B/FV, OpenFHE supports EXTENDED encryption technique.
+  if (op.getEncryptionTechniqueExtended()) {
+    os << paramsName << ".SetEncryptionTechnique(EXTENDED);\n";
+  }
   return success();
 }
 

--- a/lib/Transforms/GenerateParam/GenerateParam.td
+++ b/lib/Transforms/GenerateParam/GenerateParam.td
@@ -9,13 +9,13 @@ def GenerateParamBGV : Pass<"generate-param-bgv"> {
     The pass generates the BGV scheme parameter using a given noise model.
 
     There are four noise models available:
-    - `bgv-noise-by-bound-coeff-average-case{-pk,-sk}`
-    - `bgv-noise-by-bound-coeff-worst-case{-pk,-sk}`
-    - `bgv-noise-by-variance-coeff{-pk,-sk}`
-    - `bgv-noise-mono{-pk,-sk}`
+    - `bgv-noise-by-bound-coeff-average-case` or `bgv-noise-kpz21`
+    - `bgv-noise-by-bound-coeff-worst-case`
+    - `bgv-noise-by-variance-coeff` or `bgv-noise-mp24`
+    - `bgv-noise-mono`
 
-    The `-pk`/`-sk` suffixes assume the input ciphertexts are
-    encrypted using the public/secret key.
+    To use public-key encryption/secret-key encryption in the model, the option
+    `usePublicKey` could be set accordingly.
 
     The first two models are taken from KPZ21, and they work by bounding
     the coefficient embedding of the ciphertexts. The difference
@@ -73,11 +73,15 @@ def GenerateParamBGV : Pass<"generate-param-bgv"> {
 
   let options = [
     Option<"model", "model", "std::string",
-           /*default=*/"\"bgv-noise-by-bound-coeff-average-case-pk\"", "Noise model to validate against.">,
+           /*default=*/"\"bgv-noise-kpz21\"", "Noise model to validate against.">,
     Option<"plaintextModulus", "plaintext-modulus", "int64_t",
            /*default=*/"65537", "Plaintext modulus.">,
     Option<"slotNumber", "slot-number", "int",
            /*default=*/"0", "Minimum number of slots for parameter generation.">,
+    Option<"usePublicKey", "use-public-key", "bool", /*default=*/"true",
+           "If true, uses a public key for encryption.">,
+    Option<"encryptionTechniqueExtended", "encryption-technique-extended", "bool", /*default=*/"false",
+           "If true, uses EXTENDED encryption technique for encryption.">,
   ];
 }
 
@@ -87,11 +91,11 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
     The pass generates the BFV scheme parameter using a given noise model.
 
     There are three noise models available:
-    - `bfv-noise-by-bound-coeff-average-case{-pk,-sk}`
-    - `bfv-noise-by-bound-coeff-worst-case{-pk,-sk}`
+    - `bfv-noise-by-bound-coeff-average-case`
+    - `bfv-noise-by-bound-coeff-worst-case` or `bfv-noise-kpz21`
 
-    The `-pk`/`-sk` suffixes assume the input ciphertexts are
-    encrypted using the public/secret key.
+    To use public-key encryption/secret-key encryption in the model, the option
+    `usePublicKey` could be set accordingly.
 
     The first two models are taken from KPZ21, and they work by bounding
     the coefficient embedding of the ciphertexts. The difference
@@ -145,7 +149,7 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
 
   let options = [
     Option<"model", "model", "std::string",
-           /*default=*/"\"bfv-noise-by-bound-coeff-average-case-pk\"", "Noise model to validate against.">,
+           /*default=*/"\"bfv-noise-kpz21\"", "Noise model to validate against.">,
     Option<"modBits", "mod-bits", "int",
            /*default=*/"60", "Default number of bits for all prime coefficient modulus"
            "to use for the ciphertext space.">,
@@ -153,6 +157,10 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
            /*default=*/"0", "Minimum number of slots for parameter generation.">,
     Option<"plaintextModulus", "plaintext-modulus", "int64_t",
            /*default=*/"65537", "Plaintext modulus.">,
+    Option<"usePublicKey", "use-public-key", "bool", /*default=*/"true",
+           "If true, uses a public key for encryption.">,
+    Option<"encryptionTechniqueExtended", "encryption-technique-extended", "bool", /*default=*/"false",
+           "If true, uses EXTENDED encryption technique for encryption.">,
   ];
 }
 
@@ -212,6 +220,8 @@ def GenerateParamCKKS : Pass<"generate-param-ckks"> {
     Option<"scalingModBits", "scaling-mod-bits", "int",
            /*default=*/"45", "Default number of bits of the scaling prime "
            "coefficient modulus to use for the ciphertext space.">,
+    Option<"usePublicKey", "use-public-key", "bool", /*default=*/"true",
+           "If true, uses a public key for encryption.">,
   ];
 }
 

--- a/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
@@ -63,7 +63,7 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
     logPrimes[0] = firstModBits;
 
     auto schemeParam = ckks::SchemeParam::getConcreteSchemeParam(
-        logPrimes, scalingModBits, slotNumber);
+        logPrimes, scalingModBits, slotNumber, usePublicKey);
 
     LLVM_DEBUG(llvm::dbgs() << "Scheme Param:\n" << schemeParam << "\n");
 
@@ -76,7 +76,9 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
                                    ArrayRef(schemeParam.getQi())),
             DenseI64ArrayAttr::get(&getContext(),
                                    ArrayRef(schemeParam.getPi())),
-            schemeParam.getLogDefaultScale()));
+            schemeParam.getLogDefaultScale(),
+            usePublicKey ? ckks::CKKSEncryptionType::pk
+                         : ckks::CKKSEncryptionType::sk));
   }
 };
 

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -187,30 +187,21 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
   }
 
   void runOnOperation() override {
-    if (model == "bgv-noise-by-bound-coeff-worst-case-pk") {
-      run<NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCasePkModel>>();
-    } else if (model == "bgv-noise-by-bound-coeff-average-case-pk") {
-      run<NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCasePkModel>>();
-    } else if (model == "bgv-noise-by-bound-coeff-worst-case-sk") {
-      run<NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCaseSkModel>>();
-    } else if (model == "bgv-noise-by-bound-coeff-average-case-sk") {
-      run<NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCaseSkModel>>();
-    } else if (model == "bgv-noise-by-variance-coeff-pk") {
-      run<NoiseAnalysis<bgv::NoiseByVarianceCoeffPkModel>>();
-    } else if (model == "bgv-noise-by-variance-coeff-sk") {
-      run<NoiseAnalysis<bgv::NoiseByVarianceCoeffSkModel>>();
-    } else if (model == "bfv-noise-by-bound-coeff-worst-case-pk") {
-      run<NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCasePkModel>>();
-    } else if (model == "bfv-noise-by-bound-coeff-average-case-pk") {
-      run<NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCasePkModel>>();
-    } else if (model == "bfv-noise-by-bound-coeff-worst-case-sk") {
-      run<NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCaseSkModel>>();
-    } else if (model == "bfv-noise-by-bound-coeff-average-case-sk") {
-      run<NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseSkModel>>();
-    } else if (model == "bgv-noise-mono-pk") {
-      run<NoiseAnalysis<bgv::NoiseCanEmbPkModel>>();
-    } else if (model == "bgv-noise-mono-sk") {
-      run<NoiseAnalysis<bgv::NoiseCanEmbSkModel>>();
+    if (model == "bgv-noise-by-bound-coeff-worst-case") {
+      run<NoiseAnalysis<bgv::NoiseByBoundCoeffWorstCaseModel>>();
+    } else if (model == "bgv-noise-by-bound-coeff-average-case" ||
+               model == "bgv-noise-kpz21") {
+      run<NoiseAnalysis<bgv::NoiseByBoundCoeffAverageCaseModel>>();
+    } else if (model == "bgv-noise-by-variance-coeff" ||
+               model == "bgv-noise-mp24") {
+      run<NoiseAnalysis<bgv::NoiseByVarianceCoeffModel>>();
+    } else if (model == "bgv-noise-mono") {
+      run<NoiseAnalysis<bgv::NoiseCanEmbModel>>();
+    } else if (model == "bfv-noise-by-bound-coeff-worst-case") {
+      run<NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCaseModel>>();
+    } else if (model == "bfv-noise-by-bound-coeff-average-case" ||
+               model == "bfv-noise-kpz21") {
+      run<NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseModel>>();
     } else {
       getOperation()->emitOpError() << "Unknown noise model.\n";
       signalPassFailure();

--- a/lib/Transforms/ValidateNoise/ValidateNoise.td
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.td
@@ -29,7 +29,7 @@ def ValidateNoise : Pass<"validate-noise"> {
 
   let options = [
     Option<"model", "model", "std::string",
-           /*default=*/"\"bgv-noise-by-bound-coeff-average-case-pk\"", "Noise model to validate against.">,
+           /*default=*/"\"bgv-noise-kpz21\"", "Noise model to validate against.">,
     Option<"annotateNoiseBound", "annotate-noise-bound", "bool",
            /*default=*/"false", "Annotate the noise bound to the IR.">,
   ];

--- a/tests/Dialect/LWE/Transforms/add_client_interface.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface.mlir
@@ -22,20 +22,23 @@
 !in_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<32xi16>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 !out_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
-func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
-  %c31 = arith.constant 31 : index
-  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
-  %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
-  %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
-  %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
-  %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
-  %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
-  %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
-  return %10 : !out_ty
+// encryption type is sk
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [], P = [], plaintextModulus = 65537, encryptionType = sk>, scheme.bgv} {
+  func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
+    %c31 = arith.constant 31 : index
+    %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
+    %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
+    %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
+    %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
+    %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
+    %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
+    %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
+    %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
+    %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
+    %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
+    %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
+    return %10 : !out_ty
+  }
 }
 
 // CHECK-LABEL: @simple_sum

--- a/tests/Dialect/LWE/Transforms/add_client_interface_private_func.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface_private_func.mlir
@@ -22,23 +22,26 @@
 !in_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<32xi16>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 !out_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
-func.func private @external_func(!out_ty) -> !out_ty
+// encryption type is sk
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [], P = [], plaintextModulus = 65537, encryptionType = sk>, scheme.bgv} {
+  func.func private @external_func(!out_ty) -> !out_ty
 
-func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
-  %c31 = arith.constant 31 : index
-  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
-  %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
-  %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
-  %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
-  %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
-  %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
-  %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
-  %11 = func.call @external_func(%10) : (!out_ty) -> !out_ty
-  return %11 : !out_ty
+  func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
+    %c31 = arith.constant 31 : index
+    %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
+    %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
+    %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
+    %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
+    %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
+    %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
+    %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
+    %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
+    %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
+    %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
+    %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
+    %11 = func.call @external_func(%10) : (!out_ty) -> !out_ty
+    return %11 : !out_ty
+  }
 }
 
 // CHECK-LABEL: @simple_sum

--- a/tests/Dialect/LWE/Transforms/add_client_interface_public_key.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface_public_key.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-print-local-scope --lwe-add-client-interface=use-public-key=true %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --lwe-add-client-interface %s | FileCheck %s
 
 !Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
 !Z65537_i64_ = !mod_arith.int<65537 : i64>
@@ -22,20 +22,22 @@
 !in_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<32xi16>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 !out_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
-func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
-  %c31 = arith.constant 31 : index
-  %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
-  %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
-  %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
-  %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
-  %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
-  %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
-  %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
-  %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
-  return %10 : !out_ty
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [], P = [], plaintextModulus = 65537, encryptionType = pk>, scheme.bgv} {
+  func.func @simple_sum(%arg0: !in_ty) -> !out_ty {
+    %c31 = arith.constant 31 : index
+    %0 = bgv.rotate_cols %arg0 { offset = 16 } : !in_ty
+    %1 = bgv.add %arg0, %0 : (!in_ty, !in_ty) -> !in_ty
+    %2 = bgv.rotate_cols %1 { offset = 8 } : !in_ty
+    %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
+    %4 = bgv.rotate_cols %3 { offset = 4 } : !in_ty
+    %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
+    %6 = bgv.rotate_cols %5 { offset = 2 } : !in_ty
+    %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
+    %8 = bgv.rotate_cols %7 { offset = 1 } : !in_ty
+    %9 = bgv.add %7, %8 : (!in_ty, !in_ty) -> !in_ty
+    %10 = bgv.extract %9, %c31 : (!in_ty, index) -> !out_ty
+    return %10 : !out_ty
+  }
 }
 
 // CHECK-LABEL: @simple_sum

--- a/tests/Dialect/LWE/Transforms/add_client_interface_split.mlir
+++ b/tests/Dialect/LWE/Transforms/add_client_interface_split.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt '--lwe-add-client-interface=use-public-key=true' %s | FileCheck %s
+// RUN: heir-opt --lwe-add-client-interface %s | FileCheck %s
 
 !Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
 !Z65537_i64_ = !mod_arith.int<65537 : i64>
@@ -22,18 +22,20 @@
 !mul_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<32xi16>>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_D3_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 !out_ty = !lwe.new_lwe_ciphertext<application_data = <message_type = i16>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
-func.func @dot_product(%arg0: !in_ty, %arg1: !in_ty) -> (!out_ty, !out_ty) {
-  %c7 = arith.constant 7 : index
-  %0 = bgv.mul %arg0, %arg1 : (!in_ty, !in_ty) -> !mul_ty
-  %1 = bgv.relinearize %0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !mul_ty -> !in_ty
-  %2 = bgv.rotate_cols %1 { offset = 4 } : !in_ty
-  %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
-  %4 = bgv.rotate_cols %3 { offset = 2 } : !in_ty
-  %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
-  %6 = bgv.rotate_cols %5 { offset = 1 } : !in_ty
-  %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
-  %8 = bgv.extract %7, %c7 : (!in_ty, index) -> !out_ty
-  return %8, %8 : !out_ty, !out_ty
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [], P = [], plaintextModulus = 65537, encryptionType = pk>, scheme.bgv} {
+  func.func @dot_product(%arg0: !in_ty, %arg1: !in_ty) -> (!out_ty, !out_ty) {
+    %c7 = arith.constant 7 : index
+    %0 = bgv.mul %arg0, %arg1 : (!in_ty, !in_ty) -> !mul_ty
+    %1 = bgv.relinearize %0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !mul_ty -> !in_ty
+    %2 = bgv.rotate_cols %1 { offset = 4 } : !in_ty
+    %3 = bgv.add %1, %2 : (!in_ty, !in_ty) -> !in_ty
+    %4 = bgv.rotate_cols %3 { offset = 2 } : !in_ty
+    %5 = bgv.add %3, %4 : (!in_ty, !in_ty) -> !in_ty
+    %6 = bgv.rotate_cols %5 { offset = 1 } : !in_ty
+    %7 = bgv.add %5, %6 : (!in_ty, !in_ty) -> !in_ty
+    %8 = bgv.extract %7, %c7 : (!in_ty, index) -> !out_ty
+    return %8, %8 : !out_ty, !out_ty
+  }
 }
 
 // CHECK: func.func @dot_product__encrypt__arg0

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -174,7 +174,7 @@ module attributes {scheme.bgv} {
 // CHECK-NOT: SetPlaintextModulus
 module attributes {scheme.ckks} {
   func.func @test_ckks_no_plaintext_modulus() -> !openfhe.crypto_context {
-    %0 = openfhe.gen_params  {insecure = false, mulDepth = 2 : i64, plainMod = 0 : i64, evalAddCount = 0 : i64, keySwitchCount = 0 : i64} : () -> !openfhe.cc_params
+    %0 = openfhe.gen_params  {insecure = false, mulDepth = 2 : i64, plainMod = 0 : i64, evalAddCount = 0 : i64, keySwitchCount = 0 : i64, encryptionTechniqueExtended = false} : () -> !openfhe.cc_params
     %1 = openfhe.gen_context %0 {supportFHE = false} : (!openfhe.cc_params) -> !openfhe.crypto_context
     return %1 : !openfhe.crypto_context
   }

--- a/tests/Examples/lattigo/bfv/dot_product_8/BUILD
+++ b/tests/Examples/lattigo/bfv/dot_product_8/BUILD
@@ -9,7 +9,7 @@ heir_lattigo_lib(
     name = "dot_product_8_bfv",
     go_library_name = "dotproduct8bfv",
     heir_opt_flags = [
-        "--mlir-to-bfv=ciphertext-degree=8",
+        "--mlir-to-bfv=ciphertext-degree=8 encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "dot_product_8.mlir",

--- a/tests/Examples/lattigo/bfv/dot_product_8_debug/BUILD
+++ b/tests/Examples/lattigo/bfv/dot_product_8_debug/BUILD
@@ -17,7 +17,7 @@ heir_lattigo_lib(
     extra_srcs = ["dot_product_8_bfv_debug.go"],
     go_library_name = "dotproduct8bfvdebug",
     heir_opt_flags = [
-        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true encryption-technique-extended=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
     mlir_src = "dot_product_8.mlir",

--- a/tests/Examples/lattigo/bgv/binops/BUILD
+++ b/tests/Examples/lattigo/bgv/binops/BUILD
@@ -9,7 +9,7 @@ heir_lattigo_lib(
     name = "binops",
     go_library_name = "binops",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=4",
+        "--mlir-to-bgv=ciphertext-degree=4 encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "binops.mlir",

--- a/tests/Examples/lattigo/bgv/box_blur/BUILD
+++ b/tests/Examples/lattigo/bgv/box_blur/BUILD
@@ -9,7 +9,7 @@ heir_lattigo_lib(
     name = "box_blur",
     go_library_name = "boxblur",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=786433",
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=786433  encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "box_blur_64x64.mlir",

--- a/tests/Examples/lattigo/bgv/dot_product_8/BUILD
+++ b/tests/Examples/lattigo/bgv/dot_product_8/BUILD
@@ -9,7 +9,7 @@ heir_lattigo_lib(
     name = "dot_product_8",
     go_library_name = "dotproduct8",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=8",
+        "--mlir-to-bgv=ciphertext-degree=8 encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "dot_product_8.mlir",

--- a/tests/Examples/lattigo/bgv/dot_product_8_debug/BUILD
+++ b/tests/Examples/lattigo/bgv/dot_product_8_debug/BUILD
@@ -17,7 +17,7 @@ heir_lattigo_lib(
     extra_srcs = ["dot_product_8_debug.go"],
     go_library_name = "dotproduct8debug",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bgv=ciphertext-degree=8 annotate-noise-bound=true encryption-technique-extended=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
     mlir_src = "dot_product_8.mlir",

--- a/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/BUILD
+++ b/tests/Examples/lattigo/bgv/dot_product_8_debug_mono/BUILD
@@ -17,7 +17,7 @@ heir_lattigo_lib(
     extra_srcs = ["dot_product_8_debug.go"],
     go_library_name = "dotproduct8debug",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=8 noise-model=bgv-noise-mono-pk annotate-noise-bound=true",
+        "--mlir-to-bgv=ciphertext-degree=8 noise-model=bgv-noise-mono annotate-noise-bound=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
     mlir_src = "dot_product_8.mlir",

--- a/tests/Examples/lattigo/bgv/dot_product_8_sk/BUILD
+++ b/tests/Examples/lattigo/bgv/dot_product_8_sk/BUILD
@@ -9,7 +9,7 @@ heir_lattigo_lib(
     name = "dot_product_8_sk",
     go_library_name = "dotproduct8sk",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=8 use-public-key=false",
+        "--mlir-to-bgv=ciphertext-degree=8 use-public-key=false encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "dot_product_8.mlir",

--- a/tests/Examples/lattigo/bgv/roberts_cross/BUILD
+++ b/tests/Examples/lattigo/bgv/roberts_cross/BUILD
@@ -9,7 +9,7 @@ heir_lattigo_lib(
     name = "roberts_cross",
     go_library_name = "robertscross",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=536903681",
+        "--mlir-to-bgv=ciphertext-degree=4096 plaintext-modulus=536903681 encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "roberts_cross_64x64.mlir",

--- a/tests/Examples/lattigo/bgv/simple_sum/BUILD
+++ b/tests/Examples/lattigo/bgv/simple_sum/BUILD
@@ -18,7 +18,7 @@ heir_lattigo_lib(
     name = "simple_sum",
     go_library_name = "simplesum",
     heir_opt_flags = [
-        "--mlir-to-bgv=ciphertext-degree=32",
+        "--mlir-to-bgv=ciphertext-degree=32 encryption-technique-extended=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "simple_sum.mlir",

--- a/tests/Transforms/validate_noise/validate_noise_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_fail.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise="model=bgv-noise-by-bound-coeff-worst-case-pk" --verify-diagnostics %s
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise="model=bgv-noise-by-bound-coeff-worst-case" --verify-diagnostics %s
 
 // This is only for testing whether validate-noise would fail, but
 // not for testing the noise model.

--- a/tests/Transforms/validate_noise/validate_noise_pass.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_pass.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --generate-param-bgv --validate-noise=model=bgv-noise-by-bound-coeff-average-case-pk %s | FileCheck %s
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --generate-param-bgv --validate-noise=model=bgv-noise-by-bound-coeff-average-case %s | FileCheck %s
 
 // CHECK-LABEL: @dot_product
 func.func @dot_product(%arg0: tensor<8xi16> {secret.secret}, %arg1: tensor<8xi16> {secret.secret}) -> i16 {

--- a/tests/Transforms/validate_noise/validate_noise_preserve_user_param.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_preserve_user_param.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise=model=bgv-noise-by-bound-coeff-average-case-pk %s | FileCheck %s
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise=model=bgv-noise-kpz21 %s | FileCheck %s
 
 // CHECK: module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [2148728833, 2148794369, 1152921504607338497], P = [1152921504608747521, 1152921504609239041], plaintextModulus = 65537>, scheme.bgv} {
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [2148728833, 2148794369, 1152921504607338497], P = [1152921504608747521, 1152921504609239041], plaintextModulus = 65537>, scheme.bgv} {

--- a/tests/Transforms/validate_noise/validate_noise_preserve_user_param_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_preserve_user_param_fail.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise=model=bgv-noise-by-bound-coeff-average-case-pk %s --verify-diagnostics --split-input-file
+// RUN: heir-opt --mlir-to-secret-arithmetic --secret-insert-mgmt-bgv --validate-noise=model=bgv-noise-kpz21 %s --verify-diagnostics --split-input-file
 
 // expected-error@below {{'builtin.module' op The level in the scheme param is smaller than the max level.}}
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 11, Q = [17], P = [1093633], plaintextModulus = 65537>} {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -38,7 +38,7 @@ cc_binary(
     deps = [
         "@heir//lib/Analysis/NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseCoeffModelAnalysis",  # buildcleaner: keep
-        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCoeffModelAnalysis",  # buildcleaner: keep
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGI",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGIQuart",


### PR DESCRIPTION
As the number of noise model becomes larger, it might be favorable to reduce possible template parameters like -pk/-sk. Instead these options could be read from SchemeParam.

This PR made the following changes

* Added `usePublicKey` option to `SchemeParam` for BGV/BFV/CKKS
* Added `encryptionTechniqueExtended` option to `SchemeParam` for BGV/BFV
  + In short, messages are first encrypted at Qp then mod reduced to Q, this will have less initial noise
  + This is useful for Lattigo BGV/BFV as it defaults to the extended technique
  + Openfhe also support this option, only for BFV
  + I am still studying the noise model using Lattigo so this mode available would be convenient otherwise the model will be inaccurate
* Added these option in `SchemeParamAttr` accordingly
* Changed noise model to respect these option from `SchemeParam` and remove numerous template instantiation
* Changed `lwe-add-client-interface` to recognize `usePublicKey` from `SchemeParam` instead of from pass options
* Changed Openfhe `ConfigureCryptoContext`/`Emitter` to recognize the encryption technique. 