### PR TITLE
fix: fix path for yosys share files for bazel run

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -6,10 +6,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-# changed from "heir" (or nothing) in bazel 8
-# https://bazel.build/remote/output-directories#layout-diagram
-WORKSPACE_PATH = "_main/"
-
 # Custom `mlir-opt` replacement that links our dialect and passes
 cc_binary(
     name = "heir-opt",
@@ -29,7 +25,7 @@ cc_binary(
     defines = select({
         "@heir//:config_enable_yosys": [
             "HEIR_ABC_BINARY=\\\"$(rootpath @edu_berkeley_abc//:abc)\\\"",
-            "HEIR_YOSYS_SCRIPTS_DIR=\\\"" + WORKSPACE_PATH + "lib/Transforms/YosysOptimizer/yosys\\\"",
+            "HEIR_YOSYS_SCRIPTS_DIR=\\\"" + "lib/Transforms/YosysOptimizer/yosys\\\"",
         ],
         "//conditions:default": ["HEIR_NO_YOSYS=1"],
     }),


### PR DESCRIPTION
Came up in the discussion of https://github.com/google/heir/issues/1712#issuecomment-2798449383

The yosys share files directory doesn't use the workspace prefix _main after the bazel upgrade - it was only intended to work in the root of the repository. I think I couldn't use the rootpath on a folder of files, so that's why i can't do something like "find the location in bazel-bin".

It would be so so much easier to hold the techmap in memory but I don't think I can..