### PR TITLE
update to latest go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/google/heir
 
-go 1.22.0
+go 1.24.2
 
-toolchain go1.22.7
+toolchain go1.24.2
 
 require github.com/tuneinsight/lattigo/v6 v6.1.0
 


### PR DESCRIPTION
The go version we were using doesn't have slices.Repeat, which I want to codegen for `tensor.splat`