### PR TITLE
demo: add AES demo for tfhe_rust CPU

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -22,14 +22,19 @@
     "https://bcr.bazel.build/modules/apple_support/1.13.0/MODULE.bazel": "7c8cdea7e031b7f9f67f0b497adf6d2c6a2675e9304ca93a9af6ed84eef5a524",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/MODULE.bazel": "655c922ab1209978a94ef6ca7d9d43e940cd97d9c172fb55f94d91ac53f8610b",
+    "https://bcr.bazel.build/modules/apple_support/1.20.0/MODULE.bazel": "932c689bd541bc040433ec0cd155cc4f6d41e9aae0f8ca056287b0baac1afe5c",
+    "https://bcr.bazel.build/modules/apple_support/1.20.0/source.json": "0be4755d73584ab8a46c06b0c771125a38c1b7cdde8a1b32826d28f71f937fba",
     "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
     "https://bcr.bazel.build/modules/apple_support/1.21.0/source.json": "028d7c853f0195e21b1323ffa2792e8fc5600da3fdaaff394fe932e0e04a4322",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/source.json": "f5a28b1320e5f444e798b4afc1465c8b720bfaec7522cca38a23583dffe85e6d",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/source.json": "a8f93e4ad8843e8aa407fa5fd7c8b63a63846c0ce255371ff23384582813b13d",
     "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/source.json": "9a3668e1ee219170e22c0e7f3ab959724c6198fdd12cd503fa10b1c6923a2559",
     "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -41,7 +46,9 @@
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
     "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/source.json": "c72c61b722d7c3f884994fe647afeb2ed1ae66c437f8f370753551f7b4d8be7f",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/source.json": "ed8cf0ef05c858dce3661689d0a2b110ff398e63994e178e4f1f7555a8067fed",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
@@ -65,190 +72,252 @@
     "https://bcr.bazel.build/modules/bliss/0.73/MODULE.bazel": "26b5476884b67df20a8b87ab2806657123b439e978da76f484427a15fb552b26",
     "https://bcr.bazel.build/modules/bliss/0.73/source.json": "5cb395710670662321f492fc3d4fce3551e3d5708682e4f2320bacaadf6e5e36",
     "https://bcr.bazel.build/modules/boost.algorithm/1.83.0.bcr.1/MODULE.bazel": "8657617ad7aa55d179078faa15c131f07ae1bc35e536343211eee2d942368881",
+    "https://bcr.bazel.build/modules/boost.algorithm/1.83.0.bcr.1/source.json": "664117fe5b44d4e00e6a0b7c8f3893f22971bb11401ef6c0afa0c44c9bcf62b6",
     "https://bcr.bazel.build/modules/boost.algorithm/1.87.0/MODULE.bazel": "d1c8f1466cc1a04a16eebeefe0f54a9508cc9f1a3c21d65d806acbc36593e204",
     "https://bcr.bazel.build/modules/boost.algorithm/1.87.0/source.json": "9280ee3bfa6b9427aad20a450c33d74fabb93a69d81e201955098035a514f287",
     "https://bcr.bazel.build/modules/boost.align/1.83.0.bcr.1/MODULE.bazel": "3a4320a5c5f21e3e75024550d4db99cb19575db87ddb4bfd9b7821f87b6a7999",
+    "https://bcr.bazel.build/modules/boost.align/1.83.0.bcr.1/source.json": "ee963f5571b73693e9f2fc647efbb45f6255b49b1ad4f59e914d2ad2c20dd335",
     "https://bcr.bazel.build/modules/boost.align/1.87.0/MODULE.bazel": "b9b08a94ac9db10fa17a58fc278a8c79fdb32c915de7a9133f6f01f6fe8887f7",
     "https://bcr.bazel.build/modules/boost.align/1.87.0/source.json": "c41e1675e9686a3d82b130ccf496d5780fc4edf42ff2e91b2323fd05d3773e81",
     "https://bcr.bazel.build/modules/boost.array/1.83.0.bcr.1/MODULE.bazel": "ffe2956a8f5d90839e710cb298f0a342acc5a1d8fdfeee9578cae9657df87e38",
+    "https://bcr.bazel.build/modules/boost.array/1.83.0.bcr.1/source.json": "6d3925fef402c04bd7ea463203c1892c6ab96351c2264566e4bc9e6543fc777f",
     "https://bcr.bazel.build/modules/boost.array/1.87.0/MODULE.bazel": "beb11f5d659b17df58c07e039392edc9233e1be9565e5d4b1393fff9bf4457c4",
     "https://bcr.bazel.build/modules/boost.array/1.87.0/source.json": "0583a9fd9d24a14e33b74b4342f94b4a4a3b539af11b0c12403a1a4da1f1548a",
     "https://bcr.bazel.build/modules/boost.assert/1.83.0.bcr.1/MODULE.bazel": "abc07418c37c6e1876f56d959ff1b7cdcac70c8b7236bbacc69ab66686968910",
+    "https://bcr.bazel.build/modules/boost.assert/1.83.0.bcr.1/source.json": "05d5c7ef77352f32264b9ca625df8ca742b78a94d4b057347a54204d6cd9ded6",
     "https://bcr.bazel.build/modules/boost.assert/1.87.0/MODULE.bazel": "8a950da6e19dd6d6427b95b1cfe1d2fc86eb598f6fb753345d925eb92d74a821",
     "https://bcr.bazel.build/modules/boost.assert/1.87.0/source.json": "085a7c247d90bb4f8f5c3cc7eec1994f3d46d2a26af1947c85ff6f8ddd86ce59",
     "https://bcr.bazel.build/modules/boost.atomic/1.83.0.bcr.1/MODULE.bazel": "f2f7e2f0a7cb7764f53851e00120d468d507c9979c8e3f941a757ff5b5f74992",
+    "https://bcr.bazel.build/modules/boost.atomic/1.83.0.bcr.1/source.json": "4699e8c3d31a1fe9a84ec421c2f0cf99b8ac951db18b392ba2afec0dfd32181e",
     "https://bcr.bazel.build/modules/boost.atomic/1.87.0/MODULE.bazel": "7afe1354a8901637ba820edd6ec83a1602ba68f8af31d285d4704a1ec23a2fb6",
     "https://bcr.bazel.build/modules/boost.atomic/1.87.0/source.json": "26badcfadd6846993f1ce2308da8af4f9477bc53587167229ec3cf0be4d2fdbf",
     "https://bcr.bazel.build/modules/boost.bind/1.83.0.bcr.1/MODULE.bazel": "c226a7152112ec5329aa831fd7daab296db2e8bf1a427e05c33bb770c885e044",
+    "https://bcr.bazel.build/modules/boost.bind/1.83.0.bcr.1/source.json": "1ad06dbc6d538e539abaeb58d647d787b63c2b0eb54f61168c8501d420cdd691",
     "https://bcr.bazel.build/modules/boost.bind/1.87.0/MODULE.bazel": "6d224cd013e45d15710476840fff34aa2da53389c3bfd252054e2efd893b0bf9",
     "https://bcr.bazel.build/modules/boost.bind/1.87.0/source.json": "e93e696ab6140c1f07317357b04b4d0fcf0aefa61991b8fa8b65416d81677b44",
     "https://bcr.bazel.build/modules/boost.chrono/1.83.0.bcr.1/MODULE.bazel": "3e14a982441c92d79ecd6a7229ad56e621deba5d123f39b559be13ce0ab4ec1d",
+    "https://bcr.bazel.build/modules/boost.chrono/1.83.0.bcr.1/source.json": "9c21c228f4c55418d5fa94f051a0d36f05723b6ca2fc5dd38e8098f9f97389a0",
     "https://bcr.bazel.build/modules/boost.chrono/1.87.0/MODULE.bazel": "ac035fc481cfaf6dd0b42c791938aa53d5ad7debba1a877c0169d1cc9deae874",
     "https://bcr.bazel.build/modules/boost.chrono/1.87.0/source.json": "a050f84c8488008a3ac15550592259cbf90abf86ca31052f30f120f4e60de772",
     "https://bcr.bazel.build/modules/boost.concept_check/1.83.0.bcr.1/MODULE.bazel": "987ddeeca7c552f7c15557ed9f1e1de26e976d1380002cd41e56ea0ef7e1d25e",
+    "https://bcr.bazel.build/modules/boost.concept_check/1.83.0.bcr.1/source.json": "0a5cb9c8a8b424c04a717b2cbf483f1ee576611b3370550369671ea4f5852e3c",
     "https://bcr.bazel.build/modules/boost.concept_check/1.87.0/MODULE.bazel": "6a935c9f5d739ad6d0401d1e5f71f4bfb538c66ccb1d3b8ac7a5a2b74bd207ff",
     "https://bcr.bazel.build/modules/boost.concept_check/1.87.0/source.json": "45ffc4ae171c9b14bbe595e3d3e7d0a5065ceb18f949d1a2365d328ca89e1a1c",
     "https://bcr.bazel.build/modules/boost.config/1.83.0.bcr.1/MODULE.bazel": "a9049b46df8ba7d4a895122cfbda4cf71ad01f441fad62117931cfafecba35d1",
+    "https://bcr.bazel.build/modules/boost.config/1.83.0.bcr.1/source.json": "4810a18d8d9827bf2822ca8e3e1491cfb882657224bc2def70b334120415ccc2",
     "https://bcr.bazel.build/modules/boost.config/1.87.0/MODULE.bazel": "01da6517cb341d5abea9be54337bf85ba50132b3690a621f09be5890ecd12796",
     "https://bcr.bazel.build/modules/boost.config/1.87.0/source.json": "9a00cd7c9afd6f58b349a806791c7aab040b1cd1a35464e59b79be724261a5ae",
     "https://bcr.bazel.build/modules/boost.container/1.83.0.bcr.1/MODULE.bazel": "41c6d3a367a7eea6debf93ec058acb682d83158231553a1a6a841c40679e8baa",
+    "https://bcr.bazel.build/modules/boost.container/1.83.0.bcr.1/source.json": "23f49c4fad6c0407f592b5fa825452ba67a2c0b3f78b1da8bee0bf16d2b6763f",
     "https://bcr.bazel.build/modules/boost.container/1.87.0/MODULE.bazel": "affb6e485eb13d3df0e9ee464f6a890175762526166da601a83f12d21b6c6950",
     "https://bcr.bazel.build/modules/boost.container/1.87.0/source.json": "ddf180a658ad7743e081970719a184538945b9554be8278b55a67ba281ceede0",
     "https://bcr.bazel.build/modules/boost.container_hash/1.83.0.bcr.1/MODULE.bazel": "baf420d50979d18d247681bb4f3e097c054f314c2a3c98c14f1b750871329ad7",
+    "https://bcr.bazel.build/modules/boost.container_hash/1.83.0.bcr.1/source.json": "f3248fbd4a2cd88333343bd78f317e3f7b085b6a2a31adab26f402083bdbdb26",
     "https://bcr.bazel.build/modules/boost.container_hash/1.87.0/MODULE.bazel": "a718ac13832c18ffc828f33e9cf8e566095d5ed8c80584bd1ad429c4ce91efa5",
     "https://bcr.bazel.build/modules/boost.container_hash/1.87.0/source.json": "a7a90c4dfea2da1648ac530a838faebc093cbbaeab5e4f43a8532e5b76ff32d3",
     "https://bcr.bazel.build/modules/boost.conversion/1.83.0.bcr.1/MODULE.bazel": "d05ea5d39c0399ddd0331922e64a6bb8bdfe40b83cb6d4ecee62d7cb68f6c36b",
+    "https://bcr.bazel.build/modules/boost.conversion/1.83.0.bcr.1/source.json": "7b91cda19dcf46d35b47fd30ea9a6226c880d27f6abd51f8107c5015fec9bd46",
     "https://bcr.bazel.build/modules/boost.conversion/1.87.0/MODULE.bazel": "47bafdb6a14ec58feefe69a1367b537458563e0627e1986f377cc0b4e8ebd41e",
     "https://bcr.bazel.build/modules/boost.conversion/1.87.0/source.json": "7aa865b11b0a699d15926eb87a21d17220d64265da3d280261a480b0d88b3dbb",
     "https://bcr.bazel.build/modules/boost.core/1.83.0.bcr.1/MODULE.bazel": "6aa5d86d84dbeefeda0f5e3ac596db7426ecb6f6ebdf69383c2963292ee568cf",
+    "https://bcr.bazel.build/modules/boost.core/1.83.0.bcr.1/source.json": "62f0884fe4d287b72146c3355df6d737b016f312bb3bf9c1bbf41fd84400b046",
     "https://bcr.bazel.build/modules/boost.core/1.87.0/MODULE.bazel": "33517eb46bb16f4b4f4a1bde61fe8b2475f45b5574bcd9f04c85f4bf3afe30d2",
     "https://bcr.bazel.build/modules/boost.core/1.87.0/source.json": "9e2920b45c833a6a2cd42b16e17a5b97201bb73698a3902936cc90c1aa3de667",
     "https://bcr.bazel.build/modules/boost.date_time/1.83.0.bcr.1/MODULE.bazel": "47500c0f2985abf43129c9e0c175f7846eec6dbaf29f1c5a506f3f7b24ca94e1",
+    "https://bcr.bazel.build/modules/boost.date_time/1.83.0.bcr.1/source.json": "efd4950a6be9febc2b315de7008ac72b331612c8a9bdc72eb3260bcf66f7edea",
     "https://bcr.bazel.build/modules/boost.date_time/1.87.0/MODULE.bazel": "ea715c044273af6148b68bcfb4dbb69a36ec34cd3a491e1a2740b4090bf32025",
     "https://bcr.bazel.build/modules/boost.date_time/1.87.0/source.json": "cfa5ce699286cd6eee94bace45dc701717ed58826827bd0ade18ef63623fdbe3",
     "https://bcr.bazel.build/modules/boost.describe/1.83.0.bcr.1/MODULE.bazel": "04f902525e3f53a7eec9e10bb58623d5b249afaa4f245917cc827f63933351ba",
