### PR TITLE
Add helper utils for layout propagation

### DIFF
--- a/lib/Transforms/LayoutPropagation/BUILD
+++ b/lib/Transforms/LayoutPropagation/BUILD
@@ -10,6 +10,7 @@ cc_library(
     srcs = ["LayoutPropagation.cpp"],
     hdrs = ["LayoutPropagation.h"],
     deps = [
+        ":Utils",
         ":pass_inc_gen",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Secret/IR:Dialect",
@@ -24,6 +25,25 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+cc_library(
+    name = "Utils",
+    srcs = ["Utils.cpp"],
+    hdrs = ["Utils.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "UtilsTest",
+    srcs = ["UtilsTest.cpp"],
+    deps = [
+        ":Utils",
+        "@googletest//:gtest_main",
+        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/lib/Transforms/LayoutPropagation/Utils.cpp
+++ b/lib/Transforms/LayoutPropagation/Utils.cpp
@@ -1,0 +1,57 @@
+#include "lib/Transforms/LayoutPropagation/Utils.h"
+
+#include <iostream>
+
+#include "llvm/include/llvm/ADT/ArrayRef.h"     // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"    // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+using ::llvm::ArrayRef;
+using ::llvm::SmallVector;
+
+int64_t maxOfMaxes(ArrayRef<int64_t> d1, ArrayRef<int64_t> d2) {
+  int64_t max = d1.front();
+  for (int64_t i = 1; i < d1.size(); ++i) {
+    max = std::max(max, d1[i]);
+  }
+  for (long i : d2) {
+    max = std::max(max, i);
+  }
+  return max;
+}
+
+SmallVector<int64_t> shiftByInserted(ArrayRef<int64_t> dims,
+                                     ArrayRef<int64_t> inserts,
+                                     bool increment) {
+  SmallVector<int64_t> result;
+  SmallVector<int64_t> sortedDims(dims);
+  SmallVector<int64_t> sortedInserts(inserts);
+  llvm::sort(sortedDims);
+  llvm::sort(sortedInserts);
+
+  int64_t shift = 0;
+  auto dimIt = sortedDims.begin(), insertIt = sortedInserts.begin();
+  while (dimIt != sortedDims.end()) {
+    auto materializedDim = *dimIt + (increment ? shift : -shift);
+    if (insertIt < sortedInserts.end() && *insertIt <= materializedDim) {
+      ++insertIt;
+      ++shift;
+    } else {
+      result.push_back(materializedDim);
+      ++dimIt;
+    }
+  }
+
+  return result;
+}
+
+SmallVector<int64_t> shiftByRemoved(ArrayRef<int64_t> dims,
+                                    ArrayRef<int64_t> removed) {
+  return shiftByInserted(dims, removed, false);
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/LayoutPropagation/Utils.h
+++ b/lib/Transforms/LayoutPropagation/Utils.h
@@ -1,0 +1,46 @@
+#ifndef LIB_TRANSFORMS_LAYOUTPROPAGATION_UTILS_H_
+#define LIB_TRANSFORMS_LAYOUTPROPAGATION_UTILS_H_
+
+#include "llvm/include/llvm/ADT/ArrayRef.h"     // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+int64_t maxOfMaxes(::llvm::ArrayRef<int64_t> d1, ::llvm::ArrayRef<int64_t> d2);
+
+// `dims` is a list of dims of a tensor, and `inserts` represents a list of
+// inserted dims in that tensor (via alignment attr's insertedDims). This
+// function shifts the values of `dims` as if the dims from `inserts` were
+// inserted.
+//
+// Example:
+//
+// input = [0, 1, 2, 3]
+// inserts = [1, 2]
+//
+// output = [0, 3, 4, 5]
+//
+// This allows you to track how `dims` maps to new dims as a result of the
+// inserts.
+::llvm::SmallVector<int64_t> shiftByInserted(::llvm::ArrayRef<int64_t> dims,
+                                             ::llvm::ArrayRef<int64_t> inserts,
+                                             bool increment = true);
+
+// Map the dims in the `dims` list to new dims when the dims in `removed` are
+// removed from the tensor.
+//
+// Assumes dims and removed do not have any common values
+//
+// Example:
+// input = [0, 3, 4, 5]
+// removed = [1, 2]
+//
+// output = [0, 1, 2, 3]
+::llvm::SmallVector<int64_t> shiftByRemoved(::llvm::ArrayRef<int64_t> dims,
+                                            ::llvm::ArrayRef<int64_t> removed);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_LAYOUTPROPAGATION_UTILS_H_

--- a/lib/Transforms/LayoutPropagation/UtilsTest.cpp
+++ b/lib/Transforms/LayoutPropagation/UtilsTest.cpp
@@ -1,0 +1,62 @@
+#include "gmock/gmock.h"  // from @googletest
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Transforms/LayoutPropagation/Utils.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using llvm::SmallVector;
+
+TEST(UtilsTest, TestShiftByInserted1) {
+  SmallVector<int64_t> dims = {0, 1, 2, 3};
+  SmallVector<int64_t> inserts = {1, 2};
+  SmallVector<int64_t> expected = {0, 3, 4, 5};
+  SmallVector<int64_t> actual = shiftByInserted(dims, inserts);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(UtilsTest, TestShiftByInserted2) {
+  SmallVector<int64_t> dims = {2, 6, 7, 8};
+  SmallVector<int64_t> inserts = {0, 4};
+  SmallVector<int64_t> expected = {3, 8, 9, 10};
+  SmallVector<int64_t> actual = shiftByInserted(dims, inserts);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(UtilsTest, TestShiftByInsertedCollision) {
+  SmallVector<int64_t> dims = {3, 6, 7, 8};
+  SmallVector<int64_t> inserts = {0, 4};
+  SmallVector<int64_t> expected = {5, 8, 9, 10};
+  SmallVector<int64_t> actual = shiftByInserted(dims, inserts);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(UtilsTest, TestShiftByRemoved1) {
+  SmallVector<int64_t> dims = {0, 3, 4, 5};
+  SmallVector<int64_t> removals = {1, 2};
+  SmallVector<int64_t> expected = {0, 1, 2, 3};
+  SmallVector<int64_t> actual = shiftByRemoved(dims, removals);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(UtilsTest, TestShiftByRemoved2) {
+  SmallVector<int64_t> dims = {3, 8, 9, 10};
+  SmallVector<int64_t> removals = {0, 4};
+  SmallVector<int64_t> expected = {2, 6, 7, 8};
+  SmallVector<int64_t> actual = shiftByRemoved(dims, removals);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(UtilsTest, TestShiftByRemovedCollision) {
+  SmallVector<int64_t> dims = {5, 8, 9, 10};
+  SmallVector<int64_t> removals = {0, 4};
+  SmallVector<int64_t> expected = {3, 6, 7, 8};
+  SmallVector<int64_t> actual = shiftByRemoved(dims, removals);
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1633

This is used in LayoutPropagation when converting alignment attrs before and after a linalg op like linalg.reduce.