### PR TITLE
canonicalize ct-pt ops to put ciphertext operand first

### DIFF
--- a/lib/Dialect/BGV/IR/BGVOps.cpp
+++ b/lib/Dialect/BGV/IR/BGVOps.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWEPatterns.h"
 #include "mlir/include/mlir/IR/Location.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
 #include "mlir/include/mlir/IR/Types.h"               // from @llvm-project
@@ -79,6 +80,15 @@ LogicalResult RelinearizeOp::inferReturnTypes(
     MLIRContext *ctx, std::optional<Location>, RelinearizeOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   return lwe::inferRelinearizeOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
+void MulPlainOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                             MLIRContext *context) {
+  results.add<lwe::PutCiphertextInFirstOperand<MulPlainOp>>(context);
+}
+void AddPlainOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                             MLIRContext *context) {
+  results.add<lwe::PutCiphertextInFirstOperand<AddPlainOp>>(context);
 }
 
 }  // namespace bgv

--- a/lib/Dialect/BGV/IR/BGVOps.td
+++ b/lib/Dialect/BGV/IR/BGVOps.td
@@ -49,6 +49,7 @@ def BGV_AddOp : BGV_Op<"add", [Commutative,
 def BGV_AddPlainOp : BGV_CiphertextPlaintextOp<"add_plain", [AllCiphertextTypesMatch,
         SameOperandsAndResultPlaintextTypes, Commutative]> {
   let summary = "Addition operation between ciphertext-plaintext.";
+  let hasCanonicalizer = 1;
 }
 
 def BGV_SubOp : BGV_Op<"sub", [SameOperandsAndResultRings,
@@ -88,6 +89,7 @@ def BGV_MulOp : BGV_Op<"mul", [Commutative, SameOperandsAndResultRings, InferTyp
 def BGV_MulPlainOp : BGV_CiphertextPlaintextOp<"mul_plain", [InferTypeOpAdaptor, Commutative]> {
   let summary = "Multiplication operation between ciphertext-plaintext.";
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def BGV_RotateColumnsOp : BGV_Op<"rotate_cols", [AllTypesMatch<["input", "output"]>]> {

--- a/lib/Dialect/BGV/IR/BUILD
+++ b/lib/Dialect/BGV/IR/BUILD
@@ -26,6 +26,7 @@ cc_library(
         ":enums_inc_gen",
         ":ops_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Patterns",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",

--- a/lib/Dialect/CKKS/IR/BUILD
+++ b/lib/Dialect/CKKS/IR/BUILD
@@ -26,6 +26,7 @@ cc_library(
         ":enums_inc_gen",
         ":ops_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Patterns",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",

--- a/lib/Dialect/CKKS/IR/CKKSOps.cpp
+++ b/lib/Dialect/CKKS/IR/CKKSOps.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWEPatterns.h"
 #include "mlir/include/mlir/IR/Location.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
 #include "mlir/include/mlir/IR/Types.h"               // from @llvm-project
@@ -77,6 +78,15 @@ LogicalResult RelinearizeOp::inferReturnTypes(
     MLIRContext *ctx, std::optional<Location>, RelinearizeOp::Adaptor adaptor,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   return lwe::inferRelinearizeOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
+void MulPlainOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                             MLIRContext *context) {
+  results.add<lwe::PutCiphertextInFirstOperand<MulPlainOp>>(context);
+}
+void AddPlainOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                             MLIRContext *context) {
+  results.add<lwe::PutCiphertextInFirstOperand<AddPlainOp>>(context);
 }
 
 }  // namespace ckks

--- a/lib/Dialect/CKKS/IR/CKKSOps.td
+++ b/lib/Dialect/CKKS/IR/CKKSOps.td
@@ -49,6 +49,7 @@ def CKKS_AddOp : CKKS_Op<"add", [Commutative, SameOperandsAndResultRings,
 def CKKS_AddPlainOp : CKKS_CiphertextPlaintextOp<"add_plain", [AllCiphertextTypesMatch,
       SameOperandsAndResultPlaintextTypes, Commutative]> {
   let summary = "Addition operation between ciphertext-plaintext.";
+  let hasCanonicalizer = 1;
 }
 
 def CKKS_SubOp : CKKS_Op<"sub", [SameOperandsAndResultRings,
@@ -89,6 +90,7 @@ def CKKS_MulOp : CKKS_Op<"mul", [Commutative, SameOperandsAndResultRings, InferT
 def CKKS_MulPlainOp : CKKS_CiphertextPlaintextOp<"mul_plain", [InferTypeOpAdaptor, Commutative]> {
   let summary = "Multiplication operation between ciphertext-plaintext.";
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def CKKS_RotateOp : CKKS_Op<"rotate", [AllTypesMatch<["input", "output"]>]> {

--- a/tests/Dialect/BGV/IR/canonicalize.mlir
+++ b/tests/Dialect/BGV/IR/canonicalize.mlir
@@ -1,0 +1,39 @@
+// RUN: heir-opt --canonicalize %s | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>
+
+!pt = !lwe.new_lwe_plaintext<application_data = <message_type = i3>, plaintext_space = #plaintext_space>
+
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L1_D3_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb, size = 3>
+
+!ct = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+// CHECK: @test_ciphertext_plaintext(
+// CHECK-SAME: [[arg0:[^:]*]]:
+// CHECK-SAME: , [[arg1:[^:]*]]:
+func.func @test_ciphertext_plaintext(%arg0: !pt, %arg1: !ct) -> (!ct, !ct) {
+  // CHECK: bgv.add_plain [[arg1]], [[arg0]]
+  %add = bgv.add_plain %arg0, %arg1 : (!pt, !ct) -> !ct
+  // CHECK: bgv.mul_plain [[arg1]], [[arg0]]
+  %mul = bgv.mul_plain %arg0, %arg1 : (!pt, !ct) -> !ct
+  return %add, %mul : !ct, !ct
+}


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1633