### PR TITLE
clear tensor_ext attributes when dropping secrets

### DIFF
--- a/lib/Dialect/Secret/Transforms/ForgetSecrets.cpp
+++ b/lib/Dialect/Secret/Transforms/ForgetSecrets.cpp
@@ -149,6 +149,26 @@ struct ForgetSecrets : impl::SecretForgetSecretsBase<ForgetSecrets> {
     if (failed(applyPartialConversion(func, target, std::move(patterns)))) {
       signalPassFailure();
     }
+
+    // Clear any tensor_ext attributes from the func
+    getOperation()->walk([&](FunctionOpInterface funcOp) {
+      for (int i = 0; i < funcOp.getNumArguments(); ++i) {
+        for (auto attr : funcOp.getArgAttrs(i)) {
+          // the attr name is tensor_ext.foo, so just check for the prefix
+          if (attr.getName().getValue().starts_with("tensor_ext")) {
+            funcOp.removeArgAttr(i, attr.getName());
+          }
+        }
+      }
+
+      for (int i = 0; i < funcOp.getNumResults(); ++i) {
+        for (auto attr : funcOp.getResultAttrs(i)) {
+          if (attr.getName().getValue().starts_with("tensor_ext")) {
+            funcOp.removeResultAttr(i, attr.getName());
+          }
+        }
+      }
+    });
   }
 };
 

--- a/tests/Dialect/Secret/Transforms/forget_secrets.mlir
+++ b/tests/Dialect/Secret/Transforms/forget_secrets.mlir
@@ -109,3 +109,11 @@ func.func @test_convert_call_2() -> i32 {
   %5 = secret.reveal %4 : !secret.secret<i32> -> i32
   func.return %5 : i32
 }
+
+// -----
+
+// CHECK-NOT: tensor_ext
+#orig_type = #tensor_ext.original_type<originalType = i32, layout = <map = (d0) -> (d0)>>
+func.func @test_clear_attrs(%Y : !secret.secret<i32> {tensor_ext.original_type = #orig_type}) -> (!secret.secret<i32> {tensor_ext.original_type = #orig_type}) {
+  func.return %Y : !secret.secret<i32>
+}


### PR DESCRIPTION
This is for the plaintext backend, once the layout system is merged