### PR TITLE
Emitter improvements

### DIFF
--- a/lib/Target/Lattigo/BUILD
+++ b/lib/Target/Lattigo/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Utils:TargetUtils",
         "@heir//lib/Utils/Tablegen:InplaceOpInterface",
         "@llvm-project//llvm:Support",

--- a/lib/Target/Lattigo/LattigoTemplates.h
+++ b/lib/Target/Lattigo/LattigoTemplates.h
@@ -7,23 +7,18 @@ namespace mlir {
 namespace heir {
 namespace lattigo {
 
+// prevent format mangling
 // clang-format off
-constexpr std::string_view kModulePreludeBGVTemplate = R"go(
-import (
-    "github.com/tuneinsight/lattigo/v6/core/rlwe"
-    "github.com/tuneinsight/lattigo/v6/schemes/bgv"
-)
-)go";
-
-constexpr std::string_view kModulePreludeCKKSTemplate = R"go(
-import (
-    "math"
-
-    "github.com/tuneinsight/lattigo/v6/core/rlwe"
-    "github.com/tuneinsight/lattigo/v6/schemes/ckks"
-)
-)go";
+constexpr std::string_view kRlweImport =
+    "\"github.com/tuneinsight/lattigo/v6/core/rlwe\"";
+constexpr std::string_view kBgvImport =
+    "\"github.com/tuneinsight/lattigo/v6/schemes/bgv\"";
+constexpr std::string_view kCkksImport =
+    "\"github.com/tuneinsight/lattigo/v6/schemes/ckks\"";
 // clang-format on
+//
+constexpr std::string_view kMathImport = "\"math\"";
+constexpr std::string_view kSlicesImport = "\"slices\"";
 
 }  // namespace lattigo
 }  // namespace heir

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -96,6 +96,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::arith::IndexCastOp op);
   LogicalResult printOperation(::mlir::arith::RemSIOp op);
   LogicalResult printOperation(::mlir::arith::SelectOp op);
+  LogicalResult printOperation(::mlir::tensor::ConcatOp op);
   LogicalResult printOperation(::mlir::tensor::EmptyOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractSliceOp op);

--- a/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
+++ b/tests/Dialect/Lattigo/Emitters/emit_lattigo.mlir
@@ -214,3 +214,51 @@ module attributes {scheme.bgv} {
     return %negated : !lattigo.rlwe.ciphertext
   }
 }
+
+// -----
+
+module attributes {scheme.ckks} {
+  // CHECK: func float_constant
+  func.func @float_constant(%evaluator: !lattigo.bgv.evaluator, %ct: !lattigo.rlwe.ciphertext) -> f32 {
+    // CHECK: [[v:[^, ]*]] := float32(7.5)
+    // CHECK: return v
+    %v = arith.constant 7.5 : f32
+    return %v : f32
+  }
+}
+
+// -----
+
+module attributes {scheme.ckks} {
+  // CHECK: func tensor_insert
+  func.func @tensor_insert(%evaluator: !lattigo.bgv.evaluator, %ct: !lattigo.rlwe.ciphertext) -> f32 {
+    // CHECK:  [[v0:[^ ]*]] := int64(5)
+    // CHECK:  [[v1:[^, ]*]] := float32(7.5)
+    // CHECK:  [[v2:[^ ]*]] := []float32{0, 0, 0, 0, 0, 0, 0, 0}
+    // CHECK:  [[v2]]{{\[}}[[v0]]] = [[v1]]
+    // CHECK:  return [[v1]]
+    %c5 = arith.constant 5 : index
+    %v = arith.constant 7.5 : f32
+    %tensor = arith.constant dense<0.0> : tensor<8xf32>
+    %tensor2 = tensor.insert %v into %tensor[%c5] : tensor<8xf32>
+    return %v : f32
+  }
+}
+
+// -----
+
+module attributes {scheme.ckks} {
+  // CHECK: func splat
+  func.func @splat(%evaluator: !lattigo.bgv.evaluator, %ct: !lattigo.rlwe.ciphertext) {
+  // CHECK:  [[v0:[^ ]*]] := []int32{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5}
+  // CHECK:  [[v1:[^ ]*]] := [3]int32{}
+  // CHECK:  for [[source:[^ ]*]] := 1; [[source]] < 7; [[source]] += 2 {
+  // CHECK:    [[dest:[^ ]*]] := 0
+  // CHECK:    [[v1]]{{\[}}[[dest]]] = [[v0]]{{\[}}[[source]]]
+  // CHECK:    [[dest]] += 1
+  // CHECK:  }
+    %c5 = arith.constant dense<5> : tensor<20xi32>
+    %v = tensor.extract_slice %c5[1] [3] [2] : tensor<20xi32> to tensor<3xi32>
+    return
+  }
+}

--- a/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_openfhe_pke.mlir
@@ -301,3 +301,20 @@ module attributes {scheme.bgv} {
     return %3 : i64
   }
 }
+
+// -----
+
+module attributes {scheme.bgv} {
+  // CHECK: test_concat
+  func.func @test_concat() -> tensor<64xi16> {
+    // CHECK: std::vector<int16_t> [[v0:.*]] =
+    %cst = arith.constant dense<[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]> : tensor<32xi16>
+    // CHECK: std::vector<int16_t> [[v1:.*]];
+    // CHECK: for (int i = 0; i < 2; ++i) {
+    // CHECK:   v1.insert([[v1]].end(), [[v0]].begin(), [[v0]].end());
+    // CHECK: }
+    %v = tensor.concat dim(0) %cst, %cst : (tensor<32xi16>, tensor<32xi16>) -> tensor<64xi16>
+
+    return %v : tensor<64xi16>
+  }
+}


### PR DESCRIPTION
Extracted from https://github.com/google/heir/pull/1633

- register tensor_ext dialect with emitters
- allow for dynamic lattigo imports
- lattigo: emit insert_slice, insert, splat ops
- openfhe: emit concat op