+    "https://bcr.bazel.build/modules/boost.describe/1.83.0.bcr.1/source.json": "b3201219ad62723a684c98d1f13448346774d5979adf99d88583765150a9095c",
     "https://bcr.bazel.build/modules/boost.describe/1.87.0/MODULE.bazel": "638752de4ad46348a7e3ac72910b699fde5a3c71d42fc69047d2aa8825411646",
     "https://bcr.bazel.build/modules/boost.describe/1.87.0/source.json": "c260a5c38806ea88ce50b2d070484ae634941d2be7a1ddb0f959923ca8ef10d4",
     "https://bcr.bazel.build/modules/boost.detail/1.83.0.bcr.2/MODULE.bazel": "0016cbb9f265ebd4efcbb5f1aff14ccce5754bd98c3d9ff375d3a39f4173f8de",
     "https://bcr.bazel.build/modules/boost.detail/1.83.0.bcr.3/MODULE.bazel": "89ce4454da586d3229071c94ae4fe305fa907f30f8b1ac38dfd637aebe20f306",
+    "https://bcr.bazel.build/modules/boost.detail/1.83.0.bcr.3/source.json": "2e4fd5c2b978891f79b255238d52134da48e5d388b5480138dbe5243fa6318e0",
     "https://bcr.bazel.build/modules/boost.detail/1.87.0/MODULE.bazel": "64ed391c2b60b226263de4f486fad690414afc6a68d1a5e58eed70e4a63f2d80",
     "https://bcr.bazel.build/modules/boost.detail/1.87.0/source.json": "dde910ab5e8ca18352cceaf4a922904b3de9ace042bf16f1a2015ca53776a568",
     "https://bcr.bazel.build/modules/boost.dynamic_bitset/1.83.0.bcr.1/MODULE.bazel": "2093a9d09159b97ada67ed370492f61c775ae7df5018c8ba9c69053ed7813dab",
+    "https://bcr.bazel.build/modules/boost.dynamic_bitset/1.83.0.bcr.1/source.json": "c8470feff0d94ef0c950dfa6b214cc119bbaae95355e27838b9d295c7b222b21",
     "https://bcr.bazel.build/modules/boost.dynamic_bitset/1.87.0/MODULE.bazel": "542b8afeb7534c248e9f28fdef589ba8a443d18c253a7ea06e283848bb06a237",
     "https://bcr.bazel.build/modules/boost.dynamic_bitset/1.87.0/source.json": "5b15c2b7c3164175dd861bb7eba3af9d306858f267806743d0384ce32c51f404",
     "https://bcr.bazel.build/modules/boost.endian/1.83.0.bcr.1/MODULE.bazel": "334ce9f6e18c951767261b1e0050bd1b810607b0e508cfbf9ed03e20c6950b2f",
+    "https://bcr.bazel.build/modules/boost.endian/1.83.0.bcr.1/source.json": "ab64b9e716dbf35323d08ee83654f93ce136216eda11c96d23e57e62a09d7a6d",
     "https://bcr.bazel.build/modules/boost.endian/1.87.0/MODULE.bazel": "a81d743d6b76c4d40c2289be435aa5ccfa912f0caecbc1b75948563e39b5fcf1",
     "https://bcr.bazel.build/modules/boost.endian/1.87.0/source.json": "546459497e163255dcd76ab78cadef2ede4f13c32620f219ad3d7fa43074c515",
     "https://bcr.bazel.build/modules/boost.exception/1.83.0.bcr.1/MODULE.bazel": "60d6418bbe6246f71c1ff211c08f187d975fe12a0f6845c64c6127977c51375b",
+    "https://bcr.bazel.build/modules/boost.exception/1.83.0.bcr.1/source.json": "54a9e9984fccf6f49385b28c301ff3af0e7485ac7e5281c5d249f1b5b1225c9c",
     "https://bcr.bazel.build/modules/boost.exception/1.87.0/MODULE.bazel": "2bc7bfa2166bccb25c8b814ad8d5bf462448349ffd41e9541cfa7b849bd15ca8",
     "https://bcr.bazel.build/modules/boost.exception/1.87.0/source.json": "987bb7df5cbf05e4c3349073fe889e33b8914ea9b9b0b5cf72bc742941343d8b",
     "https://bcr.bazel.build/modules/boost.function/1.83.0.bcr.1/MODULE.bazel": "b555cccb955cc4bd8d548f81ec29fdd33284ae04afd9ed92b254abe6357a5ed7",
+    "https://bcr.bazel.build/modules/boost.function/1.83.0.bcr.1/source.json": "a85e42738a1fd7eb3df45ca31fe213ca23832adb0032a7bcf9cd8dac42445f86",
     "https://bcr.bazel.build/modules/boost.function/1.87.0/MODULE.bazel": "d7ad93c26d0102b48cd6f781fcb68d16861fd6bf8772f784f034afabbabea391",
     "https://bcr.bazel.build/modules/boost.function/1.87.0/source.json": "dd6765e2d9d902fc82da874f55061cf233a17affa66acb1641f478480b80d5d2",
     "https://bcr.bazel.build/modules/boost.function_types/1.83.0.bcr.1/MODULE.bazel": "266d931a312bafb39053b6a0260e59882c1389e8126f9dc5b3f37a1c2b66a152",
+    "https://bcr.bazel.build/modules/boost.function_types/1.83.0.bcr.1/source.json": "c421295de00ee97f4d605d8a873ce002b64d9e4226f61db710ceaaf2ff1c581a",
     "https://bcr.bazel.build/modules/boost.function_types/1.87.0/MODULE.bazel": "fed8aedff1fb01468a24e53a10793411330e36ebe29aeafaadeae00e25c20371",
     "https://bcr.bazel.build/modules/boost.function_types/1.87.0/source.json": "c3a7fa0a172a109ae04a575eba033e133a38448005468dfddedab065d071dbbf",
     "https://bcr.bazel.build/modules/boost.functional/1.83.0.bcr.1/MODULE.bazel": "8e0f52ea1e5f1d34442347c1ddcb202ce2cc610175226df58770c69d7267b4a8",
+    "https://bcr.bazel.build/modules/boost.functional/1.83.0.bcr.1/source.json": "6a3c58ca81f5226221ac1565aa3a7c93e5d04b27d2f9bd71e1b113ff19f5a658",
     "https://bcr.bazel.build/modules/boost.functional/1.87.0/MODULE.bazel": "5488597db90a4d8615505e9673806db23a98a4c73eadc16999478c7b1a6c1bc7",
     "https://bcr.bazel.build/modules/boost.functional/1.87.0/source.json": "d39c98b1a9ae0a74da51ff049054fe6f77060d00c1768ea7eb6c629f3ac9eea5",
     "https://bcr.bazel.build/modules/boost.fusion/1.83.0.bcr.1/MODULE.bazel": "1a651840d5710e5f2b882535f9fd7a18d6932c24559185362a3dfe0ca3702ee4",
+    "https://bcr.bazel.build/modules/boost.fusion/1.83.0.bcr.1/source.json": "8977203271c1f1db3f329e5cdd4960d26060ef13bdc7e47820b77f61d2369909",
     "https://bcr.bazel.build/modules/boost.fusion/1.87.0/MODULE.bazel": "2c28c212edcf35584dcf09089c51d6dcb2a01cf5d8d5c2b125dc91acb083a463",
     "https://bcr.bazel.build/modules/boost.fusion/1.87.0/source.json": "35cb70a4a379e430e9efde27c9c2aa061791e9a1f693f7c85d2d4f1665ba2381",
     "https://bcr.bazel.build/modules/boost.integer/1.83.0.bcr.1/MODULE.bazel": "29655d7e043ba79065ed8fb8b8b99133470ff240f4606bebb6085d2c856578df",
+    "https://bcr.bazel.build/modules/boost.integer/1.83.0.bcr.1/source.json": "92d1105b5e005c47b10c09b42dfbc86374a069b62055c7471eb8546545ee534b",
     "https://bcr.bazel.build/modules/boost.integer/1.87.0/MODULE.bazel": "2b862679c8595b6ecb3806ec5c7a1024c9e00fca94e5ee713d75ab022c6a7444",
     "https://bcr.bazel.build/modules/boost.integer/1.87.0/source.json": "adce74ac44da997658d139f419f3c6a909fdc35d05566814c9c15e3ccb99fff6",
     "https://bcr.bazel.build/modules/boost.intrusive/1.83.0.bcr.1/MODULE.bazel": "74da910d77fbd42847917c0603a5c78ce7d8085d28a3fb9a98c56bd070238a10",
+    "https://bcr.bazel.build/modules/boost.intrusive/1.83.0.bcr.1/source.json": "dbeb235ffc10db2e0c553e21f266bdb32b3c82ef93d2cbfbbe78fa6e8fc760b5",
     "https://bcr.bazel.build/modules/boost.intrusive/1.87.0/MODULE.bazel": "9dd904f7da54b7efa8476da8152e8cd60702e7b61bfae2689672f185458dc478",
     "https://bcr.bazel.build/modules/boost.intrusive/1.87.0/source.json": "cc603911503905072f8596510bb6e95ce210a82564258d3fd319f9499f339cf6",
     "https://bcr.bazel.build/modules/boost.io/1.83.0.bcr.1/MODULE.bazel": "ce3b42ee33880f7250263a158c51b6c33c38ccbff754b78703c8af3f842e1cb1",
+    "https://bcr.bazel.build/modules/boost.io/1.83.0.bcr.1/source.json": "94e74cc68d9ba9821aa35c207a943c8140856fbc494b3524d3729f0caa9e97db",
     "https://bcr.bazel.build/modules/boost.io/1.87.0/MODULE.bazel": "30b1fbdc4a0463f727e2a78558550adf05c61e1fc209a6dcd35df03eaa4dafac",
     "https://bcr.bazel.build/modules/boost.io/1.87.0/source.json": "b42dd52763c9bce54ed4a4c8ef48d560460f854bb53770f37c839180dba897e0",
     "https://bcr.bazel.build/modules/boost.iterator/1.83.0.bcr.1/MODULE.bazel": "6ac7783146113154a83e841bfa4449105718006378edff7fbfc53aeddf00812b",
+    "https://bcr.bazel.build/modules/boost.iterator/1.83.0.bcr.1/source.json": "16e10bfe39dd3096147160668219e7a9bb8a42bbce5bd6a8a9bfcb9c428f7912",
     "https://bcr.bazel.build/modules/boost.iterator/1.87.0/MODULE.bazel": "7e6ce23b059902c1709ba033dd1f4783b3de3f48ec4dc9f5e6ab82ddc699223e",
     "https://bcr.bazel.build/modules/boost.iterator/1.87.0/source.json": "69d37225c6ffc3e8af0e7ea427ff51ccb04d84c6e7e361bbb8f1dc859b4412ea",
     "https://bcr.bazel.build/modules/boost.lexical_cast/1.83.0.bcr.1/MODULE.bazel": "80f23d54f238b4dc9ae7e408621d1358af93617880675dea6a5338b690642841",
+    "https://bcr.bazel.build/modules/boost.lexical_cast/1.83.0.bcr.1/source.json": "e016aee7804f47d861b3ad9ea045d79ef861b0f3101c8d0ceb33e73e98e7f620",
     "https://bcr.bazel.build/modules/boost.lexical_cast/1.87.0/MODULE.bazel": "878478bbe6d3350cad171dd1b4558732dbee7021ab69e40a3c5bf9e59b37922c",
     "https://bcr.bazel.build/modules/boost.lexical_cast/1.87.0/source.json": "80e0443943851508f2fa427c1c48b714690691c7022082ec65551dbe4680c82e",
     "https://bcr.bazel.build/modules/boost.math/1.83.0.bcr.1/MODULE.bazel": "659d025c87e1b2a0eef9ca001156b6b96432034332e9be9d901328f448e22111",
+    "https://bcr.bazel.build/modules/boost.math/1.83.0.bcr.1/source.json": "9ec7345a110fc9b0ac6df2c2ff93f1d37aa5aad292a2ba05e5139a196cfebf5c",
     "https://bcr.bazel.build/modules/boost.math/1.87.0/MODULE.bazel": "80f886ab97e394f8c106014a19a8c1de7a78b8fd7d5bfc89ac431896b26816b4",
     "https://bcr.bazel.build/modules/boost.math/1.87.0/source.json": "8dd908b8e87cf8b2529b75e4571c4c772495f6e294ea7dc7fc36aeb8153ca1b9",
     "https://bcr.bazel.build/modules/boost.move/1.83.0.bcr.1/MODULE.bazel": "e901ceb363762eb989a7a53418fe7ce2acf8f542a413109105184a4e22e38096",
+    "https://bcr.bazel.build/modules/boost.move/1.83.0.bcr.1/source.json": "978a8ff249833ab0764a7c2a83a9bda299960112613f22c1ee3bb3ec97fbddbf",
     "https://bcr.bazel.build/modules/boost.move/1.87.0/MODULE.bazel": "5f26dacea41a8d617b6097219df961405c8a08a9315da14cefa8da15587a7fc5",
     "https://bcr.bazel.build/modules/boost.move/1.87.0/source.json": "a95f9b258ddf918c3137c2b8d223b0b55cf9a17a52d4e19ccabfe650dcf118e3",
     "https://bcr.bazel.build/modules/boost.mp11/1.83.0.bcr.1/MODULE.bazel": "cf0d62cfca8865a1e1672953bd5b08cf5cb95e3aae819427565606305dd29165",
+    "https://bcr.bazel.build/modules/boost.mp11/1.83.0.bcr.1/source.json": "554cee46c279651fc3ffca71d947e8b99cb26bd87661debe7946eb21b61031f7",
     "https://bcr.bazel.build/modules/boost.mp11/1.87.0/MODULE.bazel": "af9644d2b668f3e014ac335a8a84ac74d9cb263454cd07cd5b84ce206f5dd81f",
     "https://bcr.bazel.build/modules/boost.mp11/1.87.0/source.json": "fb17f9453d8e62a6425efccc3a827f29ddb4577aaffee68393c86bd21e517187",
     "https://bcr.bazel.build/modules/boost.mpl/1.83.0.bcr.1/MODULE.bazel": "9cd97b224f9c1d8ffefdf48a7163767ca3968fbdfbc76f057caefbb4054be33e",
