### PR TITLE
Openfhe: support more param options

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -74,16 +74,35 @@ def GenParamsOp : Openfhe_Op<"gen_params"> {
     are using CKKS, this is 0.
 
     `insecure` is a flag that determines whether the parameters
-    are generated securely or not. This is mainly used for
-    testing purposes.
+    are generated securely or not. In Openfhe, this means setting
+    HEStd_NotSet for security level.
+
+    For other flags, see the OpenFHE documentation in
+    https://github.com/openfheorg/openfhe-development/blob/main/src/pke/examples/README.md#description-of-the-cryptocontext-parameters-and-their-restrictions
   }];
   let arguments = (ins
+    // Essential parameters
     I64Attr:$mulDepth,
     I64Attr:$plainMod,
-    BoolAttr:$insecure,
-    I64Attr:$evalAddCount,
-    I64Attr:$keySwitchCount,
-    BoolAttr:$encryptionTechniqueExtended
+    // Optional parameters
+    DefaultValuedAttr<I64Attr, "0">:$ringDim,
+    DefaultValuedAttr<I64Attr, "0">:$batchSize,
+    // Modulus chain parameters
+    DefaultValuedAttr<I64Attr, "0">:$firstModSize,
+    DefaultValuedAttr<I64Attr, "0">:$scalingModSize,
+    // KPZ21 way of noise estimation
+    DefaultValuedAttr<I64Attr, "0">:$evalAddCount,
+    DefaultValuedAttr<I64Attr, "0">:$keySwitchCount,
+    // Key switching technique parameters
+    DefaultValuedAttr<I64Attr, "0">:$digitSize,
+    DefaultValuedAttr<I64Attr, "0">:$numLargeDigits,
+    // Relinearization parameters
+    DefaultValuedAttr<I64Attr, "0">:$maxRelinSkDeg,
+    // Option switches
+    DefaultValuedAttr<BoolAttr, "false">:$insecure,
+    DefaultValuedAttr<BoolAttr, "false">:$encryptionTechniqueExtended,
+    DefaultValuedAttr<BoolAttr, "false">:$keySwitchingTechniqueBV,
+    DefaultValuedAttr<BoolAttr, "false">:$scalingTechniqueFixedManual
   );
   let results = (outs Openfhe_CCParams:$params);
 }

