### PR TITLE
Openfhe and Lattigo emitter improvements

### DIFF
--- a/lib/Target/Lattigo/LattigoEmitter.h
+++ b/lib/Target/Lattigo/LattigoEmitter.h
@@ -66,6 +66,15 @@ class LattigoEmitter {
   std::string prelude;
   std::set<std::string> imports;
 
+  // general binary op helper
+  LogicalResult printBinaryOp(Operation *op, ::mlir::Value lhs,
+                              ::mlir::Value rhs, std::string_view opName);
+  // General typecast helper
+  LogicalResult typecast(Value operand, Value result);
+  // emit an if statement
+  void emitIf(const std::string &cond, const std::function<void()> &trueBranch,
+              const std::function<void()> &falseBranch);
+
   // Functions for printing individual ops
   LogicalResult printOperation(::mlir::ModuleOp op);
   LogicalResult printOperation(::mlir::affine::AffineForOp op);
@@ -73,11 +82,25 @@ class LattigoEmitter {
   LogicalResult printOperation(::mlir::func::FuncOp op);
   LogicalResult printOperation(::mlir::func::ReturnOp op);
   LogicalResult printOperation(::mlir::func::CallOp op);
+  LogicalResult printOperation(::mlir::arith::AddIOp op);
+  LogicalResult printOperation(::mlir::arith::CmpIOp op);
+  LogicalResult printOperation(::mlir::arith::DivSIOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  LogicalResult printOperation(::mlir::arith::ExtFOp op);
+  LogicalResult printOperation(::mlir::arith::ExtSIOp op);
+  LogicalResult printOperation(::mlir::arith::ExtUIOp op);
+  LogicalResult printOperation(::mlir::arith::IndexCastOp op);
+  LogicalResult printOperation(::mlir::arith::MulIOp op);
+  LogicalResult printOperation(::mlir::arith::RemSIOp op);
+  LogicalResult printOperation(::mlir::arith::SelectOp op);
+  LogicalResult printOperation(::mlir::arith::SubIOp op);
+  LogicalResult printOperation(::mlir::tensor::ConcatOp op);
+  LogicalResult printOperation(::mlir::tensor::EmptyOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractSliceOp op);
   LogicalResult printOperation(::mlir::tensor::FromElementsOp op);
   LogicalResult printOperation(::mlir::tensor::InsertOp op);
+  LogicalResult printOperation(::mlir::tensor::InsertSliceOp op);
   LogicalResult printOperation(::mlir::tensor::SplatOp op);
 
   // Lattigo ops

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -90,17 +90,21 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::arith::AddIOp op);
   LogicalResult printOperation(::mlir::arith::CmpIOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  LogicalResult printOperation(::mlir::arith::DivSIOp op);
   LogicalResult printOperation(::mlir::arith::ExtFOp op);
   LogicalResult printOperation(::mlir::arith::ExtSIOp op);
   LogicalResult printOperation(::mlir::arith::ExtUIOp op);
   LogicalResult printOperation(::mlir::arith::IndexCastOp op);
+  LogicalResult printOperation(::mlir::arith::MulIOp op);
   LogicalResult printOperation(::mlir::arith::RemSIOp op);
   LogicalResult printOperation(::mlir::arith::SelectOp op);
+  LogicalResult printOperation(::mlir::arith::SubIOp op);
   LogicalResult printOperation(::mlir::tensor::ConcatOp op);
   LogicalResult printOperation(::mlir::tensor::EmptyOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractOp op);
   LogicalResult printOperation(::mlir::tensor::ExtractSliceOp op);
   LogicalResult printOperation(::mlir::tensor::InsertOp op);
+  LogicalResult printOperation(::mlir::tensor::InsertSliceOp op);
   LogicalResult printOperation(::mlir::tensor::SplatOp op);
   LogicalResult printOperation(::mlir::func::FuncOp op);
   LogicalResult printOperation(::mlir::func::CallOp op);
@@ -143,6 +147,9 @@ class OpenFhePkeEmitter {
                                 std::string_view op);
   LogicalResult printBinaryOp(Operation *op, ::mlir::Value lhs,
                               ::mlir::Value rhs, std::string_view opName);
+
+  // A helper for a special case of ExtractSliceOp
+  LogicalResult extractRowFromMatrix(tensor::ExtractSliceOp op);
 
   // Emit an OpenFhe type, using a const specifier.
   LogicalResult emitType(::mlir::Type type, ::mlir::Location loc,


### PR DESCRIPTION
Added to lattigo:

- arith: addi, cmpi, divsi, extf, extsi, extui, index_cast, muli, remsi, select, subi
- tensor: concat, empty, insert_slice

Added to openfhe:

- arith: divsi, muli, subi
- tensor: extract_slice

Also fixes a bug with nested loop generation in extract_slice where the destination index was being initialized inside the loop instead of outside.