### PR TITLE
Relax tensor_ext attributes to support layouts of scalars

### DIFF
--- a/lib/Dialect/TensorExt/IR/BUILD
+++ b/lib/Dialect/TensorExt/IR/BUILD
@@ -45,8 +45,10 @@ cc_library(
         ":attributes_inc_gen",
         ":dialect_inc_gen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )
 

--- a/lib/Dialect/TensorExt/IR/TensorExtAttributes.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtAttributes.cpp
@@ -20,8 +20,8 @@ LogicalResult AlignmentAttr::verify(
     function_ref<InFlightDiagnostic()> emitError, mlir::DenseI64ArrayAttr in,
     mlir::DenseI64ArrayAttr out, mlir::DenseI64ArrayAttr insertedDims,
     mlir::DenseI64ArrayAttr padding, TypedAttr paddingValue) {
-  if (in.empty() || out.empty()) {
-    return emitError() << "in and out may not be empty arrays";
+  if (out.empty()) {
+    return emitError() << "out may not be an empty array";
   }
 
   if (in.size() + insertedDims.size() != out.size()) {
@@ -32,6 +32,20 @@ LogicalResult AlignmentAttr::verify(
   for (auto dim : insertedDims.asArrayRef()) {
     if (dim < 0 || dim >= out.size()) {
       return emitError() << "insertedDims must be in the range [0, out.size())";
+    }
+  }
+
+  for (int i = 0; i < out.size(); i++) {
+    if (out[i] <= 0) {
+      return emitError() << "out dimension " << i
+                         << " must be positive, but was " << out[i];
+    }
+  }
+
+  for (int i = 0; i < in.size(); i++) {
+    if (in[i] <= 0) {
+      return emitError() << "in dimension " << i
+                         << " must be positive, but was " << in[i];
     }
   }
 

--- a/lib/Dialect/TensorExt/IR/TensorExtAttributes.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtAttributes.td
@@ -78,13 +78,14 @@ def TensorExt_SIMDPackingAttr : TensorExt_Attr<"SIMDPacking", "simd_packing",
 def TensorExt_AlignmentAttr : TensorExt_Attr<"Alignment", "alignment"> {
   let summary = "An attribute describing padding and alignment of a tensor.";
   let description = [{
-    This attribute is used to describe how a data-semantic tensor is padded
+    This attribute is used to describe how a data-semantic value is padded
     and replicated to align its size before applying a ciphertext layout
     (see `tensor_ext.layout`).
 
-    It describes transformations to be applied to an input tensor.
+    It describes transformations to be applied to an input tensor or scalar.
 
-    The `in` attribute describes the shape of the original tensor.
+    The `in` attribute describes the shape of the original value. An empty list
+    for `in` indicates a scalar value that must be materialized as a tensor.
     The following transformations are applied to the input tensor.
 
     1. New unit dimensions are inserted to match the number of dimensions
@@ -149,6 +150,20 @@ def TensorExt_AlignmentAttr : TensorExt_Attr<"Alignment", "alignment"> {
     second axis to make a `tensor<1x16xi32>`. Finally, it is replicated twice
     along the columns and 32 times along the rows to fill the 32x32 output
     tensor.
+
+    Example:
+
+    ```mlir
+    #repl = #tensor_ext.alignment<
+      in = [],
+      insertedDims = [0],
+      out = [1],
+    >
+    ```
+
+    This indicates that the original input is a scalar such as `i32`, and it is
+    elevated to a `tensor<1xi32>` before being replicated to fill the
+    ciphertext shape.
   }];
 
   let parameters = (ins
@@ -158,6 +173,31 @@ def TensorExt_AlignmentAttr : TensorExt_Attr<"Alignment", "alignment"> {
     DefaultValuedParameter<"::mlir::DenseI64ArrayAttr", "$_builder.getDenseI64ArrayAttr({})">:$padding,
     DefaultValuedParameter<"TypedAttr", "nullptr">:$paddingValue
   );
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::DenseI64ArrayAttr":$in,
+                                        "::mlir::DenseI64ArrayAttr":$out), [{
+      return $_get(
+        in.getContext(),
+        in,
+        out,
+        DenseI64ArrayAttr::get(in.getContext(), {}),
+        DenseI64ArrayAttr::get(in.getContext(), {}),
+        nullptr);
+    }]>,
+
+    AttrBuilder<(ins "::llvm::ArrayRef<int64_t>":$in,
+                     "::llvm::ArrayRef<int64_t>":$out), [{
+      return $_get(
+        $_ctxt,
+        DenseI64ArrayAttr::get($_ctxt, in),
+        DenseI64ArrayAttr::get($_ctxt, out),
+        DenseI64ArrayAttr::get($_ctxt, {}),
+        DenseI64ArrayAttr::get($_ctxt, {}),
+        nullptr
+      );
+    }]>,
+  ];
 
   let assemblyFormat =  "`<` struct(params) `>`";
   let genVerifyDecl = 1;

--- a/lib/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.td
@@ -79,10 +79,10 @@ def TensorExt_PermuteOp : TensorExt_Op<"permute", [Pure, AllTypesMatch<["input",
   let hasVerifier = 1;
 }
 
-def TensorExt_ConvertLayoutOp : TensorExt_Op<"convert_layout", [Pure, AllTypesMatch<["tensor", "output"]>]> {
+def TensorExt_ConvertLayoutOp : TensorExt_Op<"convert_layout", [Pure, AllTypesMatch<["value", "output"]>]> {
   let summary = "Convert from one layout to another.";
   let description = [{
-    This op represents the conversion of a tensor from one packed layout to
+    This op represents the conversion of a value from one packed layout to
     another. This is implemented via a "shift network" of ciphertext rotations,
     plaintext masks (ciphertext-plaintext multiplications), and additions.
 
@@ -90,16 +90,16 @@ def TensorExt_ConvertLayoutOp : TensorExt_Op<"convert_layout", [Pure, AllTypesMa
   }];
 
   let assemblyFormat = "operands attr-dict `:` type($output)";
-  let arguments = (ins AnyRankedTensor:$tensor, TensorExt_LayoutAttr:$from_layout, TensorExt_LayoutAttr:$to_layout);
-  let results = (outs AnyRankedTensor:$output);
+  let arguments = (ins AnyType:$value, TensorExt_LayoutAttr:$from_layout, TensorExt_LayoutAttr:$to_layout);
+  let results = (outs AnyType:$output);
   let hasVerifier = 1;
   let hasFolder = 1;
 }
 
-def TensorExt_AssignLayoutOp : TensorExt_Op<"assign_layout", [Pure, AllTypesMatch<["tensor", "output"]>]> {
-  let summary = "Assign a layout to a plaintext tensor.";
+def TensorExt_AssignLayoutOp : TensorExt_Op<"assign_layout", [Pure, AllTypesMatch<["value", "output"]>]> {
+  let summary = "Assign a layout to a plaintext tensor or scalar.";
   let description = [{
-    This op allows the ingestion of a plaintext tensor into the layout system.
+    This op allows the ingestion of a plaintext value into the layout system.
     For example, ops like `linalg.reduce`, require a tensor input to represent
     initial values. These will generally be created by an `arith.constant` or
     `tensor.empty` op, which does not have secret results. Lowerings will
@@ -110,8 +110,8 @@ def TensorExt_AssignLayoutOp : TensorExt_Op<"assign_layout", [Pure, AllTypesMatc
   }];
 
   let assemblyFormat = "operands attr-dict `:` type($output)";
-  let arguments = (ins AnyRankedTensor:$tensor, TensorExt_LayoutAttr:$layout);
-  let results = (outs AnyRankedTensor:$output);
+  let arguments = (ins AnyType:$value, TensorExt_LayoutAttr:$layout);
+  let results = (outs AnyType:$output);
   let hasVerifier = 1;
 }
 

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
@@ -195,7 +195,7 @@ LayoutOptimization::OpHoistResult LayoutOptimization::hoistOp(
 
   // Replace uses of the convert layout op with its input.
   builder.replaceAllUsesWith(minHoistingResult->convertLayoutOp.getResult(),
-                             minHoistingResult->convertLayoutOp.getTensor());
+                             minHoistingResult->convertLayoutOp.getValue());
 
   // Ensure that any other convert_layout ops have their from_layouts updated.
   // Update downstream ops.

--- a/tests/Dialect/TensorExt/IR/alignment_verifier.mlir
+++ b/tests/Dialect/TensorExt/IR/alignment_verifier.mlir
@@ -1,12 +1,12 @@
 // RUN: heir-opt --verify-diagnostics --split-input-file %s
 
-// expected-error@below {{in and out may not be empty arrays}}
-#align = #tensor_ext.alignment<in = [], out = [32]>
-func.func private @test_fn(tensor<16xi32> {foo.bar = #align})
+// in == [] implies the input is a scalar
+#align = #tensor_ext.alignment<in = [], out = [32], insertedDims = [0]>
+func.func private @test_fn(i32 {foo.bar = #align})
 
 // -----
 
-// expected-error@below {{in and out may not be empty arrays}}
+// expected-error@below {{out may not be an empty array}}
 #align = #tensor_ext.alignment<in = [16], out = []>
 func.func private @test_fn(tensor<16xi32> {foo.bar = #align})
 


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1633

This allows one to write 

- repeat a scalar in a ciphertext: `#alignment = #tensor_ext.alignment<in = [], out = [1], insertedDims = [0]>`
- put the scalar in the first position and pad with zeros: `#alignment = #tensor_ext.alignment<in = [], out = [1], insertedDims = [0], padding = [1023], paddingValue = 0 : i16>`

Followup PRs will update the layout passes to support assigning and materializing scalar layouts