### PR TITLE
Fix go_library_bzl

### DIFF
--- a/tests/Examples/lattigo/BUILD
+++ b/tests/Examples/lattigo/BUILD
@@ -7,7 +7,6 @@ bzl_library(
     srcs = ["test.bzl"],
     visibility = ["//visibility:private"],
     deps = [
-        "//tools/build_defs/go:go_library_bzl",
         "@heir//tools:heir_opt_bzl",
         "@heir//tools:heir_translate_bzl",
     ],


### PR DESCRIPTION
This line is causing build failure on main.

I could not find this macro anywhere. The only place I found it is under https://github.com/google/saxml/blob/c13a410b64f30c4b4e201aebaeceb1605104c7e4/saxml/BUILD#L27 but under its own `//tools` there is no other macros, so it should come from other packages, but I did not find that package (not rules_go nor bazel_tools, bazel_tools should be a candidate as it has `tools/build_defs/` but it does not contain the `go` path)