+    "https://bcr.bazel.build/modules/boost.mpl/1.83.0.bcr.1/source.json": "2ad7f4a254613fe2c0722d6127d9b366dbd19dcd8e44ad23f3ff66bf48163019",
     "https://bcr.bazel.build/modules/boost.mpl/1.87.0/MODULE.bazel": "72eba3a8cc5711e15a852829d00482abbf7869ed2ee6f598b8f295261f3e5496",
     "https://bcr.bazel.build/modules/boost.mpl/1.87.0/source.json": "81a99487d926f8a26dd5d80662e14baa0a6842b81a2a47f3f529064d0a36f36f",
     "https://bcr.bazel.build/modules/boost.multiprecision/1.83.0.bcr.1/MODULE.bazel": "8cfeff36485d9e8687d904f38dca74ee26c37ea7ba8433f076d961e7f9329e8d",
+    "https://bcr.bazel.build/modules/boost.multiprecision/1.83.0.bcr.1/source.json": "39672d3d0db7afe04384c63d2af93f95221a7afe7762e390a8a0a99adad38b6f",
     "https://bcr.bazel.build/modules/boost.multiprecision/1.87.0/MODULE.bazel": "943a11350489c1c583ce622c04f4a844be5c56e17cdf3e02d357f4ae9233b359",
     "https://bcr.bazel.build/modules/boost.multiprecision/1.87.0/source.json": "07a84e82ded8d55cd80159594eadc2d9577a1938d2f6cd16cbb97ccd498ac596",
     "https://bcr.bazel.build/modules/boost.numeric_conversion/1.83.0.bcr.1/MODULE.bazel": "1920d71f656a0433947579a86c22e0dd897816eadee3ae20d5c51dab9505deb3",
+    "https://bcr.bazel.build/modules/boost.numeric_conversion/1.83.0.bcr.1/source.json": "fc35a1dbb8810812f05fa54667f0edeac142f5fc144f9426236694a1d01e875c",
     "https://bcr.bazel.build/modules/boost.numeric_conversion/1.87.0/MODULE.bazel": "0164792509fbf8e6374eeb94a8e84ba8aa5e939620266177a112eac118e67f7c",
     "https://bcr.bazel.build/modules/boost.numeric_conversion/1.87.0/source.json": "b19fe476ce051ee4b127f78b2ee4fcec917f60e2f0a06a26528c5666b355d623",
     "https://bcr.bazel.build/modules/boost.optional/1.83.0.bcr.1/MODULE.bazel": "971e786a19e31dfbd8d311dff3bbffc7c1e16f348e019dfca50620fd9c475092",
+    "https://bcr.bazel.build/modules/boost.optional/1.83.0.bcr.1/source.json": "486e1173f8b24120078f072f434a79fb3aa8c6b0dafbc19c56b7780ea2336595",
     "https://bcr.bazel.build/modules/boost.optional/1.87.0/MODULE.bazel": "a12ca5b2394521bd60e432c9a98623d5a33edf9f7f891fb26c5d0840fb6b182e",
     "https://bcr.bazel.build/modules/boost.optional/1.87.0/source.json": "38de88d9d67d2c7673a2c3a817a578c2ead946a11ae111f24f71859b401b0656",
     "https://bcr.bazel.build/modules/boost.phoenix/1.83.0.bcr.1/MODULE.bazel": "62399f244151ee55b04a8adf620daf5fc106b149f5f18b155759381a1ebe656f",
+    "https://bcr.bazel.build/modules/boost.phoenix/1.83.0.bcr.1/source.json": "0974bc6d0f46611eb85eacea0ec68a59944cc3186989553d0b70764092a9b509",
     "https://bcr.bazel.build/modules/boost.phoenix/1.87.0/MODULE.bazel": "0623287d2455a16617b924e8b81aee4115d94903d08a7262bee932628ce55f5f",
     "https://bcr.bazel.build/modules/boost.phoenix/1.87.0/source.json": "5f037245a0ced437e8f112e8de8653836075b6d2f9794171e956fb4a2f20151a",
     "https://bcr.bazel.build/modules/boost.pool/1.83.0.bcr.1/MODULE.bazel": "7b7cae959d31e55cfdead4122cddf2ec84d7f3a8f0cf5cbc8d8176d226a1e83a",
+    "https://bcr.bazel.build/modules/boost.pool/1.83.0.bcr.1/source.json": "030c265079a757f423cb4fa86aff594ea3e20f3187e4a8a3a68a613d0eebeff4",
     "https://bcr.bazel.build/modules/boost.pool/1.87.0/MODULE.bazel": "f579ff6f6883b594f792c15b3528d1a17532f4b2454e1b457eeedf03cb9f3cf7",
     "https://bcr.bazel.build/modules/boost.pool/1.87.0/source.json": "acb6b53f4b50fbb3f5246b23eef833f98acd8ccf0894d48e9b93fd76a89f2d0c",
     "https://bcr.bazel.build/modules/boost.predef/1.83.0.bcr.1/MODULE.bazel": "0dd34241f892423a9dcd20e1256b6a1c787d60849e9576c724a71607ad8a1955",
+    "https://bcr.bazel.build/modules/boost.predef/1.83.0.bcr.1/source.json": "deb64fec0911e7a5d38d8517ecdd470b0b3983506662e01f63f8925688c05c01",
     "https://bcr.bazel.build/modules/boost.predef/1.87.0/MODULE.bazel": "4bb0cc9a326ea8ffde86044c2dbdf08b75d5e8fe7e4ea8c399b058262680a890",
     "https://bcr.bazel.build/modules/boost.predef/1.87.0/source.json": "421162e76f175a64d22296b9cf3272441324fa994766acffd367182a777ad092",
     "https://bcr.bazel.build/modules/boost.preprocessor/1.83.0.bcr.1/MODULE.bazel": "edb9fb7900ea7002cbefffd97302b071d7cbd8f948b51c7b1a75043bd2985eba",
+    "https://bcr.bazel.build/modules/boost.preprocessor/1.83.0.bcr.1/source.json": "69dc4f6fc76305c21c4a651c94ccfdc8a76d8fbae1151e7c1d1a4599dffc0f03",
     "https://bcr.bazel.build/modules/boost.preprocessor/1.87.0/MODULE.bazel": "fdbcce15c585de47e4a5e9f6e2b9aa87f690a87e205eded400c5590f7e64535a",
     "https://bcr.bazel.build/modules/boost.preprocessor/1.87.0/source.json": "ef9b9006890126f5880bb51ccbe8a97a95baf21606e2f30acdb1c30c0dd79758",
     "https://bcr.bazel.build/modules/boost.proto/1.83.0.bcr.1/MODULE.bazel": "a7f5243ab1919fca16f9016374e96fd6956d320592b5967e2f025a95b30f32fe",
+    "https://bcr.bazel.build/modules/boost.proto/1.83.0.bcr.1/source.json": "2be12e6b8f170aa8aff437b269b4c0f2d7b63125475507e437b7150184f27d5e",
     "https://bcr.bazel.build/modules/boost.proto/1.87.0/MODULE.bazel": "4f5261cd14d9dfff6e7d6335ae60b54f5269f3bfc8c7660cc06a94c10cac584a",
     "https://bcr.bazel.build/modules/boost.proto/1.87.0/source.json": "e7b865a406fc16e7a12efacc0b6083254652b0d343c1b9dab8b1ab13019ef2c9",
     "https://bcr.bazel.build/modules/boost.random/1.83.0.bcr.1/MODULE.bazel": "cabe3ba820c9588a9ca22548b88ad8c4b307be085691b286ff0dae8a46b25fa0",
+    "https://bcr.bazel.build/modules/boost.random/1.83.0.bcr.1/source.json": "5cc5c8c13e525c5b1c12ea5b31359a16bfaf25b750c0601c0624b9342872e05d",
     "https://bcr.bazel.build/modules/boost.random/1.87.0/MODULE.bazel": "4e145cf085222598574e08e328867995b38d520f763d02a44f13cc0074762139",
     "https://bcr.bazel.build/modules/boost.random/1.87.0/source.json": "d5ae4fbacf288a7b14984f2abddc87d9b98b3d6bb863ddf9e9a58b189bd18a5c",
     "https://bcr.bazel.build/modules/boost.range/1.83.0.bcr.1/MODULE.bazel": "136d623462d1d5c7cf79df83b5ce17a8582a92abb116da9d88c5e5594e5a7d92",
+    "https://bcr.bazel.build/modules/boost.range/1.83.0.bcr.1/source.json": "f99062101034f19d9bf2bef3e07cc99bf192640b72560663227e5375efd1e144",
     "https://bcr.bazel.build/modules/boost.range/1.87.0/MODULE.bazel": "b1604553c080ca8620fb8e16267b397d4345986acae9ddd8277f36ad87236b60",
     "https://bcr.bazel.build/modules/boost.range/1.87.0/source.json": "3477215270d2295f882b0b127347fddf69aecdb7cd77ba315e55199c36208661",
     "https://bcr.bazel.build/modules/boost.ratio/1.83.0.bcr.1/MODULE.bazel": "3ad15c17bd4dbe71910bb413ac19523e41688f6957103b68bb4d02ac20af567c",
+    "https://bcr.bazel.build/modules/boost.ratio/1.83.0.bcr.1/source.json": "eb58a64870c8c06383748081107e092512f9e781407e28b6cfcf648aa74c8fc8",
     "https://bcr.bazel.build/modules/boost.ratio/1.87.0/MODULE.bazel": "c5a3695cd1bbb22d6a00a6df2c857be1f52f64f36fa3a89bd6835de94485fa60",
     "https://bcr.bazel.build/modules/boost.ratio/1.87.0/source.json": "86662c1c2dd510741c8838c43b53a685183fd7ca793d04a8660f0d3f68317005",
     "https://bcr.bazel.build/modules/boost.rational/1.83.0.bcr.1/MODULE.bazel": "cb0953fb163d4b42c67b762896a357c9ae45a59f2fef5ff25f0dc2f0127710a4",
+    "https://bcr.bazel.build/modules/boost.rational/1.83.0.bcr.1/source.json": "79bfbaf9da65bd765fa4b47e1ac0a914b17151120e6a29286976fa7c5b92eb60",
     "https://bcr.bazel.build/modules/boost.rational/1.87.0/MODULE.bazel": "421044b95b2db3ca1ae3a93ba12e235db938c9786c3a209a2b50754c3c0a07d7",
     "https://bcr.bazel.build/modules/boost.rational/1.87.0/source.json": "876156ee5dacf41912b6f3516160ab70b07ee974321ec141f58f6caf99999630",
     "https://bcr.bazel.build/modules/boost.regex/1.83.0.bcr.1/MODULE.bazel": "5e2c235ea0bdbd8fa942f429ed8aefa1ad3e1471993a17a7b82c1f127dbcb3a2",
+    "https://bcr.bazel.build/modules/boost.regex/1.83.0.bcr.1/source.json": "1d5fda14ae73d5f12ced3c8731006f28b54bdaf75da35f6cc06c2b57b724d011",
     "https://bcr.bazel.build/modules/boost.regex/1.87.0/MODULE.bazel": "b91f176af90ce5ad96c8be6f83c4fb253fc8b391055e23a349f35e76e679e302",
     "https://bcr.bazel.build/modules/boost.regex/1.87.0/source.json": "a887e4a0ac22ae2eb6203bbfbc2b6a9581edc1d65af0a8c392b30327a7688432",
     "https://bcr.bazel.build/modules/boost.serialization/1.83.0.bcr.1/MODULE.bazel": "38913136b1e818768a25338a21640277cfa73d3af5d4eb6865ef0eb973c6b042",
+    "https://bcr.bazel.build/modules/boost.serialization/1.83.0.bcr.1/source.json": "0aea602e3a56afd785f49d4275ea6fa037c936be48bdc67a8c556ed9c2d6def4",
     "https://bcr.bazel.build/modules/boost.serialization/1.87.0/MODULE.bazel": "b1d3c48e3287036825f7ea649ff59382558478e913adcc86d10cf38d56a82cab",
     "https://bcr.bazel.build/modules/boost.serialization/1.87.0/source.json": "c543d9d7bdaaf9e1134649cf2a990e799e3644122f98d4015aaaaeae6b6fb7de",
     "https://bcr.bazel.build/modules/boost.smart_ptr/1.83.0.bcr.1/MODULE.bazel": "5652293a4b393e5a56ef4113e0f41b6121d22a0d8f7ccd3e27c4042b947683e3",
+    "https://bcr.bazel.build/modules/boost.smart_ptr/1.83.0.bcr.1/source.json": "1b1b6b549073ef6b1bdbd9898490f73ddb6324774d441cd24d6d1181d4bc75f4",
     "https://bcr.bazel.build/modules/boost.smart_ptr/1.87.0/MODULE.bazel": "a2a2b804d33fd47e37b33bb0b47a66b07aab616c12083654f4d9b92ab1308470",
     "https://bcr.bazel.build/modules/boost.smart_ptr/1.87.0/source.json": "ff2c2bc2620fd9f404ea1937f38c1776a6b88ae17516c440eda88366fbd14c91",
     "https://bcr.bazel.build/modules/boost.spirit/1.83.0.bcr.1/MODULE.bazel": "7d50233e6108a0a8fc6fcfde4ce55a09796a65fdcae48d3c78167c25ca7d73fa",
+    "https://bcr.bazel.build/modules/boost.spirit/1.83.0.bcr.1/source.json": "21e666c55355d43edd19fb8a4535a33dd988571f02289a15035de7cb902377d4",
     "https://bcr.bazel.build/modules/boost.spirit/1.87.0/MODULE.bazel": "bd5a28e70ae5a0146f9a68ccca94852f2c9ba5a547096dbd55dac60bb942434e",
     "https://bcr.bazel.build/modules/boost.spirit/1.87.0/source.json": "9934075ffe3d5eaa07d36a4a54a8ca6ceb2ceb9a949f7f0d8c8c9f96f9276843",
     "https://bcr.bazel.build/modules/boost.static_assert/1.83.0.bcr.1/MODULE.bazel": "2b605adc483c6241865f1e862437331bc6f56c0d376769908b70ba18d3da1f07",
