### PR TITLE
Add setAttributeAssociatedWith, getUndistinguishedResultAttr

### DIFF
--- a/lib/Utils/AttributeUtils.cpp
+++ b/lib/Utils/AttributeUtils.cpp
@@ -55,6 +55,21 @@ Attribute findAttributeForBlockArgument(BlockArgument blockArg,
       .Default([](Operation *op) { return nullptr; });
 }
 
+Attribute getUndistinguishedResultAttr(Operation *op, int resultNumber,
+                                       StringRef attrName) {
+  Attribute attr = op->getAttr(attrName);
+  // Some ops store the relevant attribute as an array attr with a name
+  // (e.g., "tensor_ext.layout" being an array of layout attrs for a
+  // multi-result op. In this case, we assert the array entries match
+  // with operation results, and return the relevant entry.
+  if (auto arrayAttr = dyn_cast_or_null<ArrayAttr>(attr)) {
+    assert(arrayAttr.size() == op->getNumResults() &&
+           "Array attr does not match number of results");
+    return arrayAttr[resultNumber];
+  }
+  return attr;
+}
+
 Attribute findAttributeForResult(Value result, StringRef attrName) {
   auto *parentOp = result.getDefiningOp();
   assert(parentOp &&
@@ -66,20 +81,10 @@ Attribute findAttributeForResult(Value result, StringRef attrName) {
       .Case<OperandAndResultAttrInterface>([&](auto op) -> Attribute {
         Attribute attr = op.getResultAttr(resultNumber, attrName);
         if (attr) return attr;
-        return op->getAttr(attrName);
+        return getUndistinguishedResultAttr(op, resultNumber, attrName);
       })
       .Default([&](Operation *op) {
-        Attribute attr = op->getAttr(attrName);
-        // Some ops store the relevant attribute as an array attr with a name
-        // (e.g., "tensor_ext.layout" being an array of layout attrs for a
-        // multi-result op. In this case, we assert the array entries match
-        // with operation results, and return the relevant entry.
-        if (auto arrayAttr = dyn_cast_or_null<ArrayAttr>(attr)) {
-          assert(arrayAttr.size() == op->getNumResults() &&
-                 "Array attr does not match number of results");
-          return arrayAttr[resultNumber];
-        }
-        return attr;
+        return getUndistinguishedResultAttr(op, resultNumber, attrName);
       });
 }
 
@@ -95,6 +100,70 @@ FailureOr<Attribute> findAttributeAssociatedWith(Value value,
   if (!attr) return failure();
 
   return attr;
+}
+
+void setAttributeForBlockArgument(BlockArgument blockArg, StringRef attrName,
+                                  Attribute attr) {
+  auto *parentOp = blockArg.getOwner()->getParentOp();
+  assert(parentOp != nullptr &&
+         "Missing parent op! Was this value not properly remapped?");
+
+  llvm::TypeSwitch<Operation *>(parentOp)
+      .Case<FunctionOpInterface>([&](auto op) {
+        return op.setArgAttr(blockArg.getArgNumber(), attrName, attr);
+      })
+      .Case<affine::AffineForOp>([&](affine::AffineForOp op) {
+        // For op has as its first block argument the induction
+        // variable, which does not correspond to a single operand.
+        if (blockArg.getArgNumber() == 0) return;
+
+        auto argAttrInterface = cast<OperandAndResultAttrInterface>(*op);
+        auto initArg = op.getInits()[blockArg.getArgNumber() - 1];
+        int operandNumber = getOperandNumber(op, initArg);
+        if (operandNumber == -1) return;
+        return argAttrInterface.setOperandAttr(operandNumber, attrName, attr);
+      })
+      .Case<OperandAndResultAttrInterface>([&](auto op) {
+        return op.setOperandAttr(blockArg.getArgNumber(), attrName, attr);
+      });
+}
+
+void setAttributeForResult(Value result, StringRef attrName, Attribute attr) {
+  auto *parentOp = result.getDefiningOp();
+  assert(parentOp &&
+         "Missing defining op, but the input value is not a BlockArgument. "
+         "This is madness.");
+  int resultNumber = cast<OpResult>(result).getResultNumber();
+
+  llvm::TypeSwitch<Operation *>(parentOp)
+      .Case<OperandAndResultAttrInterface>(
+          [&](auto op) { op.setResultAttr(resultNumber, attrName, attr); })
+      .Default([&](Operation *op) {
+        // If the op has an existing array attr, set the attribute in the
+        // existing array attr's index.
+        auto existingAttr = op->getAttr(attrName);
+        if (auto existingArrayAttr =
+                dyn_cast_or_null<ArrayAttr>(existingAttr)) {
+          assert(existingArrayAttr.size() == op->getNumResults() &&
+                 "Array attr does not match number of results");
+          existingArrayAttr[resultNumber] = attr;
+          op->setAttr(attrName, existingArrayAttr);
+        } else {
+          assert(op->getNumResults() == 1 &&
+                 "Op has multiple results but no array attr was passed or "
+                 "existing.");
+          op->setAttr(attrName, attr);
+        }
+      });
+}
+
+void setAttributeAssociatedWith(Value value, StringRef attrName,
+                                Attribute attr) {
+  if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+    setAttributeForBlockArgument(blockArg, attrName, attr);
+  } else {
+    setAttributeForResult(value, attrName, attr);
+  }
 }
 
 void clearAttrs(Operation *op, StringRef attrName) {

--- a/lib/Utils/AttributeUtils.h
+++ b/lib/Utils/AttributeUtils.h
@@ -25,6 +25,9 @@ namespace heir {
 FailureOr<Attribute> findAttributeAssociatedWith(Value value,
                                                  StringRef attrName);
 
+void setAttributeAssociatedWith(Value value, StringRef attrName,
+                                Attribute attr);
+
 // Remove attributes with a given name from a given op, taking into account
 // FunctionOpInterface's arg/result attrs as well as
 // OperandAndResultAttrInterface.


### PR DESCRIPTION
setAttributeAssociatedWith is the converse of findAttributeAssociatedWith. getUndistinguishedResultAttr is a generalized helper to allow an op to specify attributes for multiple results via an ArrayAttr. This also makes it so that one can have both a single-result op with a single attr and a single-result op with an ArrayAttr of size 1, though the former is preferred.

Extracted from https://github.com/google/heir/pull/1552