### PR TITLE
B/FV: use msb encryption type in LWE type

### DIFF
--- a/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/BUILD
@@ -13,6 +13,7 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -161,7 +161,7 @@ class SecretToCKKSTypeConverter
             ctx, plaintextRing, lwe::InverseCanonicalEncodingAttr::get(ctx, 0)),
         lwe::CiphertextSpaceAttr::get(ctx,
                                       getRlweRNSRingWithLevel(ring_, level),
-                                      lwe::LweEncryptionType::lsb, dimension),
+                                      lwe::LweEncryptionType::mix, dimension),
         lwe::KeyAttr::get(ctx, 0),
         lwe::ModulusChainAttr::get(ctx, moduliChain, level));
 

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/bfv.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/bfv.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt --mlir-print-local-scope --canonicalize --secret-to-bgv %s | FileCheck %s
+
+!eui1 = !secret.secret<tensor<1024xi1>>
+#mgmt = #mgmt.mgmt<level = 0, dimension = 2>
+
+module attributes {scheme.bfv, bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [67239937, 17179967489, 17180262401, 17180295169, 17180393473, 70368744210433], P = [70368744570881, 70368744701953], plaintextModulus = 65537>} {
+  // CHECK-LABEL: func @test_arith_ops
+  func.func @test_arith_ops(%arg0 : !eui1 {mgmt.mgmt = #mgmt}, %arg1 : !eui1 {mgmt.mgmt = #mgmt}, %arg2 : !eui1 {mgmt.mgmt = #mgmt}) -> (!eui1 {mgmt.mgmt = #mgmt}) {
+    %0 = secret.generic ins(%arg0, %arg1 :  !eui1, !eui1) attrs = {__resattrs = [{mgmt.mgmt = #mgmt}]} {
+    // CHECK: bgv.add
+    // CHECK-SAME: encryption_type = msb
+      ^bb0(%ARG0 : tensor<1024xi1>, %ARG1 : tensor<1024xi1>):
+        %1 = arith.addi %ARG0, %ARG1 : tensor<1024xi1>
+        secret.yield %1 : tensor<1024xi1>
+    } -> !eui1
+    // CHECK: return
+    return %0 : !eui1
+  }
+}


### PR DESCRIPTION
B/FV should has encryption type specified as `msb` instead of the BGV `lsb` in LWE type. For CKKS it should be `mixed`.