### PR TITLE
[WIP]: generalize polynomial.eval lowering via a dialect interface

### DIFF
--- a/lib/Dialect/BUILD
+++ b/lib/Dialect/BUILD
@@ -14,6 +14,7 @@ cc_library(
     hdrs = ["HEIRInterfaces.h"],
     deps = [
         ":interfaces_inc_gen",
+        "@heir//lib/Dialect/Polynomial/IR:PolynomialAttributes",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:IR",
     ],

--- a/lib/Dialect/HEIRInterfaces.cpp
+++ b/lib/Dialect/HEIRInterfaces.cpp
@@ -8,6 +8,22 @@ namespace mlir {
 namespace heir {
 #include "lib/Dialect/HEIRInterfaces.cpp.inc"
 
+bool PolynomialEvalInterface::supportsPolynomial(Attribute polynomialAttr,
+                                                 Dialect *dialect) {
+  if (auto *handler = getInterfaceFor(dialect))
+    return handler->supportsPolynomial(polynomialAttr);
+  return false;
+}
+
+FailureOr<Value> PolynomialEvalInterface::constructConstant(
+    OpBuilder &builder, Location loc, Attribute constantAttr,
+    Type evaluatedType, Dialect *dialect) {
+  if (auto *handler = getInterfaceFor(dialect))
+    return handler->constructConstant(builder, loc, constantAttr,
+                                      evaluatedType);
+  return failure();
+}
+
 void registerOperandAndResultAttrInterface(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, affine::AffineDialect *dialect) {
     affine::AffineForOp::attachInterface<OperandAndResultAttrInterface>(*ctx);

--- a/lib/Dialect/HEIRInterfaces.cpp
+++ b/lib/Dialect/HEIRInterfaces.cpp
@@ -1,5 +1,6 @@
 #include "lib/Dialect/HEIRInterfaces.h"
 
+#include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/DialectRegistry.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"      // from @llvm-project
@@ -45,9 +46,57 @@ Value PolynomialEvalInterface::constructAdd(OpBuilder &builder, Location loc,
   return Value();
 }
 
+// Interface implementations of upstream dialects
+namespace {
+struct ArithPolynomialEvalInterface : public DialectPolynomialEvalInterface {
+  using DialectPolynomialEvalInterface::DialectPolynomialEvalInterface;
+
+  bool supportsPolynomial(Attribute polynomialAttr) const final {
+    return isa<::mlir::heir::polynomial::IntPolynomialAttr,
+               ::mlir::heir::polynomial::TypedIntPolynomialAttr,
+               ::mlir::heir::polynomial::FloatPolynomialAttr,
+               ::mlir::heir::polynomial::TypedFloatPolynomialAttr>(
+        polynomialAttr);
+  }
+
+  Value constructConstant(OpBuilder &builder, Location loc,
+                          Attribute constantAttr,
+                          Type evaluatedType) const final {
+    TypedAttr typedAttr = dyn_cast<TypedAttr>(constantAttr);
+    return builder
+        .create<::mlir::arith::ConstantOp>(loc, evaluatedType, typedAttr)
+        .getResult();
+  }
+
+  Value constructMul(OpBuilder &builder, Location loc, Value lhs,
+                     Value rhs) const final {
+    if (lhs.getType().isFloat() && rhs.getType().isFloat()) {
+      return builder.create<::mlir::arith::MulFOp>(loc, lhs, rhs).getResult();
+    }
+
+    return builder.create<::mlir::arith::MulIOp>(loc, lhs, rhs).getResult();
+  }
+
+  Value constructAdd(OpBuilder &builder, Location loc, Value lhs,
+                     Value rhs) const final {
+    if (lhs.getType().isFloat() && rhs.getType().isFloat()) {
+      return builder.create<::mlir::arith::AddFOp>(loc, lhs, rhs).getResult();
+    }
+
+    return builder.create<::mlir::arith::AddIOp>(loc, lhs, rhs).getResult();
+  }
+};
+}  // namespace
+
 void registerOperandAndResultAttrInterface(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, affine::AffineDialect *dialect) {
     affine::AffineForOp::attachInterface<OperandAndResultAttrInterface>(*ctx);
+  });
+}
+
+void registerPolynomialEvalInterface(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, arith::ArithDialect *dialect) {
+    dialect->addInterfaces<ArithPolynomialEvalInterface>();
   });
 }
 

--- a/lib/Dialect/HEIRInterfaces.cpp
+++ b/lib/Dialect/HEIRInterfaces.cpp
@@ -15,13 +15,34 @@ bool PolynomialEvalInterface::supportsPolynomial(Attribute polynomialAttr,
   return false;
 }
 
