### PR TITLE
LattigoEmitter: add tensor.insert, improve tensor.extract, improve constant emitter

### DIFF
--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -58,6 +58,8 @@ class LattigoEmitter {
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractOp op);
   LogicalResult printOperation(::mlir::tensor::FromElementsOp op);
+  LogicalResult printOperation(::mlir::tensor::InsertOp op);
+
   // Lattigo ops
   // RLWE
   LogicalResult printOperation(RLWENewEncryptorOp op);

--- a/lib/Utils/TargetUtils.h
+++ b/lib/Utils/TargetUtils.h
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <string>
 
+#include "llvm/include/llvm/ADT/StringExtras.h"          // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypeInterfaces.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/TypeRange.h"              // from @llvm-project

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -214,3 +214,33 @@ module attributes {scheme.bgv} {
     return %negated : !lattigo.rlwe.ciphertext
   }
 }
+
+// -----
+
+module attributes {scheme.ckks} {
+  // CHECK: func float_constant
+  func.func @float_constant(%evaluator: !lattigo.bgv.evaluator, %ct: !lattigo.rlwe.ciphertext) -> f32 {
+    // CHECK: [[v:[^, ]*]] := float32(7.5)
+    // CHECK: return v
+    %v = arith.constant 7.5 : f32
+    return %v : f32
+  }
+}
+
+// -----
+
+module attributes {scheme.ckks} {
+  // CHECK: func tensor_insert
+  func.func @tensor_insert(%evaluator: !lattigo.bgv.evaluator, %ct: !lattigo.rlwe.ciphertext) -> f32 {
+    // CHECK:  [[v0:[^ ]*]] := int64(5)
+    // CHECK:  [[v1:[^, ]*]] := float32(7.5)
+    // CHECK:  [[v2:[^ ]*]] := []float32{0, 0, 0, 0, 0, 0, 0, 0}
+    // CHECK:  [[v2]]{{\[}}[[v0]]] = [[v1]]
+    // CHECK:  return [[v1]]
+    %c5 = arith.constant 5 : index
+    %v = arith.constant 7.5 : f32
+    %tensor = arith.constant dense<0.0> : tensor<8xf32>
+    %tensor2 = tensor.insert %v into %tensor[%c5] : tensor<8xf32>
+    return %v : f32
+  }
+}


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1633/commits

Support more things in lattigo emitter needed for codegen of new layout engine IR.