### PR TITLE
Openfhe: allow embedded header path

### DIFF
--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -933,7 +933,8 @@ LogicalResult OpenFhePkeEmitter::printOperation(
   os << "auto " << inputVarFilledName << " = " << inputVarName << ";\n";
   os << inputVarFilledName << ".clear();\n";
   os << inputVarFilledName << ".reserve(" << inputVarFilledLengthName << ");\n";
-  os << "for (auto i = 0; i < " << inputVarFilledLengthName << "; ++i) {\n";
+  // inputVarFilledLengthName is unsigned
+  os << "for (unsigned i = 0; i < " << inputVarFilledLengthName << "; ++i) {\n";
   os << "  " << inputVarFilledName << ".push_back(" << inputVarName << "[i % "
      << inputVarName << ".size()]);\n";
   os << "}\n";

--- a/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
@@ -13,6 +13,9 @@ constexpr std::string_view kSourceRelativeOpenfheImport = R"cpp(
 constexpr std::string_view kInstallationRelativeOpenfheImport = R"cpp(
 #include "openfhe/pke/openfhe.h"  // from @openfhe
 )cpp";
+constexpr std::string_view kEmbeddedOpenfheImport = R"cpp(
+#include "openfhe.h"
+)cpp";
 
 // clang-format off
 constexpr std::string_view kModulePreludeTemplate = R"cpp(

--- a/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
+++ b/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
@@ -42,7 +42,11 @@ struct TranslateOptions {
           clEnumValN(mlir::heir::openfhe::OpenfheImportType::SOURCE_RELATIVE,
                      "source-relative",
                      "Emit OpenFHE with source-relative import paths (default "
-                     "for HEIR-internal development)"))};
+                     "for HEIR-internal development)"),
+          clEnumValN(mlir::heir::openfhe::OpenfheImportType::EMBEDDED,
+                     "embedded",
+                     "Emit OpenFHE with embedded import paths (default "
+                     "for code to be included in OpenFHE source files)"))};
   llvm::cl::opt<std::string> weightsFile{
       "weights-file",
       llvm::cl::desc("Emit all dense elements attributes to this binary file")};

--- a/lib/Target/OpenFhePke/OpenFheUtils.cpp
+++ b/lib/Target/OpenFhePke/OpenFheUtils.cpp
@@ -28,7 +28,9 @@ std::string getModulePrelude(OpenfheScheme scheme,
                              OpenfheImportType importType) {
   auto import = importType == OpenfheImportType::SOURCE_RELATIVE
                     ? kSourceRelativeOpenfheImport
-                    : kInstallationRelativeOpenfheImport;
+                    : (importType == OpenfheImportType::INSTALL_RELATIVE
+                           ? kInstallationRelativeOpenfheImport
+                           : kEmbeddedOpenfheImport);
   auto prelude = std::string(
       llvm::formatv(kModulePreludeTemplate.data(),
                     scheme == OpenfheScheme::CKKS

--- a/lib/Target/OpenFhePke/OpenFheUtils.h
+++ b/lib/Target/OpenFhePke/OpenFheUtils.h
@@ -28,7 +28,13 @@ enum class OpenfheImportType {
   // like #include "openfhe/pke/openfhe.h". This is useful for user-facing code
   // generation, where the openfhe backend is installed by the user or shipped
   // as a shared library dependency of a heir frontend.
-  INSTALL_RELATIVE
+  INSTALL_RELATIVE,
+
+  // Import paths are embedded directly in the generated code, i.e., paths like
+  // #include "openfhe.h". This is useful for generating code that is intended
+  // to be put in openfhe source files, where the openfhe headers are already
+  // handled by the build system.
+  EMBEDDED,
 };
 
 std::string getModulePrelude(OpenfheScheme scheme,


### PR DESCRIPTION
Sometimes it may be preferred that the generated openfhe code could be directly put into `src/pke/examples/` folder of openfhe (then openfhe automatically find it) to ease the compilation process without the mess of installing openfhe.

As for the `auto` to `unsigned`, Openfhe has stricter check

```
error: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Werror=sign-compare]
  159 |     for (auto i = 0; i < v2_filled_n; ++i) {
      |                      ~~^~~~~~~~~~~~~
```

Side note: I will have large suite of artifact/test against openfhe. The openfhe shipped by bazel in HEIR is tooo slow so I turned to this solution. Also there is quite a bunch of auto-generated mlir with combination of different compiling flags (i.e. different noise model), which then I do not want to use bazel as the test driver.