### PR TITLE
add `-select-rewrite` pass that converts `arith.select` to HE-friendly add/mul

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -36,6 +36,7 @@
 #include "lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/Secretize/Passes.h"
+#include "lib/Transforms/SelectRewrite/SelectRewrite.h"
 #include "lib/Transforms/ValidateNoise/ValidateNoise.h"
 #include "llvm/include/llvm/ADT/SmallVector.h"      // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
@@ -95,6 +96,7 @@ void mlirToSecretArithmeticPipelineBuilder(
     OpPassManager &pm, const MlirToRLWEPipelineOptions &options) {
   pm.addPass(createWrapGeneric());
   convertToDataObliviousPipelineBuilder(pm);
+  pm.addPass(createSelectRewrite());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "@heir//lib/Transforms/ElementwiseToAffine",
         "@heir//lib/Transforms/MemrefToArith:ExpandCopy",
         "@heir//lib/Transforms/MemrefToArith:MemrefToArithRegistration",
+        "@heir//lib/Transforms/SelectRewrite",
         "@llvm-project//mlir:AffineToStandard",
         "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:ArithTransforms",

--- a/lib/Transforms/SelectRewrite/BUILD
+++ b/lib/Transforms/SelectRewrite/BUILD
@@ -1,0 +1,52 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "SelectRewrite",
+    srcs = ["SelectRewrite.cpp"],
+    hdrs = ["SelectRewrite.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Utils:ConversionUtils",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=SelectRewrite",
+            ],
+            "SelectRewrite.h.inc",
+        ),
+        (
+            ["-gen-pass-doc"],
+            "SelectRewritePasses.md",
+        ),
+        (
+            ["-gen-rewriters"],
+            "SelectRewrite.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "SelectRewrite.td",
+    deps = [
+        "@heir//lib/Utils/DRR",
+        "@llvm-project//mlir:ArithOpsTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Transforms/SelectRewrite/SelectRewrite.cpp
+++ b/lib/Transforms/SelectRewrite/SelectRewrite.cpp
@@ -1,0 +1,55 @@
+#include "lib/Transforms/SelectRewrite/SelectRewrite.h"
+
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/TypeUtilities.h"          // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_SELECTREWRITE
+#include "lib/Transforms/SelectRewrite/SelectRewrite.h.inc"
+
+Value matchShapedType(OpBuilder builder, Value op, Value target) {
+  auto targetShapedType = mlir::dyn_cast<ShapedType>(target.getType());
+  auto opShapedType = mlir::dyn_cast<ShapedType>(op.getType());
+  if (targetShapedType && !opShapedType) {
+    auto newShapedType =
+        targetShapedType.cloneWith(targetShapedType.getShape(), op.getType());
+    return builder.create<tensor::SplatOp>(op.getLoc(), op, newShapedType);
+  }
+  return op;
+}
+
+TypedAttr getMatchingOne(Value op) {
+  auto intType = getElementTypeOrSelf(op);
+  assert(intType.getIntOrFloatBitWidth() == 1 && "Expected i1 type");
+  if (auto st = mlir::dyn_cast<ShapedType>(op.getType())) {
+    return DenseElementsAttr::get(st, true);
+  }
+  return IntegerAttr::get(intType, 1);
+}
+
+namespace rewrites {
+// In an inner namespace to avoid conflicts
+#include "lib/Transforms/SelectRewrite/SelectRewrite.cpp.inc"
+}  // namespace rewrites
+
+struct SelectRewrite : impl::SelectRewriteBase<SelectRewrite> {
+  using SelectRewriteBase::SelectRewriteBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    // popiulate TD patterns
+    rewrites::populateWithGenerated(patterns);
+
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/SelectRewrite/SelectRewrite.h
+++ b/lib/Transforms/SelectRewrite/SelectRewrite.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_SELECTREWRITE_SELECTREWRITE_H_
+#define LIB_TRANSFORMS_SELECTREWRITE_SELECTREWRITE_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/SelectRewrite/SelectRewrite.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/SelectRewrite/SelectRewrite.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_SELECTREWRITE_SELECTREWRITE_H_

--- a/lib/Transforms/SelectRewrite/SelectRewrite.td
+++ b/lib/Transforms/SelectRewrite/SelectRewrite.td
@@ -1,0 +1,59 @@
+#ifndef LIB_TRANSFORMS_SELECTREWRITE_SELECTREWRITE_TD_
+#define LIB_TRANSFORMS_SELECTREWRITE_SELECTREWRITE_TD_
+
+include "mlir/Dialect/Arith/IR/ArithOps.td"
+include "lib/Utils/DRR/Utils.td"
+include "mlir/Pass/PassBase.td"
+include "mlir/IR/PatternBase.td"
+
+def SelectRewrite : Pass<"select-rewrite"> {
+  let summary = "Rewrites arith.select to a CMUX style expression";
+  let description = [{
+    "This pass rewrites arith.select %c, %t, %f to %c * %t + (1 - %c) * %f.
+     It supports all three variants of arith.select: scalar, shaped, and mixed types.
+     In the latter case, it will broadcast/splat the scalar condition value to the required shape."
+  }];
+  let dependentDialects = [
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
+// If the first input is a value of scalar type and the second is one of shaped type,
+// return the first value broadcast/splat to the same shape as the second value,
+// preserving the "element" type of the first value.
+def matchShapedType : NativeCodeCall<"matchShapedType($_builder, $0, $1)">;
+
+// Get either an IntegerAttr or DenseIntegerAtr of the same type as the input
+def getMatchingOne : NativeCodeCall<"getMatchingOne($0)">;
+
+// Rewrites arith.select %c, %t, %f to %c * %t + (1 - %c) * %f
+def SelectRewritePatternInt : Pattern<
+  (SelectOp $cond, SignlessIntegerLike:$true_value, $false_value),
+  [
+    (matchShapedType:$new_cond $cond, $true_value),
+    (Arith_ConstantOp:$one (getMatchingOne $new_cond, $true_value)),
+    (Arith_SubIOp:$not_cond $one, $new_cond, DefOverflow),
+    (Arith_ExtUIOp:$ext_cond $new_cond, (returnType $true_value)),
+    (Arith_MulIOp:$true_mul $ext_cond, $true_value, DefOverflow),
+    (Arith_ExtUIOp:$ext_not_cond $not_cond, (returnType $false_value)),
+    (Arith_MulIOp:$false_mul $ext_not_cond, $false_value, DefOverflow),
+    (Arith_AddIOp $true_mul, $false_mul, DefOverflow)
+  ]
+>;
+
+// Rewrites arith.select %c, %t, %f to %c * %t + (1 - %c) * %f
+def SelectRewritePatternFloat : Pattern<
+  (SelectOp $cond, FloatLike:$true_value, $false_value),
+  [
+    (Arith_ConstantOp:$one (getMatchingOne $cond)),
+    (Arith_SubIOp:$not_cond $one, $cond, DefOverflow),
+    (Arith_UIToFPOp:$ext_cond $cond, (returnType $true_value)),
+    (Arith_MulFOp:$true_mul $ext_cond, $true_value, DefFastMath),
+    (Arith_UIToFPOp:$ext_not_cond $not_cond, (returnType $false_value)),
+    (Arith_MulFOp:$false_mul $ext_not_cond, $false_value, DefFastMath),
+    (Arith_AddFOp $true_mul, $false_mul, DefFastMath)
+  ]
+>;
+
+
+#endif  // LIB_TRANSFORMS_SELECTREWRITE_SELECTREWRITE_TD_

--- a/lib/Utils/DRR/Utils.td
+++ b/lib/Utils/DRR/Utils.td
@@ -11,6 +11,9 @@ include "mlir/IR/PatternBase.td"
 // a default.
 defvar DefOverflow = ConstantEnumCase<Arith_IntegerOverflowAttr, "none">;
 
+// Same as `DevOverflow` but for the fastmath setting required by float ops:
+defvar DefFastMath = ConstantEnumCase<Arith_FastMathAttr, "none">;
+
 // When constructing a new variadic op, and you want to pass it a single argument
 // as its variadic input, use this helper. To understand why this is needed, see
 // https://discourse.llvm.org/t/compilation-failure-with-drr-generated-pattern/77385

--- a/tests/Transforms/select_rewrite/BUILD
+++ b/tests/Transforms/select_rewrite/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/select_rewrite/select_rewrite.mlir
+++ b/tests/Transforms/select_rewrite/select_rewrite.mlir
@@ -1,0 +1,82 @@
+// RUN: heir-opt --select-rewrite %s | FileCheck %s
+
+// CHECK-LABEL: func @scalar_arith_select
+// CHECK-SAME: [[COND:%.*]]: i1, [[LHS:%.*]]: i32, [[RHS:%.*]]: i32
+func.func @scalar_arith_select(%cond : i1, %lhs : i32, %rhs : i32) ->  i32 {
+    // CHECK: [[ONE:%.*]] = arith.constant true
+    // CHECK-DAG: [[NCOND:%.*]] = arith.subi [[ONE]], [[COND]]
+    // CHECK-DAG: [[XCOND:%.*]] = arith.extui [[COND]]
+    // CHECK-DAG: [[XNCOND:%.*]] = arith.extui [[NCOND]]
+    // CHECK-DAG: [[MLHS:%.*]] = arith.muli [[XCOND]], [[LHS]]
+    // CHECK-DAG: [[MRHS:%.*]] = arith.muli [[XNCOND]], [[RHS]]
+    // CHECK: [[RES:%.*]] = arith.addi [[MLHS]], [[MRHS]]
+    // CHECK-NOT: arith.select
+    %0 = arith.select %cond, %lhs, %rhs : i32
+    // CHECK: return [[RES:%.*]] : i32
+    return %0 : i32
+}
+
+// CHECK-LABEL: func @vector_arith_select
+// CHECK: [[COND:%.*]]: tensor<2xi1>, [[LHS:%.*]]: tensor<2xi32>, [[RHS:%.*]]: tensor<2xi32>
+func.func @vector_arith_select(%cond : tensor<2xi1>, %lhs : tensor<2xi32>, %rhs : tensor<2xi32>) ->  tensor<2xi32> {
+    // CHECK: [[ONE:%.*]] = arith.constant dense<true>
+    // CHECK-DAG: [[NCOND:%.*]] = arith.subi [[ONE]], [[COND]]
+    // CHECK-DAG: [[XCOND:%.*]] = arith.extui [[COND]]
+    // CHECK-DAG: [[XNCOND:%.*]] = arith.extui [[NCOND]]
+    // CHECK-DAG: [[MLHS:%.*]] = arith.muli [[XCOND]], [[LHS]]
+    // CHECK-DAG: [[MRHS:%.*]] = arith.muli [[XNCOND]], [[RHS]]
+    // CHECK: [[RES:%.*]] = arith.addi [[MLHS]], [[MRHS]]
+    // CHECK-NOT: arith.select
+    %0 = arith.select %cond, %lhs, %rhs :  tensor<2xi1>, tensor<2xi32>
+    // CHECK: return [[RES:%.*]] : tensor<2xi32>
+    return %0 :  tensor<2xi32>
+}
+
+// CHECK-LABEL: func @mixed_arith_select
+// CHECK: [[COND:%.*]]: i1, [[LHS:%.*]]: tensor<2xi32>, [[RHS:%.*]]: tensor<2xi32>
+func.func @mixed_arith_select(%cond : i1, %lhs : tensor<2xi32>, %rhs : tensor<2xi32>) ->  tensor<2xi32> {
+    // CHECK: [[ONE:%.*]] = arith.constant dense<true>
+    // CHECK-DAG: [[SPLAT:%.*]] = tensor.splat [[COND]]
+    // CHECK-DAG: [[NCOND:%.*]] = arith.subi [[ONE]], [[SPLAT]]
+    // CHECK-DAG: [[XCOND:%.*]] = arith.extui [[SPLAT]]
+    // CHECK-DAG: [[XNCOND:%.*]] = arith.extui [[NCOND]]
+    // CHECK-DAG: [[MLHS:%.*]] = arith.muli [[XCOND]], [[LHS]]
+    // CHECK-DAG: [[MRHS:%.*]] = arith.muli [[XNCOND]], [[RHS]]
+    // CHECK: [[RES:%.*]] = arith.addi [[MLHS]], [[MRHS]]
+    // CHECK-NOT: arith.select
+    %0 = arith.select %cond, %lhs, %rhs : i1, tensor<2xi32>
+    // CHECK: return [[RES:%.*]] : tensor<2xi32>
+    return %0 : tensor<2xi32>
+}
+
+// CHECK-LABEL func @float_arith_select
+// CHECK: [[COND:%.*]]: i1, [[LHS:%.*]]: f32, [[RHS:%.*]]: f32
+func.func @float_arith_select(%cond : i1, %lhs : f32, %rhs : f32) ->  f32 {
+    // CHECK: [[ONE:%.*]] = arith.constant true
+    // CHECK-DAG: [[NCOND:%.*]] = arith.subi [[ONE]], [[COND]]
+    // CHECK-DAG: [[XCOND:%.*]] = arith.uitofp  [[COND]]
+    // CHECK-DAG: [[XNCOND:%.*]] = arith.uitofp  [[NCOND]]
+    // CHECK-DAG: [[MLHS:%.*]] = arith.mulf [[XCOND]], [[LHS]]
+    // CHECK-DAG: [[MRHS:%.*]] = arith.mulf [[XNCOND]], [[RHS]]
+    // CHECK: [[RES:%.*]] = arith.addf [[MLHS]], [[MRHS]]
+    // CHECK-NOT: arith.select
+    %0 = arith.select %cond, %lhs, %rhs : f32
+    // CHECK: return [[RES:%.*]] : f32
+    return %0 : f32
+}
+
+// CHECK-LABEL: func @vector_float_arith_select
+// CHECK: [[COND:%.*]]: tensor<2xi1>, [[LHS:%.*]]: tensor<2xf32>, [[RHS:%.*]]: tensor<2xf32>
+func.func @vector_float_arith_select(%cond : tensor<2xi1>, %lhs : tensor<2xf32>, %rhs : tensor<2xf32>) ->  tensor<2xf32> {
+    // CHECK: [[ONE:%.*]] = arith.constant dense<true>
+    // CHECK-DAG: [[NCOND:%.*]] = arith.subi [[ONE]], [[COND]]
+    // CHECK-DAG: [[XCOND:%.*]] = arith.uitofp  [[COND]]
+    // CHECK-DAG: [[XNCOND:%.*]] = arith.uitofp  [[NCOND]]
+    // CHECK-DAG: [[MLHS:%.*]] = arith.mulf [[XCOND]], [[LHS]]
+    // CHECK-DAG: [[MRHS:%.*]] = arith.mulf [[XNCOND]], [[RHS]]
+    // CHECK: [[RES:%.*]] = arith.addf [[MLHS]], [[MRHS]]
+    // CHECK-NOT: arith.select
+    %0 = arith.select %cond, %lhs, %rhs :  tensor<2xi1>, tensor<2xf32>
+    // CHECK: return [[RES:%.*]] : tensor<2xf32>
+    return %0 :  tensor<2xf32>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -124,6 +124,7 @@ cc_binary(
         "@heir//lib/Transforms/PolynomialApproximation",
         "@heir//lib/Transforms/SecretInsertMgmt",
         "@heir//lib/Transforms/Secretize",
+        "@heir//lib/Transforms/SelectRewrite",
         "@heir//lib/Transforms/StraightLineVectorizer",
         "@heir//lib/Transforms/TensorToScalars",
         "@heir//lib/Transforms/UnusedMemRef",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -74,6 +74,7 @@
 #include "lib/Transforms/PolynomialApproximation/PolynomialApproximation.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/Secretize/Passes.h"
+#include "lib/Transforms/SelectRewrite/SelectRewrite.h"
 #include "lib/Transforms/StraightLineVectorizer/StraightLineVectorizer.h"
 #include "lib/Transforms/TensorToScalars/TensorToScalars.h"
 #include "lib/Transforms/UnusedMemRef/UnusedMemRef.h"
@@ -245,6 +246,7 @@ int main(int argc, char **argv) {
   registerSecretInsertMgmtPasses();
   registerFullLoopUnrollPasses();
   registerConvertIfToSelectPasses();
+  registerSelectRewritePasses();
   registerConvertSecretForToStaticForPasses();
   registerConvertSecretWhileToStaticForPasses();
   registerConvertSecretExtractToStaticExtractPasses();


### PR DESCRIPTION
Fixes #1572

This is a rebase/revive of https://github.com/google/heir/commit/60ee9c66301a852a97c625fe618da304f33fada which wasn't viable back then because we didn't have `arith.extui` support (#1526) at the time.