### PR TITLE
Minor improvements to context-aware dialect conversion

### DIFF
--- a/lib/Utils/ContextAwareConversionUtils.h
+++ b/lib/Utils/ContextAwareConversionUtils.h
@@ -386,7 +386,7 @@ struct ContextAwareFuncConversion
   ContextAwareFuncConversion(
       const ContextAwareTypeConverter &contextAwareTypeConverter,
       MLIRContext *context)
-      : ContextAwareOpConversionPattern(context),
+      : ContextAwareOpConversionPattern(context, /*benefit=*/2),
         contextAwareTypeConverter(&contextAwareTypeConverter) {}
 
   LogicalResult matchAndRewrite(

--- a/lib/Utils/ContextAwareDialectConversion.h
+++ b/lib/Utils/ContextAwareDialectConversion.h
@@ -98,6 +98,7 @@ template <typename SourceOp>
 class ContextAwareOpConversionPattern : public ContextAwareConversionPattern {
  public:
   using OpAdaptor = typename SourceOp::Adaptor;
+  using ContextAwareConversionPattern::matchAndRewrite;
 
   ContextAwareOpConversionPattern(MLIRContext *context,
                                   PatternBenefit benefit = 1)

--- a/lib/Utils/ContextAwareTypeConversion.cpp
+++ b/lib/Utils/ContextAwareTypeConversion.cpp
@@ -61,13 +61,17 @@ void ContextAwareTypeConverter::SignatureConversion::remapInput(
 
 LogicalResult ContextAwareTypeConverter::convertType(
     Type t, Value v, SmallVectorImpl<Type> &results) const {
+  LLVM_DEBUG(llvm::dbgs() << "Fetching contextual attr for value: " << v
+                          << "\n");
   auto contextAttr = getContextualAttr(v);
   // If no usable attribute is found, then we don't need to convert the type,
   // and we can return the type as-is
   if (failed(contextAttr)) {
+    LLVM_DEBUG(llvm::dbgs() << "Failed to fetch attr\n");
     results.push_back(t);
     return success();
   }
+  LLVM_DEBUG(llvm::dbgs() << "Fetched attr: " << contextAttr.value() << "\n");
   return convertType(t, contextAttr.value(), results);
 }
 

--- a/lib/Utils/ContextAwareTypeConversion.h
+++ b/lib/Utils/ContextAwareTypeConversion.h
@@ -8,22 +8,19 @@
 #include <type_traits>
 #include <utility>
 
-#include "lib/Dialect/HEIRInterfaces.h"
 #include "lib/Utils/AttributeUtils.h"
 #include "llvm/include/llvm/ADT/DenseMapInfo.h"    // from @llvm-project
 #include "llvm/include/llvm/ADT/Hashing.h"         // from @llvm-project
 #include "llvm/include/llvm/ADT/PointerIntPair.h"  // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"       // from @llvm-project
-#include "llvm/include/llvm/ADT/TypeSwitch.h"      // from @llvm-project
 #include "llvm/include/llvm/Support/RWMutex.h"     // from @llvm-project
-#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Attributes.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Builders.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/Location.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/TypeRange.h"   // from @llvm-project
-#include "mlir/include/mlir/IR/Types.h"       // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"       // from @llvm-project
-#include "mlir/include/mlir/IR/ValueRange.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Attributes.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Location.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/TypeRange.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/ValueRange.h"       // from @llvm-project
 #include "mlir/include/mlir/Interfaces/FunctionInterfaces.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project


### PR DESCRIPTION
- `using ContextAwareConversionPattern::matchAndRewrite;` removes a compile-time warning.
- Default to ContextAwareFuncConversion using a higher benefit
- Debug logs for failure to find context attrs
- Cleaned up imports

Extracted from https://github.com/google/heir/pull/1552