### PR TITLE
try simplifying mod-arith syntax

### DIFF
--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -94,7 +94,7 @@ def ModArith_ConstantOp : Op<ModArith_Dialect, "constant",
   }];
   let arguments = (ins TypedAttrInterface:$value);
   let results = (outs ModArithLike:$output);
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "attr-dict $value `:` type($output)";
   let hasVerifier = 1;
   let hasFolder = 1;
 

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -27,6 +27,8 @@ func.func @test_arith_syntax() {
   %constdenseZero = mod_arith.constant dense<[0, 2, 3, 4]> : !Zp_vec
   // CHECK: mod_arith.constant dense<[-1, -2, -3, -4]> : tensor<4x!mod_arith.int<17 : i10>>
   %constdenseNegative = mod_arith.constant dense<[-1, -2, -3, -4]> : !Zp_vec
+  // CHECK: mod_arith.constant dense<0> : tensor<1024x!mod_arith.int<17 : i10>>
+  %denseSplat = mod_arith.constant dense<0> : tensor<1024x!Zp>
 
   // CHECK-COUNT-6: mod_arith.encapsulate
   %e4 = mod_arith.encapsulate %c4 : i10 -> !Zp

--- a/tests/Dialect/ModArith/Transforms/canonicalize.mlir
+++ b/tests/Dialect/ModArith/Transforms/canonicalize.mlir
@@ -1,0 +1,22 @@
+// RUN: heir-opt --canonicalize %s | FileCheck %s
+
+!Z17_i64 = !mod_arith.int<17 : i64>
+func.func @dot_product(%arg0: tensor<1024x!Z17_i64>, %arg1: tensor<1024x!Z17_i64>) -> tensor<1024x!Z17_i64> {
+  %c7 = arith.constant 7 : index
+  %0 = mod_arith.constant 1 : !Z17_i64
+  %1 = mod_arith.constant dense<0> : tensor<1024x!Z17_i64>
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+  %inserted = tensor.insert %0 into %1[%c7] : tensor<1024x!Z17_i64>
+  %2 = mod_arith.mul %arg0, %arg1 : tensor<1024x!Z17_i64>
+  %3 = tensor_ext.rotate %2, %c4 : tensor<1024x!Z17_i64>, index
+  %4 = mod_arith.add %2, %3 : tensor<1024x!Z17_i64>
+  %5 = tensor_ext.rotate %4, %c2 : tensor<1024x!Z17_i64>, index
+  %6 = mod_arith.add %4, %5 : tensor<1024x!Z17_i64>
+  %7 = tensor_ext.rotate %6, %c1 : tensor<1024x!Z17_i64>, index
+  %8 = mod_arith.add %6, %7 : tensor<1024x!Z17_i64>
+  %9 = mod_arith.mul %inserted, %8 : tensor<1024x!Z17_i64>
+  %10 = tensor_ext.rotate %9, %c7 : tensor<1024x!Z17_i64>, index
+  return %10 : tensor<1024x!Z17_i64>
+}


### PR DESCRIPTION
mod_arith.constant prints something it can't parse (`mod_arith.constant dense<0>`) and this is making me think about upstream changes that I could make to simplify this situation. This PR is created as a draft while I tinker with it.

My idea is to add a type attribute upstream corresponding to "IntegerLike" that exposes things like the underlying storage bit width, which we can implement for `mod_arith`.