### PR TITLE
fix iter args bug, allow multi-test files

### DIFF
--- a/frontend/heir/mlir_emitter.py
+++ b/frontend/heir/mlir_emitter.py
@@ -533,7 +533,7 @@ class TextualMlirEmitter:
         raise NotImplementedError("Nested loops are not supported")
 
     body_str = self.emit_block(loop_block, blocks_to_print)
-    if len(loop.inits) > 1:
+    if loop.inits:
       # Yield the iter args
       yield_vars = ", ".join([self.get_name(init) for init in loop.inits])
       ret_types = ", ".join(

--- a/frontend/loop_test.py
+++ b/frontend/loop_test.py
@@ -4,7 +4,7 @@ from heir.mlir import I64, Secret
 from absl.testing import absltest  # fmt: skip
 
 
-class EndToEndTest(absltest.TestCase):
+class LoopTest(absltest.TestCase):
 
   def test_loop(self):
 
@@ -20,6 +20,19 @@ class EndToEndTest(absltest.TestCase):
       return result1
 
     self.assertEqual(32, loopa(2))
+
+  def test_loop_one_iter_arg(self):
+
+    @compile()
+    def one_iter_arg(a: Secret[I64]):
+      result1 = a
+      lb = 1
+      ub = 5
+      for _ in range(lb, ub):
+        result1 = result1 + result1
+      return result1
+
+    self.assertEqual(32, one_iter_arg(2))
 
 
 if __name__ == "__main__":

--- a/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
@@ -80,18 +80,22 @@ using namespace lbcrypto;
 namespace py = pybind11;
 
 // Minimal bindings required for generated functions to run.
+// Cf. https://pybind11.readthedocs.io/en/stable/advanced/classes.html#module-local-class-bindings
+// which is a temporary workaround to allow us to have multiple compilations in
+// the same python program. Better would be to cache the pybind11 module across
+// calls.
 void bind_common(py::module &m)
 {
-    py::class_<PublicKeyImpl<DCRTPoly>, std::shared_ptr<PublicKeyImpl<DCRTPoly>>>(m, "PublicKey")
+    py::class_<PublicKeyImpl<DCRTPoly>, std::shared_ptr<PublicKeyImpl<DCRTPoly>>>(m, "PublicKey", py::module_local())
         .def(py::init<>());
-    py::class_<PrivateKeyImpl<DCRTPoly>, std::shared_ptr<PrivateKeyImpl<DCRTPoly>>>(m, "PrivateKey")
+    py::class_<PrivateKeyImpl<DCRTPoly>, std::shared_ptr<PrivateKeyImpl<DCRTPoly>>>(m, "PrivateKey", py::module_local())
         .def(py::init<>());
-    py::class_<KeyPair<DCRTPoly>>(m, "KeyPair")
+    py::class_<KeyPair<DCRTPoly>>(m, "KeyPair", py::module_local())
         .def_readwrite("publicKey", &KeyPair<DCRTPoly>::publicKey)
         .def_readwrite("secretKey", &KeyPair<DCRTPoly>::secretKey);
-    py::class_<CiphertextImpl<DCRTPoly>, std::shared_ptr<CiphertextImpl<DCRTPoly>>>(m, "Ciphertext")
+    py::class_<CiphertextImpl<DCRTPoly>, std::shared_ptr<CiphertextImpl<DCRTPoly>>>(m, "Ciphertext", py::module_local())
         .def(py::init<>());
-    py::class_<CryptoContextImpl<DCRTPoly>, std::shared_ptr<CryptoContextImpl<DCRTPoly>>>(m, "CryptoContext")
+    py::class_<CryptoContextImpl<DCRTPoly>, std::shared_ptr<CryptoContextImpl<DCRTPoly>>>(m, "CryptoContext", py::module_local())
         .def(py::init<>())
         .def("KeyGen", &CryptoContextImpl<DCRTPoly>::KeyGen);
 }

--- a/tests/Dialect/Openfhe/Emitters/emit_pybind.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_pybind.mlir
@@ -12,18 +12,18 @@
 // CHECK: namespace py = pybind11;
 // CHECK: void bind_common(py::module &m)
 // CHECK: {
-// CHECK:     py::class_<PublicKeyImpl<DCRTPoly>, std::shared_ptr<PublicKeyImpl<DCRTPoly>>>(m, "PublicKey")
-// CHECK:         .def(py::init<>());
-// CHECK:     py::class_<PrivateKeyImpl<DCRTPoly>, std::shared_ptr<PrivateKeyImpl<DCRTPoly>>>(m, "PrivateKey")
-// CHECK:         .def(py::init<>());
-// CHECK:     py::class_<KeyPair<DCRTPoly>>(m, "KeyPair")
-// CHECK:         .def_readwrite("publicKey", &KeyPair<DCRTPoly>::publicKey)
-// CHECK:         .def_readwrite("secretKey", &KeyPair<DCRTPoly>::secretKey);
-// CHECK:     py::class_<CiphertextImpl<DCRTPoly>, std::shared_ptr<CiphertextImpl<DCRTPoly>>>(m, "Ciphertext")
-// CHECK:         .def(py::init<>());
-// CHECK:     py::class_<CryptoContextImpl<DCRTPoly>, std::shared_ptr<CryptoContextImpl<DCRTPoly>>>(m, "CryptoContext")
-// CHECK:         .def(py::init<>())
-// CHECK:         .def("KeyGen", &CryptoContextImpl<DCRTPoly>::KeyGen);
+// CHECK:    py::class_<PublicKeyImpl<DCRTPoly>, std::shared_ptr<PublicKeyImpl<DCRTPoly>>>(m, "PublicKey", py::module_local())
+// CHECK:        .def(py::init<>());
+// CHECK:    py::class_<PrivateKeyImpl<DCRTPoly>, std::shared_ptr<PrivateKeyImpl<DCRTPoly>>>(m, "PrivateKey", py::module_local())
+// CHECK:        .def(py::init<>());
+// CHECK:    py::class_<KeyPair<DCRTPoly>>(m, "KeyPair", py::module_local())
+// CHECK:        .def_readwrite("publicKey", &KeyPair<DCRTPoly>::publicKey)
+// CHECK:        .def_readwrite("secretKey", &KeyPair<DCRTPoly>::secretKey);
+// CHECK:    py::class_<CiphertextImpl<DCRTPoly>, std::shared_ptr<CiphertextImpl<DCRTPoly>>>(m, "Ciphertext", py::module_local())
+// CHECK:        .def(py::init<>());
+// CHECK:    py::class_<CryptoContextImpl<DCRTPoly>, std::shared_ptr<CryptoContextImpl<DCRTPoly>>>(m, "CryptoContext", py::module_local())
+// CHECK:        .def(py::init<>())
+// CHECK:        .def("KeyGen", &CryptoContextImpl<DCRTPoly>::KeyGen);
 // CHECK: }
 
 // CHECK: PYBIND11_MODULE(_heir_foo, m) {


### PR DESCRIPTION
Fixes bug with frontend loop generation when there is only one iter arg.

Uses https://pybind11.readthedocs.io/en/stable/advanced/classes.html#module-local-class-bindings to allow multiple compiled functions in the same program.

Better long-term effort would be to cache the pybind11 module in the OpenFHE backend, but as I understand this should still have the local instantiations be interoperable.