### PR TITLE
Lattigo: use DropLevel API for level reduce

### DIFF
--- a/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoRLWEOps.td
@@ -122,16 +122,17 @@ def Lattigo_RLWEDecryptOp : Lattigo_RLWEOp<"decrypt"> {
   let results = (outs Lattigo_RLWEPlaintext:$plaintext);
 }
 
-def Lattigo_RLWELevelReduceNewOp : Lattigo_RLWEOp<"level_reduce_new"> {
+def Lattigo_RLWEDropLevelNewOp : Lattigo_RLWEOp<"drop_level_new"> {
   let summary = "Drop level of a ciphertext";
   let arguments = (ins
+    Lattigo_RLWEEvaluator:$evaluator,
     Lattigo_RLWECiphertext:$input,
     DefaultValuedAttr<I64Attr, "1">:$levelToDrop
   );
   let results = (outs Lattigo_RLWECiphertext:$output);
 }
 
-def Lattigo_RLWELevelReduceOp : Lattigo_RLWEOp<"level_reduce", [InplaceOpInterface]> {
+def Lattigo_RLWEDropLevelOp : Lattigo_RLWEOp<"drop_level", [InplaceOpInterface]> {
   let summary = "Drop level of a ciphertext";
   let description = [{
     This operation drops the level of a ciphertext
@@ -140,13 +141,14 @@ def Lattigo_RLWELevelReduceOp : Lattigo_RLWEOp<"level_reduce", [InplaceOpInterfa
     a transitive reference to the `inplace` operand for sake of the MLIR SSA form.
   }];
   let arguments = (ins
+    Lattigo_RLWEEvaluator:$evaluator,
     Lattigo_RLWECiphertext:$input,
     Lattigo_RLWECiphertext:$inplace,
     DefaultValuedAttr<I64Attr, "1">:$levelToDrop
   );
   let results = (outs Lattigo_RLWECiphertext:$output);
 
-  let extraClassDeclaration = "int getInplaceOperandIndex() { return 1; }";
+  let extraClassDeclaration = "int getInplaceOperandIndex() { return 2; }";
 }
 
 #endif  // LIB_DIALECT_LATTIGO_IR_LATTIGORLWEOPS_TD_

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -65,7 +65,7 @@ LogicalResult LattigoEmitter::translate(Operation &op) {
               RLWENewEncryptorOp, RLWENewDecryptorOp, RLWENewKeyGeneratorOp,
               RLWEGenKeyPairOp, RLWEGenRelinearizationKeyOp, RLWEGenGaloisKeyOp,
               RLWENewEvaluationKeySetOp, RLWEEncryptOp, RLWEDecryptOp,
-              RLWELevelReduceNewOp, RLWELevelReduceOp,
+              RLWEDropLevelNewOp, RLWEDropLevelOp,
               // BGV
               BGVNewParametersFromLiteralOp, BGVNewEncoderOp, BGVNewEvaluatorOp,
               BGVNewPlaintextOp, BGVEncodeOp, BGVDecodeOp, BGVAddNewOp,
@@ -337,25 +337,23 @@ LogicalResult LattigoEmitter::printOperation(RLWEDecryptOp op) {
                             {op.getCiphertext()}, "DecryptNew", false);
 }
 
-LogicalResult LattigoEmitter::printOperation(RLWELevelReduceNewOp op) {
-  // there is no LevelReduceNew method in Lattigo, manually create new
-  // ciphertext
+LogicalResult LattigoEmitter::printOperation(RLWEDropLevelNewOp op) {
+  // there is no DropLevelNew method in Lattigo BGV Evaluator, manually create
+  // new ciphertext
   os << getName(op.getOutput()) << " := " << getName(op.getInput())
      << ".CopyNew()\n";
-  os << getName(op.getOutput()) << ".Resize(" << getName(op.getOutput())
-     << ".Degree(), " << getName(op.getOutput()) << ".Level()-"
-     << op.getLevelToDrop() << ")\n";
+  os << getName(op.getEvaluator()) << ".DropLevel(" << getName(op.getOutput())
+     << ", " << op.getLevelToDrop() << ")\n";
   return success();
 }
 
-LogicalResult LattigoEmitter::printOperation(RLWELevelReduceOp op) {
+LogicalResult LattigoEmitter::printOperation(RLWEDropLevelOp op) {
   if (getName(op.getOutput()) != getName(op.getInput())) {
-    os << getName(op.getInput()) << ".Copy(" << getName(op.getOutput())
+    os << getName(op.getOutput()) << ".Copy(" << getName(op.getInput())
        << ")\n";
   }
-  os << getName(op.getOutput()) << ".Resize(" << getName(op.getOutput())
-     << ".Degree(), " << getName(op.getOutput()) << ".Level()-"
-     << op.getLevelToDrop() << ")\n";
+  os << getName(op.getEvaluator()) << ".DropLevel(" << getName(op.getOutput())
+     << ", " << op.getLevelToDrop() << ")\n";
   return success();
 }
 

--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -69,8 +69,8 @@ class LattigoEmitter {
   LogicalResult printOperation(RLWENewEvaluationKeySetOp op);
   LogicalResult printOperation(RLWEEncryptOp op);
   LogicalResult printOperation(RLWEDecryptOp op);
-  LogicalResult printOperation(RLWELevelReduceNewOp op);
-  LogicalResult printOperation(RLWELevelReduceOp op);
+  LogicalResult printOperation(RLWEDropLevelNewOp op);
+  LogicalResult printOperation(RLWEDropLevelOp op);
   // BGV
   LogicalResult printOperation(BGVNewParametersFromLiteralOp op);
   LogicalResult printOperation(BGVNewEncoderOp op);

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -184,3 +184,16 @@ module attributes {scheme.bgv} {
     return %ct : !lattigo.rlwe.ciphertext
   }
 }
+
+// -----
+
+module attributes {scheme.bgv} {
+  // CHECK-LABEL: func test_drop_level
+  // CHECK-SAME: ([[evaluator:.*]] *bgv.Evaluator, [[ct:.*]] *rlwe.Ciphertext)
+  func.func @test_drop_level(%evaluator: !lattigo.bgv.evaluator, %ct: !lattigo.rlwe.ciphertext) -> (!lattigo.rlwe.ciphertext) {
+    // CHECK: [[ct1:[^, ]*]] := ct.CopyNew()
+    // CHECK: evaluator.DropLevel([[ct1]], 2)
+    %ct1 = lattigo.rlwe.drop_level_new %evaluator, %ct {levelToDrop = 2}: (!lattigo.bgv.evaluator, !lattigo.rlwe.ciphertext) -> !lattigo.rlwe.ciphertext
+    return %ct1 : !lattigo.rlwe.ciphertext
+  }
+}

--- a/tests/Dialect/Lattigo/IR/rlwe_ops.mlir
+++ b/tests/Dialect/Lattigo/IR/rlwe_ops.mlir
@@ -18,6 +18,8 @@
 
 !params = !lattigo.bgv.parameter
 
+!evaluator = !lattigo.bgv.evaluator
+
 module {
   // CHECK-LABEL: func @test_rlwe_new_key_generator
   func.func @test_rlwe_new_key_generator(%params: !params) {
@@ -86,6 +88,20 @@ module {
   func.func @test_rlwe_decrypt(%decryptor: !decryptor, %ct: !ct) {
     // CHECK: %[[v1:.*]] = lattigo.rlwe.decrypt
     %pt = lattigo.rlwe.decrypt %decryptor, %ct : (!decryptor, !ct) -> !pt
+    return
+  }
+
+  // CHECK-LABEL: func @test_rlwe_drop_level_new
+  func.func @test_rlwe_drop_level_new(%evaluator : !evaluator, %ct: !ct) {
+    // CHECK: %[[v1:.*]] = lattigo.rlwe.drop_level_new
+    %ct1 = lattigo.rlwe.drop_level_new %evaluator, %ct : (!evaluator, !ct) -> !ct
+    return
+  }
+
+  // CHECK-LABEL: func @test_rlwe_drop_level
+  func.func @test_rlwe_drop_level(%evaluator : !evaluator, %ct: !ct) {
+    // CHECK: %[[v1:.*]] = lattigo.rlwe.drop_level
+    %ct1 = lattigo.rlwe.drop_level %evaluator, %ct, %ct : (!evaluator, !ct, !ct) -> !ct
     return
   }
 }

--- a/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_drop_level.mlir
+++ b/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_drop_level.mlir
@@ -1,0 +1,12 @@
+// RUN: heir-opt --lattigo-alloc-to-inplace %s | FileCheck %s
+
+!evaluator = !lattigo.bgv.evaluator
+!ct = !lattigo.rlwe.ciphertext
+
+// CHECK-LABEL: func.func @drop_level
+func.func @drop_level(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    // CHECK: lattigo.rlwe.drop_level
+    // CHECK-NOT: lattigo.rlwe.drop_level_new
+    %0 = lattigo.rlwe.drop_level_new %evaluator, %ct : (!evaluator, !ct) -> !ct
+    return %0 : !ct
+}


### PR DESCRIPTION
DropLevel in Lattigo has the implementation:

```GO
// DropLevel reduces the level of op0 by levels and returns the result in op0.
// No rescaling is applied during this procedure.
func (eval Evaluator) DropLevel(op0 *rlwe.Ciphertext, levels int) {
	op0.Resize(op0.Degree(), op0.Level()-levels)
}
```

which is the same as what LattigoEmitter implements.

In the meantime, CKKS has DropLevelNew but BGV does not have one, so the emitter does not use the DropLevelNew API. Will PR Lattigo to try to add this API.