+    "https://bcr.bazel.build/modules/boost.static_assert/1.83.0.bcr.1/source.json": "a0eac8de976fff7efdf498933d7494df30eff471c51c1edfc822007069697ed7",
     "https://bcr.bazel.build/modules/boost.static_assert/1.87.0/MODULE.bazel": "06e7170d6e4ec08d6a4a83d1f0bce3f7fdacd89e4dcaa93d508f971e4e363d4f",
     "https://bcr.bazel.build/modules/boost.static_assert/1.87.0/source.json": "d5b3f81fba6382b83885ff2dfaef07a5788323ed82d472d2fd629fcbba04ec7a",
     "https://bcr.bazel.build/modules/boost.system/1.83.0.bcr.1/MODULE.bazel": "5f905d0fbb1ce99231f3fa278b2e5999aa7395c6393ac42d479ae21824adf03f",
+    "https://bcr.bazel.build/modules/boost.system/1.83.0.bcr.1/source.json": "0676ab63c01c5ddf731a5cf54667ffc6560e9fb52401a2a9ac6a10c5a9909019",
     "https://bcr.bazel.build/modules/boost.system/1.87.0/MODULE.bazel": "fe98a0cf5cd04613f81b2b4338ccf22d75f4049875c294a35c0949c3c6e8cbc1",
     "https://bcr.bazel.build/modules/boost.system/1.87.0/source.json": "470c81ca91d728f1410def4849789a329da81a9080acdca6e1dace58e30728bb",
     "https://bcr.bazel.build/modules/boost.thread/1.83.0.bcr.1/MODULE.bazel": "2c5da147f251b0c7af2f0861477271878ed364248edd85c6e93175cf6e5f98ce",
+    "https://bcr.bazel.build/modules/boost.thread/1.83.0.bcr.1/source.json": "bd25b519fd0d8ade2bcb1ddef2276e4bf88f8254381ecab27ec0cc05b36d871d",
     "https://bcr.bazel.build/modules/boost.thread/1.87.0/MODULE.bazel": "c257782276b173bc0ccedeb13d0448a891f3dc4f82cb2414915a6cd8fbb6ef6d",
     "https://bcr.bazel.build/modules/boost.thread/1.87.0/source.json": "91a57ffad27c5f4b5d13d7d767d2c154c8c349ae959a75770565679013a68f6f",
     "https://bcr.bazel.build/modules/boost.throw_exception/1.83.0.bcr.1/MODULE.bazel": "b757c832f5f5f818d87c9eaa993d3eb211554197321c3edf641e2c8821cf19c2",
+    "https://bcr.bazel.build/modules/boost.throw_exception/1.83.0.bcr.1/source.json": "c752d584840e9183141f9d53f07f2051016c16771a973cdd1487f9585980c2e5",
     "https://bcr.bazel.build/modules/boost.throw_exception/1.87.0/MODULE.bazel": "d02c1799ff6bc1bd0a9e7f149ac35a4851c89156be7d81805df9238d52047f02",
     "https://bcr.bazel.build/modules/boost.throw_exception/1.87.0/source.json": "b52fb8b064d825ebb7047a72cf2c101a047dc60c1d0a89829b7ed8e39ff4fe6a",
     "https://bcr.bazel.build/modules/boost.tokenizer/1.83.0.bcr.1/MODULE.bazel": "486e2806e0682f12d1ea8f97013b65719eaefb3078f347b3a3518cd6f7b2c837",
+    "https://bcr.bazel.build/modules/boost.tokenizer/1.83.0.bcr.1/source.json": "c4f3923d7b4e094cd70cff03d59b556653b78cc1a5dc3652e88609df566a9839",
     "https://bcr.bazel.build/modules/boost.tokenizer/1.87.0/MODULE.bazel": "48ecacd7bf0fcb7cbf27b55a7d6bf82b988f308666bda2d51840450ea6d62401",
     "https://bcr.bazel.build/modules/boost.tokenizer/1.87.0/source.json": "c39ec91706ad8eeab142528eac47737b6fc314b952ffdb9578ab95e5f3c690b4",
     "https://bcr.bazel.build/modules/boost.tuple/1.83.0.bcr.1/MODULE.bazel": "1d540b5efd3b65eeabd3621e5187a799e21bfa9ffc6afd7d4ad307cc4a27a6d4",
+    "https://bcr.bazel.build/modules/boost.tuple/1.83.0.bcr.1/source.json": "7aa33ec2aaae45605049ea0ec1c1de9517a1e1278a22d0a521521d4023f9ad87",
     "https://bcr.bazel.build/modules/boost.tuple/1.87.0/MODULE.bazel": "94a17666a0d0e875a346b4e8db75ec05e3a1c9c7a681ac5eca80c18e68b5d547",
     "https://bcr.bazel.build/modules/boost.tuple/1.87.0/source.json": "5f42023d26b3abefc034817a535d3d0ab06712f4740a93aa4e247287fba1cb47",
     "https://bcr.bazel.build/modules/boost.type_index/1.83.0.bcr.1/MODULE.bazel": "6d78322266adba397ef8c2568ab90bb87432b052e724857b4b9f30f85544ef15",
+    "https://bcr.bazel.build/modules/boost.type_index/1.83.0.bcr.1/source.json": "08db090d1570232c3f513ca8f6a107bd1d10be9a65d7d0f8b850cfdd9055ab22",
     "https://bcr.bazel.build/modules/boost.type_index/1.87.0/MODULE.bazel": "a871d18870b21f00c89ba8dd469e027cd697363a9f3dd525176d91e837b8bb38",
     "https://bcr.bazel.build/modules/boost.type_index/1.87.0/source.json": "fe14f80f9a857b92af204396d0e81bf57751113e37a77586b9610a7894407092",
     "https://bcr.bazel.build/modules/boost.type_traits/1.83.0.bcr.1/MODULE.bazel": "89bbca2de42dc79ffcabb3625103771e4b04566eee6b8cfe7fa807d133d053f7",
+    "https://bcr.bazel.build/modules/boost.type_traits/1.83.0.bcr.1/source.json": "051e4969558e4a356c5059f4a4f41335b3968b91fa8ae1772898676ec95ded56",
     "https://bcr.bazel.build/modules/boost.type_traits/1.87.0/MODULE.bazel": "8d2d44e992e85a59b6bd13b145ae27736d932a29e5aec743a0cfd014af5aee27",
     "https://bcr.bazel.build/modules/boost.type_traits/1.87.0/source.json": "fd7434b8e36d19a1c8e9349e041ceaf19d0b98e90b6d4c7b86249735907cea34",
     "https://bcr.bazel.build/modules/boost.typeof/1.83.0.bcr.1/MODULE.bazel": "6b3dd6cfe993a8ccf98bce79506be41ec893c65013d7a5be9177c8a185e86d87",
+    "https://bcr.bazel.build/modules/boost.typeof/1.83.0.bcr.1/source.json": "0ec40beca58de1b17c1ddb18c357ef525977e4312540122b3b91cbe485556f17",
     "https://bcr.bazel.build/modules/boost.typeof/1.87.0/MODULE.bazel": "c3cd122b8745c835229c58df8c46e81b944996b4bd3822f947873cb617374dd8",
     "https://bcr.bazel.build/modules/boost.typeof/1.87.0/source.json": "ba36c7ce360efd31bf7ab5c1503b785de5c8db673056067ff8c7e3e94efccb68",
     "https://bcr.bazel.build/modules/boost.unordered/1.83.0.bcr.1/MODULE.bazel": "c9be557708b3390921d02880774fd76299e5b9523f045d8b09b067777bf47bb4",
+    "https://bcr.bazel.build/modules/boost.unordered/1.83.0.bcr.1/source.json": "1f64a4e380153091443c069cdfebaa2102faa22673a5bf2c3690bfe67eaf4685",
     "https://bcr.bazel.build/modules/boost.unordered/1.87.0/MODULE.bazel": "bfee6daa324bb37c618fc073c50a0754985b9538e13de0e873381d41d634168c",
     "https://bcr.bazel.build/modules/boost.unordered/1.87.0/source.json": "3b237fcd1dda18408dbdcb06984e50a13f0688fd0dca480a552f1ff37a6f50b5",
     "https://bcr.bazel.build/modules/boost.utility/1.83.0.bcr.1/MODULE.bazel": "1346dc27d6c8b7ced10896224ed3e406adac3fd79c8450d78c291228f1b9075d",
+    "https://bcr.bazel.build/modules/boost.utility/1.83.0.bcr.1/source.json": "15636369b5452784e7bd04f7ae52c751e591dd4ebb852688fccc66234d452929",
     "https://bcr.bazel.build/modules/boost.utility/1.87.0/MODULE.bazel": "8ab710d4feac76acba004a1cac6d64823c812bfeefea18fb7b1a907c86a9ecf6",
     "https://bcr.bazel.build/modules/boost.utility/1.87.0/source.json": "ab5744c8cc722dd83c96ae672e01010b944ad4e864e445de66f78164152a7a23",
     "https://bcr.bazel.build/modules/boost.variant/1.83.0.bcr.1/MODULE.bazel": "adafe526c9f34d61cc49d9676057d8d039aa53905e3333707d667447e58b322a",
+    "https://bcr.bazel.build/modules/boost.variant/1.83.0.bcr.1/source.json": "a088bfec1fc7eaf9c56692e0709eaba13f1be0a3fb0e81161f0d7a76d779f333",
     "https://bcr.bazel.build/modules/boost.variant/1.87.0/MODULE.bazel": "acb5de2feaec8b682125c8426b2cbbb287b6919e23b122d5fa6335bdcb436d16",
     "https://bcr.bazel.build/modules/boost.variant/1.87.0/source.json": "4af1edbcf06ad0f37a8c07efb35aa0f22c1424421921aa5864f4208d1624eed7",
     "https://bcr.bazel.build/modules/boost.variant2/1.83.0.bcr.1/MODULE.bazel": "c60baa3b8923712a156197ffaf5cf9972bf35e44d00a90f7019a06761f391d3e",
+    "https://bcr.bazel.build/modules/boost.variant2/1.83.0.bcr.1/source.json": "041f94707bd509bc1f93782ccb6c38d491ac0dca25d26011f2047639d3a2bcd1",
     "https://bcr.bazel.build/modules/boost.variant2/1.87.0/MODULE.bazel": "c0d8e1d486e3080200b74af21f50e4993b0d6dc649ae5700e42fc1d74e1f72b8",
     "https://bcr.bazel.build/modules/boost.variant2/1.87.0/source.json": "d57a8992e410f6def5c2e876e53bb21d7907a0df1b9608f59ff90113a4879e67",
     "https://bcr.bazel.build/modules/boost.winapi/1.83.0.bcr.1/MODULE.bazel": "faf78b50dae672a38b77db545a460428cfe47a8d79466455ef397d76037e9e40",
+    "https://bcr.bazel.build/modules/boost.winapi/1.83.0.bcr.1/source.json": "0957b4dabe425e7f9d8d02db63969b808a280c11388ad7814e50b0779ae592cc",
     "https://bcr.bazel.build/modules/boost.winapi/1.87.0/MODULE.bazel": "b36870b9f3ebe56c1dadd0507fb6ee6b5a59e13c5c0b784baaa509722bd0ffba",
     "https://bcr.bazel.build/modules/boost.winapi/1.87.0/source.json": "8e363a11b36f5f78b4d00a4543a8b181313d78abdcc5dec6e438a5c4b2fd2a7e",
     "https://bcr.bazel.build/modules/boringssl/0.0.0-20211025-d4f1ab9/MODULE.bazel": "6ee6353f8b1a701fe2178e1d925034294971350b6d3ac37e67e5a7d463267834",
@@ -268,7 +337,10 @@
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.2/MODULE.bazel": "23fd0e097bfc0952632b854377b79ccee80fd473db6d55e0e26fce80a919f0c5",
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/MODULE.bazel": "f6561baff0fc0035c9c1a9e2b0820de106cdb01b37bf5c81276860ccc863e5b2",
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/source.json": "a8611a2b5577929ad7e1f44ded19dab21a188125a74ac6192d21d283609f280f",
+    "https://bcr.bazel.build/modules/eigen/4.0.0-20241125.bcr.1/MODULE.bazel": "1fb30b496d87fe8e17c671c73f00d66b6291f0e058b23cdef2ce2d12110405db",
+    "https://bcr.bazel.build/modules/eigen/4.0.0-20241125.bcr.1/source.json": "f968205702f1b75f2ec4e6683e14d681c25fa39ee9d6c8d23f4bd364da49d934",
     "https://bcr.bazel.build/modules/fmt/11.1.1/MODULE.bazel": "5d8be02924a69c13d2fb0b22d5511bb8cf2fe52a557ad6d095688fcd6b7beefb",
+    "https://bcr.bazel.build/modules/fmt/11.1.1/source.json": "fbf9d442fec272274d0af20ccf36b3387c3d85ea27680c98a197c01c00c3dfc7",
     "https://bcr.bazel.build/modules/fmt/11.1.3/MODULE.bazel": "3f422eb59fec5a54faf6d6c5b4cfbd173ad989e2ee5a2da944e19a39a8a90e00",
     "https://bcr.bazel.build/modules/fmt/11.1.3/source.json": "2cc63e28b3de6d476e2730add655af10faaf76523e2b9d72e7752a50e24eeb7d",
     "https://bcr.bazel.build/modules/fuzztest/20250214.0/MODULE.bazel": "b65b66befece838904a4e1a8bf5bb8d610b0e7519f0e4654fae6e61f3b9a54e8",