-FailureOr<Value> PolynomialEvalInterface::constructConstant(
-    OpBuilder &builder, Location loc, Attribute constantAttr,
-    Type evaluatedType, Dialect *dialect) {
+Value PolynomialEvalInterface::constructConstant(OpBuilder &builder,
+                                                 Location loc,
+                                                 Attribute constantAttr,
+                                                 Type evaluatedType,
+                                                 Dialect *dialect) {
   if (auto *handler = getInterfaceFor(dialect))
     return handler->constructConstant(builder, loc, constantAttr,
                                       evaluatedType);
-  return failure();
+  llvm_unreachable("unsupported dialect");
+  return Value();
+}
+
+Value PolynomialEvalInterface::constructMul(OpBuilder &builder, Location loc,
+                                            Value lhs, Value rhs,
+                                            Dialect *dialect) {
+  if (auto *handler = getInterfaceFor(dialect))
+    return handler->constructMul(builder, loc, lhs, rhs);
+  llvm_unreachable("unsupported dialect");
+  return Value();
+}
+
+Value PolynomialEvalInterface::constructAdd(OpBuilder &builder, Location loc,
+                                            Value lhs, Value rhs,
+                                            Dialect *dialect) {
+  if (auto *handler = getInterfaceFor(dialect))
+    return handler->constructAdd(builder, loc, lhs, rhs);
+  llvm_unreachable("unsupported dialect");
+  return Value();
 }
 
 void registerOperandAndResultAttrInterface(DialectRegistry &registry) {

--- a/lib/Dialect/HEIRInterfaces.h
+++ b/lib/Dialect/HEIRInterfaces.h
@@ -17,11 +17,11 @@
 namespace mlir {
 namespace heir {
 
-/// This class defines a Dialect Interface for any dialect wants to support
-/// polynomial evaluation. The polynomial.eval op support an arbitrary input
-/// type, and so this interface provides the necessary hooks to construct
-/// multiplication and addition ops that work with that type, as well as
-/// how to convert constants into the appropriate type.
+/// This class defines a Dialect Interface for any dialect that wants to loewr
+/// polynomial evaluation via lower-polynomial-eval. The polynomial.eval op
+/// support an arbitrary input type, and so this interface provides the
+/// necessary hooks to construct multiplication and addition ops that work with
+/// that type, as well as how to convert constants into the appropriate type.
 class DialectPolynomialEvalInterface
     : public DialectInterface::Base<DialectPolynomialEvalInterface> {
  public:
@@ -52,7 +52,7 @@ class DialectPolynomialEvalInterface
                                   Attribute constantAttr,
                                   Type evaluatedType) const = 0;
 
-  // FIXME: add add, mul, scalar_add, scalar_mul interface methods
+  // FIXME: add add, mul interface methods
 };
 
 // This is a convenience wrapper that collects all dialects implementing the

--- a/lib/Dialect/HEIRInterfaces.h
+++ b/lib/Dialect/HEIRInterfaces.h
@@ -109,6 +109,7 @@ class PolynomialEvalInterface
 };
 
 void registerOperandAndResultAttrInterface(DialectRegistry &registry);
+void registerPolynomialEvalInterface(DialectRegistry &registry);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/HEIRInterfaces.h
+++ b/lib/Dialect/HEIRInterfaces.h
@@ -52,6 +52,38 @@ class DialectPolynomialEvalInterface
                                   Attribute constantAttr,
                                   Type evaluatedType) const = 0;
 
+  // Construct one or more operations that implement a multiplication
+  // between two values of the appropriate type for this dialect.
+  //
+  // Inputs:
+  //
+  //   - builder: the OpBuilder to use for construction
+  //   - loc: the location to use for op construction
+  //   - lhs: the lhs of the multiplication
+  //   - rhs: the rhs of the multiplication
+  //
+  //  Returns:
+  //
+  //    a Value corresponding to the result of the multiplication
+  virtual Value constructMul(OpBuilder &builder, Location loc, Value lhs,
+                             Value rhs) const = 0;
+
+  // Construct one or more operations that implement an addition
+  // between two values of the appropriate type for this dialect.
+  //
+  // Inputs:
+  //
+  //   - builder: the OpBuilder to use for construction
+  //   - loc: the location to use for op construction
+  //   - lhs: the lhs of the addition
+  //   - rhs: the rhs of the addition
+  //
+  //  Returns:
+  //
+  //    a Value corresponding to the result of the addition
+  virtual Value constructAdd(OpBuilder &builder, Location loc, Value lhs,
+                             Value rhs) const = 0;
+
   // FIXME: add add, mul interface methods
 };
 
@@ -65,9 +97,15 @@ class PolynomialEvalInterface
 
   bool supportsPolynomial(Attribute polynomialAttr, Dialect *dialect);
 
-  FailureOr<Value> constructConstant(OpBuilder &builder, Location loc,
-                                     Attribute constantAttr, Type evaluatedType,
-                                     Dialect *dialect);
+  Value constructConstant(OpBuilder &builder, Location loc,
+                          Attribute constantAttr, Type evaluatedType,
+                          Dialect *dialect);
+
+  Value constructMul(OpBuilder &builder, Location loc, Value lhs, Value rhs,
+                     Dialect *dialect);
+
+  Value constructAdd(OpBuilder &builder, Location loc, Value lhs, Value rhs,
+                     Dialect *dialect);
 };
 
 void registerOperandAndResultAttrInterface(DialectRegistry &registry);

