### PR TITLE
frontend: use bazel-built OpenFHE if no OpenFHE installed

### DIFF
--- a/frontend/heir/backends/util/common.py
+++ b/frontend/heir/backends/util/common.py
@@ -1,4 +1,19 @@
 from heir.interfaces import CompilationResult, EncValue
+import os
+import pathlib
+from pathlib import Path
+
+
+def find_above(dirname: str) -> Path | None:
+  path = pathlib.Path(__file__).resolve()
+  matching = [p for p in path.parents if (p / dirname).exists()]
+  return matching[-1] if matching else None
+
+
+def get_repo_root() -> Path | None:
+  default = find_above("bazel-bin")
+  found = os.getenv("HEIR_REPO_ROOT_MARKER")
+  return Path(found) if found else default
 
 
 def strip_and_verify_eval_arg_consistency(

--- a/frontend/heir/heir_cli/heir_cli_config.py
+++ b/frontend/heir/heir_cli/heir_cli_config.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 from pathlib import Path
 import shutil
+from heir.backends.util.common import get_repo_root
 
 dataclass = dataclasses.dataclass
 
@@ -15,26 +16,14 @@ class HEIRConfig:
   heir_translate_path: str | Path
 
 
-def find_above(dirname: str) -> Path | None:
-  path = pathlib.Path(__file__).resolve()
-  matching = [p / dirname for p in path.parents if (p / dirname).exists()]
-  return matching[-1] if matching else None
-
-
-def get_repo_root() -> Path | None:
-  default = find_above("bazel-bin")
-  found = os.getenv("HEIR_REPO_ROOT_MARKER")
-  return Path(found) if found else default
-
-
 def development_heir_config() -> HEIRConfig:
   repo_root = get_repo_root()
   if not repo_root:
     raise RuntimeError("Could not build development config. Did you run bazel?")
 
   return HEIRConfig(
-      heir_opt_path=repo_root / "tools" / "heir-opt",
-      heir_translate_path=repo_root / "tools" / "heir-translate",
+      heir_opt_path=repo_root / "bazel-bin" / "tools" / "heir-opt",
+      heir_translate_path=repo_root / "bazel-bin" / "tools" / "heir-translate",
   )
 
 

--- a/frontend/testing.bzl
+++ b/frontend/testing.bzl
@@ -38,7 +38,7 @@ def frontend_test(name, srcs, deps = [], data = [], tags = []):
             "OPENFHE_INCLUDE_TYPE": "source-relative",
             "OPENFHE_LINK_LIBS": ":".join(libs),
             "OPENFHE_INCLUDE_DIR": ":".join(include_dirs),
-            "HEIR_REPO_ROOT_MARKER": "bazel-bin",
+            "HEIR_REPO_ROOT_MARKER": ".",
             "HEIR_OPT_PATH": "tools/heir-opt",
             "HEIR_TRANSLATE_PATH": "tools/heir-translate",
             "PYBIND11_INCLUDE_PATH": "pybind11/include",


### PR DESCRIPTION
It's quite convenient to run the frontend directly from python (e.g.,`python frontend/example.py`) without using bazel. However, the OpenFHE backend would only work if either (a) one manually sets the same environment variables that bazel uses or (b) had OpenFHE installed to its default location. 

This PR extends the OpenFHE backend config so that, if no environment variables are found, and no default OpenFHE installation is found, it'll try to find the bazel-built OpenFHE.