@@ -355,11 +427,13 @@
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_apple/3.13.0/MODULE.bazel": "b4559a2c6281ca3165275bb36c1f0ac74666632adc5bdb680e366de7ce845f43",
+    "https://bcr.bazel.build/modules/rules_apple/3.13.0/source.json": "fe31c678e2256daa91a802664b578c1de71dc43a49a7ccc16db001378f312cd3",
     "https://bcr.bazel.build/modules/rules_apple/3.20.1/MODULE.bazel": "d9049cabd0becdf8d26377927dda874e2febc803401269814776f232fde91b7c",
     "https://bcr.bazel.build/modules/rules_apple/3.20.1/source.json": "7870121042c518ca6109fa16fb070b4dd6762f42aefdd9ddcc259194ca6627cd",
     "https://bcr.bazel.build/modules/rules_bison/0.3/MODULE.bazel": "e97b53b38b480ac8c9d86e64b745929bb152c57115a8c23d21ec1247923472fd",
     "https://bcr.bazel.build/modules/rules_bison/0.3/source.json": "1591beee5a8c6e571451c4b57f1ac4fc0990dcd65f7f8de8579c4e90a33d6ef4",
     "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/source.json": "021363d254f7438f3f10725355969c974bb2c67e0c28667782ade31a9cdb747f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -413,6 +487,7 @@
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.6.3/MODULE.bazel": "e90505b7a931d194245ffcfb6ff4ca8ef9d46b4e830d12e64817752e0198e2ed",
+    "https://bcr.bazel.build/modules/rules_java/8.6.3/source.json": "8330cc5d277085bbcf93e9f1c85c24d06975585606a1215df4faf886a8d3cc9e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -433,6 +508,7 @@
     "https://bcr.bazel.build/modules/rules_m4/0.2.3/MODULE.bazel": "a201ad119823e1af5024240e1e1ef294425d9be73a698cb41c8450e6c8e107e3",
     "https://bcr.bazel.build/modules/rules_m4/0.2.3/source.json": "d2fd4b91471317d0e6368ece3da2334884879ed6d6289591c7312944e50dea70",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -461,6 +537,7 @@
     "https://bcr.bazel.build/modules/rules_python/1.2.0/source.json": "5b7892685c9a843526fd5a31e7d7a93eb819c59fd7b7fc444b5b143558e1b073",
     "https://bcr.bazel.build/modules/rules_rust/0.45.1/MODULE.bazel": "a69d0db3a958fab2c6520961e1b2287afcc8b36690fd31bbc4f6f7391397150d",
     "https://bcr.bazel.build/modules/rules_rust/0.51.0/MODULE.bazel": "2b6d1617ac8503bfdcc0e4520c20539d4bba3a691100bee01afe193ceb0310f9",
+    "https://bcr.bazel.build/modules/rules_rust/0.51.0/source.json": "79a530199d9826a93b31d05b7d9b39dc753a80f88856d3ca5376f665a82cc5e6",
     "https://bcr.bazel.build/modules/rules_rust/0.60.0/MODULE.bazel": "911ff2a12d01ac574fd6dfec0b05fa976ff8693d8c2420db637a9f98f697b0ae",
     "https://bcr.bazel.build/modules/rules_rust/0.60.0/source.json": "2b17f77e27489aa1b86b765a141642a1966a2a35fed0207277f3327fd09ef3d4",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
@@ -468,6 +545,7 @@
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
     "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
     "https://bcr.bazel.build/modules/rules_swift/2.4.0/source.json": "a6577f57f9febbdc015a01f2a8f3487422032f134d6c61d18ed8e8ca3b9acc7c",
     "https://bcr.bazel.build/modules/scip/9.2.0.bcr.3/MODULE.bazel": "c5f8ebefa7fe493ae7412f5268081187228a30cf3919b0d983bbd053f2c32d7f",
@@ -475,6 +553,7 @@
     "https://bcr.bazel.build/modules/snappy/1.2.0/MODULE.bazel": "cc7a727b46089c7fdae0ede21b1fd65bdb14d01823da118ef5c48044f40b6b27",
     "https://bcr.bazel.build/modules/snappy/1.2.0/source.json": "17f5527e15d30a9d9eebf79ed73b280b56cac44f8c8fea696666d99943f84c33",
     "https://bcr.bazel.build/modules/soplex/7.1.2.bcr.1/MODULE.bazel": "25212bddb61e56fab42b7e4faf039880aa868b1a116621fba5941eb6db41b393",
+    "https://bcr.bazel.build/modules/soplex/7.1.2.bcr.1/source.json": "6a779e6c9e55ceb90a5acf1ea09a6a275359faee4d540451ecd96b5c385e0b3f",
     "https://bcr.bazel.build/modules/soplex/7.1.4.bcr.1/MODULE.bazel": "dbba514d47728de2ebd08ca7d02ee9bb3d6349dee1b4fbe78f6f15694acb94ff",
     "https://bcr.bazel.build/modules/soplex/7.1.4.bcr.1/source.json": "ca82ab37a51da4880fdf49c2f75531368033d7c50833b621025293b25e74b13c",
     "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
@@ -502,6 +581,7 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.4/MODULE.bazel": "fc880fa3bd9c5299be64b712fbc60a1978ea9ce0a9f74f6bbd0b61c12db1aee6",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.6/MODULE.bazel": "e937cf0a3772f93ad91f3c7af4f330b76a878bbfee06527ca1a9673b790eb896",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.6/source.json": "5f397158198f338129c865a4c3ae21bc5626a9664b3c3b40fa3b3c2ec1ff83bf",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
@@ -557,6 +637,298 @@
             "bazel_tools",
             "rules_cc",
             "rules_cc+"
+          ]
+        ]
+      }
+    },
+    "@@aspect_bazel_lib+//lib:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "TGnRoh+5JjQRL6rkWCQneJpM89XjhPyydRXWIn0HmDw=",
+        "usagesDigest": "HyCD/AMcHKcynL86oRSbi4rhw9cjPb8yfXrC363gBKE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "copy_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_directory"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "jq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.6"
+            }
+          },
+          "jq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_host_alias_repo",
+            "attributes": {}
+          },
+          "jq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.25.2"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_host_alias_repo",
+            "attributes": {}
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "expand_template_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "expand_template_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "expand_template_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "expand_template_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "expand_template_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "expand_template_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "expand_template_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "expand_template"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }
@@ -1329,6 +1701,30 @@
         "recordedRepoMappingEntries": []
       }
     },
+    "@@rules_buf+//buf:extensions.bzl%ext": {
+      "general": {
+        "bzlTransitiveDigest": "3jGepUu1j86kWsTP3Fgogw/XfktHd4UIQt8zj494n/Y=",
+        "usagesDigest": "RTc2BMQ2b0wGU8CRvN3EoPz34m3LMe+K/oSkFkN83+M=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_buf_toolchains": {
+            "repoRuleId": "@@rules_buf+//buf/internal:toolchain.bzl%buf_download_releases",
+            "attributes": {
+              "version": "v1.27.0"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_buf+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_flex+//flex/internal:default_toolchain_ext.bzl%default_toolchain_ext": {
       "general": {
         "bzlTransitiveDigest": "fn+aX2vKsiaNLj3QtNfsRcI8fiATDtxAayRTJFGJkNI=",
@@ -1828,6 +2224,28 @@
         ]
       }
     },
+    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "9SPkp75wN6dP9sKiOgU1uOCTNNA08v8PVBMYs+SZ27s=",
+        "usagesDigest": "ZsMvJZXTm/u0lYuq0P/yTF2h6FdynULVT3mwKA1SE5k=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
@@ -1922,6 +2340,96 @@
           "reproducible": false
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_nodejs+//nodejs:extensions.bzl%node": {
+      "general": {
+        "bzlTransitiveDigest": "btnelILPo3ngQN9vWtsQMclvJZPf3X2vcGTjmW7Owy8=",
+        "usagesDigest": "CtwJeycIo1YVyKAUrO/7bkpB6yqctQd8XUnRtqUbwRI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nodejs_linux_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_s390x": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_s390x",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_ppc64le": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_windows_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "windows_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_host": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_toolchains": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_nodejs+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_nodejs+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@rules_python+//python/extensions:pip.bzl%pip": {
@@ -14703,9 +15211,2989 @@
         ]
       }
     },
+    "@@rules_rust+//rust:extensions.bzl%rust": {
+      "general": {
+        "bzlTransitiveDigest": "u0AbcREuyXinWoLmuEjo7UWBx+Y+ROXvSITNXzSqOvo=",
+        "usagesDigest": "ozx08ZbgRXTJw0zCaO/xtMUzgGLvwaQkZGnUo6tlyHM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rust_analyzer_1.81.0_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_analyzer_toolchain_tools_repository",
+            "attributes": {
+              "version": "1.81.0",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_analyzer_1.81.0": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_analyzer_1.81.0_tools//:rust_analyzer_toolchain",
+              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
+              "exec_compatible_with": [],
+              "target_compatible_with": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-apple-darwin",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-apple-darwin",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__aarch64-apple-darwin__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_aarch64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_aarch64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_darwin_aarch64__aarch64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_aarch64__aarch64-apple-darwin__nightly//:toolchain",
+                "@rust_darwin_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_darwin_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_darwin_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-apple-darwin"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-pc-windows-msvc",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-pc-windows-msvc",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_aarch64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_aarch64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly//:toolchain",
+                "@rust_windows_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_windows_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_windows_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_windows_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-pc-windows-msvc"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "aarch64-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "aarch64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_aarch64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_aarch64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_aarch64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_aarch64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_aarch64__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_aarch64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "aarch64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "s390x-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "s390x-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "s390x-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_s390x__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_s390x__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_s390x": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_s390x__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_s390x__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_s390x__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_s390x__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "s390x-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:s390x",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-apple-darwin",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-apple-darwin",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__x86_64-apple-darwin__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-apple-darwin",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_darwin_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_darwin_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_darwin_x86_64__x86_64-apple-darwin__stable//:toolchain",
+                "@rust_darwin_x86_64__x86_64-apple-darwin__nightly//:toolchain",
+                "@rust_darwin_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_darwin_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_darwin_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-apple-darwin"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-pc-windows-msvc",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-pc-windows-msvc",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-pc-windows-msvc",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_windows_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_windows_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable//:toolchain",
+                "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly//:toolchain",
+                "@rust_windows_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_windows_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_windows_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_windows_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-pc-windows-msvc"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-freebsd",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-freebsd",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-freebsd",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_freebsd_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_freebsd_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable//:toolchain",
+                "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_freebsd_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-freebsd"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-unknown-unknown",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-unknown-unknown__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:none"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__stable_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "1.81.0",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__stable": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:stable"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__nightly_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_tools_repository",
+            "attributes": {
+              "exec_triple": "x86_64-unknown-linux-gnu",
+              "allocator_library": "@rules_rust//ffi/cc/allocator_library",
+              "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
+              "target_triple": "wasm32-wasi",
+              "version": "nightly/2024-09-05",
+              "rustfmt_version": "nightly/2024-09-05",
+              "edition": "2021",
+              "dev_components": false,
+              "extra_rustc_flags": [],
+              "extra_exec_rustc_flags": [],
+              "opt_level": {},
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": []
+            }
+          },
+          "rust_linux_x86_64__wasm32-wasi__nightly": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+              "target_settings": [
+                "@rules_rust//rust/toolchain/channel:nightly"
+              ],
+              "toolchain_type": "@rules_rust//rust:toolchain",
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": [
+                "@platforms//cpu:wasm32",
+                "@platforms//os:wasi"
+              ]
+            }
+          },
+          "rust_linux_x86_64": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rust_toolchain_set_repository",
+            "attributes": {
+              "toolchains": [
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable//:toolchain",
+                "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly//:toolchain",
+                "@rust_linux_x86_64__wasm32-unknown-unknown__stable//:toolchain",
+                "@rust_linux_x86_64__wasm32-unknown-unknown__nightly//:toolchain",
+                "@rust_linux_x86_64__wasm32-wasi__stable//:toolchain",
+                "@rust_linux_x86_64__wasm32-wasi__nightly//:toolchain"
+              ]
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly/2024-09-05",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "netrc": "",
+              "auth_patterns": {},
+              "exec_triple": "x86_64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_rust+//rust:repositories.bzl%toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rust_toolchains": {
+            "repoRuleId": "@@rules_rust+//rust/private:repository_utils.bzl%toolchain_repository_hub",
+            "attributes": {
+              "toolchain_names": [
+                "rust_analyzer_1.81.0",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_darwin_aarch64__wasm32-wasi__stable",
+                "rust_darwin_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_windows_aarch64__wasm32-wasi__stable",
+                "rust_windows_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly",
+                "rust_linux_aarch64__wasm32-wasi__stable",
+                "rust_linux_aarch64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly",
+                "rust_linux_s390x__wasm32-wasi__stable",
+                "rust_linux_s390x__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_darwin_x86_64__wasm32-wasi__stable",
+                "rust_darwin_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_windows_x86_64__wasm32-wasi__stable",
+                "rust_windows_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_freebsd_x86_64__wasm32-wasi__stable",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly",
+                "rust_linux_x86_64__wasm32-wasi__stable",
+                "rust_linux_x86_64__wasm32-wasi__nightly",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu"
+              ],
+              "toolchain_labels": {
+                "rust_analyzer_1.81.0": "@rust_analyzer_1.81.0_tools//:rust_analyzer_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__nightly": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rustfmt_nightly-2024-09-05__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_aarch64__wasm32-wasi__nightly": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_aarch64__wasm32-wasi__nightly": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rust_linux_s390x__s390x-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rust_linux_s390x__s390x-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": "@rust_linux_s390x__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": "@rust_linux_s390x__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-wasi__stable": "@rust_linux_s390x__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_s390x__wasm32-wasi__nightly": "@rust_linux_s390x__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__nightly": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rustfmt_nightly-2024-09-05__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_windows_x86_64__wasm32-wasi__nightly": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
+                "rust_linux_x86_64__wasm32-wasi__nightly": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
+              },
+              "toolchain_types": {
+                "rust_analyzer_1.81.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_s390x__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_darwin_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_windows_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
+                "rust_linux_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
+              },
+              "exec_compatible_with": {
+                "rust_analyzer_1.81.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-wasi__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-wasi__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ]
+              },
+              "target_compatible_with": {
+                "rust_analyzer_1.81.0": [],
+                "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__aarch64-apple-darwin__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_darwin_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-apple-darwin": [],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_windows_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-pc-windows-msvc": [],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:aarch64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_aarch64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_aarch64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__aarch64-unknown-linux-gnu": [],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__s390x-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:s390x",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_s390x__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_s390x__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_s390x__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__s390x-unknown-linux-gnu": [],
+                "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__x86_64-apple-darwin__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:osx"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_darwin_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-apple-darwin": [],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:windows"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_windows_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-pc-windows-msvc": [],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:freebsd"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_freebsd_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-freebsd": [],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": [
+                  "@platforms//cpu:x86_64",
+                  "@platforms//os:linux"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_x86_64__wasm32-unknown-unknown__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:none"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__stable": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rust_linux_x86_64__wasm32-wasi__nightly": [
+                  "@platforms//cpu:wasm32",
+                  "@platforms//os:wasi"
+                ],
+                "rustfmt_nightly-2024-09-05__x86_64-unknown-linux-gnu": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ]
+        ]
+      }
+    },
     "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "hNHTAfoM6YZwUAHSOQ3qj3IXBjzcXrq7uH3M8BY2Xso=",