--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -35,235 +35,306 @@ namespace mlir {
 namespace heir {
 namespace openfhe {
 
+struct Config {
+  // computed from IR
+  bool hasRelinOp;
+  bool hasBootstrapOp;
+  SmallVector<int64_t> rotIndices;
+  // inherited from IR mgmt.openfhe_params
+  int64_t evalAddCount;
+  int64_t keySwitchCount;
+  // inherited from IR LWE type
+  int64_t plaintextModulus;
+  // inhertied from scheme param
+  bool encryptionTechniqueExtended;
+  // merge from IR and pass options
+  int mulDepth;  // user may want to override this; bootstrap also modifies
+                 // this
+  // from pass options
+  // directly applies to GenParamsOp
+  int ringDim;
+  // TODO(#1441): inherit batch size from IR
+  int batchSize;
+  int firstModSize;
+  int scalingModSize;
+  int digitSize;
+  int numLargeDigits;
+  int maxRelinSkDeg;
+  bool insecure;
+  bool keySwitchingTechniqueBV;
+  bool scalingTechniqueFixedManual;
+  // for bootstrapping
+  int64_t levelBudgetEncode;
+  int64_t levelBudgetDecode;
+};
+
 #define GEN_PASS_DEF_CONFIGURECRYPTOCONTEXT
 #include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
-
-// Helper function to check if the function has RelinOp
-bool hasRelinOp(func::FuncOp op) {
-  bool result = false;
-  op.walk<WalkOrder::PreOrder>([&](Operation *op) {
-    if (isa<openfhe::RelinOp>(op)) {
-      result = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return result;
-}
-
-// Helper function to find all the rotation indices in the function
-SmallVector<int64_t> findAllRotIndices(func::FuncOp op) {
-  std::set<int64_t> distinctRotIndices;
-  op.walk([&](openfhe::RotOp rotOp) {
-    distinctRotIndices.insert(rotOp.getIndex().getInt());
-    return WalkResult::advance();
-  });
-  SmallVector<int64_t> rotIndicesResult(distinctRotIndices.begin(),
-                                        distinctRotIndices.end());
-  return rotIndicesResult;
-}
-
-// Helper function to check if the function has BootstrapOp
-bool hasBootstrapOp(func::FuncOp op) {
-  bool result = false;
-  op.walk<WalkOrder::PreOrder>([&](Operation *op) {
-    if (isa<openfhe::BootstrapOp>(op)) {
-      result = true;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-  return result;
-}
-
-// function that generates the crypto context with proper parameters
-LogicalResult generateGenFunc(func::FuncOp op, const std::string &genFuncName,
-                              int64_t mulDepth, bool hasBootstrapOp,
-                              bool insecure, bool encryptionTechniqueExtended,
-                              ImplicitLocOpBuilder &builder) {
-  Type openfheContextType =
-      openfhe::CryptoContextType::get(builder.getContext());
-  SmallVector<Type> funcArgTypes;
-  SmallVector<Type> funcResultTypes;
-  funcResultTypes.push_back(openfheContextType);
-
-  FunctionType genFuncType =
-      FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
-  auto genFuncOp = builder.create<func::FuncOp>(genFuncName, genFuncType);
-  builder.setInsertionPointToEnd(genFuncOp.addEntryBlock());
-
-  // get plaintext modulus from function argument ciphertext type
-  // for CKKS, plainMod is 0
-  int64_t plainMod = 0;
-  for (auto arg : op.getArguments()) {
-    if (auto argType = dyn_cast<lwe::NewLWECiphertextType>(
-            getElementTypeOrSelf(arg.getType()))) {
-      if (auto modArithType = dyn_cast<mod_arith::ModArithType>(
-              argType.getPlaintextSpace().getRing().getCoefficientType())) {
-        plainMod = modArithType.getModulus().getInt();
-        // implicitly assume arguments have the same plaintext modulus
-        break;
-      }
-    }
-  }
-
-  // get evalAddCount/KeySwitchCount from func attribute, if present
-  int64_t evalAddCount = 0;
-  int64_t keySwitchCount = 0;
-  if (auto openfheParamsAttr = op->getAttrOfType<mgmt::OpenfheParamsAttr>(
-          mgmt::MgmtDialect::kArgOpenfheParamsAttrName)) {
-    evalAddCount = openfheParamsAttr.getEvalAddCount();
-    keySwitchCount = openfheParamsAttr.getKeySwitchCount();
-    // remove the attribute after reading
-    op->removeAttr(mgmt::MgmtDialect::kArgOpenfheParamsAttrName);
-  }
-
-  Type openfheParamsType = openfhe::CCParamsType::get(builder.getContext());
-  Value ccParams = builder.create<openfhe::GenParamsOp>(
-      openfheParamsType, mulDepth, plainMod, insecure, evalAddCount,
-      keySwitchCount, encryptionTechniqueExtended);
-  Value cryptoContext = builder.create<openfhe::GenContextOp>(
-      openfheContextType, ccParams,
-      BoolAttr::get(builder.getContext(), hasBootstrapOp));
-
-  builder.create<func::ReturnOp>(cryptoContext);
-  return success();
-}
-
-// function that configures the crypto context with proper keygeneration
-LogicalResult generateConfigFunc(
-    func::FuncOp op, const std::string &configFuncName, bool hasRelinOp,
-    SmallVector<int64_t> rotIndices, bool hasBootstrapOp, int levelBudgetEncode,
-    int levelBudgetDecode, ImplicitLocOpBuilder &builder) {
-  Type openfheContextType =
-      openfhe::CryptoContextType::get(builder.getContext());
-  Type privateKeyType = openfhe::PrivateKeyType::get(builder.getContext());
-
-  SmallVector<Type> funcArgTypes;
-  funcArgTypes.push_back(openfheContextType);
-  funcArgTypes.push_back(privateKeyType);
-
-  SmallVector<Type> funcResultTypes;
-  funcResultTypes.push_back(openfheContextType);
-
-  FunctionType configFuncType =
-      FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
-  auto configFuncOp =
-      builder.create<func::FuncOp>(configFuncName, configFuncType);
-  builder.setInsertionPointToEnd(configFuncOp.addEntryBlock());
-
-  Value cryptoContext = configFuncOp.getArgument(0);
-  Value privateKey = configFuncOp.getArgument(1);
-
-  if (hasRelinOp || hasBootstrapOp) {
-    builder.create<openfhe::GenMulKeyOp>(cryptoContext, privateKey);
-  }
-  if (!rotIndices.empty()) {
-    builder.create<openfhe::GenRotKeyOp>(cryptoContext, privateKey, rotIndices);
-  }
-  if (hasBootstrapOp) {
-    builder.create<openfhe::SetupBootstrapOp>(
-        cryptoContext,
-        IntegerAttr::get(IndexType::get(builder.getContext()),
-                         levelBudgetEncode),
-        IntegerAttr::get(IndexType::get(builder.getContext()),
-                         levelBudgetDecode));
-    builder.create<openfhe::GenBootstrapKeyOp>(cryptoContext, privateKey);
-  }
-
-  builder.create<func::ReturnOp>(cryptoContext);
-  return success();
-}
-
-LogicalResult convertFunc(func::FuncOp op, int levelBudgetEncode,
-                          int levelBudgetDecode, bool insecure) {
-  auto module = op->getParentOfType<ModuleOp>();
-  std::string genFuncName("");
-  llvm::raw_string_ostream genNameOs(genFuncName);
-  genNameOs << op.getSymName() << "__generate_crypto_context";
-
-  std::string configFuncName("");
-  llvm::raw_string_ostream configNameOs(configFuncName);
-  configNameOs << op.getSymName() << "__configure_crypto_context";
-
-  ImplicitLocOpBuilder builder =
-      ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
-
-  bool encryptionTechniqueExtended = false;
-  // remove bgv.schemeParam attribute if present
-  if (auto schemeParamAttr = module->getAttrOfType<bgv::SchemeParamAttr>(
-          bgv::BGVDialect::kSchemeParamAttrName)) {
-    if (moduleIsBGV(module) && schemeParamAttr.getEncryptionTechnique() ==
-                                   bgv::BGVEncryptionTechnique::extended) {
-      module->emitError(
-          "Extended encryption technique is not supported in OpenFHE BGV");
-      return failure();
-    }
-    encryptionTechniqueExtended = schemeParamAttr.getEncryptionTechnique() ==
-                                  bgv::BGVEncryptionTechnique::extended;
-    module->removeAttr(bgv::BGVDialect::kSchemeParamAttrName);
-  }
-
-  // remove ckks.schemeParam attribute if present
-  if (auto schemeParamAttr = module->getAttrOfType<ckks::SchemeParamAttr>(
-          ckks::CKKSDialect::kSchemeParamAttrName)) {
-    module->removeAttr(ckks::CKKSDialect::kSchemeParamAttrName);
-  }
-
-  // get mulDepth from function argument ciphertext type
-  int64_t mulDepth = 0;
-  for (auto arg : op.getArguments()) {
-    if (auto argType = dyn_cast<lwe::NewLWECiphertextType>(
-            getElementTypeOrSelf(arg.getType()))) {
-      if (auto rnsType = dyn_cast<rns::RNSType>(
-              argType.getCiphertextSpace().getRing().getCoefficientType())) {
-        mulDepth = rnsType.getBasisTypes().size() - 1;
-        // implicitly assume arguments have the same level
-        break;
-      }
-    }
-  }
-
-  bool hasBootstrapOpResult = hasBootstrapOp(op);
-  // TODO(#1207): determine mulDepth earlier in mgmt level
-  // approxModDepth = 14, this solely depends on secretKeyDist
-  // here we use the value for UNIFORM_TERNARY
-  int bootstrapDepth = levelBudgetEncode + 14 + levelBudgetDecode;
-  if (hasBootstrapOpResult) {
-    mulDepth += bootstrapDepth;
-  }
-  if (failed(generateGenFunc(op, genFuncName, mulDepth, hasBootstrapOpResult,
-                             insecure, encryptionTechniqueExtended, builder))) {
-    return failure();
-  }
-
-  builder.setInsertionPointToEnd(module.getBody());
-
-  bool hasRelinOpResult = hasRelinOp(op);
-  SmallVector<int64_t> rotIndices = findAllRotIndices(op);
-  if (failed(generateConfigFunc(op, configFuncName, hasRelinOpResult,
-                                rotIndices, hasBootstrapOpResult,
-                                levelBudgetEncode, levelBudgetDecode,
-                                builder))) {
-    return failure();
-  }
-  return success();
-}
 
 struct ConfigureCryptoContext
     : impl::ConfigureCryptoContextBase<ConfigureCryptoContext> {
   using ConfigureCryptoContextBase::ConfigureCryptoContextBase;
 
+ private:
+  Config config;
+
+  // Helper function to check if the function has RelinOp
+  bool hasRelinOp(func::FuncOp op) {
+    bool result = false;
+    op.walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (isa<openfhe::RelinOp>(op)) {
+        result = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    return result;
+  }
+
+  // Helper function to find all the rotation indices in the function
+  SmallVector<int64_t> findAllRotIndices(func::FuncOp op) {
+    std::set<int64_t> distinctRotIndices;
+    op.walk([&](openfhe::RotOp rotOp) {
+      distinctRotIndices.insert(rotOp.getIndex().getInt());
+      return WalkResult::advance();
+    });
+    SmallVector<int64_t> rotIndicesResult(distinctRotIndices.begin(),
+                                          distinctRotIndices.end());
+    return rotIndicesResult;
+  }
+
+  // Helper function to check if the function has BootstrapOp
+  bool hasBootstrapOp(func::FuncOp op) {
+    bool result = false;
+    op.walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (isa<openfhe::BootstrapOp>(op)) {
+        result = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    return result;
+  }
+
+  // function that generates the crypto context with proper parameters
+  LogicalResult generateGenFunc(func::FuncOp op, const std::string &genFuncName,
+                                ImplicitLocOpBuilder &builder) {
+    Type openfheContextType =
+        openfhe::CryptoContextType::get(builder.getContext());
+    SmallVector<Type> funcArgTypes;
+    SmallVector<Type> funcResultTypes;
+    funcResultTypes.push_back(openfheContextType);
+
+    FunctionType genFuncType =
+        FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
+    auto genFuncOp = builder.create<func::FuncOp>(genFuncName, genFuncType);
+    builder.setInsertionPointToEnd(genFuncOp.addEntryBlock());
+
+    Type openfheParamsType = openfhe::CCParamsType::get(builder.getContext());
+    Value ccParams = builder.create<openfhe::GenParamsOp>(
+        openfheParamsType,
+        // Essential parameters
+        /*mulDepth*/ config.mulDepth,
+        /*plainMod*/ config.plaintextModulus,
+        // Optional parameters
+        /*ringDim*/ config.ringDim,
+        /*batchSize*/ config.batchSize,
+        /*firstModSize*/ config.firstModSize,
+        /*scalingModSize*/ config.scalingModSize,
+        /*evalAddCount*/ config.evalAddCount,
+        /*keySwitchCount*/ config.keySwitchCount,
+        /*digitSize*/ config.digitSize,
+        /*numLargeDigits*/ config.numLargeDigits,
+        /*maxRelinSkDeg*/ config.maxRelinSkDeg,
+        /*insecure*/ config.insecure,
+        /*encryptionTechniqueExtended*/ config.encryptionTechniqueExtended,
+        /*keySwitchingTechniqueBV*/ config.keySwitchingTechniqueBV,
+        /*scalingTechniqueFixedManual*/ config.scalingTechniqueFixedManual);
+    Value cryptoContext = builder.create<openfhe::GenContextOp>(
+        openfheContextType, ccParams,
+        BoolAttr::get(builder.getContext(), config.hasBootstrapOp));
+
+    builder.create<func::ReturnOp>(cryptoContext);
+    return success();
+  }
+
+  // function that configures the crypto context with proper keygeneration
+  LogicalResult generateConfigFunc(func::FuncOp op,
+                                   const std::string &configFuncName,
+                                   ImplicitLocOpBuilder &builder) {
+    Type openfheContextType =
+        openfhe::CryptoContextType::get(builder.getContext());
+    Type privateKeyType = openfhe::PrivateKeyType::get(builder.getContext());
+
+    SmallVector<Type> funcArgTypes;
+    funcArgTypes.push_back(openfheContextType);
+    funcArgTypes.push_back(privateKeyType);
+
+    SmallVector<Type> funcResultTypes;
+    funcResultTypes.push_back(openfheContextType);
+
+    FunctionType configFuncType =
+        FunctionType::get(builder.getContext(), funcArgTypes, funcResultTypes);
+    auto configFuncOp =
+        builder.create<func::FuncOp>(configFuncName, configFuncType);
+    builder.setInsertionPointToEnd(configFuncOp.addEntryBlock());
+
+    Value cryptoContext = configFuncOp.getArgument(0);
+    Value privateKey = configFuncOp.getArgument(1);
+
+    if (config.hasRelinOp || config.hasBootstrapOp) {
+      builder.create<openfhe::GenMulKeyOp>(cryptoContext, privateKey);
+    }
+    if (!config.rotIndices.empty()) {
+      builder.create<openfhe::GenRotKeyOp>(cryptoContext, privateKey,
+                                           config.rotIndices);
+    }
+    if (config.hasBootstrapOp) {
+      builder.create<openfhe::SetupBootstrapOp>(
+          cryptoContext,
+          IntegerAttr::get(IndexType::get(builder.getContext()),
+                           config.levelBudgetEncode),
+          IntegerAttr::get(IndexType::get(builder.getContext()),
+                           config.levelBudgetDecode));
+      builder.create<openfhe::GenBootstrapKeyOp>(cryptoContext, privateKey);
+    }
+
+    builder.create<func::ReturnOp>(cryptoContext);
+    return success();
+  }
+
+  LogicalResult convertFunc(func::FuncOp op) {
+    auto module = op->getParentOfType<ModuleOp>();
+    std::string genFuncName("");
+    llvm::raw_string_ostream genNameOs(genFuncName);
+    genNameOs << op.getSymName() << "__generate_crypto_context";
+
+    std::string configFuncName("");
+    llvm::raw_string_ostream configNameOs(configFuncName);
+    configNameOs << op.getSymName() << "__configure_crypto_context";
+
+    ImplicitLocOpBuilder builder =
+        ImplicitLocOpBuilder::atBlockEnd(module.getLoc(), module.getBody());
+
+    if (failed(generateGenFunc(op, genFuncName, builder))) {
+      return failure();
+    }
+
+    builder.setInsertionPointToEnd(module.getBody());
+
+    if (failed(generateConfigFunc(op, configFuncName, builder))) {
+      return failure();
+    }
+    return success();
+  }
+
+  LogicalResult getConfig(func::FuncOp op) {
+    auto module = op->getParentOfType<ModuleOp>();
+
+    // remove bgv.schemeParam attribute if present
+    // fill encryptionTechniqueExtended
+    if (auto schemeParamAttr = module->getAttrOfType<bgv::SchemeParamAttr>(
+            bgv::BGVDialect::kSchemeParamAttrName)) {
+      if (moduleIsBGV(module) && schemeParamAttr.getEncryptionTechnique() ==
+                                     bgv::BGVEncryptionTechnique::extended) {
+        module->emitError(
+            "Extended encryption technique is not supported in OpenFHE BGV");
+        return failure();
+      }
+      config.encryptionTechniqueExtended =
+          schemeParamAttr.getEncryptionTechnique() ==
+          bgv::BGVEncryptionTechnique::extended;
+      module->removeAttr(bgv::BGVDialect::kSchemeParamAttrName);
+    }
+
+    // remove ckks.schemeParam attribute if present
+    if (auto schemeParamAttr = module->getAttrOfType<ckks::SchemeParamAttr>(
+            ckks::CKKSDialect::kSchemeParamAttrName)) {
+      module->removeAttr(ckks::CKKSDialect::kSchemeParamAttrName);
+    }
+
+    /// Compute muldepth from multiply aspects...
+    // get mulDepth from function argument ciphertext type
+    for (auto arg : op.getArguments()) {
+      if (auto argType = dyn_cast<lwe::NewLWECiphertextType>(
+              getElementTypeOrSelf(arg.getType()))) {
+        if (auto rnsType = dyn_cast<rns::RNSType>(
+                argType.getCiphertextSpace().getRing().getCoefficientType())) {
+          config.mulDepth = rnsType.getBasisTypes().size() - 1;
+          // implicitly assume arguments have the same level
+          break;
+        }
+      }
+    }
+
+    config.hasBootstrapOp = hasBootstrapOp(op);
+    // TODO(#1207): determine mulDepth earlier in mgmt level
+    // approxModDepth = 14, this solely depends on secretKeyDist
+    // here we use the value for UNIFORM_TERNARY
+    int bootstrapDepth = levelBudgetEncode + 14 + levelBudgetDecode;
+    if (config.hasBootstrapOp) {
+      config.mulDepth += bootstrapDepth;
+    }
+
+    // pass option could override mulDepth
+    if (mulDepth != 0) {
+      config.mulDepth = mulDepth;
+    }
+
+    // relin and rotation
+    config.hasRelinOp = hasRelinOp(op);
+    config.rotIndices = findAllRotIndices(op);
+
+    // get plaintext modulus from function argument ciphertext type
+    // for CKKS, plainMod is 0
+    for (auto arg : op.getArguments()) {
+      if (auto argType = dyn_cast<lwe::NewLWECiphertextType>(
+              getElementTypeOrSelf(arg.getType()))) {
+        if (auto modArithType = dyn_cast<mod_arith::ModArithType>(
+                argType.getPlaintextSpace().getRing().getCoefficientType())) {
+          config.plaintextModulus = modArithType.getModulus().getInt();
+          // implicitly assume arguments have the same plaintext modulus
+          break;
+        }
+      }
+    }
+
+    // get evalAddCount/KeySwitchCount from func attribute, if present
+    if (auto openfheParamsAttr = op->getAttrOfType<mgmt::OpenfheParamsAttr>(
+            mgmt::MgmtDialect::kArgOpenfheParamsAttrName)) {
+      config.evalAddCount = openfheParamsAttr.getEvalAddCount();
+      config.keySwitchCount = openfheParamsAttr.getKeySwitchCount();
+      // remove the attribute after reading
+      op->removeAttr(mgmt::MgmtDialect::kArgOpenfheParamsAttrName);
+    }
+
+    // fill config with pass options
+    config.ringDim = ringDim;
+    config.batchSize = batchSize;
+    config.firstModSize = firstModSize;
+    config.scalingModSize = scalingModSize;
+    config.digitSize = digitSize;
+    config.numLargeDigits = numLargeDigits;
+    config.maxRelinSkDeg = maxRelinSkDeg;
+    config.insecure = insecure;
+    config.keySwitchingTechniqueBV = keySwitchingTechniqueBV;
+    config.scalingTechniqueFixedManual = scalingTechniqueFixedManual;
+    config.levelBudgetDecode = levelBudgetDecode;
+    config.levelBudgetEncode = levelBudgetEncode;
+    return success();
+  }
+
+ public:
   void runOnOperation() override {
     auto funcOp =
         detectEntryFunction(cast<ModuleOp>(getOperation()), entryFunction);
-    if (funcOp && failed(convertFunc(funcOp, levelBudgetEncode,
-                                     levelBudgetDecode, insecure))) {
+    if (funcOp && succeeded(getConfig(funcOp)) && failed(convertFunc(funcOp))) {
       funcOp->emitError("Failed to configure the crypto context for func");
       signalPassFailure();
     }
   }
 };
+
 }  // namespace openfhe
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Openfhe/Transforms/Passes.td
+++ b/lib/Dialect/Openfhe/Transforms/Passes.td
@@ -8,6 +8,9 @@ def ConfigureCryptoContext : Pass<"openfhe-configure-crypto-context"> {
   let description = [{
     This pass generates helper functions to generate and configure the OpenFHE crypto context for the given function. Generating the crypto context sets the appropriate encryption parameters, while the configuration generates the necessary evaluation keys (relinearization and rotation keys).
 
+    For the options, reader can refer to the OpenFHE documentation at
+    https://github.com/openfheorg/openfhe-development/blob/main/src/pke/examples/README.md#description-of-the-cryptocontext-parameters-and-their-restrictions
+
     For example, for an MLIR function `@my_func`, the generated helpers have the following signatures
     ```mlir
     func.func  @my_func__generate_crypto_context() -> !openfhe.crypto_context
@@ -20,13 +23,35 @@ def ConfigureCryptoContext : Pass<"openfhe-configure-crypto-context"> {
     Option<"entryFunction", "entry-function", "std::string",
            /*default=*/"", "Default entry function "
            "name of entry function.">,
+    Option<"mulDepth", "mul-depth", "int",
+           /*default=*/"0", "Manually specify the mul depth">,
+    // Options for GenParamsOp
+    Option<"ringDim", "ring-dim", "int",
+           /*default=*/"0", "Manually specify the ring dimension (insecure is implied)">,
+    // plaintext modulus is from IR
+    Option<"batchSize", "batch-size", "int",
+           /*default=*/"0", "Manually specify the batch size">,
+    Option<"firstModSize", "first-mod-size", "int",
+           /*default=*/"0", "Manually specify the first mod size">,
+    Option<"scalingModSize", "scaling-mod-size", "int",
+           /*default=*/"0", "Manually specify the scaling mod size">,
+    Option<"digitSize", "digit-size", "int",
+           /*default=*/"0", "Manually specify the digit size for relinearization">,
+    Option<"numLargeDigits", "num-large-digits", "int",
+           /*default=*/"0", "Manually specify the number of large digits for HYBRID relinearization">,
+    Option<"maxRelinSkDeg", "max-relin-sk-deg", "int",
+           /*default=*/"0", "Manually specify the max number of relin sk deg">,
+    Option<"insecure", "insecure", "bool",
+           /*default=*/"false", "Whether to use insecure parameter (defaults to false)">,
+    Option<"keySwitchingTechniqueBV", "key-switching-technique-bv", "bool",
+           /*default=*/"false", "Whether to use BV key switching technique (defaults to false)">,
+    Option<"scalingTechniqueFixedManual", "scaling-technique-fixed-manual", "bool",
+           /*default=*/"false", "Whether to use fixed manual scaling technique (defaults to false)">,
+    // For bootstrapping
     Option<"levelBudgetEncode", "level-budget-encode", "int",
            /*default=*/"3", "Level budget for CKKS bootstrap encode (s2c) phase">,
     Option<"levelBudgetDecode", "level-budget-decode", "int",
            /*default=*/"3", "Level budget for CKKS bootstrap decode (c2s) phase">,
-    Option<"insecure", "insecure", "bool",
-           /*default=*/"false", "Whether to use insecure parameter for faster evaluation"
-           "(should only be used in test) (defaults to false)">
   ];
 }
 

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -1075,26 +1075,62 @@ LogicalResult OpenFhePkeEmitter::printOperation(GenParamsOp op) {
   int64_t keySwitchCount = op.getKeySwitchCountAttr().getValue().getSExtValue();
 
   os << "CCParamsT " << paramsName << ";\n";
+  // Essential parameters
   os << paramsName << ".SetMultiplicativeDepth(" << mulDepth << ");\n";
   if (plainMod != 0) {
     os << paramsName << ".SetPlaintextModulus(" << plainMod << ");\n";
   }
-  if (op.getInsecure()) {
-    os << paramsName << ".SetSecurityLevel(lbcrypto::HEStd_NotSet);\n";
-    os << paramsName << ".SetRingDim(128);\n";
+  // Optional parameters
+  if (op.getRingDim() != 0) {
+    os << paramsName << ".SetRingDim(" << op.getRingDim() << ");\n";
   }
+  if (op.getBatchSize() != 0) {
+    os << paramsName << ".SetBatchSize(" << op.getBatchSize() << ");\n";
+  }
+  // Modulus chain parameters
+  if (op.getFirstModSize() != 0) {
+    os << paramsName << ".SetFirstModSize(" << op.getFirstModSize() << ");\n";
+  }
+  if (op.getScalingModSize() != 0) {
+    os << paramsName << ".SetScalingModSize(" << op.getScalingModSize()
+       << ");\n";
+  }
+  // Advanced parameters
   if (evalAddCount != 0) {
     os << paramsName << ".SetEvalAddCount(" << evalAddCount << ");\n";
   }
   if (keySwitchCount != 0) {
     os << paramsName << ".SetKeySwitchCount(" << keySwitchCount << ");\n";
   }
-  // B/FV defaults to BV, to match HEIR parameter generation we need to
-  // set it to HYBRID. Other schemes defaults to HYBRID.
-  os << paramsName << ".SetKeySwitchTechnique(HYBRID);\n";
+  // Key switching technique parameters
+  if (op.getDigitSize() != 0) {
+    os << paramsName << ".SetDigitSize(" << op.getDigitSize() << ");\n";
+  }
+  if (op.getNumLargeDigits() != 0) {
+    os << paramsName << ".SetNumLargeDigits(" << op.getNumLargeDigits()
+       << ");\n";
+  }
+  // Relinearization technique parameters
+  if (op.getMaxRelinSkDeg() != 0) {
+    os << paramsName << ".SetMaxRelinSkDeg(" << op.getMaxRelinSkDeg() << ");\n";
+  }
+  // Option switches
+  if (op.getInsecure()) {
+    os << paramsName << ".SetSecurityLevel(lbcrypto::HEStd_NotSet);\n";
+  }
   // For B/FV, OpenFHE supports EXTENDED encryption technique.
   if (op.getEncryptionTechniqueExtended()) {
     os << paramsName << ".SetEncryptionTechnique(EXTENDED);\n";
+  }
+  if (!op.getKeySwitchingTechniqueBV()) {
+    // B/FV defaults to BV, to match HEIR parameter generation we need to
+    // set it to HYBRID. Other schemes defaults to HYBRID.
+    os << paramsName << ".SetKeySwitchTechnique(HYBRID);\n";
+  } else {
+    os << paramsName << ".SetKeySwitchTechnique(BV);\n";
+  }
+  if (op.getScalingTechniqueFixedManual()) {
+    os << paramsName << ".SetScalingTechnique(FIXEDMANUAL);\n";
   }
   return success();
 }

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -253,3 +253,29 @@ module attributes {scheme.ckks} {
     return %1 : tensor<1024xf32>
   }
 }
+
+// -----
+
+module attributes {scheme.bgv} {
+  // CHECK-LABEL: test_gen_params_op
+  func.func @test_gen_params_op() -> !openfhe.cc_params {
+    // CHECK: CCParamsT [[PARAMS:.*]];
+    // CHECK: [[PARAMS]].SetMultiplicativeDepth(2);
+    // CHECK: [[PARAMS]].SetPlaintextModulus(17);
+    // CHECK: [[PARAMS]].SetRingDim(16384);
+    // CHECK: [[PARAMS]].SetBatchSize(8);
+    // CHECK: [[PARAMS]].SetFirstModSize(59);
+    // CHECK: [[PARAMS]].SetScalingModSize(59);
+    // CHECK: [[PARAMS]].SetEvalAddCount(2);
+    // CHECK: [[PARAMS]].SetKeySwitchCount(1);
+    // CHECK: [[PARAMS]].SetDigitSize(16);
+    // CHECK: [[PARAMS]].SetNumLargeDigits(2);
+    // CHECK: [[PARAMS]].SetMaxRelinSkDeg(3);
+    // CHECK: [[PARAMS]].SetSecurityLevel(lbcrypto::HEStd_NotSet);
+    // CHECK: [[PARAMS]].SetEncryptionTechnique(EXTENDED);
+    // CHECK: [[PARAMS]].SetKeySwitchTechnique(BV);
+    // CHECK: [[PARAMS]].SetScalingTechnique(FIXEDMANUAL);
+    %0 = openfhe.gen_params  {mulDepth = 2 : i64, plainMod = 17 : i64, ringDim = 16384, batchSize = 8, firstModSize = 59, scalingModSize = 59, evalAddCount = 2 : i64, keySwitchCount = 1 : i64, digitSize = 16, numLargeDigits = 2, maxRelinSkDeg = 3, insecure = true, encryptionTechniqueExtended = true, keySwitchingTechniqueBV = true, scalingTechniqueFixedManual = true} : () -> !openfhe.cc_params
+    return %0 : !openfhe.cc_params
+  }
+}

--- a/tests/Examples/openfhe/ckks/simple_ckks_bootstrapping/BUILD
+++ b/tests/Examples/openfhe/ckks/simple_ckks_bootstrapping/BUILD
@@ -8,7 +8,7 @@ openfhe_end_to_end_test(
     name = "simple_ckks_bootstrapping_test",
     generated_lib_header = "simple_ckks_bootstrapping_lib.h",
     heir_opt_flags = [
-        "--openfhe-configure-crypto-context=insecure=true",
+        "--openfhe-configure-crypto-context=insecure=true ring-dim=128",
     ],
     heir_translate_flags = [
         "--openfhe-include-type=source-relative",


### PR DESCRIPTION
For fine control of the openfhe backend, more options in `openfhe-configure-crypto-context` might be wanted. This is used when the information from LWE IR does not indicate all behavior (like mulDepth and number of moduli, moduli sizes, etc).

Changes

* Model almost all FHE (not threshold HE) related options in Openfhe
* Refactor openfhe-configure-crypto-context for readability
  + It used to mix finding config code and code-gen code, now it is separate
  + function args now become global object for easy reference  