### PR TITLE
Only rotate-and-reduce post matvec when original matrix is non-square

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -130,11 +130,11 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.9.0/MODULE.bazel": "e17c876cb53dcd817b7b7f0d2985b710610169729e8c371b2221cacdcd3dce4a",
-    "https://bcr.bazel.build/modules/rules_java/8.9.0/source.json": "fcf9537bfd741f6b7d74ec00898b8a79c1bc76335690943d412bc32fe1e64d03",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -932,7 +932,7 @@
     },
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "npnHl1jGdnSt5hglsMHC97vRzHsub5IeUUtFGwSXIyw=",
+        "bzlTransitiveDigest": "ZRwk3FImnZGds51y4VUhCxcswnXZbFXqTrFbSmIW2Z0=",
         "usagesDigest": "ogzJv1UVhgnb/xpM7ytUxAUUpEs+C8eyACas/3Xgl0A=",
         "recordedFileInputs": {
           "@@//frontend/requirements.txt": "af2cd992a762dabd7d9b4dc32667c9aecc82550f90aab96d637bed7496e14963",

--- a/tests/Transforms/convert_to_ciphertext_semantics/linalg_matvec.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/linalg_matvec.mlir
@@ -149,6 +149,7 @@ func.func @matvec_constant_matrix(
           ins(%enc_matrix, %input0 : tensor<16x16xi16>, tensor<16xi16>)
           outs(%enc_out : tensor<16xi16>) -> tensor<16xi16>
 
+    // CHECK-NOT: tensor_ext.rotate
     secret.yield %3 : tensor<16xi16>
   } -> !secret.secret<tensor<16xi16>>
   // CHECK: return [[output]]

--- a/tests/Transforms/convert_to_ciphertext_semantics/linalg_matvec_1024.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/linalg_matvec_1024.mlir
@@ -1,0 +1,160 @@
+// RUN: heir-opt %s --convert-to-ciphertext-semantics=ciphertext-size=1024 | FileCheck %s
+
+// This test checks an edge case of the matvec kernel where the squat kernel
+// rotate-and-reduce was being applied to square tensors incorrectly.
+
+#vec_layout = #tensor_ext.layout<map = (d0) -> (d0 mod 1024)>
+#diagonal = #tensor_ext.layout<map = (d0, d1) -> (d1 mod 16, (d0 + d1) mod 1024)>
+
+// CHECK-DAG: [[row_major_indexing_map:#[^ ]*]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG: [[diagonal_layout:#[^ ]*]] = affine_map<(d0, d1) -> (d1 mod 16, (d0 + d1) mod 1024)>
+// CHECK-DAG: [[layout_rm_1d:#[^ ]*]] = #tensor_ext.layout<map = (d0) -> (d0 mod 1024)>
+// CHECK-DAG: [[orig_type:#[^ ]*]] = #tensor_ext.original_type<originalType = tensor<16xi16>, layout = [[layout_rm_1d]]>
+
+// CHECK: @matvec_constant_matrix
+// CHECK-SAME: [[arg0:%[^:]*]]: [[materialized_ty:!secret.secret<tensor<1024xi16>>]]
+// CHECK-SAME: tensor_ext.original_type = [[orig_type]]
+// CHECK-SAME: -> ([[materialized_ty]] {tensor_ext.original_type = [[orig_type]]}
+func.func @matvec_constant_matrix(
+    %arg0: !secret.secret<tensor<16xi16>> {tensor_ext.layout = #vec_layout}) ->
+       (!secret.secret<tensor<16xi16>> {tensor_ext.layout = #vec_layout}) {
+  // CHECK: [[cst:%[^ ]+]] = arith.constant dense<1> : tensor<16x16xi16>
+  %cst = arith.constant dense<1> : tensor<16x16xi16>
+  // CHECK: [[loop_init:%[^ ]+]] = arith.constant dense<0> : tensor<16xi16>
+  %out = arith.constant dense<0> : tensor<16xi16>
+
+  // CHECK: [[output:%[^ ]+]] = secret.generic
+  // CHECK-SAME: ins([[arg0]]
+  %0 = secret.generic ins(%arg0 : !secret.secret<tensor<16xi16>>)
+                      attrs = {
+                        __argattrs = [{tensor_ext.layout = #vec_layout}],
+                        __resattrs = [{tensor_ext.layout = #vec_layout}]
+                      } {
+  // CHECK: ^body([[clear_arg0:%[^ ]+]]: tensor<1024xi16>):
+  ^body(%input0: tensor<16xi16>):
+    // Apply the row-major encoding
+    // CHECK: [[enc_vec_out:%[^ ]+]] = arith.constant dense<0> : tensor<1024xi16>
+    // CHECK: [[enc_vec:%[^ ]+]] = linalg.generic
+    // CHECK-SAME: [[loop_init]]
+    %enc_out = tensor_ext.assign_layout %out {layout = #vec_layout, tensor_ext.layout = #vec_layout} : tensor<16xi16>
+
+    // Apply the diagonal encoding
+    // CHECK: [[enc_matrix_out:%[^ ]+]] = arith.constant dense<0> : tensor<16x1024xi16>
+    // CHECK: [[enc_matrix:%[^ ]+]] = linalg.generic
+    // CHECK-SAME: indexing_maps = [
+    // CHECK-SAME: [[row_major_indexing_map]],
+    // CHECK-SAME: [[diagonal_layout]]]
+    // CHECK-SAME: iterator_types = [
+    // CHECK-SAME: "parallel", "parallel"]}
+    // CHECK-NEXT: ^bb0([[in:%[^ ]+]]: i16, [[out:%[^ ]+]]: i16):
+    // CHECK-NEXT: linalg.yield [[in]]
+    %enc_matrix = tensor_ext.assign_layout %cst {layout = #diagonal, tensor_ext.layout = #diagonal} : tensor<16x16xi16>
+
+    // Now the Halevi-Shoup kernel
+
+    // 16 iterations, unrolled
+    // CHECK: [[c0:[^ ]*]] = arith.constant 0
+    // CHECK-NEXT: [[rotated:[^ ]*]] = tensor_ext.rotate [[clear_arg0]], [[c0]]
+    // CHECK-NEXT: [[row:[^ ]*]] = tensor.extract_slice
+    // CHECK-NEXT: [[muled:[^ ]*]] = arith.muli [[rotated]], [[row]]
+    // CHECK-NEXT: [[added:[^ ]*]] = arith.addi [[enc_vec]], [[muled]]
+
+    // CHECK: [[c1:[^ ]*]] = arith.constant 1
+    // CHECK-NEXT: tensor_ext.rotate [[clear_arg0]], [[c1]]
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 2
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 3
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 4
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 5
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 6
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 7
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 8
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 9
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 10
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 11
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 12
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 13
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 14
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+
+    // CHECK: arith.constant 15
+    // CHECK-NEXT: tensor_ext.rotate
+    // CHECK-NEXT: tensor.extract_slice
+    // CHECK-NEXT: arith.muli
+    // CHECK-NEXT: arith.addi
+    %3 = linalg.matvec {tensor_ext.layout = #vec_layout}
+          ins(%enc_matrix, %input0 : tensor<16x16xi16>, tensor<16xi16>)
+          outs(%enc_out : tensor<16xi16>) -> tensor<16xi16>
+
+    // CHECK-NOT: tensor_ext.rotate
+    secret.yield %3 : tensor<16xi16>
+  } -> !secret.secret<tensor<16xi16>>
+  // CHECK: return [[output]]
+  return %0 : !secret.secret<tensor<16xi16>>
+}


### PR DESCRIPTION
I was using the packed matrix type, which may not be square even if the original matrix type is square.

[edit]: I had to pull in a few extra minor fixes from https://github.com/google/heir/pull/1633 related to the context-aware type conversion, since this new test was hitting those bugs as well