+        "bzlTransitiveDigest": "r/zoigrb42fT/zIUCLua7Xptst5Dk96z/IyAElaPNf8=",
         "usagesDigest": "9w18ec4dj90mX/JqpR2tBU2YVc1GU9yNxi/d7q6lLVA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/frontend/sbox_test.py
+++ b/frontend/sbox_test.py
@@ -1,0 +1,156 @@
+"""Example of HEIR Python usage."""
+
+from heir import compile
+from heir.mlir import F32, I1, I8, I16, I64, Secret, Tensor
+
+
+# This example does not run end to end, but is used to generate MLIR for the
+# CGGI pipeline
+@compile(debug=True, scheme="cggi")
+def func(x: Secret[I8]):
+  x0: I1 = (x >> 7) & 1
+  x1 = (x >> 6) & 1
+  x2 = (x >> 5) & 1
+  x3 = (x >> 4) & 1
+  x4 = (x >> 3) & 1
+  x5 = (x >> 2) & 1
+  x6 = (x >> 1) & 1
+  x7 = x & 1
+
+  y14 = x3 ^ x5
+  y13 = x0 ^ x6
+  y9 = x0 ^ x3
+  y8 = x0 ^ x5
+  t0 = x1 ^ x2
+  y1 = t0 ^ x7
+  y4 = y1 ^ x3
+  y12 = y13 ^ y14
+  y2 = y1 ^ x0
+  y5 = y1 ^ x6
+  y3 = y5 ^ y8
+  t1 = x4 ^ y12
+  y15 = t1 ^ x5
+  y20 = t1 ^ x1
+  y6 = y15 ^ x7
+  y10 = y15 ^ t0
+  y11 = y20 ^ y9
+  y7 = x7 ^ y11
+  y17 = y10 ^ y11
+  y19 = y10 ^ y8
+  y16 = t0 ^ y11
+  y21 = y13 ^ y16
+  y18 = x0 ^ y16
+  # nonlinear
+  t2 = y12 & y15
+  t3 = y3 & y6
+  t4 = t3 ^ t2
+  t5 = y4 & x7
+  t6 = t5 ^ t2
+  t7 = y13 & y16
+  t8 = y5 & y1
+  t9 = t8 ^ t7
+  t10 = y2 & y7
+  t11 = t10 ^ t7
+  t12 = y9 & y11
+  t13 = y14 & y17
+  t14 = t13 ^ t12
+  t15 = y8 & y10
+  t16 = t15 ^ t12
+  t17 = t4 ^ t14
+  t18 = t6 ^ t16
+  t19 = t9 ^ t14
+  t20 = t11 ^ t16
+  t21 = t17 ^ y20
+  t22 = t18 ^ y19
+  t23 = t19 ^ y21
+  t24 = t20 ^ y18
+
+  t25 = t21 ^ t22
+  t26 = t21 & t23
+  t27 = t24 ^ t26
+  t28 = t25 & t27
+  t29 = t28 ^ t22
+  t30 = t23 ^ t24
+  t31 = t22 ^ t26
+  t32 = t31 & t30
+  t33 = t32 ^ t24
+  t34 = t23 ^ t33
+  t35 = t27 ^ t33
+  t36 = t24 & t35
+  t37 = t36 ^ t34
+  t38 = t27 ^ t36
+  t39 = t29 & t38
+  t40 = t25 ^ t39
+
+  t41 = t40 ^ t37
+  t42 = t29 ^ t33
+  t43 = t29 ^ t40
+  t44 = t33 ^ t37
+  t45 = t42 ^ t41
+  z0 = t44 & y15
+  z1 = t37 & y6
+  z2 = t33 & x7
+  z3 = t43 & y16
+  z4 = t40 & y1
+  z5 = t29 & y7
+  z6 = t42 & y11
+  z7 = t45 & y17
+  z8 = t41 & y10
+  z9 = t44 & y12
+  z10 = t37 & y3
+  z11 = t33 & y4
+  z12 = t43 & y13
+  z13 = t40 & y5
+  z14 = t29 & y2
+  z15 = t42 & y9
+  z16 = t45 & y14
+  z17 = t41 & y8
+
+  t46 = z15 ^ z16
+  t47 = z10 ^ z11
+  t48 = z5 ^ z13
+  t49 = z9 ^ z10
+  t50 = z2 ^ z12
+  t51 = z2 ^ z5
+  t52 = z7 ^ z8
+  t53 = z0 ^ z3
+  t54 = z6 ^ z7
+  t55 = z16 ^ z17
+  t56 = z12 ^ t48
+  t57 = t50 ^ t53
+  t58 = z4 ^ t46
+  t59 = z3 ^ t54
+  t60 = t46 ^ t57
+  t61 = z14 ^ t57
+  t62 = t52 ^ t58
+  t63 = t49 ^ t58
+  t64 = z4 ^ t59
+  t65 = t61 ^ t62
+  t66 = z1 ^ t63
+  s0 = t59 ^ t63
+  s6 = t56 ^ ~t62
+  s7 = t48 ^ ~t60
+  t67 = t64 ^ t65
+  s3 = t53 ^ t66
+  s4 = t51 ^ t66
+  s5 = t47 ^ t65
+  s1 = t64 ^ ~s3
+  s2 = t55 ^ ~t67
+
+  q = s0
+  q = q << 1
+  q = q + s1
+  q = q << 1
+  q = q + s2
+  q = q << 1
+  q = q + s3
+  q = q << 1
+  q = q + s4
+  q = q << 1
+  q = q + s5
+  q = q << 1
+  q = q + s6
+  q = q << 1
+  q = q + s7
+
+  return q

--- a/tests/Examples/common/aes/BUILD
+++ b/tests/Examples/common/aes/BUILD
@@ -1,0 +1,12 @@
+# common MLIR files used across multiple test directories
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+)
+
+exports_files(
+    glob([
+        "*.mlir",
+    ]),
+    visibility = ["@heir//tests/Examples:__subpackages__"],
+)

--- a/tests/Examples/common/aes/add_round_key.mlir
+++ b/tests/Examples/common/aes/add_round_key.mlir
@@ -1,0 +1,13 @@
+// One block is composed of 16 bytes of 8 bits each
+
+// This function adds (xors) the two blocks
+#map = affine_map<(d0) -> (d0)>
+func.func @add_round_key(%arg0: tensor<16xi8> {secret.secret}, %arg1: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+  %8 = tensor.empty() : tensor<16xi8>
+  %9 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%arg0, %arg1: tensor<16xi8>, tensor<16xi8>) outs(%8 : tensor<16xi8>) {
+  ^bb0(%in1: i8, %in2: i8, %out: i8):
+    %res = arith.xori %in1, %in2 : i8
+    linalg.yield %res : i8
+  } -> tensor<16xi8>
+  return %9 : tensor<16xi8>
+}

--- a/tests/Examples/common/aes/inv_mix_columns.mlir
+++ b/tests/Examples/common/aes/inv_mix_columns.mlir
@@ -1,0 +1,77 @@
+// Inverse mix columns step, computing a linear combination of the columns.
+
+#map = affine_map<(d0) -> (d0)>
+
+#mapA = affine_map<(d0, d1) -> (d0, d1)> // output of 2
+#map1A = affine_map<(d0, d1) -> (d1)> // output dim 1
+#map2A = affine_map<(d0, d1) -> (d0)> // output dim 1
+module {
+  func.func private @mul_gf256_4(%x: i8 {secret.secret}, %y: i8) -> (i8) {
+      %z = arith.constant 0 : i8
+      %c0 = arith.constant 0 : i8
+      %c1 = arith.constant 1 : i8
+      %2:2 = affine.for %4 = 0 to 4 iter_args(%5 = %x, %6 = %z) -> (i8, i8) {
+        // z = if y & (1 << i): z^x else z
+        %44 = arith.index_cast %4 : index to i8
+        %ysh = arith.shrsi %y, %44 : i8
+        %ysha = arith.andi %ysh, %c1 : i8
+        %91 = arith.trunci %ysha : i8 to i1
+        %10 = arith.xori %6, %5 : i8
+        %argz = arith.select %91, %10, %6 : i8
+        // check if MSB of x is set
+        %14 = arith.cmpi slt, %5, %c0 : i8
+        %11 = arith.constant 1 : i8
+        %12 = arith.shli %5, %11 : i8
+        %17 = arith.constant 27 : i8
+        %122 = arith.xori %12, %17 : i8
+        %argxx = arith.select %14, %122, %12 : i8
+        affine.yield %argxx, %argz : i8, i8
+      }
+      func.return %2#1 : i8
+  }
+
+  func.func private @inv_mix_single_column(%arg0: tensor<4xi8> {secret.secret}) -> tensor<4xi8> {
+    %c0 = arith.constant 0 : i8
+    %valA = arith.constant dense<[[0x0e, 0x0b, 0x0d, 0x09], [0x09, 0x0e, 0x0b, 0x0d], [0x0d, 0x09, 0x0e, 0x0b], [0x0b, 0x0d, 0x09, 0x0e]]> : tensor<4x4xi8>
+    %0 = tensor.splat %c0: tensor<4xi8>
+    %1 = linalg.generic {indexing_maps = [#mapA, #map1A, #map2A], iterator_types = ["parallel", "reduction"]} ins(%valA, %arg0 : tensor<4x4xi8>, tensor<4xi8>) outs(%0 : tensor<4xi8>) {
+    ^bb0(%in: i8, %in_0: i8, %out: i8):
+      %1 = func.call @mul_gf256_4(%in_0, %in) : (i8, i8) -> i8
+      %2 = arith.xori %out, %1 : i8
+      linalg.yield %2 : i8
+    } -> tensor<4xi8>
+    return %1 : tensor<4xi8>
+  }
+
+  func.func @inv_mix_columns(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+    %out = tensor.empty() : tensor<16xi8>
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %mix = affine.for %i = 0 to 4 iter_args(%arg1 = %out) -> (tensor<16xi8>) {
+      %index = arith.muli %i, %c4 : index
+      %index1 = arith.addi %index, %c1 : index
+      %index2 = arith.addi %index1, %c1 : index
+      %index3 = arith.addi %index2, %c1 : index
+      // extract_slice bufferizes to reinterpret_cast
+      %extracted1 = tensor.extract %arg0[%index] : tensor<16xi8>
+      %extracted2 = tensor.extract %arg0[%index1] : tensor<16xi8>
+      %extracted3 = tensor.extract %arg0[%index2] : tensor<16xi8>
+      %extracted4 = tensor.extract %arg0[%index3] : tensor<16xi8>
+      %extracted = tensor.from_elements %extracted1, %extracted2, %extracted3, %extracted4 : tensor<4xi8>
+      %mixed = func.call @inv_mix_single_column(%extracted) : (tensor<4xi8>) -> tensor<4xi8>
+      %emixed = tensor.extract %mixed[%c0] : tensor<4xi8>
+      %emixed1 = tensor.extract %mixed[%c1] : tensor<4xi8>
+      %emixed2 = tensor.extract %mixed[%c2] : tensor<4xi8>
+      %emixed3 = tensor.extract %mixed[%c3] : tensor<4xi8>
+      %inserted = tensor.insert %emixed into %arg1[%index] : tensor<16xi8>
+      %inserted1 = tensor.insert %emixed1 into %inserted[%index1] : tensor<16xi8>
+      %inserted2 = tensor.insert %emixed2 into %inserted1[%index2] : tensor<16xi8>
+      %inserted3 = tensor.insert %emixed3 into %inserted2[%index3] : tensor<16xi8>
+      affine.yield %inserted3 : tensor<16xi8>
+    }
+    return %mix : tensor<16xi8>
+  }
+}

--- a/tests/Examples/common/aes/inv_shift_rows.mlir
+++ b/tests/Examples/common/aes/inv_shift_rows.mlir
@@ -1,0 +1,15 @@
+// Inverse Shift rows function, shifting the 4 rows by 0, 1, 2, and 3 steps to the left.
+
+#map = affine_map<(d0) -> (d0)>
+module {
+  func.func @inv_shift_rows(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+    %0 = tensor.empty() : tensor<16xi8>
+    %indices = arith.constant dense<[0, 1, 2, 3, 7, 4, 5, 6, 10, 11, 8, 9, 13, 14, 15, 12]> : tensor<16xindex>
+    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%indices : tensor<16xindex>) outs(%0 : tensor<16xi8>) {
+    ^bb0(%in: index, %out: i8):
+      %extracted = tensor.extract %arg0[%in] : tensor<16xi8>
+      linalg.yield %extracted : i8
+    } -> tensor<16xi8>
+    return %1 : tensor<16xi8>
+  }
+}

--- a/tests/Examples/common/aes/inv_sub_bytes.mlir
+++ b/tests/Examples/common/aes/inv_sub_bytes.mlir
@@ -1,0 +1,16 @@
+// Inverse Byte substitution function.
+
+#map = affine_map<(d0) -> (d0)>
+module {
+  func.func @inv_sub_bytes(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+    %cst = arith.constant dense<"0x52096ad53036a538bf40a39e81f3d7fb7ce339829b2fff87348e4344c4dee9cb547b9432a6c2233dee4c950b42fac34e082ea16628d924b2765ba2496d8bd12572f8f66486689816d4a45ccc5d65b6926c704850fdedb9da5e154657a78d9d8490d8ab008cbcd30af7e45805b8b34506d02c1e8fca3f0f02c1afbd0301138a6b3a9111414f67dcea97f2cfcef0b4e67396ac7422e7ad3585e2f937e81c75df6e47f11a711d29c5896fb7620eaa18be1bfc563e4bc6d279209adbc0fe78cd5af41fdda8338807c731b11210592780ec5f60517fa919b54a0d2de57a9f93c99cefa0e03b4dae2af5b0c8ebbb3c83539961172b047eba77d626e169146355210c7d"> : tensor<256xi8>
+    %0 = tensor.empty() : tensor<16xi8>
+    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : tensor<16xi8>) outs(%0 : tensor<16xi8>) {
+    ^bb0(%in: i8, %out: i8):
+      %2 = arith.index_cast %in : i8 to index
+      %extracted = tensor.extract %cst[%2] : tensor<256xi8>
+      linalg.yield %extracted : i8
+    } -> tensor<16xi8>
+    return %1 : tensor<16xi8>
+  }
+}