--- a/lib/Dialect/HEIRInterfaces.h
+++ b/lib/Dialect/HEIRInterfaces.h
@@ -1,11 +1,12 @@
 #ifndef LIB_DIALECT_HEIRINTERFACES_H_
 #define LIB_DIALECT_HEIRINTERFACES_H_
 
+#include "mlir/include/mlir/IR/Builders.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"            // from @llvm-project
+
 // IWYU pragma: begin_keep
-#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
-#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 
 // Don't mess up order
@@ -15,6 +16,59 @@
 
 namespace mlir {
 namespace heir {
+
+/// This class defines a Dialect Interface for any dialect wants to support
+/// polynomial evaluation. The polynomial.eval op support an arbitrary input
+/// type, and so this interface provides the necessary hooks to construct
+/// multiplication and addition ops that work with that type, as well as
+/// how to convert constants into the appropriate type.
+class DialectPolynomialEvalInterface
+    : public DialectInterface::Base<DialectPolynomialEvalInterface> {
+ public:
+  DialectPolynomialEvalInterface(Dialect *dialect) : Base(dialect) {}
+
+  // Returns true if the dialect supports evaluation of the given polynomial
+  // attribute. This would be false, for example, in the mod_arith dialect when
+  // given a floating-point polynomial attribute as input.
+  virtual bool supportsPolynomial(Attribute polynomialAttr) const = 0;
+
+  // Construct one or more operations that convert the input integer or
+  // floating point attribute to the appropriate type for this dialect. The
+  // implementation should use the given OpBuilder to construct one or more
+  // operations, and return a Value corresponding to the result of the
+  // construction.
+  //
+  // Inputs:
+  //
+  //   - builder: the OpBuilder to use for construction
+  //   - loc: the location to use for op construction
+  //   - constantAttr: the constant attribute to convert
+  //   - evaluatedType: the type of the input to the polynomial.eval op
+  //
+  //  Returns:
+  //
+  //    a Value corresponding to the result of the construction
+  virtual Value constructConstant(OpBuilder &builder, Location loc,
+                                  Attribute constantAttr,
+                                  Type evaluatedType) const = 0;
+
+  // FIXME: add add, mul, scalar_add, scalar_mul interface methods
+};
+
+// This is a convenience wrapper that collects all dialects implementing the
+// DialectPolynomialEvalInterface, and provides a lookup from Operation* or
+// Dialect* to the relevant interface.
+class PolynomialEvalInterface
+    : public DialectInterfaceCollection<DialectPolynomialEvalInterface> {
+ public:
+  using Base::Base;
+
+  bool supportsPolynomial(Attribute polynomialAttr, Dialect *dialect);
+
+  FailureOr<Value> constructConstant(OpBuilder &builder, Location loc,
+                                     Attribute constantAttr, Type evaluatedType,
+                                     Dialect *dialect);
+};
 
 void registerOperandAndResultAttrInterface(DialectRegistry &registry);
 

--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -23,6 +23,8 @@ cc_library(
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":types_inc_gen",
+        "@heir//lib/Dialect:HEIRInterfaces",
+        "@heir//lib/Dialect/Polynomial/IR:PolynomialAttributes",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:CommonFolders",

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -54,7 +54,8 @@ struct ModArithPolynomialEvalInterface : public DialectPolynomialEvalInterface {
   bool supportsPolynomial(Attribute polynomialAttr) const final {
     // raw int polynomials are supported, as well as int polynomials that are
     // typed to have, say, mod_arith coefficients.
-    return isa<polynomial::IntPolynomialAttr>(polynomialAttr);
+    return isa<polynomial::IntPolynomialAttr,
+               polynomial::TypedIntPolynomialAttr>(polynomialAttr);
   }
 
   Value constructConstant(OpBuilder &builder, Location loc,

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -52,8 +52,6 @@ struct ModArithPolynomialEvalInterface : public DialectPolynomialEvalInterface {
   using DialectPolynomialEvalInterface::DialectPolynomialEvalInterface;
 
   bool supportsPolynomial(Attribute polynomialAttr) const final {
-    // raw int polynomials are supported, as well as int polynomials that are
-    // typed to have, say, mod_arith coefficients.
     return isa<polynomial::IntPolynomialAttr,
                polynomial::TypedIntPolynomialAttr>(polynomialAttr);
   }
@@ -68,6 +66,16 @@ struct ModArithPolynomialEvalInterface : public DialectPolynomialEvalInterface {
             loc, modType,
             IntegerAttr::get(modType.getModulus().getType(), intAttr.getInt()))
         .getResult();
+  }
+
+  Value constructMul(OpBuilder &builder, Location loc, Value lhs,
+                     Value rhs) const final {
+    return builder.create<MulOp>(loc, lhs, rhs).getResult();
+  }
+
+  Value constructAdd(OpBuilder &builder, Location loc, Value lhs,
+                     Value rhs) const final {
+    return builder.create<AddOp>(loc, lhs, rhs).getResult();
   }
 };
 }  // namespace

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -59,13 +59,8 @@ struct ModArithPolynomialEvalInterface : public DialectPolynomialEvalInterface {
   Value constructConstant(OpBuilder &builder, Location loc,
                           Attribute constantAttr,
                           Type evaluatedType) const final {
-    auto modType = cast<ModArithType>(evaluatedType);
     auto intAttr = cast<IntegerAttr>(constantAttr);
-    return builder
-        .create<ConstantOp>(
-            loc, modType,
-            IntegerAttr::get(modType.getModulus().getType(), intAttr.getInt()))
-        .getResult();
+    return builder.create<ConstantOp>(loc, evaluatedType, intAttr).getResult();
   }
 
   Value constructMul(OpBuilder &builder, Location loc, Value lhs,

--- a/lib/Dialect/Polynomial/IR/BUILD
+++ b/lib/Dialect/Polynomial/IR/BUILD
@@ -8,10 +8,17 @@ package(
 
 cc_library(
     name = "Dialect",
-    srcs = glob(["*.cpp"]),
-    hdrs = glob(["*.h"]),
+    srcs = [
+        "PolynomialDialect.cpp",
+        "PolynomialOps.cpp",
+    ],
+    hdrs = [
+        "PolynomialDialect.h",
+        "PolynomialOps.h",
+        "PolynomialTypes.h",
+    ],
     deps = [
-        ":attributes_inc_gen",
+        ":PolynomialAttributes",
         ":canonicalization_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
@@ -23,6 +30,23 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+# ModArith implementation of PolynomialEvalInterface requires knowledge of
+# IntPolynomialAttr. So give a library for PolynomialAttributes alone.
+cc_library(
+    name = "PolynomialAttributes",
+    srcs = ["PolynomialAttributes.cpp"],
+    hdrs = [
+        "PolynomialAttributes.h",
+        "PolynomialDialect.h",
+    ],
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        "@heir//lib/Utils/Polynomial",
+        "@llvm-project//mlir:IR",
     ],
 )
 

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.h
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.h
@@ -1,8 +1,10 @@
 #ifndef LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALATTRIBUTES_H_
 #define LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALATTRIBUTES_H_
 
+// IWYU pragma: begin_keep
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "lib/Utils/Polynomial/Polynomial.h"
+// IWYU pragma: end_keep
 
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h.inc"

--- a/lib/Dialect/Polynomial/IR/PolynomialDialect.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialDialect.cpp
@@ -1,5 +1,6 @@
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
 
+// IWYU pragma: begin_keep
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
@@ -17,6 +18,7 @@
 #include "mlir/include/mlir/IR/PatternMatch.h"         // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+// IWYU pragma: end_keep
 
 using namespace mlir;
 using namespace mlir::heir::polynomial;

--- a/lib/Dialect/Polynomial/IR/PolynomialDialect.h
+++ b/lib/Dialect/Polynomial/IR/PolynomialDialect.h
@@ -1,10 +1,12 @@
 #ifndef LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALDIALECT_H_
 #define LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALDIALECT_H_
 
+// IWYU pragma: begin_keep
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+// IWYU pragma: end_keep
 
 // Generated headers (block clang-format from messing up order)
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h.inc"

--- a/lib/Transforms/LowerPolynomialEval/BUILD
+++ b/lib/Transforms/LowerPolynomialEval/BUILD
@@ -1,0 +1,27 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "LowerPolynomialEval",
+    srcs = ["LowerPolynomialEval.cpp"],
+    hdrs = ["LowerPolynomialEval.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect:HEIRInterfaces",
+        "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "LowerPolynomialEval",
+    td_file = "LowerPolynomialEval.td",
+)

--- a/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.cpp
+++ b/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.cpp
@@ -17,38 +17,126 @@ namespace heir {
 #define GEN_PASS_DEF_LOWERPOLYNOMIALEVAL
 #include "lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h.inc"
 
+struct LoweringBase : public OpRewritePattern<polynomial::EvalOp> {
+  LoweringBase(mlir::MLIRContext *context, bool force = false,
+               const std::string &dialect = "")
+      : mlir::OpRewritePattern<polynomial::EvalOp>(context),
+        force(force),
+        dialect(dialect) {}
+
+  Dialect *getDialect(polynomial::EvalOp op) const {
+    PolynomialEvalInterface evalInterface(op.getContext());
+    return dialect.empty() ? &op.getValue().getType().getDialect()
+                           : op.getContext()->getOrLoadDialect(dialect);
+  }
+
+ private:
+  // Force the use of this pattern, ignoring any heuristics on whether to apply
+  // it.
+  const bool force;
+
+  // A dialect override provided via flag to use with the
+  // PolynomialEvalInterface.
+  const std::string dialect;
+};
+
+struct LowerViaHorner : public LoweringBase {
+  using LoweringBase::LoweringBase;
+
+  LogicalResult matchAndRewrite(polynomial::EvalOp op,
+                                PatternRewriter &rewriter) const override {
+    Dialect *dialect = getDialect(op);
+    PolynomialEvalInterface interface(op.getContext());
+
+    // FIXME: if force, ignore heuristics on whether to use this method
+    // FIXME: add lowering
+
+    return success();
+  }
+};
+
+struct LowerViaPatersonStockmeyerMonomial : public LoweringBase {
+  using LoweringBase::LoweringBase;
+
+  LogicalResult matchAndRewrite(polynomial::EvalOp op,
+                                PatternRewriter &rewriter) const override {
+    Dialect *dialect = getDialect(op);
+    PolynomialEvalInterface interface(op.getContext());
+
+    // FIXME: if force, ignore heuristics on whether to use this method
+    // FIXME: add lowering
+
+    return success();
+  }
+};
+
+struct LowerViaClenshaw : public LoweringBase {
+  using LoweringBase::LoweringBase;
+
+  LogicalResult matchAndRewrite(polynomial::EvalOp op,
+                                PatternRewriter &rewriter) const override {
+    Dialect *dialect = getDialect(op);
+    PolynomialEvalInterface interface(op.getContext());
+    return failure();
+  }
+};
+
+struct LowerViaPatersonStockmeyerChebyshev : public LoweringBase {
+  using LoweringBase::LoweringBase;
+
+  LogicalResult matchAndRewrite(polynomial::EvalOp op,
+                                PatternRewriter &rewriter) const override {
+    Dialect *dialect = getDialect(op);
+    PolynomialEvalInterface interface(op.getContext());
+    return failure();
+  }
+};
+
+struct LowerViaBabyStepGiantStep : public LoweringBase {
+  using LoweringBase::LoweringBase;
+
+  LogicalResult matchAndRewrite(polynomial::EvalOp op,
+                                PatternRewriter &rewriter) const override {
+    Dialect *dialect = getDialect(op);
+    PolynomialEvalInterface interface(op.getContext());
+    return failure();
+  }
+};
+
 struct LowerPolynomialEval
     : impl::LowerPolynomialEvalBase<LowerPolynomialEval> {
   using LowerPolynomialEvalBase::LowerPolynomialEvalBase;
-
-  // FIXME: replace with actual lowering patterns
-  struct DebugPrintPattern : public OpRewritePattern<polynomial::EvalOp> {
-    DebugPrintPattern(mlir::MLIRContext *context)
-        : mlir::OpRewritePattern<polynomial::EvalOp>(context) {}
-
-    LogicalResult matchAndRewrite(polynomial::EvalOp op,
-                                  PatternRewriter &rewriter) const override {
-      LLVM_DEBUG(llvm::dbgs() << "Lowering polynomial::EvalOp: " << op << "\n");
-
-      PolynomialEvalInterface evalInterface(op.getContext());
-      Dialect *valueDialect = &op.getValue().getType().getDialect();
-      if (!evalInterface.supportsPolynomial(op.getPolynomial(), valueDialect)) {
-        return op.emitOpError()
-               << "dialect for input type " << op.getValue().getType()
-               << " does not support polynomial " << op.getPolynomial();
-      }
-
-      rewriter.modifyOpInPlace(
-          op, [&]() { op->setAttr("lowered", rewriter.getUnitAttr()); });
-      return success();
-    }
-  };
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
 
-    patterns.add<DebugPrintPattern>(context);
+    if (method.hasValue() && !method.empty()) {
+      if (method == "horner") {
+        patterns.add<LowerViaHorner>(context, /*force=*/true, dialect);
+      } else if (method == "ps") {
+        patterns.add<LowerViaPatersonStockmeyerMonomial>(
+            context, /*force=*/true, dialect);
+      } else if (method == "clenshaw") {
+        patterns.add<LowerViaClenshaw>(context, /*force=*/true, dialect);
+      } else if (method == "ps-cheb") {
+        patterns.add<LowerViaPatersonStockmeyerChebyshev>(
+            context, /*force=*/true, dialect);
+      } else if (method == "bsgs") {
+        patterns.add<LowerViaBabyStepGiantStep>(context, /*force=*/true,
+                                                dialect);
+      } else {
+        getOperation()->emitError() << "Unknown lowering method: " << method;
+        signalPassFailure();
+        return;
+      }
+    } else {
+      patterns.add<LowerViaHorner, LowerViaBabyStepGiantStep,
+                   LowerViaPatersonStockmeyerChebyshev, LowerViaClenshaw,
+                   LowerViaPatersonStockmeyerMonomial>(context,
+                                                       /*force=*/false,
+                                                       dialect);
+    }
 
     walkAndApplyPatterns(getOperation(), std::move(patterns));
   }

--- a/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.cpp
+++ b/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.cpp
@@ -1,0 +1,58 @@
+#include "lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h"
+
+#include "lib/Dialect/HEIRInterfaces.h"
+#include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+// IWYU pragma: begin_keep
+#include "llvm/include/llvm/Support/Debug.h"      // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+#define DEBUG_TYPE "lower-polynomial-eval"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_LOWERPOLYNOMIALEVAL
+#include "lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h.inc"
+
+struct LowerPolynomialEval
+    : impl::LowerPolynomialEvalBase<LowerPolynomialEval> {
+  using LowerPolynomialEvalBase::LowerPolynomialEvalBase;
+
+  // FIXME: replace with actual lowering patterns
+  struct DebugPrintPattern : public OpRewritePattern<polynomial::EvalOp> {
+    DebugPrintPattern(mlir::MLIRContext *context)
+        : mlir::OpRewritePattern<polynomial::EvalOp>(context) {}
+
+    LogicalResult matchAndRewrite(polynomial::EvalOp op,
+                                  PatternRewriter &rewriter) const override {
+      LLVM_DEBUG(llvm::dbgs() << "Lowering polynomial::EvalOp: " << op << "\n");
+
+      PolynomialEvalInterface evalInterface(op.getContext());
+      Dialect *valueDialect = &op.getValue().getType().getDialect();
+      if (!evalInterface.supportsPolynomial(op.getPolynomial(), valueDialect)) {
+        return op.emitOpError()
+               << "dialect for input type " << op.getValue().getType()
+               << " does not support polynomial " << op.getPolynomial();
+      }
+
+      rewriter.modifyOpInPlace(
+          op, [&]() { op->setAttr("lowered", rewriter.getUnitAttr()); });
+      return success();
+    }
+  };
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    patterns.add<DebugPrintPattern>(context);
+
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h
+++ b/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h
@@ -1,0 +1,21 @@
+#ifndef LIB_TRANSFORMS_LOWERPOLYNOMIALEVAL_LOWERPOLYNOMIALEVAL_H_
+#define LIB_TRANSFORMS_LOWERPOLYNOMIALEVAL_LOWERPOLYNOMIALEVAL_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_LOWERPOLYNOMIALEVAL_LOWERPOLYNOMIALEVAL_H_

--- a/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.td
+++ b/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.td
@@ -1,0 +1,31 @@
+#ifndef LIB_TRANSFORMS_LOWERPOLYNOMIALEVAL_LOWERPOLYNOMIALEVAL_TD_
+#define LIB_TRANSFORMS_LOWERPOLYNOMIALEVAL_LOWERPOLYNOMIALEVAL_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def LowerPolynomialEval : Pass<"lower-polynomial-eval"> {
+  let summary = "Lowers the polynomial.eval operation";
+  let description = [{
+  This pass lowers the `polynomial.eval` operation to a sequence of arithmetic
+  operations in the relevant dialect.
+
+  Dialects that wish to support this pass must implement the
+  `DialectPolynomialEvalInterface` dialect interface, which informs this pass
+  what operations in the target dialect correspond to scalar multiplication and
+  addition, as well as how to properly materialize constants as values.
+
+  This pass supports multiple options for lowering a `polynomial.eval` op,
+  including the following. The required basis representation of the polynomial
+  is listed alongside each method.
+
+    - Horner's method (monomial basis)
+    - Paterson-Stockmeyer (monomial basis)
+
+  // TODO(#1565): Add support for Chebyshev-basis methods
+  }];
+  let dependentDialects = [
+    "::mlir::heir::polynomial::PolynomialDialect",
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_LOWERPOLYNOMIALEVAL_LOWERPOLYNOMIALEVAL_TD_

--- a/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.td
+++ b/lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.td
@@ -16,15 +16,29 @@ def LowerPolynomialEval : Pass<"lower-polynomial-eval"> {
 
   This pass supports multiple options for lowering a `polynomial.eval` op,
   including the following. The required basis representation of the polynomial
-  is listed alongside each method.
+  is listed alongside each method. The chosen method is controlled by the
+  `method` pass option, which defaults to automatically select the method.
 
-    - Horner's method (monomial basis)
-    - Paterson-Stockmeyer (monomial basis)
+    - `"horner"`: Horner's method (monomial basis)
+    - `"ps"` Paterson-Stockmeyer (monomial basis)
 
   // TODO(#1565): Add support for Chebyshev-basis methods
+  //  - `"clenshaw"`: Clenshaw's method (Chebyshev basis)
+  //  - `"ps-cheb"`: Paterson-Stockmeyer (Chebyshev basis)
+  //  - `"bsgs"`: Baby Step Giant Step (Chebyshev basis)
   }];
   let dependentDialects = [
     "::mlir::heir::polynomial::PolynomialDialect",
+  ];
+  let options = [
+    Option<"method", "method", "std::string",
+           /*default=*/"", "The method used to lower polynomial.eval.">,
+
+    // We allow the user to override the default dialect detection
+    // for cases like BGV/CKKS/BFV where the type used to trigger
+    // the dialect detection has a shared dialect (lwe).
+    Option<"dialect", "dialect", "std::string",
+           /*default=*/"", "The dialect to target; automatically detected if unset.">,
   ];
 }
 

--- a/tests/Transforms/lower_polynomial_eval/BUILD
+++ b/tests/Transforms/lower_polynomial_eval/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/lower_polynomial_eval/f32_coeffs.mlir
+++ b/tests/Transforms/lower_polynomial_eval/f32_coeffs.mlir
@@ -1,0 +1,22 @@
+// RUN: heir-opt %s --lower-polynomial-eval=method=horner --canonicalize | FileCheck %s
+
+#ring_f32_ = #polynomial.ring<coefficientType = f32>
+!poly = !polynomial.polynomial<ring = #ring_f32_>
+
+// CHECK: @test_f32_coeffs(
+// CHECK-SAME: [[arg0:%[^ ]*]]: [[ty:f32]]
+func.func @test_f32_coeffs(%arg0: f32) -> f32 {
+  // CHECK-NEXT: [[c1:%[^ ]*]] = arith.constant 1.5
+  // CHECK-NEXT: [[c2:%[^ ]*]] = arith.constant 2.5
+  // CHECK-NEXT: [[c3:%[^ ]*]] = arith.constant 3.5
+  // CHECK-NEXT: [[c4:%[^ ]*]] = arith.constant 4.9
+  // CHECK-NEXT: [[x3_term:%[^ ]*]] = arith.mulf [[arg0]], [[c4]] : [[ty]]
+  // CHECK-NEXT: [[sum1:%[^ ]*]] = arith.addf [[x3_term]], [[c3]] : [[ty]]
+  // CHECK-NEXT: [[x2_term:%[^ ]*]] = arith.mulf [[sum1]], [[arg0]] : [[ty]]
+  // CHECK-NEXT: [[sum2:%[^ ]*]] = arith.addf [[x2_term]], [[c2]] : [[ty]]
+  // CHECK-NEXT: [[x1_term:%[^ ]*]] = arith.mulf [[sum2]], [[arg0]] : [[ty]]
+  // CHECK-NEXT: [[output:%[^ ]*]] = arith.addf [[x1_term]], [[c1]] : [[ty]]
+  // CHECK-NEXT: return [[output]] : [[ty]]
+  %0 = polynomial.eval #polynomial<typed_float_polynomial <1.5 + 2.5x + 3.5x**2 + 4.9x**3> : !poly>, %arg0 : f32
+  return %0 : f32
+}

--- a/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
+++ b/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
@@ -5,6 +5,8 @@
 !Z65537 = !mod_arith.int<65537 : i64>
 
 func.func @test_mod_arith_coeffs(%arg0: !Z65537) -> !Z65537 {
+  // FIXME: add proper assertions
+  // CHECK: polynomial.eval
   %0 = polynomial.eval #polynomial<typed_int_polynomial <1 + 2x + 3x**2 + 4x**3> : !poly>, %arg0 : !Z65537
   return %0 : !Z65537
 }

--- a/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
+++ b/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s --lower-polynomial-eval=method=horner;force=true --canonicalize | FileCheck %s
+// RUN: heir-opt %s --lower-polynomial-eval=method=horner --canonicalize | FileCheck %s
 
 #ring_i32_ = #polynomial.ring<coefficientType = i32>
 !poly = !polynomial.polynomial<ring = #ring_i32_>

--- a/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
+++ b/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
@@ -1,0 +1,10 @@
+// RUN: heir-opt %s --lower-polynomial-eval | FileCheck %s
+
+#ring_i32_ = #polynomial.ring<coefficientType = i32>
+!poly = !polynomial.polynomial<ring = #ring_i32_>
+!Z65537 = !mod_arith.int<65537 : i64>
+
+func.func @test_mod_arith_coeffs(%arg0: !Z65537) -> !Z65537 {
+  %0 = polynomial.eval #polynomial<typed_int_polynomial <1 + 2x + 3x**2 + 4x**3> : !poly>, %arg0 : !Z65537
+  return %0 : !Z65537
+}

--- a/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
+++ b/tests/Transforms/lower_polynomial_eval/mod_arith_coeffs.mlir
@@ -1,12 +1,24 @@
-// RUN: heir-opt %s --lower-polynomial-eval | FileCheck %s
+// RUN: heir-opt %s --lower-polynomial-eval=method=horner;force=true --canonicalize | FileCheck %s
 
 #ring_i32_ = #polynomial.ring<coefficientType = i32>
 !poly = !polynomial.polynomial<ring = #ring_i32_>
 !Z65537 = !mod_arith.int<65537 : i64>
 
+// CHECK: [[ty:![^ ]*]] = !mod_arith.int<65537 : i64>
+// CHECK: @test_mod_arith_coeffs(
+// CHECK-SAME: [[arg0:%[^ ]*]]: [[ty]]
 func.func @test_mod_arith_coeffs(%arg0: !Z65537) -> !Z65537 {
-  // FIXME: add proper assertions
-  // CHECK: polynomial.eval
+  // CHECK-NEXT: [[c1:%[^ ]*]] = mod_arith.constant 1 : [[ty]]
+  // CHECK-NEXT: [[c2:%[^ ]*]] = mod_arith.constant 2 : [[ty]]
+  // CHECK-NEXT: [[c3:%[^ ]*]] = mod_arith.constant 3 : [[ty]]
+  // CHECK-NEXT: [[c4:%[^ ]*]] = mod_arith.constant 4 : [[ty]]
+  // CHECK-NEXT: [[x3_term:%[^ ]*]] = mod_arith.mul [[arg0]], [[c4]] : [[ty]]
+  // CHECK-NEXT: [[sum1:%[^ ]*]] = mod_arith.add [[x3_term]], [[c3]] : [[ty]]
+  // CHECK-NEXT: [[x2_term:%[^ ]*]] = mod_arith.mul [[sum1]], [[arg0]] : [[ty]]
+  // CHECK-NEXT: [[sum2:%[^ ]*]] = mod_arith.add [[x2_term]], [[c2]] : [[ty]]
+  // CHECK-NEXT: [[x1_term:%[^ ]*]] = mod_arith.mul [[sum2]], [[arg0]] : [[ty]]
+  // CHECK-NEXT: [[output:%[^ ]*]] = mod_arith.add [[x1_term]], [[c1]] : [[ty]]
+  // CHECK-NEXT: return [[output]] : [[ty]]
   %0 = polynomial.eval #polynomial<typed_int_polynomial <1 + 2x + 3x**2 + 4x**3> : !poly>, %arg0 : !Z65537
   return %0 : !Z65537
 }

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -120,6 +120,7 @@ cc_binary(
         "@heir//lib/Transforms/LayoutOptimization",
         "@heir//lib/Transforms/LayoutPropagation",
         "@heir//lib/Transforms/LinalgCanonicalizations",
+        "@heir//lib/Transforms/LowerPolynomialEval",
         "@heir//lib/Transforms/MemrefToArith:ExpandCopy",
         "@heir//lib/Transforms/MemrefToArith:MemrefToArithRegistration",
         "@heir//lib/Transforms/OperationBalancer",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -73,6 +73,7 @@
 #include "lib/Transforms/LayoutOptimization/LayoutOptimization.h"
 #include "lib/Transforms/LayoutPropagation/LayoutPropagation.h"
 #include "lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.h"
+#include "lib/Transforms/LowerPolynomialEval/LowerPolynomialEval.h"
 #include "lib/Transforms/OperationBalancer/OperationBalancer.h"
 #include "lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.h"
 #include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h"
@@ -276,6 +277,7 @@ int main(int argc, char **argv) {
   registerLayoutPropagationPasses();
   registerLayoutOptimizationPasses();
   registerLinalgCanonicalizationsPasses();
+  registerLowerPolynomialEvalPasses();
   registerTensorToScalarsPasses();
   // Register yosys optimizer pipeline if configured.
 #ifndef HEIR_NO_YOSYS

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -334,6 +334,7 @@ int main(int argc, char **argv) {
   secret::registerBufferizableOpInterfaceExternalModels(registry);
   rns::registerExternalRNSTypeInterfaces(registry);
   registerOperandAndResultAttrInterface(registry);
+  registerPolynomialEvalInterface(registry);
 
   PassPipelineRegistration<TosaToArithOptions>(
       "heir-tosa-to-arith",


### PR DESCRIPTION
This adds a new pass `lower-polynomial-eval` (pending https://github.com/google/heir/pull/1505 and which will contain the generalized versions of those new lowerings after that PR is merged), aided by a new dialect interface `PolynomialEvalInterface`.

The new interface requires any dialect that wants to lower `polynomial.eval` via this pass to implement hooks that:

- Create a constant op for a given constant (e.g., a polynomial coefficient); this is most important for RLWE schemes where the encoding of a cleartext as a plaintext requires scale considerations, but even for `mod_arith` this requires inserting a `mod_arith.constant` op to convert a plain integer to the right modulus.
- Create add/mul ops corresponding to the underlying ring operations. E.g., `ckks.add` or `ckks.mul/mul_plain`

Then the lowering uses the interface to construct the relevant ops in the appropriate target dialect.