### PR TITLE
cggi: add verilog support for divsi op

### DIFF
--- a/lib/Target/Verilog/VerilogEmitter.cpp
+++ b/lib/Target/Verilog/VerilogEmitter.cpp
@@ -243,11 +243,12 @@ LogicalResult VerilogEmitter::translate(
             }
             return printOperation(op);
           })
-          .Case<arith::AddIOp, arith::CmpIOp, arith::ExtSIOp, arith::ExtUIOp,
-                arith::IndexCastOp, arith::MaxSIOp, arith::MinSIOp,
-                arith::MulIOp, arith::SelectOp, arith::ShLIOp, arith::ShRSIOp,
-                arith::ShRUIOp, arith::SubIOp, arith::TruncIOp, arith::AndIOp,
-                arith::XOrIOp>([&](auto op) { return printOperation(op); })
+          .Case<arith::AddIOp, arith::CmpIOp, arith::DivSIOp, arith::ExtSIOp,
+                arith::ExtUIOp, arith::IndexCastOp, arith::MaxSIOp,
+                arith::MinSIOp, arith::MulIOp, arith::SelectOp, arith::ShLIOp,
+                arith::ShRSIOp, arith::ShRUIOp, arith::SubIOp, arith::TruncIOp,
+                arith::AndIOp, arith::XOrIOp>(
+              [&](auto op) { return printOperation(op); })
           // Custom math ops.
           .Case<math::CountLeadingZerosOp>(
               [&](auto op) { return printOperation(op); })
@@ -596,6 +597,10 @@ LogicalResult VerilogEmitter::printOperation(UnrealizedConversionCastOp op) {
         << ");\n";
   }
   return success();
+}
+
+LogicalResult VerilogEmitter::printOperation(arith::DivSIOp op) {
+  return printBinaryOp(op.getResult(), op.getLhs(), op.getRhs(), "/");
 }
 
 LogicalResult VerilogEmitter::printOperation(arith::ExtSIOp op) {

--- a/lib/Target/Verilog/VerilogEmitter.h
+++ b/lib/Target/Verilog/VerilogEmitter.h
@@ -93,6 +93,7 @@ class VerilogEmitter {
   LogicalResult printOperation(mlir::arith::AndIOp op);
   LogicalResult printOperation(mlir::arith::CmpIOp op);
   LogicalResult printOperation(mlir::arith::ConstantOp op);
+  LogicalResult printOperation(mlir::arith::DivSIOp op);
   LogicalResult printOperation(mlir::arith::ExtSIOp op);
   LogicalResult printOperation(mlir::arith::ExtUIOp op);
   LogicalResult printOperation(mlir::arith::IndexCastOp op);

--- a/tests/Transforms/mlir_to_tfhe_rs/variance.mlir
+++ b/tests/Transforms/mlir_to_tfhe_rs/variance.mlir
@@ -1,0 +1,43 @@
+// RUN: heir-opt --mlir-to-cggi=abc-fast=true %s | FileCheck %s
+
+// Calculate Variance of i4 elements, returning i32
+// Uses the formula: Var(X) = E[X^2] - (E[X])^2 = (sum_sq / N) - (sum / N)^2
+func.func @calculate_variance(%input_tensor: tensor<5xi4> {secret.secret}) -> i32 {
+    %c10_i32 = arith.constant 10 : i32
+
+    // Initialize accumulators for sum and sum of squares
+    %sum_init = arith.constant 0 : i32
+    %sum_sq_init = arith.constant 0 : i32
+
+    // Loop through the tensor to calculate sum and sum of squares
+    %loop_result:2 = affine.for %iv = 0 to 5 iter_args(%sum_iter = %sum_init, %sum_sq_iter = %sum_sq_init) -> (i32, i32) {
+        // Extract element
+        %element_i4 = tensor.extract %input_tensor[%iv] : tensor<5xi4>
+        // Extend to i32
+        %element_i32 = arith.extsi %element_i4 : i4 to i32
+
+        // Accumulate sum
+        %next_sum = arith.addi %sum_iter, %element_i32 : i32
+
+        // Calculate square
+        %element_sq_i32 = arith.muli %element_i32, %element_i32 : i32
+        // Accumulate sum of squares
+        %next_sum_sq = arith.addi %sum_sq_iter, %element_sq_i32 : i32
+
+        affine.yield %next_sum, %next_sum_sq : i32, i32
+    }
+
+    // Calculate E[X] = sum / N (Use loop result #0 directly)
+    %mean = arith.divsi %loop_result#0, %c10_i32 : i32
+
+    // Calculate E[X^2] = sum_sq / N (Use loop result #1 directly)
+    %mean_sq_val = arith.divsi %loop_result#1, %c10_i32 : i32
+
+    // Calculate (E[X])^2 = mean * mean
+    %mean_pow2 = arith.muli %mean, %mean : i32
+
+    // Calculate Variance = E[X^2] - (E[X])^2
+    %variance = arith.subi %mean_sq_val, %mean_pow2 : i32
+
+    return %variance : i32
+}


### PR DESCRIPTION
From https://github.com/google/heir/issues/1712

cc @ludns

See the test case for a mini (bits are smaller) version of the variance that will run through Yosys.

There's a canonicalization blocker for converting the result to tfhe-rs but I'll fix in a separate PR.