--- a/tests/Examples/common/aes/mix_columns.mlir
+++ b/tests/Examples/common/aes/mix_columns.mlir
@@ -1,0 +1,80 @@
+// Mix columns step, computing a linear combination of the columns.
+
+#map = affine_map<(d0) -> (d0)>
+
+#mapA = affine_map<(d0, d1) -> (d0, d1)> // output of 2
+#map1A = affine_map<(d0, d1) -> (d1)> // output dim 1
+#map2A = affine_map<(d0, d1) -> (d0)> // output dim 1
+module {
+  func.func private @mul_gf256_2(%x: i8 {secret.secret}, %y: i8) -> (i8) {
+      %z = arith.constant 0 : i8
+      %c0 = arith.constant 0 : i8
+      %c1 = arith.constant 1 : i8
+      %2:2 = affine.for %4 = 0 to 2 iter_args(%5 = %x, %6 = %z) -> (i8, i8) {
+        // z = if y & (1 << i): z^x else z
+        %44 = arith.index_cast %4 : index to i8
+        %ysh = arith.shrsi %y, %44 : i8
+        %ysha = arith.andi %ysh, %c1 : i8
+        %91 = arith.trunci %ysha : i8 to i1
+        %10 = arith.xori %6, %5 : i8
+        %argz = arith.select %91, %10, %6 : i8
+        // check if MSB of x is set
+        %14 = arith.cmpi sle, %5, %c0 : i8
+        %11 = arith.constant 1 : i8
+        %12 = arith.shli %5, %11 : i8
+        %17 = arith.constant 27 : i8
+        %122 = arith.xori %12, %17 : i8
+        %argxx = arith.select %14, %122, %12 : i8
+        affine.yield %argxx, %argz : i8, i8
+      }
+      func.return %2#1 : i8
+  }
+
+  func.func private @mix_single_column(%arg0: tensor<4xi8> {secret.secret}) -> tensor<4xi8> {
+    // A 4x4 matrix with [2, 3, 1, 1], [1, 2, 3, 1], [1, 1, 2, 3], [3, 1, 1, 2]
+    // use gf256 multiplication with the vector
+    // use XOR to add
+    %c0 = arith.constant 0 : i8
+    %valA = arith.constant dense<[[2, 3, 1, 1], [1, 2, 3, 1], [1, 1, 2, 3], [3, 1, 1, 2]]> : tensor<4x4xi8>
+    %0 = tensor.splat %c0: tensor<4xi8>
+    %1 = linalg.generic {indexing_maps = [#mapA, #map1A, #map2A], iterator_types = ["parallel", "reduction"]} ins(%valA, %arg0 : tensor<4x4xi8>, tensor<4xi8>) outs(%0 : tensor<4xi8>) {
+    ^bb0(%in: i8, %in_0: i8, %out: i8):
+      %1 = func.call @mul_gf256_2(%in_0, %in) : (i8, i8) -> i8
+      %2 = arith.xori %out, %1 : i8
+      linalg.yield %2 : i8
+    } -> tensor<4xi8>
+    return %1 : tensor<4xi8>
+  }
+
+  func.func @mix_columns(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+    %out = tensor.empty() : tensor<16xi8>
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %mix = affine.for %i = 0 to 4 iter_args(%arg1 = %out) -> (tensor<16xi8>) {
+      %index = arith.muli %i, %c4 : index
+      %index1 = arith.addi %index, %c1 : index
+      %index2 = arith.addi %index1, %c1 : index
+      %index3 = arith.addi %index2, %c1 : index
+      // extract_slice bufferizes to reinterpret_cast
+      %extracted1 = tensor.extract %arg0[%index] : tensor<16xi8>
+      %extracted2 = tensor.extract %arg0[%index1] : tensor<16xi8>
+      %extracted3 = tensor.extract %arg0[%index2] : tensor<16xi8>
+      %extracted4 = tensor.extract %arg0[%index3] : tensor<16xi8>
+      %extracted = tensor.from_elements %extracted1, %extracted2, %extracted3, %extracted4 : tensor<4xi8>
+      %mixed = func.call @mix_single_column(%extracted) : (tensor<4xi8>) -> tensor<4xi8>
+      %emixed = tensor.extract %mixed[%c0] : tensor<4xi8>
+      %emixed1 = tensor.extract %mixed[%c1] : tensor<4xi8>
+      %emixed2 = tensor.extract %mixed[%c2] : tensor<4xi8>
+      %emixed3 = tensor.extract %mixed[%c3] : tensor<4xi8>
+      %inserted = tensor.insert %emixed into %arg1[%index] : tensor<16xi8>
+      %inserted1 = tensor.insert %emixed1 into %inserted[%index1] : tensor<16xi8>
+      %inserted2 = tensor.insert %emixed2 into %inserted1[%index2] : tensor<16xi8>
+      %inserted3 = tensor.insert %emixed3 into %inserted2[%index3] : tensor<16xi8>
+      affine.yield %inserted3 : tensor<16xi8>
+    }
+    return %mix : tensor<16xi8>
+  }
+}

--- a/tests/Examples/common/aes/shift_rows.mlir
+++ b/tests/Examples/common/aes/shift_rows.mlir
@@ -1,0 +1,15 @@
+// Shift rows function, shifting the 4 rows by 0, 1, 2, and 3 steps to the left.
+
+#map = affine_map<(d0) -> (d0)>
+module {
+  func.func @shift_rows(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+    %0 = tensor.empty() : tensor<16xi8>
+    %indices = arith.constant dense<[0, 1, 2, 3, 5, 6, 7, 4, 10, 11, 8, 9, 15, 12, 13, 14]> : tensor<16xindex>
+    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%indices : tensor<16xindex>) outs(%0 : tensor<16xi8>) {
+    ^bb0(%in: index, %out: i8):
+      %extracted = tensor.extract %arg0[%in] : tensor<16xi8>
+      linalg.yield %extracted : i8
+    } -> tensor<16xi8>
+    return %1 : tensor<16xi8>
+  }
+}

--- a/tests/Examples/common/aes/sub_bytes.mlir
+++ b/tests/Examples/common/aes/sub_bytes.mlir
@@ -1,0 +1,223 @@
+// Byte substitution function using Bayer-Poralta boolean method
+
+func.func private @sub_byte(%x: i8 {secret.secret}) -> i8 {
+    %c1 = arith.constant 1 : i8
+
+    %c1_i8 = arith.constant 1 : i8
+    %1 = arith.andi %x, %c1_i8 : i8
+    %x7 = arith.trunci %1 : i8 to i1
+
+    %2 = arith.shrsi %x, %c1 : i8
+    %3 = arith.andi %2, %c1_i8 : i8
+    %x6 = arith.trunci %3 : i8 to i1
+
+    %4 = arith.shrsi %2, %c1 : i8
+    %5 = arith.andi %4, %c1_i8 : i8
+    %x5 = arith.trunci %5 : i8 to i1
+
+    %6 = arith.shrsi %4, %c1 : i8
+    %7 = arith.andi %6, %c1_i8 : i8
+    %x4 = arith.trunci %7 : i8 to i1
+
+    %8 = arith.shrsi %6, %c1 : i8
+    %9 = arith.andi %8, %c1_i8 : i8
+    %x3 = arith.trunci %9 : i8 to i1
+
+    %10 = arith.shrsi %8, %c1 : i8
+    %11 = arith.andi %10, %c1_i8 : i8
+    %x2 = arith.trunci %11 : i8 to i1
+
+    %12 = arith.shrsi %10, %c1 : i8
+    %13 = arith.andi %12, %c1_i8 : i8
+    %x1 = arith.trunci %13 : i8 to i1
+
+    %14 = arith.shrsi %12, %c1 : i8
+    %15 = arith.andi %14, %c1_i8 : i8
+    %x0 = arith.trunci %15 : i8 to i1
+
+    %45 = arith.xori %x3, %x5 : i1
+    %46 = arith.xori %x0, %x6 : i1
+    %47 = arith.xori %x0, %x3 : i1
+    %48 = arith.xori %x0, %x5 : i1
+    %49 = arith.xori %x1, %x2 : i1
+    %51 = arith.xori %49, %x7 : i1
+    %52 = arith.xori %51, %x3 : i1
+    %53 = arith.xori %46, %45 : i1
+    %54 = arith.xori %51, %x0 : i1
+    %55 = arith.xori %51, %x6 : i1
+    %56 = arith.xori %55, %48 : i1
+    %57 = arith.xori %x4, %53 : i1
+    %58 = arith.xori %57, %x5 : i1
+    %59 = arith.xori %57, %x1 : i1
+    %61 = arith.xori %58, %x7 : i1
+    %62 = arith.xori %58, %49 : i1
+    %63 = arith.xori %59, %47 : i1
+    %65 = arith.xori %x7, %63 : i1
+    %66 = arith.xori %62, %63 : i1
+    %67 = arith.xori %62, %48 : i1
+    %68 = arith.xori %49, %63 : i1
+    %69 = arith.xori %46, %68 : i1
+    %70 = arith.xori %x0, %68 : i1
+    %71 = arith.andi %53, %58 : i1
+    %72 = arith.andi %56, %61 : i1
+    %73 = arith.xori %72, %71 : i1
+    %75 = arith.andi %52, %x7 : i1
+    %76 = arith.xori %75, %71 : i1
+    %77 = arith.andi %46, %68 : i1
+    %78 = arith.andi %55, %51 : i1
+    %79 = arith.xori %78, %77 : i1
+    %80 = arith.andi %54, %65 : i1
+    %81 = arith.xori %80, %77 : i1
+    %82 = arith.andi %47, %63 : i1
+    %83 = arith.andi %45, %66 : i1
+    %84 = arith.xori %83, %82 : i1
+    %85 = arith.andi %48, %62 : i1
+    %86 = arith.xori %85, %82 : i1
+    %87 = arith.xori %73, %84 : i1
+    %88 = arith.xori %76, %86 : i1
+    %89 = arith.xori %79, %84 : i1
+    %90 = arith.xori %81, %86 : i1
+    %91 = arith.xori %87, %59 : i1
+    %92 = arith.xori %88, %67 : i1
+    %93 = arith.xori %89, %69 : i1
+    %94 = arith.xori %90, %70 : i1
+    %95 = arith.xori %91, %92 : i1
+    %96 = arith.andi %91, %93 : i1
+    %97 = arith.xori %94, %96 : i1
+    %98 = arith.andi %95, %97 : i1
+    %99 = arith.xori %98, %92 : i1
+    %100 = arith.xori %93, %94 : i1
+    %101 = arith.xori %92, %96 : i1
+    %102 = arith.andi %101, %100 : i1
+    %103 = arith.xori %102, %94 : i1
+    %104 = arith.xori %93, %103 : i1
+    %105 = arith.xori %97, %103 : i1
+    %106 = arith.andi %94, %105 : i1
+    %107 = arith.xori %106, %104 : i1
+    %108 = arith.xori %97, %106 : i1
+    %109 = arith.andi %99, %108 : i1
+    %110 = arith.xori %95, %109 : i1
+    %111 = arith.xori %110, %107 : i1
+    %112 = arith.xori %99, %103 : i1
+    %113 = arith.xori %99, %110 : i1
+    %114 = arith.xori %103, %107 : i1
+    %115 = arith.xori %112, %111 : i1
+    %116 = arith.andi %114, %58 : i1
+    %117 = arith.andi %107, %61 : i1
+    %119 = arith.andi %103, %x7 : i1
+    %120 = arith.andi %113, %68 : i1
+    %121 = arith.andi %110, %51 : i1
+    %122 = arith.andi %99, %65 : i1
+    %123 = arith.andi %112, %63 : i1
+    %124 = arith.andi %115, %66 : i1
+    %125 = arith.andi %111, %62 : i1
+    %126 = arith.andi %114, %53 : i1
+    %127 = arith.andi %107, %56 : i1
+    %128 = arith.andi %103, %52 : i1
+    %129 = arith.andi %113, %46 : i1
+    %130 = arith.andi %110, %55 : i1
+    %131 = arith.andi %99, %54 : i1
+    %132 = arith.andi %112, %47 : i1
+    %133 = arith.andi %115, %45 : i1
+    %134 = arith.andi %111, %48 : i1
+    %135 = arith.xori %132, %133 : i1
+    %136 = arith.xori %127, %128 : i1
+    %137 = arith.xori %122, %130 : i1
+    %138 = arith.xori %126, %127 : i1
+    %139 = arith.xori %119, %129 : i1
+    %140 = arith.xori %119, %122 : i1
+    %141 = arith.xori %124, %125 : i1
+    %142 = arith.xori %116, %120 : i1
+    %143 = arith.xori %123, %124 : i1
+    %144 = arith.xori %133, %134 : i1
+    %145 = arith.xori %129, %137 : i1
+    %146 = arith.xori %139, %142 : i1
+    %147 = arith.xori %121, %135 : i1
+    %148 = arith.xori %120, %143 : i1
+    %149 = arith.xori %135, %146 : i1
+    %150 = arith.xori %131, %146 : i1
+    %151 = arith.xori %141, %147 : i1
+    %152 = arith.xori %138, %147 : i1
+    %153 = arith.xori %121, %148 : i1
+    %154 = arith.xori %150, %151 : i1
+    %155 = arith.xori %117, %152 : i1
+    %156 = arith.xori %148, %152 : i1
+    %157 = arith.constant 1  : i1
+    %158 = arith.xori %157, %151 : i1
+    %159 = arith.xori %145, %158 : i1
+    %160 = arith.constant 1  : i1
+    %161 = arith.xori %160, %149 : i1
+    %162 = arith.xori %137, %161 : i1
+    %163 = arith.xori %153, %154 : i1
+    %164 = arith.xori %142, %155 : i1
+    %165 = arith.xori %140, %155 : i1
+    %166 = arith.xori %136, %154 : i1
+    %167 = arith.constant 1  : i1
+    %168 = arith.xori %167, %164 : i1
+    %169 = arith.xori %153, %168 : i1
+    %170 = arith.constant 1  : i1
+    %171 = arith.xori %170, %163 : i1
+    %172 = arith.xori %144, %171 : i1
+
+    %s0 = arith.extui %156 : i1 to i8
+    %c0_i8 = arith.constant 0 : i8
+    %q = arith.addi %c0_i8, %s0 : i8
+
+    %173 = arith.constant 1 : i8
+    %175 = arith.shli %q, %173 : i8
+    %s1 = arith.extui %169 : i1 to i8
+    %176 = arith.addi %175, %s1 : i8
+    %177 = arith.constant 1 : i8
+    %179 = arith.shli %176, %177 : i8
+    %s2 = arith.extui %172 : i1 to i8
+    %180 = arith.addi %179, %s2 : i8
+    %181 = arith.constant 1 : i8
+    %183 = arith.shli %180, %181 : i8
+    %s3 = arith.extui %164 : i1 to i8
+    %184 = arith.addi %183, %s3 : i8
+    %185 = arith.constant 1 : i8
+    %187 = arith.shli %184, %185 : i8
+    %s4 = arith.extui %165 : i1 to i8
+    %188 = arith.addi %187, %s4 : i8
+    %189 = arith.constant 1 : i8
+    %191 = arith.shli %188, %189 : i8
+    %s5 = arith.extui %166 : i1 to i8
+    %192 = arith.addi %191, %s5 : i8
+    %193 = arith.constant 1 : i8
+    %195 = arith.shli %192, %193 : i8
+    %s6 = arith.extui %159 : i1 to i8
+    %196 = arith.addi %195, %s6 : i8
+    %197 = arith.constant 1 : i8
+    %199 = arith.shli %196, %197 : i8
+    %s7 = arith.extui %162 : i1 to i8
+    %200 = arith.addi %199, %s7 : i8
+    func.return %200 : i8
+}
+
+#map = affine_map<(d0) -> (d0)>
+func.func @sub_bytes(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+  %0 = tensor.empty() : tensor<16xi8>
+  %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : tensor<16xi8>) outs(%0 : tensor<16xi8>) {
+  ^bb0(%in: i8, %out: i8):
+    %extracted = func.call @sub_byte(%in) : (i8) -> i8
+    linalg.yield %extracted : i8
+  } -> tensor<16xi8>
+  return %1 : tensor<16xi8>
+}
+
+// The lookup table implementation is commented below
+
+// #map = affine_map<(d0) -> (d0)>
+// module {
+//   func.func @sub_bytes(%arg0: tensor<16xi8> {secret.secret}) -> tensor<16xi8> {
+//     %cst = arith.constant dense<"0x637C777BF26B6FC53001672BFED7AB76CA82C97DFA5947F0ADD4A2AF9CA472C0B7FD9326363FF7CC34A5E5F171D8311504C723C31896059A071280E2EB27B27509832C1A1B6E5AA0523BD6B329E32F8453D100ED20FCB15B6ACBBE394A4C58CFD0EFAAFB434D338545F9027F503C9FA851A3408F929D38F5BCB6DA2110FFF3D2CD0C13EC5F974417C4A77E3D645D197360814FDC222A908846EEB814DE5E0BDBE0323A0A4906245CC2D3AC629195E479E7C8376D8DD54EA96C56F4EA657AAE08BA78252E1CA6B4C6E8DD741F4BBD8B8A703EB5664803F60E613557B986C11D9EE1F8981169D98E949B1E87E9CE5528DF8CA1890DBFE6426841992D0FB054BB16"> : tensor<256xi8>
+//     %0 = tensor.empty() : tensor<16xi8>
+//     %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : tensor<16xi8>) outs(%0 : tensor<16xi8>) {
+//     ^bb0(%in: i8, %out: i8):
+//       %2 = arith.index_cast %in : i8 to index
+//       %extracted = tensor.extract %cst[%2] : tensor<256xi8>
+//       linalg.yield %extracted : i8
+//     } -> tensor<16xi8>
+//     return %1 : tensor<16xi8>
+//   }
+// }

