### PR TITLE
Openfhe: BFV: add independent mul test case

### DIFF
--- a/tests/Examples/openfhe/bfv/noise/mult_indep_8/BUILD
+++ b/tests/Examples/openfhe/bfv/noise/mult_indep_8/BUILD
@@ -1,0 +1,23 @@
+# See README.md for setup required to run these tests
+
+load("@heir//tests/Examples/openfhe:test.bzl", "openfhe_end_to_end_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+openfhe_end_to_end_test(
+    name = "mult_indep_8_debug_test",
+    generated_lib_header = "mult_indep_8_debug_lib.h",
+    heir_opt_flags = [
+        "--mlir-to-secret-arithmetic",
+        "--mlir-to-bfv=noise-model=bfv-noise-bmcm23 \
+          annotate-noise-bound=true",
+        # manual scheme-to-openfhe
+        "--bgv-to-lwe",
+        "--lwe-add-debug-port",
+        "--lwe-to-openfhe",
+        "--openfhe-configure-crypto-context=insecure=true ring-dim=32768 mul-depth=6 scaling-mod-size=60",
+    ],
+    mlir_src = "mult_indep_8.mlir",
+    tags = ["notap"],
+    test_src = "mult_indep_8_debug_test.cpp",
+)

--- a/tests/Examples/openfhe/bfv/noise/mult_indep_8/mult_indep_8.mlir
+++ b/tests/Examples/openfhe/bfv/noise/mult_indep_8/mult_indep_8.mlir
@@ -1,0 +1,21 @@
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 15, Q = [1152921504608747521, 1152921504614055937, 1152921504615628801, 1152921504615694337, 1152921504616480769, 1152921504616808449, 1152921504618381313, 1152921504620347393], P = [1152921504621199361, 1152921504621985793, 1152921504622510081], plaintextModulus = 65537>, scheme.bgv} {
+func.func @mult_indep(
+    %arg0: i16 {secret.secret},
+    %arg1: i16 {secret.secret},
+    %arg2: i16 {secret.secret},
+    %arg3: i16 {secret.secret},
+    %arg4: i16 {secret.secret},
+    %arg5: i16 {secret.secret},
+    %arg6: i16 {secret.secret},
+    %arg7: i16 {secret.secret}
+    ) -> i16 {
+    %0 = arith.muli %arg0, %arg1 : i16
+    %1 = arith.muli %0, %arg2 : i16
+    %2 = arith.muli %1, %arg3 : i16
+    %3 = arith.muli %2, %arg4 : i16
+    %4 = arith.muli %3, %arg5 : i16
+    %5 = arith.muli %4, %arg6 : i16
+    %6 = arith.muli %5, %arg7 : i16
+    return %6 : i16
+}
+}

