### PR TITLE
Make poly approx unit tests compatible with macos

### DIFF
--- a/lib/Utils/Approximation/CaratheodoryFejerTest.cpp
+++ b/lib/Utils/Approximation/CaratheodoryFejerTest.cpp
@@ -23,11 +23,16 @@ TEST(CaratheodoryFejerTest, ApproximateExpDegree3) {
     return APFloat(std::exp(x.convertToDouble()));
   };
   FloatPolynomial actual = caratheodoryFejerApproximation(func, 3);
-  // Values taken from reference impl are exact.
-  FloatPolynomial expected = FloatPolynomial::fromCoefficients(
-      {0.9945794763246951, 0.9956677100276301, 0.5429727883818608,
-       0.17953348361617388});
-  EXPECT_EQ(actual, expected);
+
+  auto terms = actual.getTerms();
+  EXPECT_THAT(terms[0].getCoefficient().convertToDouble(),
+              DoubleNear(0.9945794763246951, EPSILON));
+  EXPECT_THAT(terms[1].getCoefficient().convertToDouble(),
+              DoubleNear(0.9956677100276301, EPSILON));
+  EXPECT_THAT(terms[2].getCoefficient().convertToDouble(),
+              DoubleNear(0.5429727883818608, EPSILON));
+  EXPECT_THAT(terms[3].getCoefficient().convertToDouble(),
+              DoubleNear(0.17953348361617388, EPSILON));
 }
 
 TEST(CaratheodoryFejerTest, ApproximateExpDegree3MinusTwoTwoInterval) {

--- a/lib/Utils/Approximation/ChebyshevTest.cpp
+++ b/lib/Utils/Approximation/ChebyshevTest.cpp
@@ -17,6 +17,7 @@ namespace {
 using ::llvm::APFloat;
 using ::mlir::heir::polynomial::FloatPolynomial;
 using ::testing::DoubleEq;
+using ::testing::DoubleNear;
 using ::testing::ElementsAre;
 
 TEST(ChebyshevTest, TestGetChebyshevPointsSingle) {
@@ -98,7 +99,14 @@ TEST(ChebyshevTest, TestInterpolateChebyshevExpDegree3) {
   // This test is slightly off from what numpy produces (up to ~10^{-15}), not
   // sure why.
   // EXPECT_THAT(actual[3].convertToDouble(), DoubleEq(0.04433686088543568));
-  EXPECT_THAT(actual[3].convertToDouble(), DoubleEq(0.044336860885435536));
+  //
+  // This is also slightly off from what is produced on MacOS platforms by the
+  // same code. EXPECT_THAT(actual[3].convertToDouble(),
+  // DoubleEq(0.044336860885435571));
+  //
+  // EXPECT_THAT(actual[3].convertToDouble(), DoubleEq(0.044336860885435536));
+  EXPECT_THAT(actual[3].convertToDouble(),
+              DoubleNear(0.044336860885435536, 1e-14));
 }
 
 TEST(ChebyshevTest, ExpAutoSelectDegree) {
@@ -122,7 +130,7 @@ TEST(ChebyshevTest, ExpAutoSelectDegree) {
     }
     error = std::max(error, std::abs(expected - actual));
   }
-  EXPECT_LT(error, 1e-15);
+  EXPECT_LT(error, 1e-14);
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes the poly approximation failures from https://github.com/google/heir/issues/1521

The main issue seems to be that some primitives are implemented differently in macos, leading to slight differences (on the order of 1e-15) in some of the resulting values which are currently being tested for equality. This simply relaxes some of the equality checks.