### PR TITLE
Configure bazel to use a hermetic MacOS toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,9 +22,18 @@ build:linux --linkopt="-fuse-ld=lld"
 
 # macos specific options
 build:macos --apple_platform_type=macos
-build:macos --macos_minimum_os=10.13
-build:macos --macos_sdk_version=10.13
+build:macos --macos_minimum_os=10.15
+build:macos --macos_sdk_version=10.15
+# https://github.com/bazelbuild/apple_support
+build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain
+# Avoid hitting command line argument limit
+build:macos --features=archive_param_file
+
+# MacOS arm64 config
 build:macos_arm64 --cpu=darwin_arm64
+build:macos_arm64 --macos_minimum_os=11.0
 
 # run with --config=gcc to force use of gcc
 # (and the default linker, usually ld) instead

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,16 @@ module(name = "heir")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
+# Apple compilation support.
+# Note this requires full xcode, not just commandline tools
+#
+# Tested with:
+#
+# $ /usr/bin/xcodebuild -version
+#   Xcode 16.2
+#   Build version 16C5032a
+bazel_dep(name = "apple_support", version = "1.20.0", repo_name = "build_bazel_apple_support")
+
 # Gazelle puglin for BUILD file autogeneration
 bazel_dep(name = "gazelle", version = "0.42.0")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -12,9 +12,11 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/MODULE.bazel": "d1086e248cda6576862b4b3fe9ad76a214e08c189af5b42557a6e1888812c5d5",
     "https://bcr.bazel.build/modules/abseil-cpp/20250127.0/source.json": "1b996859f840d8efc7c720efc61dcf2a84b1261cb3974cbbe9b6666ebf567775",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
-    "https://bcr.bazel.build/modules/apple_support/1.15.1/source.json": "517f2b77430084c541bc9be2db63fdcbb7102938c5f64c17ee60ffda2e5cf07b",
+    "https://bcr.bazel.build/modules/apple_support/1.20.0/MODULE.bazel": "932c689bd541bc040433ec0cd155cc4f6d41e9aae0f8ca056287b0baac1afe5c",
+    "https://bcr.bazel.build/modules/apple_support/1.20.0/source.json": "0be4755d73584ab8a46c06b0c771125a38c1b7cdde8a1b32826d28f71f937fba",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
@@ -192,8 +194,8 @@
   "moduleExtensions": {
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "E970FlMbwpgJPdPUQzatKh6BMfeE0ZpWABvwshh7Tmg=",
-        "usagesDigest": "aYRVMk+1OupIp+5hdBlpzT36qgd6ntgSxYTzMLW5K4U=",
+        "bzlTransitiveDigest": "gv4nokEMGNye4Jvoh7Tw0Lzs63zfklj+n4t0UegI7Ms=",
+        "usagesDigest": "nqxcU1Nxpapai48UqcLYJnFkImqvvMpYtD//StSWrxY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/lib/Dialect/TensorExt/IR/TensorExtAttributes.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtAttributes.cpp
@@ -17,11 +17,9 @@ namespace heir {
 namespace tensor_ext {
 
 LogicalResult AlignmentAttr::verify(
-    function_ref<InFlightDiagnostic()> emitError,
-    mlir::detail::DenseArrayAttrImpl<long> in,
-    mlir::detail::DenseArrayAttrImpl<long> out,
-    mlir::detail::DenseArrayAttrImpl<long> insertedDims,
-    mlir::detail::DenseArrayAttrImpl<long> padding, TypedAttr paddingValue) {
+    function_ref<InFlightDiagnostic()> emitError, mlir::DenseI64ArrayAttr in,
+    mlir::DenseI64ArrayAttr out, mlir::DenseI64ArrayAttr insertedDims,
+    mlir::DenseI64ArrayAttr padding, TypedAttr paddingValue) {
   if (in.empty() || out.empty()) {
     return emitError() << "in and out may not be empty arrays";
   }
@@ -45,8 +43,8 @@ LogicalResult AlignmentAttr::verify(
     return emitError() << "paddingValue must be set if padding is set";
   }
 
-  DenseSet<long> insertedDimsSet(insertedDims.asArrayRef().begin(),
-                                 insertedDims.asArrayRef().end());
+  DenseSet<int64_t> insertedDimsSet(insertedDims.asArrayRef().begin(),
+                                    insertedDims.asArrayRef().end());
   if (insertedDimsSet.size() != insertedDims.size()) {
     return emitError() << "insertedDims must all be unique";
   }


### PR DESCRIPTION
This PR uses the https://github.com/bazelbuild/apple_support/ project to configure a proper CC toolchain for mac platforms. This PR follows the [analogous configuration of the Tensorflow project](https://github.com/tensorflow/tensorflow/blob/fde75f0fd00689b0731864a96efd81955897e9ba/.bazelrc#L196-L198) but using the simpler bazelmod configuration.

The _downside_ of this PR is that is requires mac users to have a full XCode installation (I tested it with XCode 16.2). The upside is that we should not expect to see any more mac versioning errors or linking errors when incompatible pieces of different toolchains are incorrectly selected by bazel via the default unix toolchain.