### PR TITLE
allow all non-secret ops in analyses

### DIFF
--- a/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.cpp
+++ b/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.cpp
@@ -111,17 +111,17 @@ LogicalResult CountAnalysis::visitOperation(
       })
       .Default(
           [&](auto &op) {
-            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
-                           arith::ExtFOp, mgmt::InitOp>(op)) {
-              op.emitError()
-                  << "Unsupported operation for count analysis encountered.";
-            }
-
             // condition on result secretness
             SmallVector<OpResult> secretResults;
             getSecretResults(&op, secretResults);
             if (secretResults.empty()) {
               return;
+            }
+
+            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                           arith::ExtFOp, mgmt::InitOp>(op)) {
+              op.emitError()
+                  << "Unsupported operation for count analysis encountered.";
             }
 
             SmallVector<OpOperand *> secretOperands;

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
@@ -173,17 +173,17 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
             return success();
           })
           .Default([&](auto &op) {
-            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
-                           arith::ExtFOp, mgmt::InitOp>(op)) {
-              op.emitError()
-                  << "Unsupported operation for noise analysis encountered.";
-            }
-
             // condition on result secretness
             SmallVector<OpResult> secretResults;
             this->getSecretResults(&op, secretResults);
             if (secretResults.empty()) {
               return success();
+            }
+
+            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                           arith::ExtFOp, mgmt::InitOp>(op)) {
+              op.emitError()
+                  << "Unsupported operation for noise analysis encountered.";
             }
 
             SmallVector<OpOperand *> secretOperands;

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
@@ -190,17 +190,17 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
             return success();
           })
           .Default([&](auto &op) {
-            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
-                           arith::ExtFOp, mgmt::InitOp>(op)) {
-              op.emitError()
-                  << "Unsupported operation for noise analysis encountered.";
-            }
-
             // condition on result secretness
             SmallVector<OpResult> secretResults;
             this->getSecretResults(&op, secretResults);
             if (secretResults.empty()) {
               return success();
+            }
+
+            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                           arith::ExtFOp, mgmt::InitOp>(op)) {
+              op.emitError()
+                  << "Unsupported operation for noise analysis encountered.";
             }
 
             SmallVector<OpOperand *> secretOperands;


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1633

The new layout system will lower a lot more plaintext ops for materializing layouts, and they're all cleartext ops, but noise analysis fails on them without swapping the order of the constraints.