### PR TITLE
CKKS: Add CCH+23 Noise Model

### DIFF
--- a/lib/Analysis/NoiseAnalysis/CKKS/BUILD
+++ b/lib/Analysis/NoiseAnalysis/CKKS/BUILD
@@ -1,0 +1,47 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "NoiseAnalysis",
+    srcs = [
+        "NoiseAnalysis.cpp",
+    ],
+    hdrs = [
+    ],
+    deps = [
+        ":NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis:Utils",
+        "@heir//lib/Analysis/DimensionAnalysis",
+        "@heir//lib/Analysis/LevelAnalysis",
+        "@heir//lib/Analysis/NoiseAnalysis",
+        "@heir//lib/Analysis/NoiseAnalysis:Noise",
+        "@heir//lib/Analysis/ScaleAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Parameters/BGV:Params",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:CallOpInterfaces",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+cc_library(
+    name = "NoiseByVarianceCoeffModel",
+    srcs = [
+        "NoiseByVarianceCoeffModel.cpp",
+    ],
+    hdrs = [
+        "NoiseByVarianceCoeffModel.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/NoiseAnalysis:Noise",
+        "@heir//lib/Parameters/CKKS:Params",
+        "@heir//lib/Utils:MathUtils",
+    ],
+)

--- a/lib/Analysis/NoiseAnalysis/CKKS/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/CKKS/NoiseAnalysis.cpp
@@ -1,0 +1,224 @@
+#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+
+#include <functional>
+
+#include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Analysis/NoiseAnalysis/CKKS/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/ScaleAnalysis/ScaleAnalysis.h"
+#include "lib/Analysis/Utils.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"             // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"              // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"     // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                   // from @llvm-project
+#include "mlir/include/mlir/Interfaces/CallInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"               // from @llvm-project
+
+#define DEBUG_TYPE "NoiseAnalysis"
+
+namespace mlir {
+namespace heir {
+
+// explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
+template <typename NoiseModel>
+void NoiseAnalysis<NoiseModel>::setToEntryState(LatticeType *lattice) {
+  // At an entry point, we have no information about the noise.
+  this->propagateIfChanged(lattice, lattice->join(NoiseState::uninitialized()));
+}
+
+// explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
+template <typename NoiseModel>
+void NoiseAnalysis<NoiseModel>::visitExternalCall(
+    CallOpInterface call, ArrayRef<const LatticeType *> argumentLattices,
+    ArrayRef<LatticeType *> resultLattices) {
+  auto callback =
+      std::bind(&NoiseAnalysis<NoiseModel>::propagateIfChangedWrapper, this,
+                std::placeholders::_1, std::placeholders::_2);
+  ::mlir::heir::visitExternalCall<NoiseState, LatticeType>(
+      call, argumentLattices, resultLattices, callback);
+}
+
+// explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
+template <typename NoiseModel>
+LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
+    Operation *op, ArrayRef<const LatticeType *> operands,
+    ArrayRef<LatticeType *> results) {
+  auto getLocalParam = [&](Value value) {
+    auto level = getLevelFromMgmtAttr(value);
+    auto dimension = getDimensionFromMgmtAttr(value);
+    auto scale = getScaleFromMgmtAttr(value);
+    return LocalParamType(&schemeParam, level, dimension, scale);
+  };
+
+  auto propagate = [&](Value value, NoiseState noise) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Propagating "
+               << NoiseModel::toLogBoundString(getLocalParam(value), noise)
+               << " to " << value << "\n");
+    LatticeType *lattice = this->getLatticeElement(value);
+    auto changeResult = lattice->join(noise);
+    this->propagateIfChanged(lattice, changeResult);
+  };
+
+  auto getOperandNoises = [&](Operation *op,
+                              SmallVectorImpl<NoiseState> &noises) {
+    SmallVector<OpOperand *> secretOperands;
+    SmallVector<OpOperand *> nonSecretOperands;
+    this->getSecretOperands(op, secretOperands);
+    this->getNonSecretOperands(op, nonSecretOperands);
+
+    for (auto *operand : secretOperands) {
+      noises.push_back(this->getLatticeElement(operand->get())->getValue());
+    }
+    for (auto *operand : nonSecretOperands) {
+      (void)operand;
+      // at least one operand is secret
+      auto localParam = getLocalParam(secretOperands[0]->get());
+      noises.push_back(NoiseModel::evalConstant(localParam));
+    }
+  };
+
+  auto res =
+      llvm::TypeSwitch<Operation &, LogicalResult>(*op)
+          .Case<secret::GenericOp>([&](auto genericOp) {
+            Block *body = genericOp.getBody();
+            for (Value &arg : body->getArguments()) {
+              auto localParam = getLocalParam(arg);
+              NoiseState encrypted = NoiseModel::evalEncrypt(localParam);
+              propagate(arg, encrypted);
+            }
+            return success();
+          })
+          .template Case<arith::MulFOp, arith::MulIOp>([&](auto mulOp) {
+            SmallVector<OpResult> secretResults;
+            this->getSecretResults(mulOp, secretResults);
+            if (secretResults.empty()) {
+              return success();
+            }
+
+            SmallVector<NoiseState, 2> operandNoises;
+            getOperandNoises(mulOp, operandNoises);
+
+            auto localParam = getLocalParam(mulOp.getResult());
+            auto lhsParam = getLocalParam(mulOp.getOperand(0));
+            auto rhsParam = getLocalParam(mulOp.getOperand(1));
+            NoiseState mult =
+                NoiseModel::evalMul(localParam, lhsParam, rhsParam,
+                                    operandNoises[0], operandNoises[1]);
+            propagate(mulOp.getResult(), mult);
+            return success();
+          })
+          .template Case<arith::AddFOp, arith::SubFOp, arith::AddIOp,
+                         arith::SubIOp>([&](auto addOp) {
+            SmallVector<OpResult> secretResults;
+            this->getSecretResults(addOp, secretResults);
+            if (secretResults.empty()) {
+              return success();
+            }
+
+            SmallVector<NoiseState, 2> operandNoises;
+            getOperandNoises(addOp, operandNoises);
+            NoiseState add =
+                NoiseModel::evalAdd(operandNoises[0], operandNoises[1]);
+            propagate(addOp.getResult(), add);
+            return success();
+          })
+          .template Case<tensor_ext::RotateOp>([&](auto rotateOp) {
+            // implicitly assumed secret
+            auto localParam = getLocalParam(rotateOp.getOperand(0));
+
+            // assume relinearize immediately after rotate
+            // when we support hoisting relinearize, we need to change
+            // this
+            NoiseState rotate = NoiseModel::evalRelinearize(
+                localParam, operands[0]->getValue());
+            propagate(rotateOp.getResult(), rotate);
+            return success();
+          })
+          // NOTE: special case for ExtractOp... it is a mulconst+rotate
+          // if not annotated with slot_extract
+          // TODO(#1174): decide packing earlier in the pipeline instead
+          // of annotation
+          //.template Case<tensor::ExtractOp>([&](auto extractOp) {
+          //  auto localParam = getLocalParam(extractOp.getOperand(0));
+
+          //  // extract = mul_plain 1 + rotate
+          //  // although the cleartext is 1, when encoded (i.e. CRT
+          //  // packing), the value multiplied to the ciphertext is not 1,
+          //  // If we can know the encoded value, we can bound it more
+          //  // precisely.
+          //  NoiseState one = NoiseModel::evalConstant(localParam);
+          //  NoiseState extract =
+          //      NoiseModel::evalMul(localParam, operands[0]->getValue(), one);
+          //  // assume relinearize immediately after rotate
+          //  // when we support hoisting relinearize, we need to change
+          //  // this
+          //  NoiseState rotate =
+          //      NoiseModel::evalRelinearize(localParam, extract);
+          //  propagate(extractOp.getResult(), extract);
+          //  return success();
+          //})
+          .template Case<mgmt::ModReduceOp>([&](auto modReduceOp) {
+            // No-op for B/FV
+            modReduceOp->emitWarning("ModReduceOp encountered in CKKS");
+            propagate(modReduceOp.getResult(), operands[0]->getValue());
+            return success();
+          })
+          .template Case<mgmt::RelinearizeOp>([&](auto relinearizeOp) {
+            auto localParam = getLocalParam(relinearizeOp.getInput());
+
+            NoiseState relinearize = NoiseModel::evalRelinearize(
+                localParam, operands[0]->getValue());
+            propagate(relinearizeOp.getResult(), relinearize);
+            return success();
+          })
+          .Default([&](auto &op) {
+            // condition on result secretness
+            SmallVector<OpResult> secretResults;
+            this->getSecretResults(&op, secretResults);
+            if (secretResults.empty()) {
+              return success();
+            }
+
+            if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
+                           arith::ExtFOp>(op)) {
+              op.emitError()
+                  << "Unsupported operation for noise analysis encountered.";
+            }
+
+            SmallVector<OpOperand *> secretOperands;
+            this->getSecretOperands(&op, secretOperands);
+            if (secretOperands.empty()) {
+              return success();
+            }
+
+            // inherit noise from the first secret operand
+            NoiseState first;
+            for (auto *operand : secretOperands) {
+              auto &noise = this->getLatticeElement(operand->get())->getValue();
+              if (!noise.isInitialized()) {
+                return success();
+              }
+              first = noise;
+              break;
+            }
+
+            for (auto result : secretResults) {
+              propagate(result, first);
+            }
+            return success();
+          });
+  return res;
+}
+
+// template instantiation
+// for variance
+template class NoiseAnalysis<ckks::NoiseByVarianceCoeffModel>;
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/CKKS/NoiseByVarianceCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/CKKS/NoiseByVarianceCoeffModel.cpp
@@ -1,0 +1,198 @@
+#include "lib/Analysis/NoiseAnalysis/CKKS/NoiseByVarianceCoeffModel.h"
+
+#include <cassert>
+#include <cmath>
+#include <iomanip>
+#include <ios>
+#include <numeric>
+#include <sstream>
+#include <string>
+
+#include "lib/Utils/MathUtils.h"
+
+namespace mlir {
+namespace heir {
+namespace ckks {
+
+// the formulae below are mainly taken from CCH+23
+// "On the precision loss in approximate homomorphic encryption"
+// https://ia.cr/2022/162 with modification that for message-noise
+// multiplication we use worst-case bound.
+
+using Model = NoiseByVarianceCoeffModel;
+
+double Model::toLogBound(const LocalParamType &param, const StateType &noise) {
+  // error probability 0.1%
+  // though this only holds if every random variable is Gaussian
+  // or similar to Gaussian
+  // so this may give underestimation, see MP24 and CCH+23
+  double alpha = 0.001;
+  auto ringDim = param.getSchemeParam()->getRingDim();
+  double bound =
+      sqrt(2.0 * noise.getValue()) * erfinv(pow(1.0 - alpha, 1.0 / ringDim));
+  return log2(bound);
+  // rhoToRealError:
+  // https://github.com/bencrts/CKKS_noise/blob/main/heuristics/CLT.py
+  // double bound = sqrt(ringDim * noise.getValue()) *
+  //               erfinv(pow(1.0 - alpha, 2.0 / ringDim));
+  // return log2(bound) - param.getScale();
+}
+
+double Model::toLogBudget(const LocalParamType &param, const StateType &noise) {
+  return toLogTotal(param) - toLogBound(param, noise);
+}
+
+double Model::toLogTotal(const LocalParamType &param) {
+  double total = 0;
+  auto logqi = param.getSchemeParam()->getLogqi();
+  for (auto i = 0; i <= param.getSchemeParam()->getLevel(); ++i) {
+    total += logqi[i];
+  }
+  return total - 1.0;
+}
+
+std::string Model::toLogBoundString(const LocalParamType &param,
+                                    const StateType &noise) {
+  auto logBound = toLogBound(param, noise);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logBound;
+  return stream.str();
+}
+
+std::string Model::toLogBudgetString(const LocalParamType &param,
+                                     const StateType &noise) {
+  auto logBudget = toLogBudget(param, noise);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logBudget;
+  return stream.str();
+}
+
+std::string Model::toLogTotalString(const LocalParamType &param) {
+  auto logTotal = toLogTotal(param);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logTotal;
+  return stream.str();
+}
+
+double Model::getVarianceErr(const LocalParamType &param) {
+  auto std0 = param.getSchemeParam()->getStd0();
+  return std0 * std0;
+}
+
+double Model::getVarianceKey(const LocalParamType &param) {
+  // assume UNIFORM_TERNARY
+  return 2.0 / 3.0;
+}
+
+typename Model::StateType Model::evalEncryptPk(const LocalParamType &param) {
+  auto varianceError = getVarianceErr(param);
+  // uniform ternary
+  auto varianceKey = getVarianceKey(param);
+  auto n = param.getSchemeParam()->getRingDim();
+  // public key (-as + e, a)
+  // public key encryption (-aus + (u * e + e_0) + (q/t) * m, au + e_1)
+  // v_fresh = u * e + e_1 * s + e_0
+  // var_fresh = (2n * var_key + 1) * var_error
+  // for ringDim, see header comment for explanation
+  double fresh = varianceError * (2. * n * varianceKey + 1.);
+  // max degree of 's' in v_fresh is 1.
+  return StateType::of(fresh);
+}
+
+typename Model::StateType Model::evalEncryptSk(const LocalParamType &param) {
+  auto varianceError = getVarianceErr(param);
+
+  // secret key s
+  // secret key encryption (-as + (q/t) * m + e, a)
+  // v_fresh = e
+  // var_fresh = var_error
+  double fresh = varianceError;
+  // max degree of 's' in v_fresh is 0.
+  return StateType::of(fresh);
+}
+
+typename Model::StateType Model::evalEncrypt(const LocalParamType &param) {
+  auto usePublicKey = param.getSchemeParam()->getUsePublicKey();
+  // TODO
+  auto isEncryptionTechniqueExtended = true;
+  // param.getSchemeParam()->isEncryptionTechniqueExtended();
+  if (isEncryptionTechniqueExtended) {
+    // for extended encryption technique, namely encrypt at Qp then mod reduce
+    // back to Q, the noise is modreduce(encrypt)
+    auto ringDim = param.getSchemeParam()->getRingDim();
+    auto varianceKey = getVarianceKey(param);
+    // the error has the form tau_0 + tau_1 * s, where tau_i is uniform in
+    // [-1/2, 1/2].
+    auto added = (1.0 + ringDim * varianceKey) / 12.0;
+    return StateType::of(added);
+  }
+  if (usePublicKey) {
+    return evalEncryptPk(param);
+  }
+  return evalEncryptSk(param);
+}
+
+typename Model::StateType Model::evalConstant(const LocalParamType &param) {
+  // constant is v = (q/t)m + 0
+  return StateType::of(0);
+}
+
+typename Model::StateType Model::evalAdd(const StateType &lhs,
+                                         const StateType &rhs) {
+  // v_add = v_0 + v_1
+  // assuming independence of course
+  return StateType::of(lhs.getValue() + rhs.getValue());
+}
+
+typename Model::StateType Model::evalMul(const LocalParamType &resultParam,
+                                         const LocalParamType &lhsParam,
+                                         const LocalParamType &rhsParam,
+                                         const StateType &lhs,
+                                         const StateType &rhs) {
+  auto ringDim = resultParam.getSchemeParam()->getRingDim();
+  auto v0 = lhs.getValue();
+  auto v1 = rhs.getValue();
+  // v0 * v1 can be averaged to ringDim * v0 * v1
+  double leftScale = pow(2.0, lhsParam.getScale());
+  double rightScale = pow(2.0, rhsParam.getScale());
+  // for v0 * m1, we do not have good method as m1 is _not uniformly random_
+  // for m1 = Encode(z), we know the bound on ||z||_infty, then we have
+  // ||m1||_infty <= Delta ||z||_infty, then we use worst-case bound
+  // for v0 * m1 by
+  //   N * ||m1||_infty * ||v0||_infty
+  //     <= N * Delta * ||z||_infty * ||v0||_infty
+  //
+  // Expressing this in variance, as v0 can still be seen as uniformly random,
+  // we can use the variance N^2 * Delta * 2 * ||z||_infty^2 * v0
+  //
+  // Still caution here as the coefficients of v0 are _not independent_.
+  // It has noticeable distance from an independent one.
+  // See "On the Independence Assumption in Quasi-Cyclic Code-Based
+  // Cryptography"
+  //
+  // we currently assume z in [-1, 1], so ||z||_infty = 1
+  // NOTE: when user is using z in, e.g. [-100, 100], we need to
+  //   change here. Should rely on the plaintext backend to provide
+  //   the correct bound.
+  return StateType::of(ringDim * v0 * v1 +
+                       ringDim * ringDim * v0 * rightScale * rightScale +
+                       ringDim * ringDim * v1 * leftScale * leftScale);
+}
+
+typename Model::StateType Model::evalRelinearizeHYBRID(
+    const LocalParamType &inputParam, const StateType &input) {
+  // Ignore it for now, as often relinearization error is small
+  return StateType::of(input.getValue());
+}
+
+typename Model::StateType Model::evalRelinearize(
+    const LocalParamType &inputParam, const StateType &input) {
+  // assume HYBRID
+  // if we further introduce BV to SchemeParam we can have alternative
+  // implementation.
+  return evalRelinearizeHYBRID(inputParam, input);
+}
+
+}  // namespace ckks
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/CKKS/NoiseByVarianceCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/CKKS/NoiseByVarianceCoeffModel.h
@@ -1,0 +1,71 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_CKKS_NOISEBYVARIANCECOEFFMODEL_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_CKKS_NOISEBYVARIANCECOEFFMODEL_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <optional>
+#include <string>
+
+#include "lib/Analysis/NoiseAnalysis/Noise.h"
+#include "lib/Parameters/CKKS/Params.h"
+
+namespace mlir {
+namespace heir {
+namespace ckks {
+
+// coefficient embedding noise model using variance
+class NoiseByVarianceCoeffModel {
+ public:
+  // NoiseState stores the variance var for the one coefficient of
+  // the error 'e', assuming coefficients are IID.
+  //
+  // MP24/CCH+23 states that for two polynomial multipication, the variance of
+  // one coefficient of the result can be approximated by ringDim * var_0 *
+  // var_1, because the polynomial multipication is a convolution.
+  using StateType = NoiseState;
+  using SchemeParamType = ckks::SchemeParam;
+  using LocalParamType = ckks::LocalParam;
+
+ private:
+  static double getVarianceErr(const LocalParamType &param);
+  static double getVarianceKey(const LocalParamType &param);
+
+  static StateType evalEncryptPk(const LocalParamType &param);
+  static StateType evalEncryptSk(const LocalParamType &param);
+  static StateType evalRelinearizeHYBRID(const LocalParamType &inputParam,
+                                         const StateType &input);
+
+ public:
+  static StateType evalEncrypt(const LocalParamType &param);
+  static StateType evalConstant(const LocalParamType &param);
+  static StateType evalAdd(const StateType &lhs, const StateType &rhs);
+  static StateType evalMul(const LocalParamType &resultParam,
+                           const LocalParamType &lhsParam,
+                           const LocalParamType &rhsParam, const StateType &lhs,
+                           const StateType &rhs);
+  static StateType evalRelinearize(const LocalParamType &inputParam,
+                                   const StateType &input);
+
+  // logTotal: log(Q / (t * 2))
+  // logBound: bound on ||e|| predicted by the model
+  // logBudget: logTotal - logBound
+  // as ||e|| < Q / (t * 2) for correct decryption
+  static double toLogBound(const LocalParamType &param, const StateType &noise);
+  static std::string toLogBoundString(const LocalParamType &param,
+                                      const StateType &noise);
+  static double toLogBudget(const LocalParamType &param,
+                            const StateType &noise);
+  static std::string toLogBudgetString(const LocalParamType &param,
+                                       const StateType &noise);
+  static double toLogTotal(const LocalParamType &param);
+  static std::string toLogTotalString(const LocalParamType &param);
+};
+
+}  // namespace ckks
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_CKKS_NOISEBYVARIANCECOEFFMODEL_H_

--- a/lib/Analysis/ScaleAnalysis/ScaleAnalysis.cpp
+++ b/lib/Analysis/ScaleAnalysis/ScaleAnalysis.cpp
@@ -113,7 +113,12 @@ LogicalResult ScaleAnalysis<ScaleModelT>::visitOperation(
   auto getLocalParam = [&](Value value) {
     auto level = getLevelFromMgmtAttr(value);
     auto dimension = getDimensionFromMgmtAttr(value);
-    return LocalParamType(&schemeParam, level, dimension);
+    [[maybe_unused]] auto scale = getScaleFromMgmtAttr(value);
+    if constexpr (std::is_same_v<LocalParamType, ckks::LocalParam>) {
+      return LocalParamType(&schemeParam, level, dimension, scale);
+    } else {
+      return LocalParamType(&schemeParam, level, dimension);
+    }
   };
 
   auto propagate = [&](Value value, const ScaleState &state) {
@@ -258,7 +263,12 @@ LogicalResult ScaleAnalysisBackward<ScaleModelT>::visitOperation(
   auto getLocalParam = [&](Value value) {
     auto level = getLevelFromMgmtAttr(value);
     auto dimension = getDimensionFromMgmtAttr(value);
-    return LocalParamType(&schemeParam, level, dimension);
+    [[maybe_unused]] auto scale = getScaleFromMgmtAttr(value);
+    if constexpr (std::is_same_v<LocalParamType, ckks::LocalParam>) {
+      return LocalParamType(&schemeParam, level, dimension, scale);
+    } else {
+      return LocalParamType(&schemeParam, level, dimension);
+    }
   };
 
   auto propagate = [&](Value value, const ScaleState &state) {

--- a/lib/Parameters/CKKS/Params.h
+++ b/lib/Parameters/CKKS/Params.h
@@ -36,13 +36,20 @@ class SchemeParam : public RLWESchemeParam {
 // Parameter for each SSA ciphertext SSA value.
 class LocalParam : public RLWELocalParam {
  public:
-  LocalParam(const SchemeParam *schemeParam, int currentLevel, int dimension)
-      : RLWELocalParam(schemeParam, currentLevel, dimension) {}
+  LocalParam(const SchemeParam *schemeParam, int currentLevel, int dimension,
+             int64_t scale)
+      : RLWELocalParam(schemeParam, currentLevel, dimension), scale(scale) {}
 
  public:
   const SchemeParam *getSchemeParam() const {
     return static_cast<const SchemeParam *>(schemeParam);
   }
+
+ public:
+  int64_t getScale() const { return scale; }
+
+ private:
+  int64_t scale;
 };
 
 }  // namespace ckks

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -19,6 +19,8 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
+        "@heir//lib/Analysis/NoiseAnalysis/CKKS:NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis/ScaleAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -38,6 +38,7 @@ cc_binary(
         "@heir//lib/Analysis/NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseAnalysis",  # buildcleaner: keep
+        "@heir//lib/Analysis/NoiseAnalysis/CKKS:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGI",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGIQuart",


### PR DESCRIPTION
The noise model is mainly taken from [On the precision loss in approximate homomorphic encryption](https://ia.cr/2022/162). Marking as draft as it need discussion (or research).

I think the most tricky part is the multiplication, unlike in BGV/BFV variance-based noise model where the message itself often does not affect much, in CKKS the message heavily affects how the noise grows.

In short, in CKKS the message is in the form $\\Delta m + e$. Then after multiplication with $\\Delta m2 + e2$, the message becomes $\\Delta (\Delta m m2 + m2 e + m e2 + ...)$. The $m2 e + m e2$ part is the major part of the noise, and we actually have no average way to analyse it.

Past work would argue that we can assume coefficients in message is uniform in $[-1, 1]$, however, this is hardly true in real world application, so we can not use average-case approach here.

Other works would ask the user to provide the input, which is common in practice (Openfhe has `EXEC_NOISE_ESTIMATION` and Lattigo has a [paper](https://ia.cr/2024/853) with an estimator asking user input). HEIR also provides similar infrasturcture by the plaintext backend, but knowing exactly what $m$ is still makes it hard to understand the behavior of $m e2$ (past paper gives little detail on this). In the code, I just use $N |\\Delta m|\infty |e2|\infty$ the worst case bound on coefficient embedding. The the bound is translated into variance by $N * N * \\Delta * \\Delta * B * B * variance$. This approach is still questionable. See the code comment for detail.

(sorry for not using subscript/superscript as the rendering issue with github)

Note that in https://github.com/bencrts/CKKS_noise/blob/main/heuristics/CLT.py they use $\\Delta * \\Delta * B * B * variance$ (note the missing $N$), which will give underestimation in my running. In the paper, the bound they use is the square of 2-norm on $m$, so N is still there, but using $N * \\Delta * \\Delta * B * B * variance$ still gives underestimation.

Missing parts in this PR: implement inverse canonical encoding in HEIR to actually know plaintext $m$ from the cleartext value, and integrate the noise model with the plaintext backend.

I would say the exact noise estimation for CKKS without knowing the input is open, and I would conjecture there might be no good way to do an average one without knowing the input. Even knowing the input or input domain, we might only be able to do worst-case one as the input distribution might be hand crafted to launch attack. After all, we can not ask the user to provide the _input distribution_. (Also some cite to the IND-CPA definition, IND-CPA-D definition and the recent application-aware security model where only the _circuit_ and its input _domain_ is asked to be provided). (For input distribution, some cite to differential privacy).

An experiment to give some sense on the above comment:

For multiplication of two freshly encrypted ciphertext, we consider the following case

#### All 0

This time $m=0$, so the noise is only $e e2$, and we can use the average-case approach by setting the new variance to $N \rho \rho 2$.

```
Input
  Scale: 45
  Precision lost: 2^-34.0
  Noise: 6.83
Input
  Scale: 45
  Precision lost: 2^-32.7
  Noise: 6.95
lattigo.ckks.mul
  Scale: 90
  Precision lost: 2^-67.2
  Noise: 19.30
```

Note that `7 + 7 + 13/2 = 20.5` where `logN = 13`, this is somekind of rough estimation (ignoring all the error function stuff).

#### All 1

The interesting part of encoding all 1 is that, the encoded message is actually $\\Delta + 0 * X + 0 * X * X + ...$, namely only a constant (see https://github.com/google/heir/issues/1604#issuecomment-2773096824). Then $m e2$ could be easily understood as a constant multiplication.

```
Input
  Scale: 45
  Precision lost: 2^-33.2
  Noise: 7.00
Input
  Scale: 45
  Precision lost: 2^-32.6
  Noise: 6.87
lattigo.ckks.mul
  Scale: 90
  Precision lost: 2^-32.3
  Noise: 52.38
```

Note that `7 + 45 = 52`.

#### The dot product input in test example 

The inputs are now `[0.1, 0.2, ..., 0.8]` and `[0.2, 0.3, ..., 0.9]`.

```
Input
  Scale: 45
  Precision lost: 2^-32.5
  Noise: 7.01
Input
  Scale: 45
  Precision lost: 2^-32.3
  Noise: 6.99
lattigo.ckks.mul
  Scale: 90
  Precision lost: 2^-25.4
  Noise: 61.90
```

#### The prediction by the model

The model does not know the exactly value for the input for now.

```
Propagating 6.82 to <block argument> of type 'tensor<8xf32>' at index: 0
Propagating 6.82 to <block argument> of type 'tensor<8xf32>' at index: 1
Propagating 65.32 to %2 = arith.mulf %input0, %input1 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3, scale = 90>} : tensor<8xf32>
```

Note that `7 + 45 + 13 = 65` where `logN = 13`.

I believe with all slots filled with hand-crafted value (may find construction clue in prevoius attacks), such bound could be reached (even exceeded). 