--- a/tests/Examples/tfhe_rust/BUILD
+++ b/tests/Examples/tfhe_rust/BUILD
@@ -1,4 +1,6 @@
 load("@heir//tests/Examples/tfhe_rust:test.bzl", "tfhe_rs_end_to_end_test")
+load("@heir//tools:heir-tfhe-rs.bzl", "tfhe_rs_lib")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
@@ -64,7 +66,6 @@ tfhe_rs_end_to_end_test(
 
 tfhe_rs_end_to_end_test(
     name = "sbox_test",
-    # Skip in debug mode
     size = "enormous",
     heir_opt_flags = [
         "--mlir-to-cggi",
@@ -93,4 +94,161 @@ tfhe_rs_end_to_end_test(
     mlir_src = "multi_output.mlir",
     tags = ["yosys"],
     test_src = "src/main_multi_output.rs",
+)
+
+tfhe_rs_lib(
+    name = "add_round_key",
+    heir_opt_flags = [
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:add_round_key.mlir",
+    rs_lib_target_name = "add_round_key_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+tfhe_rs_lib(
+    name = "mix_columns",
+    heir_opt_flags = [
+        "--convert-if-to-select",
+        "--full-loop-unroll",
+        "--inline",
+        "--symbol-dce",
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:mix_columns.mlir",
+    rs_lib_target_name = "mix_columns_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+tfhe_rs_lib(
+    name = "inv_mix_columns",
+    heir_opt_flags = [
+        "--convert-if-to-select",
+        "--full-loop-unroll",
+        "--inline",
+        "--symbol-dce",
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:inv_mix_columns.mlir",
+    rs_lib_target_name = "inv_mix_columns_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+tfhe_rs_lib(
+    name = "sub_bytes",
+    heir_opt_flags = [
+        "--inline",
+        "--symbol-dce",
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:sub_bytes.mlir",
+    rs_lib_target_name = "sub_bytes_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+tfhe_rs_lib(
+    name = "inv_sub_bytes",
+    heir_opt_flags = [
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:inv_sub_bytes.mlir",
+    rs_lib_target_name = "inv_sub_bytes_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+tfhe_rs_lib(
+    name = "shift_rows",
+    heir_opt_flags = [
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:shift_rows.mlir",
+    rs_lib_target_name = "shift_rows_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+tfhe_rs_lib(
+    name = "inv_shift_rows",
+    heir_opt_flags = [
+        "--mlir-to-cggi",
+        "--scheme-to-tfhe-rs",
+    ],
+    heir_translate_flags = [
+        "--emit-tfhe-rust",
+        "--use-levels",
+    ],
+    mlir_src = "@heir//tests/Examples/common/aes:inv_shift_rows.mlir",
+    rs_lib_target_name = "inv_shift_rows_rs_lib",
+    tags = [
+        "manual",
+        "yosys",
+    ],
+)
+
+rust_binary(
+    name = "aes",
+    srcs = ["src/main_aes.rs"],
+    tags = [
+        "manual",
+        "yosys",
+    ],
+    deps = [
+        ":add_round_key_rs_lib",
+        ":inv_mix_columns_rs_lib",
+        ":inv_shift_rows_rs_lib",
+        ":inv_sub_bytes_rs_lib",
+        ":mix_columns_rs_lib",
+        ":shift_rows_rs_lib",
+        ":sub_bytes_rs_lib",
+        "@crates//:rayon",
+        "@crates//:serde",
+        "@crates//:tfhe",
+    ],
 )

--- a/tests/Examples/tfhe_rust/src/main_aes.rs
+++ b/tests/Examples/tfhe_rust/src/main_aes.rs
@@ -1,0 +1,124 @@
+#[allow(unused_imports)]
+use std::time::Instant;
+use tfhe::shortint::prelude::*;
+use tfhe::shortint::*;
+
+use add_round_key_rs_lib;
+use mix_columns_rs_lib;
+use shift_rows_rs_lib;
+use sub_bytes_rs_lib;
+use inv_mix_columns_rs_lib;
+use inv_shift_rows_rs_lib;
+use inv_sub_bytes_rs_lib;
+
+type SecretBlock = [[Ciphertext; 8]; 16];
+
+// Encrypt a list of 16 u8s
+pub fn encrypt_u8(value: u8, client_key: &ClientKey) -> [Ciphertext; 8] {
+    core::array::from_fn(|shift| {
+        let bit = (value >> shift) & 1;
+        client_key.encrypt(if bit != 0 { 1 } else { 0 })
+    })
+}
+
+// Decrypt a list of 16 u8s
+pub fn decrypt_u8(ciphertexts: &[Ciphertext; 8], client_key: &ClientKey) -> u8 {
+    let mut accum = 0u8;
+    for (i, ct) in ciphertexts.iter().enumerate() {
+        let bit = client_key.decrypt(ct);
+        accum |= (bit as u8) << i;
+    }
+    accum
+}
+
+pub fn encrypt_block(value: [u8; 16], client_key: &ClientKey) -> [[Ciphertext; 8]; 16] {
+    let c_vec: Vec<[Ciphertext; 8]> =
+        value.into_iter().map(|v| encrypt_u8(v, client_key)).collect();
+    let c_arr: [[Ciphertext; 8]; 16] = c_vec.try_into().expect("Failed to convert to array");
+    c_arr
+}
+
+pub fn decrypt_block(ciphertexts: &[[Ciphertext; 8]; 16], client_key: &ClientKey) -> [u8; 16] {
+    let p_vec: Vec<u8> = ciphertexts.into_iter().map(|ct| decrypt_u8(ct, client_key)).collect();
+    let p_arr: [u8; 16] = p_vec.try_into().expect("Failed to convert to array");
+    p_arr
+}
+
+pub fn aes_encrypt_block(
+    server_key: &ServerKey,
+    block: &SecretBlock,
+    key: &[SecretBlock; 11],
+    n_rounds: usize,
+) -> SecretBlock {
+    let mut block = add_round_key_rs_lib::add_round_key(&server_key, &block, &key[0]);
+    for i in 1..(n_rounds + 1) {
+        block = sub_bytes_rs_lib::sub_bytes(&server_key, &block);
+        block = shift_rows_rs_lib::shift_rows(&block);
+        block = mix_columns_rs_lib::mix_columns(&server_key, &block);
+        block = add_round_key_rs_lib::add_round_key(&server_key, &block, &key[i]);
+    }
+    block = sub_bytes_rs_lib::sub_bytes(&server_key, &block);
+    block = shift_rows_rs_lib::shift_rows(&block);
+    block = mix_columns_rs_lib::mix_columns(&server_key, &block);
+    block = add_round_key_rs_lib::add_round_key(&server_key, &block, &key[n_rounds + 1]);
+    block
+}
+
+pub fn aes_decrypt_block(
+    server_key: &ServerKey,
+    block: &SecretBlock,
+    key: &[SecretBlock; 11],
+    n_rounds: usize,
+) -> SecretBlock {
+    let mut block = add_round_key_rs_lib::add_round_key(&server_key, &block, &key[n_rounds + 1]);
+    block = inv_mix_columns_rs_lib::inv_mix_columns(&server_key, &block);
+    block = inv_shift_rows_rs_lib::inv_shift_rows(&block);
+    block = inv_sub_bytes_rs_lib::inv_sub_bytes(&server_key, &block);
+
+    for i in 1..(n_rounds + 1) {
+        block = add_round_key_rs_lib::add_round_key(&server_key, &block, &key[n_rounds+1-i]);
+        block = inv_mix_columns_rs_lib::inv_mix_columns(&server_key, &block);
+        block = inv_shift_rows_rs_lib::inv_shift_rows(&block);
+        block = inv_sub_bytes_rs_lib::inv_sub_bytes(&server_key, &block);
+    }
+    block = add_round_key_rs_lib::add_round_key(&server_key, &block, &key[0]);
+    block
+}
+
+fn main() {
+    let (client_key, server_key) = gen_keys(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
+
+    let block = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    // expanded key client side
+    let expanded_key = [
+        [15, 21, 113, 201, 71, 217, 232, 89, 12, 183, 173, 214, 175, 127, 103, 152],
+        [220, 144, 55, 176, 155, 73, 223, 233, 151, 254, 114, 63, 56, 129, 21, 167],
+        [210, 201, 107, 183, 73, 128, 180, 94, 222, 126, 198, 97, 230, 255, 211, 198],
+        [192, 175, 223, 57, 137, 47, 107, 103, 87, 81, 173, 6, 177, 174, 126, 192],
+        [44, 92, 101, 241, 165, 115, 14, 150, 242, 34, 163, 144, 67, 140, 221, 80],
+        [88, 157, 54, 235, 253, 238, 56, 125, 15, 204, 155, 237, 76, 64, 70, 189],
+        [113, 199, 76, 194, 140, 41, 116, 191, 131, 229, 239, 82, 207, 165, 169, 239],
+        [55, 20, 147, 72, 187, 61, 231, 247, 56, 216, 8, 165, 247, 125, 161, 74],
+        [72, 38, 69, 32, 243, 27, 162, 215, 203, 195, 170, 114, 60, 190, 11, 56],
+        [253, 13, 66, 203, 14, 22, 224, 28, 197, 213, 74, 110, 249, 107, 65, 86],
+        [180, 142, 243, 82, 186, 152, 19, 78, 127, 77, 89, 32, 134, 38, 24, 118],
+    ];
+
+    let ct_block = encrypt_block(block, &client_key);
+    let ct_vec_expanded_key: Vec<[[Ciphertext; 8]; 16]> =
+        expanded_key.into_iter().map(|v| encrypt_block(v, &client_key)).collect();
+    let ct_expaned_key: [[[Ciphertext; 8]; 16]; 11] =
+        ct_vec_expanded_key.try_into().expect("Failed to convert to array");
+
+    println!("input: {:?}", block);
+    let mut t = Instant::now();
+    let aes_encrypted = aes_encrypt_block(&server_key, &ct_block, &ct_expaned_key, 9);
+    let mut run = t.elapsed().as_millis();
+    println!("{:?} aes encryption time", run);
+    t = Instant::now();
+    let aes_decrypted = aes_decrypt_block(&server_key, &aes_encrypted, &ct_expaned_key, 9);
+     run = t.elapsed().as_millis();
+    println!("{:?} aes decryption time", run);
+    let output = decrypt_block(&aes_decrypted, &client_key);
+    println!("output: {:?}", output);
+}


### PR DESCRIPTION
Run
```
bazel run -c opt tests/Examples/tfhe_rust:aes
```

The sbox takes quite a bit of time, so I'll update that, but at least it's working?

Depends on #1743