### PR TITLE
OpenFHE: use math backend 4 by default

### DIFF
--- a/bazel/openfhe/add_config_core.patch
+++ b/bazel/openfhe/add_config_core.patch
@@ -6,7 +6,7 @@
 +#ifndef __CMAKE_GENERATED_CONFIG_CORE_H__
 +#define __CMAKE_GENERATED_CONFIG_CORE_H__
 +
-+#define WITH_BE2
++#define WITH_BE4
 +/* #undef WITH_BE4 */
 +/* #undef WITH_NOISE_DEBUG */
 +/* #undef WITH_NTL */
@@ -15,7 +15,7 @@
 +#define CKKS_M_FACTOR 1
 +#define HAVE_INT128 TRUE
 +#define HAVE_INT64 TRUE
-+#define MATHBACKEND 2
++#define MATHBACKEND 4
 +#define NATIVEINT 64
 +
 +#endif // __CMAKE_GENERATED_CONFIG_CORE_H__


### PR DESCRIPTION
Part of https://github.com/google/heir/issues/1741