### PR TITLE
Add extra check in GenericOp::verify

### DIFF
--- a/lib/Dialect/Secret/IR/SecretOps.cpp
+++ b/lib/Dialect/Secret/IR/SecretOps.cpp
@@ -153,6 +153,10 @@ ParseResult GenericOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 LogicalResult GenericOp::verify() {
+  Region &region = this->getOperation()->getRegion(0);
+  if (region.empty()) {
+    return emitOpError() << "requires a non-empty region";
+  }
   Block *body = getBody();
 
   // Verify that the operands of the body's basic block are the non-secret


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1552

When doing context-aware dialect conversion, sometimes the GenericOp's body can be detached from the op while the conversion is ongoing.  When that happens, if the framework tries to verify the generic op, say, when attempting to dump the IR, this verification hook will fail because the region is empty and has no blocks. This extra check allows the verification to fail gracefully.