### PR TITLE
B/FV: add variance based model

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BFV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BFV/BUILD
@@ -4,14 +4,15 @@ package(
 )
 
 cc_library(
-    name = "NoiseCoeffModelAnalysis",
+    name = "NoiseAnalysis",
     srcs = [
-        "NoiseCoeffModelAnalysis.cpp",
+        "NoiseAnalysis.cpp",
     ],
     hdrs = [
     ],
     deps = [
         ":NoiseByBoundCoeffModel",
+        ":NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/DimensionAnalysis",
         "@heir//lib/Analysis/LevelAnalysis",
@@ -41,5 +42,20 @@ cc_library(
     deps = [
         "@heir//lib/Analysis/NoiseAnalysis:Noise",
         "@heir//lib/Parameters/BGV:Params",
+    ],
+)
+
+cc_library(
+    name = "NoiseByVarianceCoeffModel",
+    srcs = [
+        "NoiseByVarianceCoeffModel.cpp",
+    ],
+    hdrs = [
+        "NoiseByVarianceCoeffModel.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/NoiseAnalysis:NoiseWithDegree",
+        "@heir//lib/Parameters/BGV:Params",
+        "@heir//lib/Utils:MathUtils",
     ],
 )

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
@@ -1,9 +1,11 @@
+#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+
 #include <functional>
 
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
-#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
@@ -212,6 +214,9 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
 // template instantiation
 template class NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseModel>;
 template class NoiseAnalysis<bfv::NoiseByBoundCoeffWorstCaseModel>;
+
+// for variance
+template class NoiseAnalysis<bfv::NoiseByVarianceCoeffModel>;
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h
@@ -1,0 +1,76 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_BFV_NOISEBYVARIANCECOEFFMODEL_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_BFV_NOISEBYVARIANCECOEFFMODEL_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <optional>
+#include <string>
+
+#include "lib/Analysis/NoiseAnalysis/NoiseWithDegree.h"
+#include "lib/Parameters/BGV/Params.h"
+
+namespace mlir {
+namespace heir {
+namespace bfv {
+
+// coefficient embedding noise model using variance
+class NoiseByVarianceCoeffModel {
+ public:
+  // NoiseState stores the variance var for the one coefficient of
+  // the error 'e', assuming coefficients are IID.
+  // Note that BMCM23 tracks the invariant noise t/q(c0 + c1 * s).
+  // We adapt it to track the 'e' in [(q/t)m + e]_q for convenience
+  // and consistency with the other models.
+  //
+  // The main contribution of BMCM23 is that it considers the dependence between
+  // random variables caused by 's', so the max degree T in 's^T' of the
+  // invariant noise needs to be tracked.
+  //
+  // MP24/CCH+23 states that for two polynomial multipication, the variance of
+  // one coefficient of the result can be approximated by ringDim * var_0 *
+  // var_1, because the polynomial multipication is a convolution.
+  using StateType = NoiseWithDegree;
+  using SchemeParamType = bgv::SchemeParam;
+  using LocalParamType = bgv::LocalParam;
+
+ private:
+  static double getVarianceErr(const LocalParamType &param);
+  static double getVarianceKey(const LocalParamType &param);
+
+  static StateType evalEncryptPk(const LocalParamType &param);
+  static StateType evalEncryptSk(const LocalParamType &param);
+  static StateType evalRelinearizeHYBRID(const LocalParamType &inputParam,
+                                         const StateType &input);
+
+ public:
+  static StateType evalEncrypt(const LocalParamType &param);
+  static StateType evalConstant(const LocalParamType &param);
+  static StateType evalAdd(const StateType &lhs, const StateType &rhs);
+  static StateType evalMul(const LocalParamType &resultParam,
+                           const StateType &lhs, const StateType &rhs);
+  static StateType evalRelinearize(const LocalParamType &inputParam,
+                                   const StateType &input);
+
+  // logTotal: log(Q / (t * 2))
+  // logBound: bound on ||e|| predicted by the model
+  // logBudget: logTotal - logBound
+  // as ||e|| < Q / (t * 2) for correct decryption
+  static double toLogBound(const LocalParamType &param, const StateType &noise);
+  static std::string toLogBoundString(const LocalParamType &param,
+                                      const StateType &noise);
+  static double toLogBudget(const LocalParamType &param,
+                            const StateType &noise);
+  static std::string toLogBudgetString(const LocalParamType &param,
+                                       const StateType &noise);
+  static double toLogTotal(const LocalParamType &param);
+  static std::string toLogTotalString(const LocalParamType &param);
+};
+
+}  // namespace bfv
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_BFV_NOISEBYVARIANCECOEFFMODEL_H_

--- a/lib/Analysis/NoiseAnalysis/BGV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BGV/BUILD
@@ -69,5 +69,6 @@ cc_library(
     deps = [
         "@heir//lib/Analysis/NoiseAnalysis:Noise",
         "@heir//lib/Parameters/BGV:Params",
+        "@heir//lib/Utils:MathUtils",
     ],
 )

--- a/lib/Analysis/NoiseAnalysis/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BUILD
@@ -29,3 +29,15 @@ cc_library(
         "@llvm-project//mlir:IR",
     ],
 )
+
+cc_library(
+    name = "NoiseWithDegree",
+    srcs = ["NoiseWithDegree.cpp"],
+    hdrs = [
+        "NoiseWithDegree.h",
+    ],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)

--- a/lib/Analysis/NoiseAnalysis/NoiseWithDegree.cpp
+++ b/lib/Analysis/NoiseAnalysis/NoiseWithDegree.cpp
@@ -1,0 +1,32 @@
+#include "lib/Analysis/NoiseAnalysis/NoiseWithDegree.h"
+
+#include <cmath>
+#include <string>
+
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"       // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+std::string NoiseWithDegree::toString() const {
+  switch (noiseType) {
+    case (NoiseType::UNINITIALIZED):
+      return "NoiseWithDegree(uninitialized)";
+    case (NoiseType::SET):
+      return "NoiseWithDegree(" + std::to_string(log2(getValue())) + ", " +
+             std::to_string(degree) + ") ";
+  }
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const NoiseWithDegree &noise) {
+  return os << noise.toString();
+}
+
+Diagnostic &operator<<(Diagnostic &diagnostic, const NoiseWithDegree &noise) {
+  return diagnostic << noise.toString();
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/NoiseWithDegree.h
+++ b/lib/Analysis/NoiseAnalysis/NoiseWithDegree.h
@@ -1,0 +1,93 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_NOISEWITHDEGREE_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_NOISEWITHDEGREE_H_
+
+#include <algorithm>
+#include <cassert>
+#include <optional>
+#include <string>
+
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"       // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+class NoiseWithDegree {
+ public:
+  enum NoiseType {
+    // A min value for the lattice, discarable when joined with anything else.
+    UNINITIALIZED,
+    // A known value for the lattice, when noise can be inferred.
+    SET,
+  };
+
+  static NoiseWithDegree uninitialized() {
+    return NoiseWithDegree(NoiseType::UNINITIALIZED, std::nullopt);
+  }
+  static NoiseWithDegree of(double value, int degree) {
+    return NoiseWithDegree(NoiseType::SET, value, degree);
+  }
+
+  /// The default constructor must be equivalent to the "entry state" of the
+  /// lattice, i.e., an uninitialized noise.
+  NoiseWithDegree(NoiseType noiseType = NoiseType::UNINITIALIZED,
+                  std::optional<double> value = std::nullopt, int degree = 0)
+      : noiseType(noiseType), value(value), degree(degree) {}
+
+  bool isKnown() const { return noiseType == NoiseType::SET; }
+
+  bool isInitialized() const { return noiseType != NoiseType::UNINITIALIZED; }
+
+  const double &getValue() const {
+    assert(isKnown());
+    return *value;
+  }
+
+  int getDegree() const {
+    assert(isKnown());
+    return degree;
+  }
+
+  bool operator==(const NoiseWithDegree &rhs) const {
+    return noiseType == rhs.noiseType && value == rhs.value &&
+           degree == rhs.degree;
+  }
+
+  static NoiseWithDegree join(const NoiseWithDegree &lhs,
+                              const NoiseWithDegree &rhs) {
+    // Uninitialized noises correspond to values that are not secret,
+    // which may be the inputs to an encryption operation.
+    if (lhs.noiseType == NoiseType::UNINITIALIZED) {
+      return rhs;
+    }
+    if (rhs.noiseType == NoiseType::UNINITIALIZED) {
+      return lhs;
+    }
+
+    assert(lhs.noiseType == NoiseType::SET && rhs.noiseType == NoiseType::SET);
+    return NoiseWithDegree::of(std::max(lhs.getValue(), rhs.getValue()),
+                               std::max(lhs.getDegree(), rhs.getDegree()));
+  }
+
+  void print(llvm::raw_ostream &os) const { os << value; }
+
+  std::string toString() const;
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const NoiseWithDegree &noise);
+
+  friend Diagnostic &operator<<(Diagnostic &diagnostic,
+                                const NoiseWithDegree &noise);
+
+ private:
+  NoiseType noiseType;
+  // notice that when level becomes large (e.g. 17), the max Q could be like
+  // 3523 bits and could not be represented in double.
+  std::optional<double> value;
+  int degree;
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_NOISEWITHDEGREE_H_

--- a/lib/Analysis/NoiseAnalysis/README.md
+++ b/lib/Analysis/NoiseAnalysis/README.md
@@ -1,0 +1,10 @@
+# Noise Analysis
+
+HEIR mainly use the following papers for noise analysis
+
+- KPZ21: Revisiting Homomorphic Encryption Schemes for Finite Fields
+- MP24: A Central Limit Approach for Ring-LWE Noise Analysis
+- CCH+23: On the precision loss in approximate homomorphic encryption
+- MMLGA22: Finding and Evaluating Parameters for BGV
+- BMCM23: Improving and Automating BFV Parameters Selection: An Average-Case
+  Approacha

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -210,7 +210,10 @@ void mlirToRLWEPipeline(OpPassManager &pm,
   }
 
   // Optimize relinearization at mgmt dialect level
-  pm.addPass(createOptimizeRelinearization());
+  // TODO(#1548): respect MAX_KEY_BASIS_DEGREE for B/FV
+  OptimizeRelinearizationOptions optimizeRelinearizationOptions;
+  optimizeRelinearizationOptions.allowMixedDegreeOperands = false;
+  pm.addPass(createOptimizeRelinearization(optimizeRelinearizationOptions));
 
   // IR is stable now, compute scheme param
   switch (scheme) {

--- a/lib/Transforms/GenerateParam/BUILD
+++ b/lib/Transforms/GenerateParam/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/NoiseAnalysis",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByBoundCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",

--- a/lib/Transforms/GenerateParam/GenerateParam.td
+++ b/lib/Transforms/GenerateParam/GenerateParam.td
@@ -93,6 +93,7 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
     There are three noise models available:
     - `bfv-noise-by-bound-coeff-average-case`
     - `bfv-noise-by-bound-coeff-worst-case` or `bfv-noise-kpz21`
+    - `bfv-noise-by-variance-coeff` or `bfv-noise-bmcm23`
 
     To use public-key encryption/secret-key encryption in the model, the option
     `usePublicKey` could be set accordingly.
@@ -102,6 +103,11 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
     of the two models is expansion factor used for multiplication
     of the coefficients, the first being $2 \sqrt{N}$ and the second
     being $N$.
+
+    The third model is taken from BMCM23. It works by tracking the variance
+    of the coefficient embedding of the ciphertexts. This gives a much tighter
+    noise estimate for independent ciphertext input, but may give underestimation
+    for dependent ciphertext input. See [the paper](https://ia.cr/2023/600) for more details.
 
     This pass then generates the moduli chain consisting of primes
     of bits specified by the `mod-bits` field.

--- a/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
@@ -1,6 +1,7 @@
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
@@ -200,6 +201,9 @@ struct GenerateParamBFV : impl::GenerateParamBFVBase<GenerateParamBFV> {
     } else if (model == "bfv-noise-by-bound-coeff-average-case" ||
                model == "bfv-noise-kpz21") {
       run<NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseModel>>();
+    } else if (model == "bfv-noise-by-variance-coeff" ||
+               model == "bfv-noise-bmcm23") {
+      run<NoiseAnalysis<bfv::NoiseByVarianceCoeffModel>>();
     } else {
       getOperation()->emitWarning() << "Unknown noise model.\n";
       generateFallbackParam();

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/NoiseAnalysis",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByBoundCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -8,6 +8,7 @@
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
@@ -208,6 +209,9 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
     } else if (model == "bfv-noise-by-bound-coeff-average-case" ||
                model == "bfv-noise-kpz21") {
       run<NoiseAnalysis<bfv::NoiseByBoundCoeffAverageCaseModel>>();
+    } else if (model == "bfv-noise-by-variance-coeff" ||
+               model == "bfv-noise-bmcm23") {
+      run<NoiseAnalysis<bfv::NoiseByVarianceCoeffModel>>();
     } else {
       getOperation()->emitOpError() << "Unknown noise model.\n";
       signalPassFailure();

--- a/lib/Utils/BUILD
+++ b/lib/Utils/BUILD
@@ -125,6 +125,12 @@ cc_library(
 )
 
 cc_library(
+    name = "MathUtils",
+    srcs = ["MathUtils.cpp"],
+    hdrs = ["MathUtils.h"],
+)
+
+cc_library(
     name = "TargetUtils",
     srcs = ["TargetUtils.cpp"],
     hdrs = ["TargetUtils.h"],

--- a/lib/Utils/MathUtils.cpp
+++ b/lib/Utils/MathUtils.cpp
@@ -1,0 +1,40 @@
+#include "lib/Utils/MathUtils.h"
+
+#include <cmath>
+
+namespace mlir {
+namespace heir {
+
+// https://stackoverflow.com/questions/27229371/inverse-error-function-in-c
+double erfinv(double a) {
+  double p, r, t;
+  t = fma(a, 0.0 - a, 1.0);
+  t = log(t);
+  if (fabs(t) > 6.125) {            // maximum ulp error = 2.35793
+    p = 3.03697567e-10;             //  0x1.4deb44p-32
+    p = fma(p, t, 2.93243101e-8);   //  0x1.f7c9aep-26
+    p = fma(p, t, 1.22150334e-6);   //  0x1.47e512p-20
+    p = fma(p, t, 2.84108955e-5);   //  0x1.dca7dep-16
+    p = fma(p, t, 3.93552968e-4);   //  0x1.9cab92p-12
+    p = fma(p, t, 3.02698812e-3);   //  0x1.8cc0dep-9
+    p = fma(p, t, 4.83185798e-3);   //  0x1.3ca920p-8
+    p = fma(p, t, -2.64646143e-1);  // -0x1.0eff66p-2
+    p = fma(p, t, 8.40016484e-1);   //  0x1.ae16a4p-1
+  } else {                          // maximum ulp error = 2.35002
+    p = 5.43877832e-9;              //  0x1.75c000p-28
+    p = fma(p, t, 1.43285448e-7);   //  0x1.33b402p-23
+    p = fma(p, t, 1.22774793e-6);   //  0x1.499232p-20
+    p = fma(p, t, 1.12963626e-7);   //  0x1.e52cd2p-24
+    p = fma(p, t, -5.61530760e-5);  // -0x1.d70bd0p-15
+    p = fma(p, t, -1.47697632e-4);  // -0x1.35be90p-13
+    p = fma(p, t, 2.31468678e-3);   //  0x1.2f6400p-9
+    p = fma(p, t, 1.15392581e-2);   //  0x1.7a1e50p-7
+    p = fma(p, t, -2.32015476e-1);  // -0x1.db2aeep-3
+    p = fma(p, t, 8.86226892e-1);   //  0x1.c5bf88p-1
+  }
+  r = a * p;
+  return r;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/MathUtils.h
+++ b/lib/Utils/MathUtils.h
@@ -1,0 +1,13 @@
+#ifndef LIB_UTILS_MATHUTILS_H_
+#define LIB_UTILS_MATHUTILS_H_
+
+namespace mlir {
+namespace heir {
+
+/// inverse error function
+double erfinv(double a);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_UTILS_MATHUTILS_H_

--- a/tests/Examples/common/mult_dep_16.mlir
+++ b/tests/Examples/common/mult_dep_16.mlir
@@ -1,0 +1,20 @@
+func.func @mult_dep(
+    %arg0: i16 {secret.secret}
+    ) -> i16 {
+    %0 = arith.muli %arg0, %arg0 : i16
+    %1 = arith.muli %0, %arg0 : i16
+    %2 = arith.muli %1, %arg0 : i16
+    %3 = arith.muli %2, %arg0 : i16
+    %4 = arith.muli %3, %arg0 : i16
+    %5 = arith.muli %4, %arg0 : i16
+    %6 = arith.muli %5, %arg0 : i16
+    %7 = arith.muli %6, %arg0 : i16
+    %8 = arith.muli %7, %arg0 : i16
+    %9 = arith.muli %8, %arg0 : i16
+    %10 = arith.muli %9, %arg0 : i16
+    %11 = arith.muli %10, %arg0 : i16
+    %12 = arith.muli %11, %arg0 : i16
+    %13 = arith.muli %12, %arg0 : i16
+    %14 = arith.muli %13, %arg0 : i16
+    return %6 : i16
+}

--- a/tests/Examples/common/mult_dep_8.mlir
+++ b/tests/Examples/common/mult_dep_8.mlir
@@ -1,0 +1,12 @@
+func.func @mult_dep(
+    %arg0: i16 {secret.secret}
+    ) -> i16 {
+    %0 = arith.muli %arg0, %arg0 : i16
+    %1 = arith.muli %0, %arg0 : i16
+    %2 = arith.muli %1, %arg0 : i16
+    %3 = arith.muli %2, %arg0 : i16
+    %4 = arith.muli %3, %arg0 : i16
+    %5 = arith.muli %4, %arg0 : i16
+    %6 = arith.muli %5, %arg0 : i16
+    return %6 : i16
+}

--- a/tests/Examples/common/mult_indep_16.mlir
+++ b/tests/Examples/common/mult_indep_16.mlir
@@ -1,0 +1,35 @@
+func.func @mult_indep(
+    %arg0: i16 {secret.secret},
+    %arg1: i16 {secret.secret},
+    %arg2: i16 {secret.secret},
+    %arg3: i16 {secret.secret},
+    %arg4: i16 {secret.secret},
+    %arg5: i16 {secret.secret},
+    %arg6: i16 {secret.secret},
+    %arg7: i16 {secret.secret},
+    %arg8: i16 {secret.secret},
+    %arg9: i16 {secret.secret},
+    %arg10: i16 {secret.secret},
+    %arg11: i16 {secret.secret},
+    %arg12: i16 {secret.secret},
+    %arg13: i16 {secret.secret},
+    %arg14: i16 {secret.secret},
+    %arg15: i16 {secret.secret}
+    ) -> i16 {
+    %0 = arith.muli %arg0, %arg1 : i16
+    %1 = arith.muli %0, %arg2 : i16
+    %2 = arith.muli %1, %arg3 : i16
+    %3 = arith.muli %2, %arg4 : i16
+    %4 = arith.muli %3, %arg5 : i16
+    %5 = arith.muli %4, %arg6 : i16
+    %6 = arith.muli %5, %arg7 : i16
+    %7 = arith.muli %6, %arg8 : i16
+    %8 = arith.muli %7, %arg9 : i16
+    %9 = arith.muli %8, %arg10 : i16
+    %10 = arith.muli %9, %arg11 : i16
+    %11 = arith.muli %10, %arg12 : i16
+    %12 = arith.muli %11, %arg13 : i16
+    %13 = arith.muli %12, %arg14 : i16
+    %14 = arith.muli %13, %arg15 : i16
+    return %14 : i16
+}

--- a/tests/Examples/common/mult_indep_32.mlir
+++ b/tests/Examples/common/mult_indep_32.mlir
@@ -1,0 +1,67 @@
+func.func @mult_indep(
+    %arg0: i16 {secret.secret},
+    %arg1: i16 {secret.secret},
+    %arg2: i16 {secret.secret},
+    %arg3: i16 {secret.secret},
+    %arg4: i16 {secret.secret},
+    %arg5: i16 {secret.secret},
+    %arg6: i16 {secret.secret},
+    %arg7: i16 {secret.secret},
+    %arg8: i16 {secret.secret},
+    %arg9: i16 {secret.secret},
+    %arg10: i16 {secret.secret},
+    %arg11: i16 {secret.secret},
+    %arg12: i16 {secret.secret},
+    %arg13: i16 {secret.secret},
+    %arg14: i16 {secret.secret},
+    %arg15: i16 {secret.secret},
+    %arg16: i16 {secret.secret},
+    %arg17: i16 {secret.secret},
+    %arg18: i16 {secret.secret},
+    %arg19: i16 {secret.secret},
+    %arg20: i16 {secret.secret},
+    %arg21: i16 {secret.secret},
+    %arg22: i16 {secret.secret},
+    %arg23: i16 {secret.secret},
+    %arg24: i16 {secret.secret},
+    %arg25: i16 {secret.secret},
+    %arg26: i16 {secret.secret},
+    %arg27: i16 {secret.secret},
+    %arg28: i16 {secret.secret},
+    %arg29: i16 {secret.secret},
+    %arg30: i16 {secret.secret},
+    %arg31: i16 {secret.secret}
+    ) -> i16 {
+    %0 = arith.muli %arg0, %arg1 : i16
+    %1 = arith.muli %0, %arg2 : i16
+    %2 = arith.muli %1, %arg3 : i16
+    %3 = arith.muli %2, %arg4 : i16
+    %4 = arith.muli %3, %arg5 : i16
+    %5 = arith.muli %4, %arg6 : i16
+    %6 = arith.muli %5, %arg7 : i16
+    %7 = arith.muli %6, %arg8 : i16
+    %8 = arith.muli %7, %arg9 : i16
+    %9 = arith.muli %8, %arg10 : i16
+    %10 = arith.muli %9, %arg11 : i16
+    %11 = arith.muli %10, %arg12 : i16
+    %12 = arith.muli %11, %arg13 : i16
+    %13 = arith.muli %12, %arg14 : i16
+    %14 = arith.muli %13, %arg15 : i16
+    %15 = arith.muli %14, %arg16 : i16
+    %16 = arith.muli %15, %arg17 : i16
+    %17 = arith.muli %16, %arg18 : i16
+    %18 = arith.muli %17, %arg19 : i16
+    %19 = arith.muli %18, %arg20 : i16
+    %20 = arith.muli %19, %arg21 : i16
+    %21 = arith.muli %20, %arg22 : i16
+    %22 = arith.muli %21, %arg23 : i16
+    %23 = arith.muli %22, %arg24 : i16
+    %24 = arith.muli %23, %arg25 : i16
+    %25 = arith.muli %24, %arg26 : i16
+    %26 = arith.muli %25, %arg27 : i16
+    %27 = arith.muli %26, %arg28 : i16
+    %28 = arith.muli %27, %arg29 : i16
+    %29 = arith.muli %28, %arg30 : i16
+    %30 = arith.muli %29, %arg31 : i16
+    return %30 : i16
+}

--- a/tests/Examples/common/mult_indep_8.mlir
+++ b/tests/Examples/common/mult_indep_8.mlir
@@ -1,0 +1,19 @@
+func.func @mult_indep(
+    %arg0: i16 {secret.secret},
+    %arg1: i16 {secret.secret},
+    %arg2: i16 {secret.secret},
+    %arg3: i16 {secret.secret},
+    %arg4: i16 {secret.secret},
+    %arg5: i16 {secret.secret},
+    %arg6: i16 {secret.secret},
+    %arg7: i16 {secret.secret}
+    ) -> i16 {
+    %0 = arith.muli %arg0, %arg1 : i16
+    %1 = arith.muli %0, %arg2 : i16
+    %2 = arith.muli %1, %arg3 : i16
+    %3 = arith.muli %2, %arg4 : i16
+    %4 = arith.muli %3, %arg5 : i16
+    %5 = arith.muli %4, %arg6 : i16
+    %6 = arith.muli %5, %arg7 : i16
+    return %6 : i16
+}

--- a/tests/Examples/lattigo/bfv/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/bfv_debug.go
@@ -1,5 +1,4 @@
-// Package dotproduct8bfvdebug is a debug handler callback for the compiled lattigo code.
-package dotproduct8bfvdebug
+package main
 
 import (
 	"fmt"

--- a/tests/Examples/lattigo/bfv/dot_product_8/BUILD
+++ b/tests/Examples/lattigo/bfv/dot_product_8/BUILD
@@ -6,8 +6,8 @@ load("@rules_go//go:def.bzl", "go_test")
 package(default_applicable_licenses = ["@heir//:license"])
 
 heir_lattigo_lib(
-    name = "dot_product_8_bfv",
-    go_library_name = "dotproduct8bfv",
+    name = "dot_product_8",
+    go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=bfv",
         "--mlir-to-bfv=ciphertext-degree=8",
@@ -20,7 +20,7 @@ heir_lattigo_lib(
 # above.
 
 go_test(
-    name = "dotproduct8bfv_test",
-    srcs = ["dot_product_8_bfv_test.go"],
-    embed = [":dotproduct8bfv"],
+    name = "dotproduct8_test",
+    srcs = ["dot_product_8_test.go"],
+    embed = [":main"],
 )

--- a/tests/Examples/lattigo/bfv/dot_product_8/dot_product_8_test.go
+++ b/tests/Examples/lattigo/bfv/dot_product_8/dot_product_8_test.go
@@ -1,4 +1,4 @@
-package dotproduct8bfvdebug
+package main
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ func TestBinops(t *testing.T) {
 	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
 	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
 
-	resultCt := dot_product(evaluator, params, ecd, dec, ct0, ct1)
+	resultCt := dot_product(evaluator, params, ecd, ct0, ct1)
 
 	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
 

--- a/tests/Examples/lattigo/bfv/dot_product_8_debug/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/dot_product_8_debug/bfv_debug.go
@@ -1,0 +1,1 @@
+../bfv_debug.go

--- a/tests/Examples/lattigo/bfv/dot_product_8_debug/dot_product_8_debug_test.go
+++ b/tests/Examples/lattigo/bfv/dot_product_8_debug/dot_product_8_debug_test.go
@@ -1,4 +1,4 @@
-package dotproduct8bfv
+package main
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ func TestBinops(t *testing.T) {
 	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
 	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
 
-	resultCt := dot_product(evaluator, params, ecd, ct0, ct1)
+	resultCt := dot_product(evaluator, params, ecd, dec, ct0, ct1)
 
 	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
 

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/BUILD
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/BUILD
@@ -13,22 +13,23 @@ glaze_ignore = [
 ]
 
 heir_lattigo_lib(
-    name = "dot_product_8_debug",
+    name = "mult_dep_16_debug",
     extra_srcs = ["bfv_debug.go"],
     go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=bfv",
-        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bfv=noise-model=bfv-noise-bmcm23 \
+          annotate-noise-bound=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
-    mlir_src = "dot_product_8.mlir",
+    mlir_src = "mult_dep_16.mlir",
 )
 
 # For Google-internal reasons we must separate the go_test rules from the macro
 # above.
 
 go_test(
-    name = "dotproduct8debug_test",
-    srcs = ["dot_product_8_debug_test.go"],
+    name = "multdep16debug_test",
+    srcs = ["mult_dep_16_debug_test.go"],
     embed = [":main"],
 )

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/bfv_debug.go
@@ -1,0 +1,1 @@
+../../bfv_debug.go

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/mult_dep_16.mlir
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/mult_dep_16.mlir
@@ -1,0 +1,1 @@
+../../../../common/mult_dep_16.mlir

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/mult_dep_16_debug_test.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_16_debug/mult_dep_16_debug_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	t.Skip("Expected to fail")
+	evaluator, params, ecd, enc, dec := mult_dep__configure()
+
+	arg0 := int16(1)
+
+	expected := int16(1)
+
+	ct0 := mult_dep__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+
+	resultCt := mult_dep(evaluator, params, ecd, dec, ct0)
+
+	result := mult_dep__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/BUILD
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/BUILD
@@ -13,22 +13,23 @@ glaze_ignore = [
 ]
 
 heir_lattigo_lib(
-    name = "dot_product_8_debug",
+    name = "mult_dep_8_debug",
     extra_srcs = ["bfv_debug.go"],
     go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=bfv",
-        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bfv=noise-model=bfv-noise-bmcm23 \
+          annotate-noise-bound=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
-    mlir_src = "dot_product_8.mlir",
+    mlir_src = "mult_dep_8.mlir",
 )
 
 # For Google-internal reasons we must separate the go_test rules from the macro
 # above.
 
 go_test(
-    name = "dotproduct8debug_test",
-    srcs = ["dot_product_8_debug_test.go"],
+    name = "multdep8debug_test",
+    srcs = ["mult_dep_8_debug_test.go"],
     embed = [":main"],
 )

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/bfv_debug.go
@@ -1,0 +1,1 @@
+../../bfv_debug.go

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/mult_dep_8.mlir
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/mult_dep_8.mlir
@@ -1,0 +1,1 @@
+../../../../common/mult_dep_8.mlir

--- a/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/mult_dep_8_debug_test.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_dep_8_debug/mult_dep_8_debug_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	t.Skip("Expected to fail")
+	evaluator, params, ecd, enc, dec := mult_dep__configure()
+
+	arg0 := int16(1)
+
+	expected := int16(1)
+
+	ct0 := mult_dep__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+
+	resultCt := mult_dep(evaluator, params, ecd, dec, ct0)
+
+	result := mult_dep__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/BUILD
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/BUILD
@@ -13,22 +13,23 @@ glaze_ignore = [
 ]
 
 heir_lattigo_lib(
-    name = "dot_product_8_debug",
+    name = "mult_indep_16_debug",
     extra_srcs = ["bfv_debug.go"],
     go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=bfv",
-        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bfv=noise-model=bfv-noise-bmcm23 \
+          annotate-noise-bound=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
-    mlir_src = "dot_product_8.mlir",
+    mlir_src = "mult_indep_16.mlir",
 )
 
 # For Google-internal reasons we must separate the go_test rules from the macro
 # above.
 
 go_test(
-    name = "dotproduct8debug_test",
-    srcs = ["dot_product_8_debug_test.go"],
+    name = "multindep16debug_test",
+    srcs = ["mult_indep_16_debug_test.go"],
     embed = [":main"],
 )

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/bfv_debug.go
@@ -1,0 +1,1 @@
+../../bfv_debug.go

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/mult_indep_16.mlir
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/mult_indep_16.mlir
@@ -1,0 +1,1 @@
+../../../../common/mult_indep_16.mlir

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/mult_indep_16_debug_test.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_16_debug/mult_indep_16_debug_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := mult_indep__configure()
+
+	arg0 := int16(1)
+
+	expected := int16(1)
+
+	ct0 := mult_indep__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := mult_indep__encrypt__arg1(evaluator, params, ecd, enc, arg0)
+	ct2 := mult_indep__encrypt__arg2(evaluator, params, ecd, enc, arg0)
+	ct3 := mult_indep__encrypt__arg3(evaluator, params, ecd, enc, arg0)
+	ct4 := mult_indep__encrypt__arg4(evaluator, params, ecd, enc, arg0)
+	ct5 := mult_indep__encrypt__arg5(evaluator, params, ecd, enc, arg0)
+	ct6 := mult_indep__encrypt__arg6(evaluator, params, ecd, enc, arg0)
+	ct7 := mult_indep__encrypt__arg7(evaluator, params, ecd, enc, arg0)
+	ct8 := mult_indep__encrypt__arg8(evaluator, params, ecd, enc, arg0)
+	ct9 := mult_indep__encrypt__arg9(evaluator, params, ecd, enc, arg0)
+	ct10 := mult_indep__encrypt__arg10(evaluator, params, ecd, enc, arg0)
+	ct11 := mult_indep__encrypt__arg11(evaluator, params, ecd, enc, arg0)
+	ct12 := mult_indep__encrypt__arg12(evaluator, params, ecd, enc, arg0)
+	ct13 := mult_indep__encrypt__arg13(evaluator, params, ecd, enc, arg0)
+	ct14 := mult_indep__encrypt__arg14(evaluator, params, ecd, enc, arg0)
+	ct15 := mult_indep__encrypt__arg15(evaluator, params, ecd, enc, arg0)
+
+	resultCt := mult_indep(evaluator, params, ecd, dec,
+		ct0, ct1,
+		ct2, ct3,
+		ct4, ct5,
+		ct6, ct7,
+		ct8, ct9,
+		ct10, ct11,
+		ct12, ct13,
+		ct14, ct15)
+
+	result := mult_indep__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/BUILD
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/BUILD
@@ -13,22 +13,22 @@ glaze_ignore = [
 ]
 
 heir_lattigo_lib(
-    name = "dot_product_8_debug",
+    name = "mult_indep_32_debug",
     extra_srcs = ["bfv_debug.go"],
     go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=bfv",
-        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bfv=noise-model=bfv-noise-bmcm23 annotate-noise-bound=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
-    mlir_src = "dot_product_8.mlir",
+    mlir_src = "mult_indep_32.mlir",
 )
 
 # For Google-internal reasons we must separate the go_test rules from the macro
 # above.
 
 go_test(
-    name = "dotproduct8debug_test",
-    srcs = ["dot_product_8_debug_test.go"],
+    name = "multindep32debug_test",
+    srcs = ["mult_indep_32_debug_test.go"],
     embed = [":main"],
 )

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/bfv_debug.go
@@ -1,0 +1,1 @@
+../../bfv_debug.go

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/mult_indep_32.mlir
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/mult_indep_32.mlir
@@ -1,0 +1,1 @@
+../../../../common/mult_indep_32.mlir

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/mult_indep_32_debug_test.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_32_debug/mult_indep_32_debug_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := mult_indep__configure()
+
+	arg0 := int16(1)
+
+	expected := int16(1)
+
+	ct0 := mult_indep__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := mult_indep__encrypt__arg1(evaluator, params, ecd, enc, arg0)
+	ct2 := mult_indep__encrypt__arg2(evaluator, params, ecd, enc, arg0)
+	ct3 := mult_indep__encrypt__arg3(evaluator, params, ecd, enc, arg0)
+	ct4 := mult_indep__encrypt__arg4(evaluator, params, ecd, enc, arg0)
+	ct5 := mult_indep__encrypt__arg5(evaluator, params, ecd, enc, arg0)
+	ct6 := mult_indep__encrypt__arg6(evaluator, params, ecd, enc, arg0)
+	ct7 := mult_indep__encrypt__arg7(evaluator, params, ecd, enc, arg0)
+	ct8 := mult_indep__encrypt__arg8(evaluator, params, ecd, enc, arg0)
+	ct9 := mult_indep__encrypt__arg9(evaluator, params, ecd, enc, arg0)
+	ct10 := mult_indep__encrypt__arg10(evaluator, params, ecd, enc, arg0)
+	ct11 := mult_indep__encrypt__arg11(evaluator, params, ecd, enc, arg0)
+	ct12 := mult_indep__encrypt__arg12(evaluator, params, ecd, enc, arg0)
+	ct13 := mult_indep__encrypt__arg13(evaluator, params, ecd, enc, arg0)
+	ct14 := mult_indep__encrypt__arg14(evaluator, params, ecd, enc, arg0)
+	ct15 := mult_indep__encrypt__arg15(evaluator, params, ecd, enc, arg0)
+	ct16 := mult_indep__encrypt__arg16(evaluator, params, ecd, enc, arg0)
+	ct17 := mult_indep__encrypt__arg17(evaluator, params, ecd, enc, arg0)
+	ct18 := mult_indep__encrypt__arg18(evaluator, params, ecd, enc, arg0)
+	ct19 := mult_indep__encrypt__arg19(evaluator, params, ecd, enc, arg0)
+	ct20 := mult_indep__encrypt__arg20(evaluator, params, ecd, enc, arg0)
+	ct21 := mult_indep__encrypt__arg21(evaluator, params, ecd, enc, arg0)
+	ct22 := mult_indep__encrypt__arg22(evaluator, params, ecd, enc, arg0)
+	ct23 := mult_indep__encrypt__arg23(evaluator, params, ecd, enc, arg0)
+	ct24 := mult_indep__encrypt__arg24(evaluator, params, ecd, enc, arg0)
+	ct25 := mult_indep__encrypt__arg25(evaluator, params, ecd, enc, arg0)
+	ct26 := mult_indep__encrypt__arg26(evaluator, params, ecd, enc, arg0)
+	ct27 := mult_indep__encrypt__arg27(evaluator, params, ecd, enc, arg0)
+	ct28 := mult_indep__encrypt__arg28(evaluator, params, ecd, enc, arg0)
+	ct29 := mult_indep__encrypt__arg29(evaluator, params, ecd, enc, arg0)
+	ct30 := mult_indep__encrypt__arg30(evaluator, params, ecd, enc, arg0)
+	ct31 := mult_indep__encrypt__arg31(evaluator, params, ecd, enc, arg0)
+
+	resultCt := mult_indep(evaluator, params, ecd, dec,
+		ct0, ct1,
+		ct2, ct3,
+		ct4, ct5,
+		ct6, ct7,
+		ct8, ct9,
+		ct10, ct11,
+		ct12, ct13,
+		ct14, ct15,
+		ct16, ct17,
+		ct18, ct19,
+		ct20, ct21,
+		ct22, ct23,
+		ct24, ct25,
+		ct26, ct27,
+		ct28, ct29,
+		ct30, ct31)
+
+	result := mult_indep__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/BUILD
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/BUILD
@@ -13,22 +13,23 @@ glaze_ignore = [
 ]
 
 heir_lattigo_lib(
-    name = "dot_product_8_debug",
+    name = "mult_indep_8_debug",
     extra_srcs = ["bfv_debug.go"],
     go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=bfv",
-        "--mlir-to-bfv=ciphertext-degree=8 annotate-noise-bound=true",
+        "--mlir-to-bfv=noise-model=bfv-noise-bmcm23 \
+          annotate-noise-bound=true",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
-    mlir_src = "dot_product_8.mlir",
+    mlir_src = "mult_indep_8.mlir",
 )
 
 # For Google-internal reasons we must separate the go_test rules from the macro
 # above.
 
 go_test(
-    name = "dotproduct8debug_test",
-    srcs = ["dot_product_8_debug_test.go"],
+    name = "multindep8debug_test",
+    srcs = ["mult_indep_8_debug_test.go"],
     embed = [":main"],
 )

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/bfv_debug.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/bfv_debug.go
@@ -1,0 +1,1 @@
+../../bfv_debug.go

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/mult_indep_8.mlir
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/mult_indep_8.mlir
@@ -1,0 +1,1 @@
+../../../../common/mult_indep_8.mlir

--- a/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/mult_indep_8_debug_test.go
+++ b/tests/Examples/lattigo/bfv/noise/mult_indep_8_debug/mult_indep_8_debug_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBinops(t *testing.T) {
+	evaluator, params, ecd, enc, dec := mult_indep__configure()
+
+	arg0 := int16(1)
+
+	expected := int16(1)
+
+	ct0 := mult_indep__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := mult_indep__encrypt__arg1(evaluator, params, ecd, enc, arg0)
+	ct2 := mult_indep__encrypt__arg2(evaluator, params, ecd, enc, arg0)
+	ct3 := mult_indep__encrypt__arg3(evaluator, params, ecd, enc, arg0)
+	ct4 := mult_indep__encrypt__arg4(evaluator, params, ecd, enc, arg0)
+	ct5 := mult_indep__encrypt__arg5(evaluator, params, ecd, enc, arg0)
+	ct6 := mult_indep__encrypt__arg6(evaluator, params, ecd, enc, arg0)
+	ct7 := mult_indep__encrypt__arg7(evaluator, params, ecd, enc, arg0)
+
+	resultCt := mult_indep(evaluator, params, ecd, dec,
+		ct0, ct1,
+		ct2, ct3,
+		ct4, ct5,
+		ct6, ct7)
+
+	result := mult_indep__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	if result != expected {
+		t.Errorf("Decryption error %d != %d", result, expected)
+	}
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -37,7 +37,7 @@ cc_binary(
     includes = ["include"],
     deps = [
         "@heir//lib/Analysis/NoiseAnalysis",  # buildcleaner: keep
-        "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseCoeffModelAnalysis",  # buildcleaner: keep
+        "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGI",


### PR DESCRIPTION
This adds a noise model for B/FV based on variance analysis in coefficient embedding from BMCM23 (https://ia.cr/2023/600)

BMCM23 gives a tight bound *within* 1-bit (experimentally verified) when all inputs are independently generated ciphertext, and it won't underestimate as the depth goes on, unlike the BGV model.

This is achieved by considering the dependence factor on `s`. Note that `Var(s^2) != Var(s) * Var(s)`, so higher degree of `s` will introduce more error. For each ciphertext, its error could be written as `sum k_i * s^i`, so the max degree `T` of it will affect how error grows. They give a correction factor for multiplication `f(T + 1)` as in each multiplicaiton its degree is increased by 1.

However, for dependent ciphertext like consequtive multiplication of one ciphertext, _this implementation_ will give underestimation. Although in their paper they give partial result on dependent cases, they say it could not be generalized to all circuit so the problem remains open.

### Experiment setup

We give 5 cases, `mult_indep_{8,16,32}` and `mult_dep_{8,16}` where the independent cases are the multiplication of independently generated `k` ciphertext, and the dependent case is the multiplication of one ciphertext `k` times. We rely on `operation-balancer` to balance the input MLIR into a tree.

As expected, all independent cases survive the real noise, while all depedent cases fail. The log for `mult_indep_32` is digested below

```
Input
  [1]
  Noise: 6.83 Total: 160
  Noise Bound: 7.35 Gap: 0.52
// Depth 1
lattigo.bgv.mul
  [1]
  Noise: 35.78 Total: 160
  Noise Bound: 36.27 Gap: 0.49
// Depth 2
lattigo.bgv.mul
  [1]
  Noise: 65.27 Total: 160
  Noise Bound: 65.48 Gap: 0.21
// Depth 3
lattigo.bgv.mul
  [1]
  Noise: 94.21 Total: 160
  Noise Bound: 94.89 Gap: 0.68
// Depth 4
lattigo.bgv.mul
  [1]
  Noise: 124.23 Total: 160
  Noise Bound: 124.47 Gap: 0.24
// Depth 5
lattigo.bgv.mul
  [1]
  Noise: 153.88 Total: 160
  Noise Bound: 154.17 Gap: 0.29
```