--- a/tests/Examples/openfhe/bfv/noise/mult_indep_8/mult_indep_8_debug_test.cpp
+++ b/tests/Examples/openfhe/bfv/noise/mult_indep_8/mult_indep_8_debug_test.cpp
@@ -1,0 +1,179 @@
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"                               // from @googletest
+#include "src/core/include/lattice/hal/lat-backend.h"  // from @openfhe
+#include "src/core/include/utils/inttypes.h"           // from @openfhe
+#include "src/pke/include/key/privatekey-fwd.h"        // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/bfv/noise/mult_indep_8/mult_indep_8_debug_lib.h"
+
+// DecryptCore not accessible from CryptoContext
+// so copy from @openfhe//src/pke/lib/schemerns/rns-pke.cpp
+DCRTPoly DecryptCore(const std::vector<DCRTPoly>& cv,
+                     const PrivateKey<DCRTPoly> privateKey) {
+  const DCRTPoly& s = privateKey->GetPrivateElement();
+
+  size_t sizeQ = s.GetParams()->GetParams().size();
+  size_t sizeQl = cv[0].GetParams()->GetParams().size();
+
+  size_t diffQl = sizeQ - sizeQl;
+
+  auto scopy(s);
+  scopy.DropLastElements(diffQl);
+
+  DCRTPoly sPower(scopy);
+
+  DCRTPoly b(cv[0]);
+  b.SetFormat(Format::EVALUATION);
+
+  DCRTPoly ci;
+  for (size_t i = 1; i < cv.size(); i++) {
+    ci = cv[i];
+    ci.SetFormat(Format::EVALUATION);
+
+    b += sPower * ci;
+    sPower *= scopy;
+  }
+  return b;
+}
+
+#define OP
+#define DECRYPT
+#define NOISE
+
+void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct,
+                  const std::map<std::string, std::string>& debugAttrMap) {
+#ifdef OP
+  auto isBlockArgument = debugAttrMap.at("asm.is_block_arg");
+  if (isBlockArgument == "1") {
+    std::cout << "Input" << std::endl;
+  } else {
+    std::cout << debugAttrMap.at("asm.op_name") << std::endl;
+  }
+#endif
+
+#ifdef DECRYPT
+  PlaintextT ptxt;
+  cc->Decrypt(sk, ct, &ptxt);
+  ptxt->SetLength(std::stod(debugAttrMap.at("message.size")));
+  std::cout << "  " << ptxt << std::endl;
+#endif
+
+#ifdef NOISE
+  auto cv = ct->GetElements();
+  size_t sizeQl = cv[0].GetParams()->GetParams().size();
+
+  auto b = DecryptCore(cv, sk);
+  b.SetFormat(Format::COEFFICIENT);
+
+  // B/FV specific
+  // from @openfhe//src/pke/extras/bfv-mult-bug.cpp
+  const auto cryptoParams = std::static_pointer_cast<CryptoParametersBFVRNS>(
+      sk->GetCryptoParameters());
+
+  const auto encParams = cryptoParams->GetElementParams();
+  NativeInteger NegQModt = cryptoParams->GetNegQModt();
+  NativeInteger NegQModtPrecon = cryptoParams->GetNegQModtPrecon();
+  const NativeInteger t = cryptoParams->GetPlaintextModulus();
+  std::vector<NativeInteger> tInvModq = cryptoParams->GettInvModq();
+
+  // Get a new plaintext with full slots
+  // SetLength(8) above will truncate the plaintext
+  PlaintextT newPtxt;
+  cc->Decrypt(sk, ct, &newPtxt);
+  // Repack to convert from NativePoly to DCRTPoly
+  std::vector<int64_t> value = newPtxt->GetPackedValue();
+  Plaintext repack = cc->MakePackedPlaintext(value);
+  DCRTPoly plain = repack->GetElement<DCRTPoly>();
+  plain.SetFormat(Format::COEFFICIENT);
+  plain.TimesQovert(encParams, tInvModq, t, NegQModt, NegQModtPrecon);
+
+  // remove the message, leave only the noise
+  DCRTPoly res;
+  res = b - plain;
+
+  double noise = (log2(res.Norm()));
+
+  double logQ = 0;
+  std::vector<double> logqi_v;
+  for (usint i = 0; i < sizeQl; i++) {
+    double logqi =
+        log2(cv[0].GetParams()->GetParams()[i]->GetModulus().ConvertToInt());
+    logqi_v.push_back(logqi);
+    logQ += logqi;
+  }
+
+  auto logT = log2(t.ConvertToInt());
+
+  std::cout << "  cv " << cv.size() << " Ql " << sizeQl
+            << " log(Q/2T): " << logQ - logT - 1 << " logqi: " << logqi_v
+            << " budget " << logQ - logT - 1 - noise << " noise: " << noise
+            << std::endl;
+
+  // print the predicted bound by analysis
+  if (debugAttrMap.find("noise.bound") != debugAttrMap.end()) {
+    double noiseBound = std::stod(debugAttrMap.at("noise.bound"));
+
+    std::cout << "  noise bound: " << noiseBound
+              << "  gap: " << noiseBound - noise << std::endl;
+    if (noiseBound - noise < 0) {
+      std::cout << "  WARNING: noise bound exceeded" << std::endl;
+      abort();
+    }
+  }
+#endif
+}
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(DotProduct8Test, RunTest) {
+  auto cryptoContext = mult_indep__generate_crypto_context();
+  std::cout << *(cryptoContext->GetCryptoParameters()) << std::endl;
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      mult_indep__configure_crypto_context(cryptoContext, secretKey);
+
+  int16_t arg0 = 1;
+  int64_t expected = 1;
+
+  auto arg0Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg1Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg2Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg3Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg4Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg5Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg6Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg7Encrypted =
+      mult_indep__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto outputEncrypted =
+      mult_indep(cryptoContext, secretKey, arg0Encrypted, arg1Encrypted,
+                 arg2Encrypted, arg3Encrypted, arg4Encrypted, arg5Encrypted,
+                 arg6Encrypted, arg7Encrypted);
+  auto actual =
+      mult_indep__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
Somewhat related to #1614. Put in draft state because the test mlir file contains some arbitrary parameter.

The tricky part of get a correct noise comparison between the noise model and openfhe is that, we need to ensure their parameter is the same (at least $N$ is the same). Not until #1638 do we have the ability to manually override parameters like ring-dim.

So currently N is guaranteed to be the same by

1. Specifying logN in mlir input so the noise model uses the wanted $N$
2. Speicfying `ring-dim` for openfhe codegen

### sample trace

```
Element Parameters: ILDCRTParams [m=65536 n=32768 q=1766847064733791804985468586732463984033679517732465750209237490428280833 ru=0 bigq=0 bigru=0]
  m_params:
    0: ILParams [m=65536 n=32768 q=1152921504606584833 ru=4443670208963 bigq=0 bigru=0]
    1: ILParams [m=65536 n=32768 q=1152921504598720513 ru=100545759574150 bigq=0 bigru=0]
    2: ILParams [m=65536 n=32768 q=1152921504597016577 ru=31693996050849 bigq=0 bigru=0]
    3: ILParams [m=65536 n=32768 q=1152921504595968001 ru=88651361085495 bigq=0 bigru=0]
  m_originalModulus: 0

Input
  ( 1 ... )
  cv 2 Ql 4 log(Q/2T): 223 logqi: [ 60 60 60 60 ] budget 212.053 noise: 10.9469
  noise bound: 11.86  gap: 0.913094
// first level mul
openfhe.mul_no_relin
  ( 1 ... )
  cv 3 Ql 4 log(Q/2T): 223 logqi: [ 60 60 60 60 ] budget 182.17 noise: 40.83
  noise bound: 41.77  gap: 0.940004
// second level mul
openfhe.mul_no_relin
  ( 1 ... )
  cv 3 Ql 4 log(Q/2T): 223 logqi: [ 60 60 60 60 ] budget 152.184 noise: 70.8156
  noise bound: 71.98  gap: 1.16444
// third level mul
openfhe.mul_no_relin
  ( 1 ... )
  cv 3 Ql 4 log(Q/2T): 223 logqi: [ 60 60 60 60 ] budget 121.814 noise: 101.186
  noise bound: 102.39  gap: 1.20444
```