### PR TITLE
Add rlwe plain ops

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -343,12 +343,11 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.6.3/MODULE.bazel": "e90505b7a931d194245ffcfb6ff4ca8ef9d46b4e830d12e64817752e0198e2ed",
+    "https://bcr.bazel.build/modules/rules_java/8.6.3/source.json": "8330cc5d277085bbcf93e9f1c85c24d06975585606a1215df4faf886a8d3cc9e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -446,6 +445,24 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@apple_rules_lint+//lint:extensions.bzl%linter": {
+      "general": {
+        "bzlTransitiveDigest": "g7izj5kLCmsajh8IospHh4ZQ35dyM0FIrA8D4HapAsM=",
+        "usagesDigest": "CZ3zTNUXS/3G0ZyuPiHDOU3Fqzwk8N59OOLNI26OIuo=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "apple_linters": {
+            "repoRuleId": "@@apple_rules_lint+//lint/private:register_linters.bzl%register_linters",
+            "attributes": {
+              "linters": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "gv4nokEMGNye4Jvoh7Tw0Lzs63zfklj+n4t0UegI7Ms=",
@@ -769,6 +786,680 @@
         ]
       }
     },
+    "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
+      "general": {
+        "bzlTransitiveDigest": "YFxExAsY9FQhfx6FXmH7g9n/R01JoBUW4iqddCl4TfI=",
+        "usagesDigest": "fgIozj3Siw6cYs9usn8up+ymSZ1+1zcwDhiSi/omptE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pnpm": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "root_package": "",
+              "link_workspace": "",
+              "link_packages": {},
+              "integrity": "sha512-vRIWpD/L4phf9Bk2o/O2TDR8fFoJnpYrp2TKqTIZF/qZ2/rgL3qKXzHofHgbXsinwMoSEigz28sqk3pQ+yMEQQ==",
+              "url": "",
+              "commit": "",
+              "patch_args": [
+                "-p0"
+              ],
+              "patches": [],
+              "custom_postinstall": "",
+              "npm_auth": "",
+              "npm_auth_basic": "",
+              "npm_auth_username": "",
+              "npm_auth_password": "",
+              "lifecycle_hooks": [],
+              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
+              "generate_bzl_library_targets": false
+            }
+          },
+          "pnpm__links": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "dev": false,
+              "root_package": "",
+              "link_packages": {},
+              "deps": {},
+              "transitive_closure": {},
+              "lifecycle_build_target": false,
+              "lifecycle_hooks_env": [],
+              "lifecycle_hooks_execution_requirements": [
+                "no-sandbox"
+              ],
+              "lifecycle_hooks_use_default_shell_env": false,
+              "bins": {},
+              "npm_translate_lock_repo": "",
+              "package_visibility": [
+                "//visibility:public"
+              ],
+              "replace_package": ""
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "aspect_rules_js+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@contrib_rules_jvm+//java/private:non-module-deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "m/awS0g0w6eMs1NqzGjszZGJvZl3XsuICpEzKd0IMLM=",
+        "usagesDigest": "Evyr4GdQeRRjnrytKQZtjuwFw0XcPAX4HzeieHhcdU0=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "io_grpc_grpc_java": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "17dd91014032a147c978ae99582fddd950f5444388eae700cf51eda0326ad2f9",
+              "strip_prefix": "grpc-java-1.56.1",
+              "urls": [
+                "https://github.com/grpc/grpc-java/archive/v1.56.1.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "contrib_rules_jvm+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@grpc+//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "mcyDA0lHK6hTy6PlDFj4+lGpuyTkf7ePBPrlwF8+udM=",
+        "usagesDigest": "xS2qe/7xYEc+234OodvQ7dM5a+N5+D8ta5tLS29jwto=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "boringssl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f150aa2d73017fe8576a8a335f29030488d851c94368a79ac56142d107bf9e9a",
+              "strip_prefix": "boringssl-e46383fc18d08def901b2ed5a194295693e905c7",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/e46383fc18d08def901b2ed5a194295693e905c7.tar.gz",
+                "https://github.com/google/boringssl/archive/e46383fc18d08def901b2ed5a194295693e905c7.tar.gz"
+              ]
+            }
+          },
+          "zlib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@grpc+//third_party:zlib.BUILD",
+              "sha256": "90f43a9c998740e8a0db24b0af0147033db2aaaa99423129abbd76640757cac9",
+              "strip_prefix": "zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/madler/zlib/archive/04f42ceca40f73e2978b50e93806c2a18c1281fc.tar.gz",
+                "https://github.com/madler/zlib/archive/04f42ceca40f73e2978b50e93806c2a18c1281fc.tar.gz"
+              ]
+            }
+          },
+          "com_google_googletest": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c8de6c60e12ad014a28225c5247ee735861d85cf906df617f6a29954ca05f547",
+              "strip_prefix": "googletest-0e402173c97aea7a00749e825b194bfede4f2e45",
+              "urls": [
+                "https://github.com/google/googletest/archive/0e402173c97aea7a00749e825b194bfede4f2e45.tar.gz"
+              ]
+            }
+          },
+          "com_google_fuzztest": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cdf8d8cd3cdc77280a7c59b310edf234e489a96b6e727cb271e7dfbeb9bcca8d",
+              "strip_prefix": "fuzztest-4ecaeb5084a061a862af8f86789ee184cd3d3f18",
+              "urls": [
+                "https://github.com/google/fuzztest/archive/4ecaeb5084a061a862af8f86789ee184cd3d3f18.tar.gz"
+              ]
+            }
+          },
+          "rules_cc": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3d9e271e2876ba42e114c9b9bc51454e379cbf0ec9ef9d40e2ae4cec61a31b40",
+              "strip_prefix": "rules_cc-0.0.6",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz",
+                "https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"
+              ]
+            }
+          },
+          "com_github_google_benchmark": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a43368d3ec48afe784573cf962fe98c084e89a1e3d176c00715a84366316e7d",
+              "strip_prefix": "benchmark-361e8d1cfe0c6c36d30b39f1b61302ece5507320",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/361e8d1cfe0c6c36d30b39f1b61302ece5507320.tar.gz",
+                "https://github.com/google/benchmark/archive/361e8d1cfe0c6c36d30b39f1b61302ece5507320.tar.gz"
+              ]
+            }
+          },
+          "com_googlesource_code_re2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9",
+              "strip_prefix": "re2-2022-04-01",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/re2/archive/2022-04-01.tar.gz",
+                "https://github.com/google/re2/archive/2022-04-01.tar.gz"
+              ]
+            }
+          },
+          "com_github_cares_cares": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@grpc+//third_party:cares/cares.BUILD",
+              "sha256": "bf26e5b25e259911914a85ae847b6d723488adb5af4f8bdeb9d0871a318476e3",
+              "strip_prefix": "c-ares-6360e96b5cf8e5980c887ce58ef727e53d77243a",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/c-ares/c-ares/archive/6360e96b5cf8e5980c887ce58ef727e53d77243a.tar.gz",
+                "https://github.com/c-ares/c-ares/archive/6360e96b5cf8e5980c887ce58ef727e53d77243a.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5366d7e7fa7ba0d915014d387b66d0d002c03236448e1ba9ef98122c13b35c36",
+              "strip_prefix": "abseil-cpp-20230125.3",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz",
+                "https://github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz"
+              ]
+            }
+          },
+          "bazel_toolchains": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
+              "strip_prefix": "bazel-toolchains-4.1.0",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz"
+              ]
+            }
+          },
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz"
+              ],
+              "sha256": "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44"
+            }
+          },
+          "bazel_compdb": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bcecfd622c4ef272fd4ba42726a52e140b961c4eac23025f18b346c968a8cfb4",
+              "strip_prefix": "bazel-compilation-database-0.4.5",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz",
+                "https://github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz"
+              ]
+            }
+          },
+          "io_opencensus_cpp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "46b3b5812c150a21bacf860c2f76fc42b89773ed77ee954c32adeb8593aa2a8e",
+              "strip_prefix": "opencensus-cpp-5501a1a255805e0be83a41348bb5f2630d5ed6b3",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-cpp/archive/5501a1a255805e0be83a41348bb5f2630d5ed6b3.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-cpp/archive/5501a1a255805e0be83a41348bb5f2630d5ed6b3.tar.gz"
+              ]
+            }
+          },
+          "upb": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7d19f2ac9c1e508a86a272913d9aa67c8147827f949035828910bb05d9f2cf03",
+              "strip_prefix": "upb-61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98.tar.gz",
+                "https://github.com/protocolbuffers/upb/archive/61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98.tar.gz"
+              ]
+            }
+          },
+          "envoy_api": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3c7372b5cb33e5e5cc3afd82573fc6275f9a2cac8b1530e1af14f52f34047328",
+              "strip_prefix": "data-plane-api-68d4315167352ffac71f149a43b8088397d3f33d",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/68d4315167352ffac71f149a43b8088397d3f33d.tar.gz",
+                "https://github.com/envoyproxy/data-plane-api/archive/68d4315167352ffac71f149a43b8088397d3f33d.tar.gz"
+              ]
+            }
+          },
+          "build_bazel_rules_apple": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/releases/download/1.1.3/rules_apple.1.1.3.tar.gz",
+                "https://github.com/bazelbuild/rules_apple/releases/download/1.1.3/rules_apple.1.1.3.tar.gz"
+              ]
+            }
+          },
+          "build_bazel_apple_support": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f4fdf5c9b42b92ea12f229b265d74bb8cedb8208ca7a445b383c9f866cf53392",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz",
+                "https://github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz"
+              ]
+            }
+          },
+          "com_github_libuv_libuv": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@grpc+//third_party:libuv.BUILD",
+              "sha256": "5ca4e9091f3231d8ad8801862dc4e851c23af89c69141d27723157776f7291e7",
+              "strip_prefix": "libuv-02a9e1be252b623ee032a3137c0b0c94afbe6809",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/libuv/libuv/archive/02a9e1be252b623ee032a3137c0b0c94afbe6809.tar.gz",
+                "https://github.com/libuv/libuv/archive/02a9e1be252b623ee032a3137c0b0c94afbe6809.tar.gz"
+              ]
+            }
+          },
+          "com_google_googleapis": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5bb6b0253ccf64b53d6c7249625a7e3f6c3bc6402abd52d3778bfa48258703a0",
+              "strip_prefix": "googleapis-2f9af297c84c55c8b871ba4495e01ade42476c92",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/googleapis/archive/2f9af297c84c55c8b871ba4495e01ade42476c92.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/2f9af297c84c55c8b871ba4495e01ade42476c92.tar.gz"
+              ]
+            }
+          },
+          "bazel_gazelle": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz"
+              ]
+            }
+          },
+          "opencensus_proto": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b7e13f0b4259e80c3070b583c2f39e53153085a6918718b1c710caf7037572b0",
+              "strip_prefix": "opencensus-proto-0.3.0/src",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
+              ],
+              "patches": [
+                "@@grpc+//third_party:opencensus-proto.patch"
+              ],
+              "patch_args": [
+                "-p2"
+              ]
+            }
+          },
+          "com_envoyproxy_protoc_gen_validate": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "strip_prefix": "protoc-gen-validate-4694024279bdac52b77e22dc87808bd0fd732b69",
+              "sha256": "1e490b98005664d149b379a9529a6aa05932b8a11b76b4cd86f3d22d76346f47",
+              "urls": [
+                "https://github.com/envoyproxy/protoc-gen-validate/archive/4694024279bdac52b77e22dc87808bd0fd732b69.tar.gz"
+              ],
+              "patches": [
+                "@@grpc+//third_party:protoc-gen-validate.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_cncf_udpa": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0d33b83f8c6368954e72e7785539f0d272a8aba2f6e2e336ed15fd1514bc9899",
+              "strip_prefix": "xds-e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz",
+                "https://github.com/cncf/xds/archive/e9ce68804cb4e64cab5a52e3c8baf840d4ff87b7.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc+",
+            "com_github_grpc_grpc",
+            "grpc+"
+          ]
+        ]
+      }
+    },
+    "@@grpc+//bazel:grpc_extra_deps.bzl%grpc_extra_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "/+C6QXSv3IU2SL5ruvghMnAV7C+FQPW778aEyGIMaO0=",
+        "usagesDigest": "BY9iaBuI51W+iyhY4Nmom6cjK/1zFFYXkN9SiDcmjzg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "repoRuleId": "@@grpc++grpc_repo_deps_ext+com_google_googleapis//:repository_rules.bzl%switched_rules",
+            "attributes": {
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "@com_github_grpc_grpc//bazel:python_rules.bzl",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "@com_github_grpc_grpc//bazel:python_rules.bzl",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "native.cc_proto_library",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "@com_github_grpc_grpc//bazel:cc_grpc_library.bzl",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc+",
+            "com_envoyproxy_protoc_gen_validate",
+            "grpc++grpc_repo_deps_ext+com_envoyproxy_protoc_gen_validate"
+          ],
+          [
+            "grpc+",
+            "com_google_googleapis",
+            "grpc++grpc_repo_deps_ext+com_google_googleapis"
+          ],
+          [
+            "grpc+",
+            "com_google_protobuf",
+            "protobuf+"
+          ],
+          [
+            "grpc+",
+            "envoy_api",
+            "grpc++grpc_repo_deps_ext+envoy_api"
+          ],
+          [
+            "grpc+",
+            "io_bazel_rules_go",
+            "rules_go+"
+          ],
+          [
+            "grpc+",
+            "upb",
+            "upb+"
+          ],
+          [
+            "grpc++grpc_repo_deps_ext+bazel_gazelle",
+            "bazel_gazelle",
+            "grpc++grpc_repo_deps_ext+bazel_gazelle"
+          ],
+          [
+            "grpc++grpc_repo_deps_ext+bazel_gazelle",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc++grpc_repo_deps_ext+com_envoyproxy_protoc_gen_validate",
+            "bazel_gazelle",
+            "grpc++grpc_repo_deps_ext+bazel_gazelle"
+          ],
+          [
+            "grpc++grpc_repo_deps_ext+envoy_api",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc++grpc_repo_deps_ext+envoy_api",
+            "envoy_api",
+            "grpc++grpc_repo_deps_ext+envoy_api"
+          ],
+          [
+            "protobuf+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_go+",
+            "io_bazel_rules_go",
+            "rules_go+"
+          ],
+          [
+            "upb+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@grpc+//bazel:grpc_python_deps.bzl%grpc_python_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "zyerALv7EQtUAEtYpLO8j74Z4NT5zcDzwkMjTFUxM6M=",
+        "usagesDigest": "DFOlU21+OzU+IhRpTR0jJu6qlQs6nFR7xn7mnx2oxW8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cython": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@grpc+//third_party:cython.BUILD",
+              "sha256": "a2da56cc22be823acf49741b9aa3aa116d4f07fa8e8b35a3cb08b8447b37c607",
+              "strip_prefix": "cython-0.29.35",
+              "urls": [
+                "https://github.com/cython/cython/archive/0.29.35.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "grpc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "grpc+",
+            "com_github_grpc_grpc",
+            "grpc+"
+          ]
+        ]
+      }
+    },
     "@@hedron_compile_commands+//:workspace_setup.bzl%hedron_compile_commands_extension": {
       "general": {
         "bzlTransitiveDigest": "7Ey+orEPG9KH85wB77is9jsTlAqjXehBmrGP1vKxaCk=",
@@ -821,11 +1512,9 @@
     },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "yA4GkX1zdUTOXU4qKsh/YkjZKHAWkG8Fd7adNeGwiRc=",
-        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
-        "recordedFileInputs": {
-          "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
-        },
+        "bzlTransitiveDigest": "wXImnqOfGKOqkiPwQBuez+TGQdj1tuLQU6OYcfhB97I=",
+        "usagesDigest": "tVQNvLoXMWAbiK39am3yovKGpwINdftfn7RpDyN+JZc=",
+        "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -833,10 +1522,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
-              "strip_prefix": "pybind11-2.12.0",
-              "urls": [
-                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
-              ]
+              "strip_prefix": "pybind11-2.13.6",
+              "url": "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz",
+              "integrity": "sha256-4Iy4f0dz2pf6e18DXeh2OrxlbYfVdz5i9toFh9Hw7CA="
             }
           }
         },
@@ -845,6 +1533,88 @@
             "pybind11_bazel+",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "hZCvQv44IOPVXQfP7WieqV08zTAfJeFLMBfdAKDgQ3o=",
+        "usagesDigest": "psOpdgXeuVhvtx8Ak4S+6SwKh72K97zlAfY+3cRDSr0=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_provisioning_profiles": {
+            "repoRuleId": "@@rules_apple+//apple/internal:local_provisioning_profiles.bzl%provisioning_profile_repository",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_apple+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_apple+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_apple+",
+            "build_bazel_apple_support",
+            "apple_support+"
+          ],
+          [
+            "rules_apple+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_swift+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_swift+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_apple_support",
+            "apple_support+"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift_local_config",
+            "rules_swift++non_module_deps+build_bazel_rules_swift_local_config"
           ]
         ]
       }
@@ -1404,6 +2174,28 @@
         ]
       }
     },
+    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "9SPkp75wN6dP9sKiOgU1uOCTNNA08v8PVBMYs+SZ27s=",
+        "usagesDigest": "ZsMvJZXTm/u0lYuq0P/yTF2h6FdynULVT3mwKA1SE5k=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
@@ -1592,8 +2384,8 @@
     },
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "pBYZfL5VYF4BT5jARY3p7l3d7Uknixz0stBBKWj2iaw=",
-        "usagesDigest": "fJqnUFr/GgZxd/VmNa3e4q3P8xv3wi51f6kXAa9+tsg=",
+        "bzlTransitiveDigest": "vKDNEc7MJLQpnsEBRqgLsrNo+zskN5XVJzAg1j5LtPs=",
+        "usagesDigest": "biag8XSu0P17XXjbARhiolCWispwUXMzVI6y3BjkYxQ=",
         "recordedFileInputs": {
           "@@//requirements-dev.txt": "26da3dcbf88e8d5600d4bbedf32ac5d38e6992ba510cb49d693891310b5d473c",
           "@@//requirements.txt": "7efa66b1fcb36e4aac632075969146e3f087ec5049cd926b84ffdabaa58b8c49",
@@ -12734,9 +13526,121 @@
         ]
       }
     },
+    "@@rules_rust+//crate_universe/private/module_extensions:cargo_bazel_bootstrap.bzl%cargo_bazel_bootstrap": {
+      "general": {
+        "bzlTransitiveDigest": "g3ZbUc2bn8NsmghGwoxg+hYMFq+jqGrAG6i5FNKW7ug=",
+        "usagesDigest": "xq2oYPqCUFn7Kh1i+nAW1fxF9FfdrgC5ntyrMn367Qc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cargo_bazel_bootstrap": {
+            "repoRuleId": "@@rules_rust+//cargo/private:cargo_bootstrap.bzl%cargo_bootstrap_repository",
+            "attributes": {
+              "srcs": [
+                "@@rules_rust+//crate_universe:src/api.rs",
+                "@@rules_rust+//crate_universe:src/api/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/cli.rs",
+                "@@rules_rust+//crate_universe:src/cli/generate.rs",
+                "@@rules_rust+//crate_universe:src/cli/query.rs",
+                "@@rules_rust+//crate_universe:src/cli/splice.rs",
+                "@@rules_rust+//crate_universe:src/cli/vendor.rs",
+                "@@rules_rust+//crate_universe:src/config.rs",
+                "@@rules_rust+//crate_universe:src/context.rs",
+                "@@rules_rust+//crate_universe:src/context/crate_context.rs",
+                "@@rules_rust+//crate_universe:src/context/platforms.rs",
+                "@@rules_rust+//crate_universe:src/lib.rs",
+                "@@rules_rust+//crate_universe:src/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/main.rs",
+                "@@rules_rust+//crate_universe:src/metadata.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_bin.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_resolver.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
+                "@@rules_rust+//crate_universe:src/metadata/dependency.rs",
+                "@@rules_rust+//crate_universe:src/metadata/metadata_annotation.rs",
+                "@@rules_rust+//crate_universe:src/rendering.rs",
+                "@@rules_rust+//crate_universe:src/rendering/template_engine.rs",
+                "@@rules_rust+//crate_universe:src/rendering/templates/module_bzl.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/header.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/vendor_module.j2",
+                "@@rules_rust+//crate_universe:src/rendering/verbatim/alias_rules.bzl",
+                "@@rules_rust+//crate_universe:src/select.rs",
+                "@@rules_rust+//crate_universe:src/splicing.rs",
+                "@@rules_rust+//crate_universe:src/splicing/cargo_config.rs",
+                "@@rules_rust+//crate_universe:src/splicing/crate_index_lookup.rs",
+                "@@rules_rust+//crate_universe:src/splicing/splicer.rs",
+                "@@rules_rust+//crate_universe:src/test.rs",
+                "@@rules_rust+//crate_universe:src/utils.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/glob.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/label.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_dict.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_list.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_scalar.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_set.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/serialize.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/target_compatible_with.rs",
+                "@@rules_rust+//crate_universe:src/utils/symlink.rs",
+                "@@rules_rust+//crate_universe:src/utils/target_triple.rs"
+              ],
+              "binary": "cargo-bazel",
+              "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
+              "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
+              "version": "1.81.0",
+              "timeout": 900,
+              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
+              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ]
+        ]
+      }
+    },
     "@@rules_rust+//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "0XHSLimPR0yIi1HIZgsMrr67WhwiJ9YwNk9n4/D118s=",
+        "bzlTransitiveDigest": "u0AbcREuyXinWoLmuEjo7UWBx+Y+ROXvSITNXzSqOvo=",
         "usagesDigest": "ozx08ZbgRXTJw0zCaO/xtMUzgGLvwaQkZGnUo6tlyHM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -15714,6 +16618,10144 @@
         ]
       }
     },
+    "@@rules_rust+//rust/private:extensions.bzl%i": {
+      "general": {
+        "bzlTransitiveDigest": "zl7dpoEco7tLqgsAG1yxbjmScAvK1vZIsDBzlRbEe8s=",
+        "usagesDigest": "cmoHByGEUkrUYi29nYHIHIq+fe1551lnSFI6CaNLugY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_rust_tinyjson": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a",
+              "url": "https://static.crates.io/crates/tinyjson/tinyjson-2.5.1.crate",
+              "strip_prefix": "tinyjson-2.5.1",
+              "type": "tar.gz",
+              "build_file": "@@rules_rust+//util/process_wrapper:BUILD.tinyjson.bazel"
+            }
+          },
+          "cui": {
+            "repoRuleId": "@@rules_rust+//crate_universe/private:crates_vendor.bzl%crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust+//crate_universe/3rdparty/crates:defs.bzl"
+            }
+          },
+          "cui__adler-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "cui__aho-corasick-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "cui__android-tzdata-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
+              ],
+              "strip_prefix": "android-tzdata-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
+            }
+          },
+          "cui__android_system_properties-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
+              ],
+              "strip_prefix": "android_system_properties-0.1.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
+            }
+          },
+          "cui__anstream-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.3.2/download"
+              ],
+              "strip_prefix": "anstream-0.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
+            }
+          },
+          "cui__anstyle-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "cui__anstyle-parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "cui__anstyle-query-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
+              ],
+              "strip_prefix": "anstyle-query-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+            }
+          },
+          "cui__anstyle-wincon-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "cui__anyhow-1.0.75": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.75/download"
+              ],
+              "strip_prefix": "anyhow-1.0.75",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anyhow-1.0.75.bazel"
+            }
+          },
+          "cui__arc-swap-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/arc-swap/1.6.0/download"
+              ],
+              "strip_prefix": "arc-swap-1.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.arc-swap-1.6.0.bazel"
+            }
+          },
+          "cui__arrayvec-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/arrayvec/0.7.4/download"
+              ],
+              "strip_prefix": "arrayvec-0.7.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.arrayvec-0.7.4.bazel"
+            }
+          },
+          "cui__autocfg-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "cui__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "cui__bitflags-2.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.4.1/download"
+              ],
+              "strip_prefix": "bitflags-2.4.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
+            }
+          },
+          "cui__block-buffer-0.10.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/block-buffer/0.10.4/download"
+              ],
+              "strip_prefix": "block-buffer-0.10.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.block-buffer-0.10.4.bazel"
+            }
+          },
+          "cui__bstr-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/1.6.0/download"
+              ],
+              "strip_prefix": "bstr-1.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bstr-1.6.0.bazel"
+            }
+          },
+          "cui__btoi-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/btoi/0.4.3/download"
+              ],
+              "strip_prefix": "btoi-0.4.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.btoi-0.4.3.bazel"
+            }
+          },
+          "cui__bumpalo-3.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+              ],
+              "strip_prefix": "bumpalo-3.13.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+            }
+          },
+          "cui__byteyarn-0.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7534301c0ea17abb4db06d75efc7b4b0fa360fce8e175a4330d721c71c942ff",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteyarn/0.2.3/download"
+              ],
+              "strip_prefix": "byteyarn-0.2.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.byteyarn-0.2.3.bazel"
+            }
+          },
+          "cui__camino-1.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/camino/1.1.6/download"
+              ],
+              "strip_prefix": "camino-1.1.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.camino-1.1.6.bazel"
+            }
+          },
+          "cui__cargo-lock-9.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-lock/9.0.0/download"
+              ],
+              "strip_prefix": "cargo-lock-9.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo-lock-9.0.0.bazel"
+            }
+          },
+          "cui__cargo-platform-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-platform/0.1.4/download"
+              ],
+              "strip_prefix": "cargo-platform-0.1.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo-platform-0.1.4.bazel"
+            }
+          },
+          "cui__cargo_metadata-0.18.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_metadata/0.18.1/download"
+              ],
+              "strip_prefix": "cargo_metadata-0.18.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo_metadata-0.18.1.bazel"
+            }
+          },
+          "cui__cargo_toml-0.19.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_toml/0.19.2/download"
+              ],
+              "strip_prefix": "cargo_toml-0.19.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo_toml-0.19.2.bazel"
+            }
+          },
+          "cui__cc-1.0.79": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.79/download"
+              ],
+              "strip_prefix": "cc-1.0.79",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cc-1.0.79.bazel"
+            }
+          },
+          "cui__cfg-expr-0.15.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-expr/0.15.5/download"
+              ],
+              "strip_prefix": "cfg-expr-0.15.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.15.5.bazel"
+            }
+          },
+          "cui__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "cui__chrono-0.4.26": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono/0.4.26/download"
+              ],
+              "strip_prefix": "chrono-0.4.26",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
+            }
+          },
+          "cui__chrono-tz-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono-tz/0.8.4/download"
+              ],
+              "strip_prefix": "chrono-tz-0.8.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.chrono-tz-0.8.4.bazel"
+            }
+          },
+          "cui__chrono-tz-build-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono-tz-build/0.2.1/download"
+              ],
+              "strip_prefix": "chrono-tz-build-0.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.chrono-tz-build-0.2.1.bazel"
+            }
+          },
+          "cui__clap-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.3.11/download"
+              ],
+              "strip_prefix": "clap-4.3.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap-4.3.11.bazel"
+            }
+          },
+          "cui__clap_builder-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
+              ],
+              "strip_prefix": "clap_builder-4.3.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
+            }
+          },
+          "cui__clap_derive-4.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+              ],
+              "strip_prefix": "clap_derive-4.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+            }
+          },
+          "cui__clap_lex-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "cui__clru-0.6.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clru/0.6.1/download"
+              ],
+              "strip_prefix": "clru-0.6.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clru-0.6.1.bazel"
+            }
+          },
+          "cui__colorchoice-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "cui__core-foundation-sys-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
+              ],
+              "strip_prefix": "core-foundation-sys-0.8.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
+            }
+          },
+          "cui__cpufeatures-0.2.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cpufeatures/0.2.9/download"
+              ],
+              "strip_prefix": "cpufeatures-0.2.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cpufeatures-0.2.9.bazel"
+            }
+          },
+          "cui__crates-index-2.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "33bc10579ea08741ae173928194b6c42c90b295d51ddd0d18238eaf15502ac87",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crates-index/2.2.0/download"
+              ],
+              "strip_prefix": "crates-index-2.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crates-index-2.2.0.bazel"
+            }
+          },
+          "cui__crc32fast-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
+          "cui__crossbeam-0.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam/0.8.2/download"
+              ],
+              "strip_prefix": "crossbeam-0.8.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-0.8.2.bazel"
+            }
+          },
+          "cui__crossbeam-channel-0.5.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
+            }
+          },
+          "cui__crossbeam-deque-0.8.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.8.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
+            }
+          },
+          "cui__crossbeam-epoch-0.9.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.9.15",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
+            }
+          },
+          "cui__crossbeam-queue-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-queue/0.3.8/download"
+              ],
+              "strip_prefix": "crossbeam-queue-0.3.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-queue-0.3.8.bazel"
+            }
+          },
+          "cui__crossbeam-utils-0.8.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "cui__crypto-common-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crypto-common/0.1.6/download"
+              ],
+              "strip_prefix": "crypto-common-0.1.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crypto-common-0.1.6.bazel"
+            }
+          },
+          "cui__deranged-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/deranged/0.3.9/download"
+              ],
+              "strip_prefix": "deranged-0.3.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.deranged-0.3.9.bazel"
+            }
+          },
+          "cui__deunicode-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/deunicode/0.4.3/download"
+              ],
+              "strip_prefix": "deunicode-0.4.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.deunicode-0.4.3.bazel"
+            }
+          },
+          "cui__digest-0.10.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/digest/0.10.7/download"
+              ],
+              "strip_prefix": "digest-0.10.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.digest-0.10.7.bazel"
+            }
+          },
+          "cui__dunce-1.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/dunce/1.0.4/download"
+              ],
+              "strip_prefix": "dunce-1.0.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.dunce-1.0.4.bazel"
+            }
+          },
+          "cui__either-1.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.9.0/download"
+              ],
+              "strip_prefix": "either-1.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.either-1.9.0.bazel"
+            }
+          },
+          "cui__encoding_rs-0.8.33": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/encoding_rs/0.8.33/download"
+              ],
+              "strip_prefix": "encoding_rs-0.8.33",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.encoding_rs-0.8.33.bazel"
+            }
+          },
+          "cui__equivalent-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "cui__errno-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "cui__errno-dragonfly-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "cui__faster-hex-0.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/faster-hex/0.8.1/download"
+              ],
+              "strip_prefix": "faster-hex-0.8.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.faster-hex-0.8.1.bazel"
+            }
+          },
+          "cui__fastrand-2.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.0.1/download"
+              ],
+              "strip_prefix": "fastrand-2.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.fastrand-2.0.1.bazel"
+            }
+          },
+          "cui__filetime-0.2.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.22/download"
+              ],
+              "strip_prefix": "filetime-0.2.22",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.filetime-0.2.22.bazel"
+            }
+          },
+          "cui__flate2-1.0.28": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/flate2/1.0.28/download"
+              ],
+              "strip_prefix": "flate2-1.0.28",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "cui__fnv-1.0.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "cui__form_urlencoded-1.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.1/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.form_urlencoded-1.2.1.bazel"
+            }
+          },
+          "cui__fuchsia-cprng-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-cprng/0.1.1/download"
+              ],
+              "strip_prefix": "fuchsia-cprng-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.fuchsia-cprng-0.1.1.bazel"
+            }
+          },
+          "cui__generic-array-0.14.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/generic-array/0.14.7/download"
+              ],
+              "strip_prefix": "generic-array-0.14.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.generic-array-0.14.7.bazel"
+            }
+          },
+          "cui__getrandom-0.2.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
+              ],
+              "strip_prefix": "getrandom-0.2.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+            }
+          },
+          "cui__gix-0.54.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix/0.54.1/download"
+              ],
+              "strip_prefix": "gix-0.54.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-0.54.1.bazel"
+            }
+          },
+          "cui__gix-actor-0.27.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "08c60e982c5290897122d4e2622447f014a2dadd5a18cb73d50bb91b31645e27",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-actor/0.27.0/download"
+              ],
+              "strip_prefix": "gix-actor-0.27.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-actor-0.27.0.bazel"
+            }
+          },
+          "cui__gix-attributes-0.19.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-attributes/0.19.0/download"
+              ],
+              "strip_prefix": "gix-attributes-0.19.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-attributes-0.19.0.bazel"
+            }
+          },
+          "cui__gix-bitmap-0.2.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-bitmap/0.2.7/download"
+              ],
+              "strip_prefix": "gix-bitmap-0.2.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-bitmap-0.2.7.bazel"
+            }
+          },
+          "cui__gix-chunk-0.4.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-chunk/0.4.4/download"
+              ],
+              "strip_prefix": "gix-chunk-0.4.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-chunk-0.4.4.bazel"
+            }
+          },
+          "cui__gix-command-0.2.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3c576cfbf577f72c097b5f88aedea502cd62952bdc1fb3adcab4531d5525a4c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-command/0.2.10/download"
+              ],
+              "strip_prefix": "gix-command-0.2.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-command-0.2.10.bazel"
+            }
+          },
+          "cui__gix-commitgraph-0.21.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-commitgraph/0.21.0/download"
+              ],
+              "strip_prefix": "gix-commitgraph-0.21.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-commitgraph-0.21.0.bazel"
+            }
+          },
+          "cui__gix-config-0.30.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config/0.30.0/download"
+              ],
+              "strip_prefix": "gix-config-0.30.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-config-0.30.0.bazel"
+            }
+          },
+          "cui__gix-config-value-0.14.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config-value/0.14.0/download"
+              ],
+              "strip_prefix": "gix-config-value-0.14.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-config-value-0.14.0.bazel"
+            }
+          },
+          "cui__gix-credentials-0.20.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "46900b884cc5af6a6c141ee741607c0c651a4e1d33614b8d888a1ba81cc0bc8a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-credentials/0.20.0/download"
+              ],
+              "strip_prefix": "gix-credentials-0.20.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-credentials-0.20.0.bazel"
+            }
+          },
+          "cui__gix-date-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-date/0.8.0/download"
+              ],
+              "strip_prefix": "gix-date-0.8.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-date-0.8.0.bazel"
+            }
+          },
+          "cui__gix-diff-0.36.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-diff/0.36.0/download"
+              ],
+              "strip_prefix": "gix-diff-0.36.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-diff-0.36.0.bazel"
+            }
+          },
+          "cui__gix-discover-0.25.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "69507643d75a0ea9a402fcf73ced517d2b95cc95385904ac09d03e0b952fde33",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-discover/0.25.0/download"
+              ],
+              "strip_prefix": "gix-discover-0.25.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-discover-0.25.0.bazel"
+            }
+          },
+          "cui__gix-features-0.35.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-features/0.35.0/download"
+              ],
+              "strip_prefix": "gix-features-0.35.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-features-0.35.0.bazel"
+            }
+          },
+          "cui__gix-filter-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1be40d28cd41445bb6cd52c4d847d915900e5466f7433eaee6a9e0a3d1d88b08",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-filter/0.5.0/download"
+              ],
+              "strip_prefix": "gix-filter-0.5.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-filter-0.5.0.bazel"
+            }
+          },
+          "cui__gix-fs-0.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-fs/0.7.0/download"
+              ],
+              "strip_prefix": "gix-fs-0.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-fs-0.7.0.bazel"
+            }
+          },
+          "cui__gix-glob-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-glob/0.13.0/download"
+              ],
+              "strip_prefix": "gix-glob-0.13.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-glob-0.13.0.bazel"
+            }
+          },
+          "cui__gix-hash-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hash/0.13.1/download"
+              ],
+              "strip_prefix": "gix-hash-0.13.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-hash-0.13.1.bazel"
+            }
+          },
+          "cui__gix-hashtable-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hashtable/0.4.0/download"
+              ],
+              "strip_prefix": "gix-hashtable-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-hashtable-0.4.0.bazel"
+            }
+          },
+          "cui__gix-ignore-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ignore/0.8.0/download"
+              ],
+              "strip_prefix": "gix-ignore-0.8.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-ignore-0.8.0.bazel"
+            }
+          },
+          "cui__gix-index-0.25.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f54d63a9d13c13088f41f5a3accbec284e492ac8f4f707fcc307c139622e17b7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-index/0.25.0/download"
+              ],
+              "strip_prefix": "gix-index-0.25.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-index-0.25.0.bazel"
+            }
+          },
+          "cui__gix-lock-10.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-lock/10.0.0/download"
+              ],
+              "strip_prefix": "gix-lock-10.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-lock-10.0.0.bazel"
+            }
+          },
+          "cui__gix-macros-0.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-macros/0.1.0/download"
+              ],
+              "strip_prefix": "gix-macros-0.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-macros-0.1.0.bazel"
+            }
+          },
+          "cui__gix-negotiate-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-negotiate/0.8.0/download"
+              ],
+              "strip_prefix": "gix-negotiate-0.8.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-negotiate-0.8.0.bazel"
+            }
+          },
+          "cui__gix-object-0.37.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-object/0.37.0/download"
+              ],
+              "strip_prefix": "gix-object-0.37.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-object-0.37.0.bazel"
+            }
+          },
+          "cui__gix-odb-0.53.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-odb/0.53.0/download"
+              ],
+              "strip_prefix": "gix-odb-0.53.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-odb-0.53.0.bazel"
+            }
+          },
+          "cui__gix-pack-0.43.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pack/0.43.0/download"
+              ],
+              "strip_prefix": "gix-pack-0.43.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-pack-0.43.0.bazel"
+            }
+          },
+          "cui__gix-packetline-0.16.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8a8384b1e964151aff0d5632dd9b191059d07dff358b96bd940f1b452600d7ab",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline/0.16.7/download"
+              ],
+              "strip_prefix": "gix-packetline-0.16.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.16.7.bazel"
+            }
+          },
+          "cui__gix-packetline-blocking-0.16.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7d8395f7501c84d6a1fe902035fdfd8cd86d89e2dd6be0200ec1a72fd3c92d39",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline-blocking/0.16.6/download"
+              ],
+              "strip_prefix": "gix-packetline-blocking-0.16.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-packetline-blocking-0.16.6.bazel"
+            }
+          },
+          "cui__gix-path-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-path/0.10.0/download"
+              ],
+              "strip_prefix": "gix-path-0.10.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-path-0.10.0.bazel"
+            }
+          },
+          "cui__gix-pathspec-0.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3e26c9b47c51be73f98d38c84494bd5fb99334c5d6fda14ef5d036d50a9e5fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pathspec/0.3.0/download"
+              ],
+              "strip_prefix": "gix-pathspec-0.3.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-pathspec-0.3.0.bazel"
+            }
+          },
+          "cui__gix-prompt-0.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-prompt/0.7.0/download"
+              ],
+              "strip_prefix": "gix-prompt-0.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-prompt-0.7.0.bazel"
+            }
+          },
+          "cui__gix-protocol-0.40.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cc7b700dc20cc9be8a5130a1fd7e10c34117ffa7068431c8c24d963f0a2e0c9b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-protocol/0.40.0/download"
+              ],
+              "strip_prefix": "gix-protocol-0.40.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-protocol-0.40.0.bazel"
+            }
+          },
+          "cui__gix-quote-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-quote/0.4.7/download"
+              ],
+              "strip_prefix": "gix-quote-0.4.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-quote-0.4.7.bazel"
+            }
+          },
+          "cui__gix-ref-0.37.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ref/0.37.0/download"
+              ],
+              "strip_prefix": "gix-ref-0.37.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-ref-0.37.0.bazel"
+            }
+          },
+          "cui__gix-refspec-0.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-refspec/0.18.0/download"
+              ],
+              "strip_prefix": "gix-refspec-0.18.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-refspec-0.18.0.bazel"
+            }
+          },
+          "cui__gix-revision-0.22.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c8c4b15cf2ab7a35f5bcb3ef146187c8d36df0177e171ca061913cbaaa890e89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revision/0.22.0/download"
+              ],
+              "strip_prefix": "gix-revision-0.22.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-revision-0.22.0.bazel"
+            }
+          },
+          "cui__gix-revwalk-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revwalk/0.8.0/download"
+              ],
+              "strip_prefix": "gix-revwalk-0.8.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-revwalk-0.8.0.bazel"
+            }
+          },
+          "cui__gix-sec-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-sec/0.10.0/download"
+              ],
+              "strip_prefix": "gix-sec-0.10.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-sec-0.10.0.bazel"
+            }
+          },
+          "cui__gix-submodule-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-submodule/0.4.0/download"
+              ],
+              "strip_prefix": "gix-submodule-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-submodule-0.4.0.bazel"
+            }
+          },
+          "cui__gix-tempfile-10.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-tempfile/10.0.0/download"
+              ],
+              "strip_prefix": "gix-tempfile-10.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-tempfile-10.0.0.bazel"
+            }
+          },
+          "cui__gix-trace-0.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-trace/0.1.3/download"
+              ],
+              "strip_prefix": "gix-trace-0.1.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-trace-0.1.3.bazel"
+            }
+          },
+          "cui__gix-transport-0.37.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b9ec726e6a245e68ace59a34126a1d679de60360676612985e70b0d3b102fb4e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-transport/0.37.0/download"
+              ],
+              "strip_prefix": "gix-transport-0.37.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-transport-0.37.0.bazel"
+            }
+          },
+          "cui__gix-traverse-0.33.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-traverse/0.33.0/download"
+              ],
+              "strip_prefix": "gix-traverse-0.33.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-traverse-0.33.0.bazel"
+            }
+          },
+          "cui__gix-url-0.24.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-url/0.24.0/download"
+              ],
+              "strip_prefix": "gix-url-0.24.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-url-0.24.0.bazel"
+            }
+          },
+          "cui__gix-utils-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-utils/0.1.5/download"
+              ],
+              "strip_prefix": "gix-utils-0.1.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-utils-0.1.5.bazel"
+            }
+          },
+          "cui__gix-validate-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-validate/0.8.0/download"
+              ],
+              "strip_prefix": "gix-validate-0.8.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-validate-0.8.0.bazel"
+            }
+          },
+          "cui__gix-worktree-0.26.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-worktree/0.26.0/download"
+              ],
+              "strip_prefix": "gix-worktree-0.26.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-worktree-0.26.0.bazel"
+            }
+          },
+          "cui__globset-0.4.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/globset/0.4.11/download"
+              ],
+              "strip_prefix": "globset-0.4.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.globset-0.4.11.bazel"
+            }
+          },
+          "cui__globwalk-0.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/globwalk/0.8.1/download"
+              ],
+              "strip_prefix": "globwalk-0.8.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.globwalk-0.8.1.bazel"
+            }
+          },
+          "cui__hashbrown-0.14.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hashbrown-0.14.3.bazel"
+            }
+          },
+          "cui__heck-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "cui__hermit-abi-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "cui__hex-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hex/0.4.3/download"
+              ],
+              "strip_prefix": "hex-0.4.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hex-0.4.3.bazel"
+            }
+          },
+          "cui__home-0.5.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/home/0.5.5/download"
+              ],
+              "strip_prefix": "home-0.5.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.home-0.5.5.bazel"
+            }
+          },
+          "cui__humansize-2.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humansize/2.1.3/download"
+              ],
+              "strip_prefix": "humansize-2.1.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.humansize-2.1.3.bazel"
+            }
+          },
+          "cui__iana-time-zone-0.1.57": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
+              ],
+              "strip_prefix": "iana-time-zone-0.1.57",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
+            }
+          },
+          "cui__iana-time-zone-haiku-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
+              ],
+              "strip_prefix": "iana-time-zone-haiku-0.1.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
+            }
+          },
+          "cui__idna-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.5.0/download"
+              ],
+              "strip_prefix": "idna-0.5.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.idna-0.5.0.bazel"
+            }
+          },
+          "cui__ignore-0.4.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ignore/0.4.18/download"
+              ],
+              "strip_prefix": "ignore-0.4.18",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ignore-0.4.18.bazel"
+            }
+          },
+          "cui__indexmap-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.1.0/download"
+              ],
+              "strip_prefix": "indexmap-2.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.indexmap-2.1.0.bazel"
+            }
+          },
+          "cui__indoc-2.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indoc/2.0.4/download"
+              ],
+              "strip_prefix": "indoc-2.0.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.indoc-2.0.4.bazel"
+            }
+          },
+          "cui__io-lifetimes-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "cui__is-terminal-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "cui__itertools-0.12.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.12.0/download"
+              ],
+              "strip_prefix": "itertools-0.12.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.itertools-0.12.0.bazel"
+            }
+          },
+          "cui__itoa-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "cui__js-sys-0.3.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
+              ],
+              "strip_prefix": "js-sys-0.3.64",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
+            }
+          },
+          "cui__jwalk-0.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/jwalk/0.8.1/download"
+              ],
+              "strip_prefix": "jwalk-0.8.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.jwalk-0.8.1.bazel"
+            }
+          },
+          "cui__lazy_static-1.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "cui__libc-0.2.149": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.149/download"
+              ],
+              "strip_prefix": "libc-0.2.149",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.libc-0.2.149.bazel"
+            }
+          },
+          "cui__libm-0.2.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libm/0.2.7/download"
+              ],
+              "strip_prefix": "libm-0.2.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.libm-0.2.7.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.4.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.10/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.4.10.bazel"
+            }
+          },
+          "cui__lock_api-0.4.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.11/download"
+              ],
+              "strip_prefix": "lock_api-0.4.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.lock_api-0.4.11.bazel"
+            }
+          },
+          "cui__log-0.4.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "cui__maplit-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maplit/1.0.2/download"
+              ],
+              "strip_prefix": "maplit-1.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.maplit-1.0.2.bazel"
+            }
+          },
+          "cui__maybe-async-0.2.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maybe-async/0.2.7/download"
+              ],
+              "strip_prefix": "maybe-async-0.2.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.maybe-async-0.2.7.bazel"
+            }
+          },
+          "cui__memchr-2.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.6.4/download"
+              ],
+              "strip_prefix": "memchr-2.6.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.memchr-2.6.4.bazel"
+            }
+          },
+          "cui__memmap2-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memmap2/0.7.1/download"
+              ],
+              "strip_prefix": "memmap2-0.7.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.memmap2-0.7.1.bazel"
+            }
+          },
+          "cui__memoffset-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
+              ],
+              "strip_prefix": "memoffset-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
+            }
+          },
+          "cui__miniz_oxide-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
+            }
+          },
+          "cui__normpath-1.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/normpath/1.1.1/download"
+              ],
+              "strip_prefix": "normpath-1.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.normpath-1.1.1.bazel"
+            }
+          },
+          "cui__nu-ansi-term-0.46.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/nu-ansi-term/0.46.0/download"
+              ],
+              "strip_prefix": "nu-ansi-term-0.46.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.nu-ansi-term-0.46.0.bazel"
+            }
+          },
+          "cui__num-0.1.42": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num/0.1.42/download"
+              ],
+              "strip_prefix": "num-0.1.42",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-0.1.42.bazel"
+            }
+          },
+          "cui__num-bigint-0.1.44": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-bigint/0.1.44/download"
+              ],
+              "strip_prefix": "num-bigint-0.1.44",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-bigint-0.1.44.bazel"
+            }
+          },
+          "cui__num-complex-0.1.43": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-complex/0.1.43/download"
+              ],
+              "strip_prefix": "num-complex-0.1.43",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-complex-0.1.43.bazel"
+            }
+          },
+          "cui__num-conv-0.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-conv/0.1.0/download"
+              ],
+              "strip_prefix": "num-conv-0.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-conv-0.1.0.bazel"
+            }
+          },
+          "cui__num-integer-0.1.45": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-integer/0.1.45/download"
+              ],
+              "strip_prefix": "num-integer-0.1.45",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-integer-0.1.45.bazel"
+            }
+          },
+          "cui__num-iter-0.1.43": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-iter/0.1.43/download"
+              ],
+              "strip_prefix": "num-iter-0.1.43",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-iter-0.1.43.bazel"
+            }
+          },
+          "cui__num-rational-0.1.42": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-rational/0.1.42/download"
+              ],
+              "strip_prefix": "num-rational-0.1.42",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-rational-0.1.42.bazel"
+            }
+          },
+          "cui__num-traits-0.2.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
+              ],
+              "strip_prefix": "num-traits-0.2.15",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
+            }
+          },
+          "cui__num_threads-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
+              ],
+              "strip_prefix": "num_threads-0.1.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
+            }
+          },
+          "cui__once_cell-1.19.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
+            }
+          },
+          "cui__overload-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/overload/0.1.1/download"
+              ],
+              "strip_prefix": "overload-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.overload-0.1.1.bazel"
+            }
+          },
+          "cui__parking_lot-0.12.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.1/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.parking_lot-0.12.1.bazel"
+            }
+          },
+          "cui__parking_lot_core-0.9.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.9/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.parking_lot_core-0.9.9.bazel"
+            }
+          },
+          "cui__parse-zoneinfo-0.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parse-zoneinfo/0.3.0/download"
+              ],
+              "strip_prefix": "parse-zoneinfo-0.3.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.parse-zoneinfo-0.3.0.bazel"
+            }
+          },
+          "cui__pathdiff-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pathdiff/0.2.1/download"
+              ],
+              "strip_prefix": "pathdiff-0.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pathdiff-0.2.1.bazel"
+            }
+          },
+          "cui__percent-encoding-2.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "cui__pest-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest/2.7.0/download"
+              ],
+              "strip_prefix": "pest-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest-2.7.0.bazel"
+            }
+          },
+          "cui__pest_derive-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_derive/2.7.0/download"
+              ],
+              "strip_prefix": "pest_derive-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest_derive-2.7.0.bazel"
+            }
+          },
+          "cui__pest_generator-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_generator/2.7.0/download"
+              ],
+              "strip_prefix": "pest_generator-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest_generator-2.7.0.bazel"
+            }
+          },
+          "cui__pest_meta-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_meta/2.7.0/download"
+              ],
+              "strip_prefix": "pest_meta-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest_meta-2.7.0.bazel"
+            }
+          },
+          "cui__phf-0.11.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf/0.11.2/download"
+              ],
+              "strip_prefix": "phf-0.11.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.phf-0.11.2.bazel"
+            }
+          },
+          "cui__phf_codegen-0.11.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf_codegen/0.11.2/download"
+              ],
+              "strip_prefix": "phf_codegen-0.11.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.phf_codegen-0.11.2.bazel"
+            }
+          },
+          "cui__phf_generator-0.11.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf_generator/0.11.2/download"
+              ],
+              "strip_prefix": "phf_generator-0.11.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.phf_generator-0.11.2.bazel"
+            }
+          },
+          "cui__phf_shared-0.11.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/phf_shared/0.11.2/download"
+              ],
+              "strip_prefix": "phf_shared-0.11.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.phf_shared-0.11.2.bazel"
+            }
+          },
+          "cui__pin-project-lite-0.2.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.13/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.13",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pin-project-lite-0.2.13.bazel"
+            }
+          },
+          "cui__powerfmt-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/powerfmt/0.2.0/download"
+              ],
+              "strip_prefix": "powerfmt-0.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.powerfmt-0.2.0.bazel"
+            }
+          },
+          "cui__ppv-lite86-0.2.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.17",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
+            }
+          },
+          "cui__proc-macro2-1.0.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "cui__prodash-26.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prodash/26.2.2/download"
+              ],
+              "strip_prefix": "prodash-26.2.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.prodash-26.2.2.bazel"
+            }
+          },
+          "cui__quote-1.0.29": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "cui__rand-0.4.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.4.6/download"
+              ],
+              "strip_prefix": "rand-0.4.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rand-0.4.6.bazel"
+            }
+          },
+          "cui__rand-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "cui__rand_chacha-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "cui__rand_core-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.3.1/download"
+              ],
+              "strip_prefix": "rand_core-0.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rand_core-0.3.1.bazel"
+            }
+          },
+          "cui__rand_core-0.4.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.4.2/download"
+              ],
+              "strip_prefix": "rand_core-0.4.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rand_core-0.4.2.bazel"
+            }
+          },
+          "cui__rand_core-0.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "cui__rayon-1.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon/1.8.0/download"
+              ],
+              "strip_prefix": "rayon-1.8.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rayon-1.8.0.bazel"
+            }
+          },
+          "cui__rayon-core-1.12.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon-core/1.12.0/download"
+              ],
+              "strip_prefix": "rayon-core-1.12.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rayon-core-1.12.0.bazel"
+            }
+          },
+          "cui__rdrand-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rdrand/0.4.0/download"
+              ],
+              "strip_prefix": "rdrand-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rdrand-0.4.0.bazel"
+            }
+          },
+          "cui__redox_syscall-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "cui__redox_syscall-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.4.1/download"
+              ],
+              "strip_prefix": "redox_syscall-0.4.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.4.1.bazel"
+            }
+          },
+          "cui__regex-1.10.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.2/download"
+              ],
+              "strip_prefix": "regex-1.10.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-1.10.2.bazel"
+            }
+          },
+          "cui__regex-automata-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "cui__regex-automata-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-automata-0.4.3.bazel"
+            }
+          },
+          "cui__regex-syntax-0.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.2/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-syntax-0.8.2.bazel"
+            }
+          },
+          "cui__rustc-hash-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+              ],
+              "strip_prefix": "rustc-hash-1.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+            }
+          },
+          "cui__rustc-serialize-0.3.25": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-serialize/0.3.25/download"
+              ],
+              "strip_prefix": "rustc-serialize-0.3.25",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustc-serialize-0.3.25.bazel"
+            }
+          },
+          "cui__rustix-0.37.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "cui__rustix-0.38.21": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.21/download"
+              ],
+              "strip_prefix": "rustix-0.38.21",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustix-0.38.21.bazel"
+            }
+          },
+          "cui__ryu-1.0.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "cui__same-file-1.0.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/same-file/1.0.6/download"
+              ],
+              "strip_prefix": "same-file-1.0.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.same-file-1.0.6.bazel"
+            }
+          },
+          "cui__scopeguard-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
+            }
+          },
+          "cui__semver-1.0.20": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.20/download"
+              ],
+              "strip_prefix": "semver-1.0.20",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.semver-1.0.20.bazel"
+            }
+          },
+          "cui__serde-1.0.190": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.190/download"
+              ],
+              "strip_prefix": "serde-1.0.190",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde-1.0.190.bazel"
+            }
+          },
+          "cui__serde_derive-1.0.190": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.190/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.190",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_derive-1.0.190.bazel"
+            }
+          },
+          "cui__serde_json-1.0.108": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.108/download"
+              ],
+              "strip_prefix": "serde_json-1.0.108",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_json-1.0.108.bazel"
+            }
+          },
+          "cui__serde_spanned-0.6.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_spanned/0.6.5/download"
+              ],
+              "strip_prefix": "serde_spanned-0.6.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_spanned-0.6.5.bazel"
+            }
+          },
+          "cui__serde_starlark-0.1.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "29675b116dd4c7ab4012e00e71f6dee9ed8c731108468b4434779c6b9eec7957",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_starlark/0.1.14/download"
+              ],
+              "strip_prefix": "serde_starlark-0.1.14",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_starlark-0.1.14.bazel"
+            }
+          },
+          "cui__sha1_smol-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
+              ],
+              "strip_prefix": "sha1_smol-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
+            }
+          },
+          "cui__sha2-0.10.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha2/0.10.8/download"
+              ],
+              "strip_prefix": "sha2-0.10.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.sha2-0.10.8.bazel"
+            }
+          },
+          "cui__sharded-slab-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sharded-slab/0.1.7/download"
+              ],
+              "strip_prefix": "sharded-slab-0.1.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.sharded-slab-0.1.7.bazel"
+            }
+          },
+          "cui__siphasher-0.3.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/siphasher/0.3.10/download"
+              ],
+              "strip_prefix": "siphasher-0.3.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.siphasher-0.3.10.bazel"
+            }
+          },
+          "cui__slug-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slug/0.1.4/download"
+              ],
+              "strip_prefix": "slug-0.1.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.slug-0.1.4.bazel"
+            }
+          },
+          "cui__smallvec-1.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.11.0/download"
+              ],
+              "strip_prefix": "smallvec-1.11.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.smallvec-1.11.0.bazel"
+            }
+          },
+          "cui__smawk-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smawk/0.3.1/download"
+              ],
+              "strip_prefix": "smawk-0.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.smawk-0.3.1.bazel"
+            }
+          },
+          "cui__smol_str-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smol_str/0.2.0/download"
+              ],
+              "strip_prefix": "smol_str-0.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.smol_str-0.2.0.bazel"
+            }
+          },
+          "cui__spdx-0.10.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62bde1398b09b9f93fc2fc9b9da86e362693e999d3a54a8ac47a99a5a73f638b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spdx/0.10.3/download"
+              ],
+              "strip_prefix": "spdx-0.10.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.spdx-0.10.3.bazel"
+            }
+          },
+          "cui__spectral-0.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spectral/0.6.0/download"
+              ],
+              "strip_prefix": "spectral-0.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.spectral-0.6.0.bazel"
+            }
+          },
+          "cui__strsim-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "cui__syn-1.0.109": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
+          "cui__syn-2.0.32": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.32/download"
+              ],
+              "strip_prefix": "syn-2.0.32",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.syn-2.0.32.bazel"
+            }
+          },
+          "cui__tempfile-3.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.8.1/download"
+              ],
+              "strip_prefix": "tempfile-3.8.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tempfile-3.8.1.bazel"
+            }
+          },
+          "cui__tera-1.19.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "970dff17c11e884a4a09bc76e3a17ef71e01bb13447a11e85226e254fe6d10b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tera/1.19.1/download"
+              ],
+              "strip_prefix": "tera-1.19.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tera-1.19.1.bazel"
+            }
+          },
+          "cui__textwrap-0.16.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/textwrap/0.16.0/download"
+              ],
+              "strip_prefix": "textwrap-0.16.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.textwrap-0.16.0.bazel"
+            }
+          },
+          "cui__thiserror-1.0.50": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thiserror/1.0.50/download"
+              ],
+              "strip_prefix": "thiserror-1.0.50",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.thiserror-1.0.50.bazel"
+            }
+          },
+          "cui__thiserror-impl-1.0.50": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thiserror-impl/1.0.50/download"
+              ],
+              "strip_prefix": "thiserror-impl-1.0.50",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.thiserror-impl-1.0.50.bazel"
+            }
+          },
+          "cui__thread_local-1.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thread_local/1.1.4/download"
+              ],
+              "strip_prefix": "thread_local-1.1.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.thread_local-1.1.4.bazel"
+            }
+          },
+          "cui__time-0.3.36": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time/0.3.36/download"
+              ],
+              "strip_prefix": "time-0.3.36",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.time-0.3.36.bazel"
+            }
+          },
+          "cui__time-core-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-core/0.1.2/download"
+              ],
+              "strip_prefix": "time-core-0.1.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.time-core-0.1.2.bazel"
+            }
+          },
+          "cui__time-macros-0.2.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-macros/0.2.18/download"
+              ],
+              "strip_prefix": "time-macros-0.2.18",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.time-macros-0.2.18.bazel"
+            }
+          },
+          "cui__tinyvec-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
+            }
+          },
+          "cui__tinyvec_macros-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "cui__toml-0.7.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml/0.7.6/download"
+              ],
+              "strip_prefix": "toml-0.7.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml-0.7.6.bazel"
+            }
+          },
+          "cui__toml-0.8.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml/0.8.10/download"
+              ],
+              "strip_prefix": "toml-0.8.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml-0.8.10.bazel"
+            }
+          },
+          "cui__toml_datetime-0.6.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_datetime/0.6.5/download"
+              ],
+              "strip_prefix": "toml_datetime-0.6.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml_datetime-0.6.5.bazel"
+            }
+          },
+          "cui__toml_edit-0.19.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_edit/0.19.13/download"
+              ],
+              "strip_prefix": "toml_edit-0.19.13",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml_edit-0.19.13.bazel"
+            }
+          },
+          "cui__toml_edit-0.22.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_edit/0.22.4/download"
+              ],
+              "strip_prefix": "toml_edit-0.22.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml_edit-0.22.4.bazel"
+            }
+          },
+          "cui__tracing-0.1.40": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "cui__tracing-attributes-0.1.27": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "cui__tracing-core-0.1.32": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
+              ],
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
+            }
+          },
+          "cui__tracing-log-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-log/0.1.4/download"
+              ],
+              "strip_prefix": "tracing-log-0.1.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-log-0.1.4.bazel"
+            }
+          },
+          "cui__tracing-subscriber-0.3.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-subscriber/0.3.17/download"
+              ],
+              "strip_prefix": "tracing-subscriber-0.3.17",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-subscriber-0.3.17.bazel"
+            }
+          },
+          "cui__typenum-1.16.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/typenum/1.16.0/download"
+              ],
+              "strip_prefix": "typenum-1.16.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.typenum-1.16.0.bazel"
+            }
+          },
+          "cui__ucd-trie-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ucd-trie/0.1.6/download"
+              ],
+              "strip_prefix": "ucd-trie-0.1.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ucd-trie-0.1.6.bazel"
+            }
+          },
+          "cui__uluru-3.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/uluru/3.0.0/download"
+              ],
+              "strip_prefix": "uluru-3.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.uluru-3.0.0.bazel"
+            }
+          },
+          "cui__unic-char-property-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-char-property/0.9.0/download"
+              ],
+              "strip_prefix": "unic-char-property-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-char-property-0.9.0.bazel"
+            }
+          },
+          "cui__unic-char-range-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-char-range/0.9.0/download"
+              ],
+              "strip_prefix": "unic-char-range-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-char-range-0.9.0.bazel"
+            }
+          },
+          "cui__unic-common-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-common/0.9.0/download"
+              ],
+              "strip_prefix": "unic-common-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-common-0.9.0.bazel"
+            }
+          },
+          "cui__unic-segment-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-segment/0.9.0/download"
+              ],
+              "strip_prefix": "unic-segment-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-segment-0.9.0.bazel"
+            }
+          },
+          "cui__unic-ucd-segment-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-ucd-segment/0.9.0/download"
+              ],
+              "strip_prefix": "unic-ucd-segment-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-ucd-segment-0.9.0.bazel"
+            }
+          },
+          "cui__unic-ucd-version-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-ucd-version/0.9.0/download"
+              ],
+              "strip_prefix": "unic-ucd-version-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-ucd-version-0.9.0.bazel"
+            }
+          },
+          "cui__unicode-bidi-0.3.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
+              ],
+              "strip_prefix": "unicode-bidi-0.3.13",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
+            }
+          },
+          "cui__unicode-bom-2.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bom/2.0.2/download"
+              ],
+              "strip_prefix": "unicode-bom-2.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-bom-2.0.2.bazel"
+            }
+          },
+          "cui__unicode-ident-1.0.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "cui__unicode-linebreak-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-linebreak/0.1.5/download"
+              ],
+              "strip_prefix": "unicode-linebreak-0.1.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-linebreak-0.1.5.bazel"
+            }
+          },
+          "cui__unicode-normalization-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "cui__unicode-width-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.10/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
+            }
+          },
+          "cui__url-2.5.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.5.2/download"
+              ],
+              "strip_prefix": "url-2.5.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.url-2.5.2.bazel"
+            }
+          },
+          "cui__utf8parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "cui__valuable-0.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/valuable/0.1.0/download"
+              ],
+              "strip_prefix": "valuable-0.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.valuable-0.1.0.bazel"
+            }
+          },
+          "cui__version_check-0.9.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/version_check/0.9.4/download"
+              ],
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
+            }
+          },
+          "cui__walkdir-2.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walkdir/2.3.3/download"
+              ],
+              "strip_prefix": "walkdir-2.3.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.walkdir-2.3.3.bazel"
+            }
+          },
+          "cui__wasi-0.11.0-wasi-snapshot-preview1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "cui__wasm-bindgen-0.2.87": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-0.2.87",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-backend-0.2.87": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-backend-0.2.87",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-macro-0.2.87": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-0.2.87",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-macro-support-0.2.87": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-support-0.2.87",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.87.bazel"
+            }
+          },
+          "cui__wasm-bindgen-shared-0.2.87": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.87/download"
+              ],
+              "strip_prefix": "wasm-bindgen-shared-0.2.87",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.87.bazel"
+            }
+          },
+          "cui__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "cui__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__winapi-util-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "cui__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__windows-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows/0.48.0/download"
+              ],
+              "strip_prefix": "windows-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+            }
+          },
+          "cui__windows-sys-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "cui__windows-targets-0.48.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "cui__windows_aarch64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__windows_aarch64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_i686_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "cui__windows_i686_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__winnow-0.5.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winnow/0.5.18/download"
+              ],
+              "strip_prefix": "winnow-0.5.18",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winnow-0.5.18.bazel"
+            }
+          },
+          "cargo_bazel.buildifier-darwin-amd64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-amd64"
+              ],
+              "integrity": "sha256-N1+CMQPQFiCq7CCgwpxsvKmfT9ByWuMLk2VcZwT0TXE=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-darwin-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-arm64"
+              ],
+              "integrity": "sha256-Wmr8asegn1RVuguJvZnVriO0F03F3J1sDtXOjKrD+BM=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-amd64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"
+              ],
+              "integrity": "sha256-VHTMUSinToBng9VAgfWBZixL6K5lAi9VfpKB7V3IgAk=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-arm64"
+              ],
+              "integrity": "sha256-C/hsS//69PCO7Xe95bIILkrlA5oR4uiwOYTBc8NKVhw=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-s390x": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-s390x"
+              ],
+              "integrity": "sha256-4tef9YhdRSdPdlMfGtvHtzoSn1nnZ/d36PveYz2dTi4=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-windows-amd64.exe": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-windows-amd64.exe"
+              ],
+              "integrity": "sha256-NwzVdgda0pkwqC9d4TLxod5AhMeEqCUUvU2oDIWs9Kg=",
+              "downloaded_file_path": "buildifier.exe",
+              "executable": true
+            }
+          },
+          "rules_rust_prost": {
+            "repoRuleId": "@@rules_rust+//crate_universe/private:crates_vendor.bzl%crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust+//proto/prost/private/3rdparty/crates:defs.bzl"
+            }
+          },
+          "rules_rust_prost__addr2line-0.22.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/addr2line/0.22.0/download"
+              ],
+              "strip_prefix": "addr2line-0.22.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.addr2line-0.22.0.bazel"
+            }
+          },
+          "rules_rust_prost__adler-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__aho-corasick-1.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_prost__anyhow-1.0.86": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.86/download"
+              ],
+              "strip_prefix": "anyhow-1.0.86",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.anyhow-1.0.86.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-0.3.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.async-stream-0.3.5.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-impl-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream-impl/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-impl-0.3.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.async-stream-impl-0.3.5.bazel"
+            }
+          },
+          "rules_rust_prost__async-trait-0.1.81": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-trait/0.1.81/download"
+              ],
+              "strip_prefix": "async-trait-0.1.81",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.async-trait-0.1.81.bazel"
+            }
+          },
+          "rules_rust_prost__atomic-waker-1.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atomic-waker/1.1.2/download"
+              ],
+              "strip_prefix": "atomic-waker-1.1.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.atomic-waker-1.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__autocfg-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.3.0/download"
+              ],
+              "strip_prefix": "autocfg-1.3.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.autocfg-1.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__axum-0.7.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum/0.7.5/download"
+              ],
+              "strip_prefix": "axum-0.7.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.axum-0.7.5.bazel"
+            }
+          },
+          "rules_rust_prost__axum-core-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum-core/0.4.3/download"
+              ],
+              "strip_prefix": "axum-core-0.4.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.axum-core-0.4.3.bazel"
+            }
+          },
+          "rules_rust_prost__backtrace-0.3.73": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/backtrace/0.3.73/download"
+              ],
+              "strip_prefix": "backtrace-0.3.73",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.backtrace-0.3.73.bazel"
+            }
+          },
+          "rules_rust_prost__base64-0.22.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.22.1/download"
+              ],
+              "strip_prefix": "base64-0.22.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.base64-0.22.1.bazel"
+            }
+          },
+          "rules_rust_prost__bitflags-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_prost__byteorder-1.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.5.0/download"
+              ],
+              "strip_prefix": "byteorder-1.5.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.byteorder-1.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__bytes-1.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/1.7.1/download"
+              ],
+              "strip_prefix": "bytes-1.7.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.bytes-1.7.1.bazel"
+            }
+          },
+          "rules_rust_prost__cc-1.1.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.1.14/download"
+              ],
+              "strip_prefix": "cc-1.1.14",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.cc-1.1.14.bazel"
+            }
+          },
+          "rules_rust_prost__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_prost__either-1.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__equivalent-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__errno-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.9/download"
+              ],
+              "strip_prefix": "errno-0.3.9",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.errno-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__fastrand-2.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.1.1/download"
+              ],
+              "strip_prefix": "fastrand-2.1.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.fastrand-2.1.1.bazel"
+            }
+          },
+          "rules_rust_prost__fixedbitset-0.4.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fixedbitset/0.4.2/download"
+              ],
+              "strip_prefix": "fixedbitset-0.4.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.fixedbitset-0.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__fnv-1.0.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "rules_rust_prost__futures-channel-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-channel/0.3.30/download"
+              ],
+              "strip_prefix": "futures-channel-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-channel-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-core-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-core/0.3.30/download"
+              ],
+              "strip_prefix": "futures-core-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-core-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-sink-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-sink/0.3.30/download"
+              ],
+              "strip_prefix": "futures-sink-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-sink-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-task-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-task/0.3.30/download"
+              ],
+              "strip_prefix": "futures-task-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-task-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-util-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-util/0.3.30/download"
+              ],
+              "strip_prefix": "futures-util-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-util-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__getrandom-0.2.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.15/download"
+              ],
+              "strip_prefix": "getrandom-0.2.15",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.getrandom-0.2.15.bazel"
+            }
+          },
+          "rules_rust_prost__gimli-0.29.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.29.0/download"
+              ],
+              "strip_prefix": "gimli-0.29.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.gimli-0.29.0.bazel"
+            }
+          },
+          "rules_rust_prost__h2-0.4.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/h2/0.4.6/download"
+              ],
+              "strip_prefix": "h2-0.4.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.h2-0.4.6.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.12.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.12.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.14.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.5/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.14.5.bazel"
+            }
+          },
+          "rules_rust_prost__heck-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__hermit-abi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.9/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.9",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__http-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http/1.1.0/download"
+              ],
+              "strip_prefix": "http-1.1.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.http-1.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body/1.0.1/download"
+              ],
+              "strip_prefix": "http-body-1.0.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.http-body-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-util-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body-util/0.1.2/download"
+              ],
+              "strip_prefix": "http-body-util-0.1.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.http-body-util-0.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__httparse-1.9.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.9.4/download"
+              ],
+              "strip_prefix": "httparse-1.9.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.httparse-1.9.4.bazel"
+            }
+          },
+          "rules_rust_prost__httpdate-1.0.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.3/download"
+              ],
+              "strip_prefix": "httpdate-1.0.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.httpdate-1.0.3.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-1.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper/1.4.1/download"
+              ],
+              "strip_prefix": "hyper-1.4.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hyper-1.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-timeout-0.5.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-timeout/0.5.1/download"
+              ],
+              "strip_prefix": "hyper-timeout-0.5.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hyper-timeout-0.5.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-util-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-util/0.1.7/download"
+              ],
+              "strip_prefix": "hyper-util-0.1.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hyper-util-0.1.7.bazel"
+            }
+          },
+          "rules_rust_prost__indexmap-1.9.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
+            }
+          },
+          "rules_rust_prost__indexmap-2.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.4.0/download"
+              ],
+              "strip_prefix": "indexmap-2.4.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.indexmap-2.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__itertools-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__itoa-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.11/download"
+              ],
+              "strip_prefix": "itoa-1.0.11",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.itoa-1.0.11.bazel"
+            }
+          },
+          "rules_rust_prost__libc-0.2.158": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "rules_rust_prost__linux-raw-sys-0.4.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.14/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.14",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.linux-raw-sys-0.4.14.bazel"
+            }
+          },
+          "rules_rust_prost__lock_api-0.4.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.12/download"
+              ],
+              "strip_prefix": "lock_api-0.4.12",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.lock_api-0.4.12.bazel"
+            }
+          },
+          "rules_rust_prost__log-0.4.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "rules_rust_prost__matchit-0.7.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/matchit/0.7.3/download"
+              ],
+              "strip_prefix": "matchit-0.7.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.matchit-0.7.3.bazel"
+            }
+          },
+          "rules_rust_prost__memchr-2.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_prost__mime-0.3.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime/0.3.17/download"
+              ],
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_prost__miniz_oxide-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.4/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.miniz_oxide-0.7.4.bazel"
+            }
+          },
+          "rules_rust_prost__mio-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/1.0.2/download"
+              ],
+              "strip_prefix": "mio-1.0.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.mio-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__multimap-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multimap/0.10.0/download"
+              ],
+              "strip_prefix": "multimap-0.10.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.multimap-0.10.0.bazel"
+            }
+          },
+          "rules_rust_prost__object-0.36.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/object/0.36.3/download"
+              ],
+              "strip_prefix": "object-0.36.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.object-0.36.3.bazel"
+            }
+          },
+          "rules_rust_prost__once_cell-1.19.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot-0.12.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.3/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.parking_lot-0.12.3.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot_core-0.9.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.10/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.10",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.parking_lot_core-0.9.10.bazel"
+            }
+          },
+          "rules_rust_prost__percent-encoding-2.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__petgraph-0.6.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/petgraph/0.6.5/download"
+              ],
+              "strip_prefix": "petgraph-0.6.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.petgraph-0.6.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-1.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-1.1.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-project-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-internal-1.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-internal/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-internal-1.1.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-project-internal-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-lite-0.2.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.14/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.14",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-project-lite-0.2.14.bazel"
+            }
+          },
+          "rules_rust_prost__pin-utils-0.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-utils/0.1.0/download"
+              ],
+              "strip_prefix": "pin-utils-0.1.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-utils-0.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__ppv-lite86-0.2.20": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.20/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.20",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.ppv-lite86-0.2.20.bazel"
+            }
+          },
+          "rules_rust_prost__prettyplease-0.2.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "rules_rust_prost__proc-macro2-1.0.86": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
+            }
+          },
+          "rules_rust_prost__prost-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost/0.13.1/download"
+              ],
+              "strip_prefix": "prost-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-build-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-build/0.13.1/download"
+              ],
+              "strip_prefix": "prost-build-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-build-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-derive-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-derive/0.13.1/download"
+              ],
+              "strip_prefix": "prost-derive-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-derive-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-types-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-types/0.13.1/download"
+              ],
+              "strip_prefix": "prost-types-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-types-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-prost-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "77eb17a7657a703f30cb9b7ba4d981e4037b8af2d819ab0077514b0bef537406",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-prost/0.4.0/download"
+              ],
+              "strip_prefix": "protoc-gen-prost-0.4.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-prost-0.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-tonic-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6ab6a0d73a0914752ed8fd7cc51afe169e28da87be3efef292de5676cc527634",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-tonic/0.4.1/download"
+              ],
+              "strip_prefix": "protoc-gen-tonic-0.4.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-tonic-0.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__quote-1.0.37": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_prost__rand-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_prost__rand_chacha-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__rand_core-0.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_prost__redox_syscall-0.5.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.5.3/download"
+              ],
+              "strip_prefix": "redox_syscall-0.5.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.redox_syscall-0.5.3.bazel"
+            }
+          },
+          "rules_rust_prost__regex-1.10.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "rules_rust_prost__regex-automata-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "rules_rust_prost__regex-syntax-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rules_rust_prost__rustc-demangle-0.1.24": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.24/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.24",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rustc-demangle-0.1.24.bazel"
+            }
+          },
+          "rules_rust_prost__rustix-0.38.34": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.34/download"
+              ],
+              "strip_prefix": "rustix-0.38.34",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rustix-0.38.34.bazel"
+            }
+          },
+          "rules_rust_prost__rustversion-1.0.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustversion/1.0.17/download"
+              ],
+              "strip_prefix": "rustversion-1.0.17",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rustversion-1.0.17.bazel"
+            }
+          },
+          "rules_rust_prost__scopeguard-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
+            }
+          },
+          "rules_rust_prost__serde-1.0.209": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.209/download"
+              ],
+              "strip_prefix": "serde-1.0.209",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.serde-1.0.209.bazel"
+            }
+          },
+          "rules_rust_prost__serde_derive-1.0.209": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.209/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.209",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.serde_derive-1.0.209.bazel"
+            }
+          },
+          "rules_rust_prost__shlex-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shlex/1.3.0/download"
+              ],
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__signal-hook-registry-1.4.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/signal-hook-registry/1.4.2/download"
+              ],
+              "strip_prefix": "signal-hook-registry-1.4.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.signal-hook-registry-1.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__slab-0.4.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.9/download"
+              ],
+              "strip_prefix": "slab-0.4.9",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.slab-0.4.9.bazel"
+            }
+          },
+          "rules_rust_prost__smallvec-1.13.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.13.2/download"
+              ],
+              "strip_prefix": "smallvec-1.13.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.smallvec-1.13.2.bazel"
+            }
+          },
+          "rules_rust_prost__socket2-0.5.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/socket2/0.5.7/download"
+              ],
+              "strip_prefix": "socket2-0.5.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.socket2-0.5.7.bazel"
+            }
+          },
+          "rules_rust_prost__syn-2.0.76": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.76/download"
+              ],
+              "strip_prefix": "syn-2.0.76",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.syn-2.0.76.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/0.1.2/download"
+              ],
+              "strip_prefix": "sync_wrapper-0.1.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/1.0.1/download"
+              ],
+              "strip_prefix": "sync_wrapper-1.0.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__tempfile-3.12.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.12.0/download"
+              ],
+              "strip_prefix": "tempfile-3.12.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tempfile-3.12.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-1.39.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/1.39.3/download"
+              ],
+              "strip_prefix": "tokio-1.39.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-1.39.3.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-macros-2.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-macros/2.4.0/download"
+              ],
+              "strip_prefix": "tokio-macros-2.4.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-macros-2.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-stream-0.1.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-stream/0.1.15/download"
+              ],
+              "strip_prefix": "tokio-stream-0.1.15",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-stream-0.1.15.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-util-0.7.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-util/0.7.11/download"
+              ],
+              "strip_prefix": "tokio-util-0.7.11",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-util-0.7.11.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-0.12.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-0.12.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tonic-0.12.1.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-build-0.12.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic-build/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-build-0.12.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tonic-build-0.12.1.bazel"
+            }
+          },
+          "rules_rust_prost__tower-0.4.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower/0.4.13/download"
+              ],
+              "strip_prefix": "tower-0.4.13",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tower-0.4.13.bazel"
+            }
+          },
+          "rules_rust_prost__tower-layer-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-layer/0.3.3/download"
+              ],
+              "strip_prefix": "tower-layer-0.3.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tower-layer-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__tower-service-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-service/0.3.3/download"
+              ],
+              "strip_prefix": "tower-service-0.3.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tower-service-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-0.1.40": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-attributes-0.1.27": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-core-0.1.32": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
+              ],
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
+            }
+          },
+          "rules_rust_prost__try-lock-0.2.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/try-lock/0.2.5/download"
+              ],
+              "strip_prefix": "try-lock-0.2.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.try-lock-0.2.5.bazel"
+            }
+          },
+          "rules_rust_prost__unicode-ident-1.0.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.12/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.12",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.unicode-ident-1.0.12.bazel"
+            }
+          },
+          "rules_rust_prost__want-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/want/0.3.1/download"
+              ],
+              "strip_prefix": "want-0.3.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.want-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__wasi-0.11.0-wasi-snapshot-preview1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.52.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.59.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-targets-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-0.7.35": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-0.7.35",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.zerocopy-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-derive-0.7.35": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy-derive/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-derive-0.7.35",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.zerocopy-derive-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__heck": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "integrity": "sha256-IwTgCYP4f/s4tVtES147YKiEtdMMD8p9gv4zRJu+Veo=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/heck-0.5.0.crate"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__autocfg-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_proto__base64-0.9.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.9.3/download"
+              ],
+              "strip_prefix": "base64-0.9.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.base64-0.9.3.bazel"
+            }
+          },
+          "rules_rust_proto__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_proto__byteorder-1.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.4.3/download"
+              ],
+              "strip_prefix": "byteorder-1.4.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.byteorder-1.4.3.bazel"
+            }
+          },
+          "rules_rust_proto__bytes-0.4.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/0.4.12/download"
+              ],
+              "strip_prefix": "bytes-0.4.12",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.bytes-0.4.12.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/0.1.10/download"
+              ],
+              "strip_prefix": "cfg-if-0.1.10",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.cfg-if-0.1.10.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__cloudabi-0.0.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cloudabi/0.0.3/download"
+              ],
+              "strip_prefix": "cloudabi-0.0.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.cloudabi-0.0.3.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-deque-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.7.4/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.7.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-deque-0.7.4.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-epoch-0.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.8.2/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.8.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-epoch-0.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-queue-0.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-queue/0.2.3/download"
+              ],
+              "strip_prefix": "crossbeam-queue-0.2.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-queue-0.2.3.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-utils-0.7.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.7.2/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.7.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-utils-0.7.2.bazel"
+            }
+          },
+          "rules_rust_proto__fnv-1.0.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "rules_rust_proto__fuchsia-zircon-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-zircon/0.3.3/download"
+              ],
+              "strip_prefix": "fuchsia-zircon-0.3.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__fuchsia-zircon-sys-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-zircon-sys/0.3.3/download"
+              ],
+              "strip_prefix": "fuchsia-zircon-sys-0.3.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-sys-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__futures-0.1.31": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures/0.1.31/download"
+              ],
+              "strip_prefix": "futures-0.1.31",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.futures-0.1.31.bazel"
+            }
+          },
+          "rules_rust_proto__futures-cpupool-0.1.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-cpupool/0.1.8/download"
+              ],
+              "strip_prefix": "futures-cpupool-0.1.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.futures-cpupool-0.1.8.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-0.6.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2aaf1d741fe6f3413f1f9f71b99f5e4e26776d563475a8a53ce53a73a8534c1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-0.6.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.grpc-0.6.2.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-compiler-0.6.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "907274ce8ee7b40a0d0b0db09022ea22846a47cfb1fc8ad2c983c70001b4ffb1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc-compiler/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-compiler-0.6.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.grpc-compiler-0.6.2.bazel"
+            }
+          },
+          "rules_rust_proto__hermit-abi-0.2.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
+              ],
+              "strip_prefix": "hermit-abi-0.2.6",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
+            }
+          },
+          "rules_rust_proto__httpbis-0.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7689cfa896b2a71da4f16206af167542b75d242b6906313e53857972a92d5614",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpbis/0.7.0/download"
+              ],
+              "strip_prefix": "httpbis-0.7.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.httpbis-0.7.0.bazel"
+            }
+          },
+          "rules_rust_proto__iovec-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iovec/0.1.4/download"
+              ],
+              "strip_prefix": "iovec-0.1.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.iovec-0.1.4.bazel"
+            }
+          },
+          "rules_rust_proto__kernel32-sys-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/kernel32-sys/0.2.2/download"
+              ],
+              "strip_prefix": "kernel32-sys-0.2.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.kernel32-sys-0.2.2.bazel"
+            }
+          },
+          "rules_rust_proto__lazy_static-1.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__libc-0.2.139": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.139/download"
+              ],
+              "strip_prefix": "libc-0.2.139",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.libc-0.2.139.bazel"
+            }
+          },
+          "rules_rust_proto__lock_api-0.3.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.3.4/download"
+              ],
+              "strip_prefix": "lock_api-0.3.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.lock_api-0.3.4.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.3.9/download"
+              ],
+              "strip_prefix": "log-0.3.9",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.log-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.4.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.17/download"
+              ],
+              "strip_prefix": "log-0.4.17",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.log-0.4.17.bazel"
+            }
+          },
+          "rules_rust_proto__maybe-uninit-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maybe-uninit/2.0.0/download"
+              ],
+              "strip_prefix": "maybe-uninit-2.0.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.maybe-uninit-2.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__memoffset-0.5.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.5.6/download"
+              ],
+              "strip_prefix": "memoffset-0.5.6",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.memoffset-0.5.6.bazel"
+            }
+          },
+          "rules_rust_proto__mio-0.6.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/0.6.23/download"
+              ],
+              "strip_prefix": "mio-0.6.23",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.mio-0.6.23.bazel"
+            }
+          },
+          "rules_rust_proto__mio-uds-0.6.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio-uds/0.6.8/download"
+              ],
+              "strip_prefix": "mio-uds-0.6.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.mio-uds-0.6.8.bazel"
+            }
+          },
+          "rules_rust_proto__miow-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miow/0.2.2/download"
+              ],
+              "strip_prefix": "miow-0.2.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.miow-0.2.2.bazel"
+            }
+          },
+          "rules_rust_proto__net2-0.2.38": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/net2/0.2.38/download"
+              ],
+              "strip_prefix": "net2-0.2.38",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.net2-0.2.38.bazel"
+            }
+          },
+          "rules_rust_proto__num_cpus-1.15.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.15.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.15.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.num_cpus-1.15.0.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.9.0/download"
+              ],
+              "strip_prefix": "parking_lot-0.9.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.parking_lot-0.9.0.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot_core-0.6.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bda66b810a62be75176a80873726630147a5ca780cd33921e0b5709033e66b0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.6.3/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.6.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.parking_lot_core-0.6.3.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-2.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust+//proto/protobuf/3rdparty/patches:protobuf-2.8.2.patch"
+              ],
+              "sha256": "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-2.8.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-codegen-2.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3d74b9cbbf2ac9a7169c85a3714ec16c51ee9ec7cfd511549527e9a7df720795",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf-codegen/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-codegen-2.8.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.protobuf-codegen-2.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__redox_syscall-0.1.57": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.1.57/download"
+              ],
+              "strip_prefix": "redox_syscall-0.1.57",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.redox_syscall-0.1.57.bazel"
+            }
+          },
+          "rules_rust_proto__rustc_version-0.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc_version/0.2.3/download"
+              ],
+              "strip_prefix": "rustc_version-0.2.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.rustc_version-0.2.3.bazel"
+            }
+          },
+          "rules_rust_proto__safemem-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/safemem/0.3.3/download"
+              ],
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__scoped-tls-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scoped-tls/0.1.2/download"
+              ],
+              "strip_prefix": "scoped-tls-0.1.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.scoped-tls-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__scopeguard-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.1.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "rules_rust_proto__semver-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/0.9.0/download"
+              ],
+              "strip_prefix": "semver-0.9.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.semver-0.9.0.bazel"
+            }
+          },
+          "rules_rust_proto__semver-parser-0.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver-parser/0.7.0/download"
+              ],
+              "strip_prefix": "semver-parser-0.7.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.semver-parser-0.7.0.bazel"
+            }
+          },
+          "rules_rust_proto__slab-0.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.3.0/download"
+              ],
+              "strip_prefix": "slab-0.3.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.slab-0.3.0.bazel"
+            }
+          },
+          "rules_rust_proto__slab-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.7/download"
+              ],
+              "strip_prefix": "slab-0.4.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.slab-0.4.7.bazel"
+            }
+          },
+          "rules_rust_proto__smallvec-0.6.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/0.6.14/download"
+              ],
+              "strip_prefix": "smallvec-0.6.14",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.smallvec-0.6.14.bazel"
+            }
+          },
+          "rules_rust_proto__tls-api-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tls-api-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tls-api-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tls-api-stub-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c9a0cc8c149724db9de7d73a0e1bc80b1a74f5394f08c6f301e11f9c35fa061e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tls-api-stub/0.1.22/download"
+              ],
+              "strip_prefix": "tls-api-stub-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tls-api-stub-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-codec-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-codec/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-codec-0.1.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-codec-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-core-0.1.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-core/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-core-0.1.18",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-core-0.1.18.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-current-thread-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-current-thread/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-current-thread-0.1.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-current-thread-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-executor-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-executor/0.1.10/download"
+              ],
+              "strip_prefix": "tokio-executor-0.1.10",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-executor-0.1.10.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-fs-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-fs/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-fs-0.1.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-fs-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-io-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-io/0.1.13/download"
+              ],
+              "strip_prefix": "tokio-io-0.1.13",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-io-0.1.13.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-reactor-0.1.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-reactor/0.1.12/download"
+              ],
+              "strip_prefix": "tokio-reactor-0.1.12",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-reactor-0.1.12.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-sync-0.1.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-sync/0.1.8/download"
+              ],
+              "strip_prefix": "tokio-sync-0.1.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-sync-0.1.8.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tcp-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tcp/0.1.4/download"
+              ],
+              "strip_prefix": "tokio-tcp-0.1.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-tcp-0.1.4.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-threadpool-0.1.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-threadpool/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-threadpool-0.1.18",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-threadpool-0.1.18.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-timer-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-timer/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-timer-0.1.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-timer-0.2.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-timer/0.2.13/download"
+              ],
+              "strip_prefix": "tokio-timer-0.2.13",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.2.13.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tls-api-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "68d0e040d5b1f4cfca70ec4f371229886a5de5bb554d272a4a8da73004a7b2c9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-tls-api-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-tls-api-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-udp-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-udp/0.1.6/download"
+              ],
+              "strip_prefix": "tokio-udp-0.1.6",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-udp-0.1.6.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.1.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.2.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.2.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.2.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.2.7.bazel"
+            }
+          },
+          "rules_rust_proto__unix_socket-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unix_socket/0.5.0/download"
+              ],
+              "strip_prefix": "unix_socket-0.5.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.unix_socket-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__void-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/void/1.0.2/download"
+              ],
+              "strip_prefix": "void-1.0.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-0.2.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.2.8/download"
+              ],
+              "strip_prefix": "winapi-0.2.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-0.2.8.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-build-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-build/0.1.1/download"
+              ],
+              "strip_prefix": "winapi-build-0.1.1",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-build-0.1.1.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__ws2_32-sys-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ws2_32-sys/0.2.1/download"
+              ],
+              "strip_prefix": "ws2_32-sys-0.2.1",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.ws2_32-sys-0.2.1.bazel"
+            }
+          },
+          "llvm-raw": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
+              ],
+              "strip_prefix": "llvm-project-14.0.6.src",
+              "sha256": "8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a",
+              "build_file_content": "# empty",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust+//bindgen/3rdparty/patches:llvm-project.cxx17.patch",
+                "@@rules_rust+//bindgen/3rdparty/patches:llvm-project.incompatible_disallow_empty_glob.patch"
+              ]
+            }
+          },
+          "rules_rust_bindgen__bindgen-cli-0.70.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "integrity": "sha256-Mz+eRtWNh1r7irkjwi27fmF4j1WtKPK12Yv5ENkL1ao=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bindgen-cli/bindgen-cli-0.70.1.crate"
+              ],
+              "strip_prefix": "bindgen-cli-0.70.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty:BUILD.bindgen-cli.bazel"
+            }
+          },
+          "rules_rust_bindgen__aho-corasick-1.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__annotate-snippets-0.9.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/annotate-snippets/0.9.2/download"
+              ],
+              "strip_prefix": "annotate-snippets-0.9.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.annotate-snippets-0.9.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstream-0.6.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.6.15/download"
+              ],
+              "strip_prefix": "anstream-0.6.15",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstream-0.6.15.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.8/download"
+              ],
+              "strip_prefix": "anstyle-1.0.8",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-1.0.8.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-parse-0.2.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.5/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.5",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-parse-0.2.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-query-1.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.1.1/download"
+              ],
+              "strip_prefix": "anstyle-query-1.1.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-query-1.1.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-wincon-3.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/3.0.4/download"
+              ],
+              "strip_prefix": "anstyle-wincon-3.0.4",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-wincon-3.0.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__bindgen-0.70.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bindgen/0.70.1/download"
+              ],
+              "strip_prefix": "bindgen-0.70.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.bindgen-0.70.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__bitflags-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__cexpr-0.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cexpr/0.6.0/download"
+              ],
+              "strip_prefix": "cexpr-0.6.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.cexpr-0.6.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__clang-sys-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clang-sys/1.8.1/download"
+              ],
+              "strip_prefix": "clang-sys-1.8.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clang-sys-1.8.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap-4.5.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.5.17/download"
+              ],
+              "strip_prefix": "clap-4.5.17",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap-4.5.17.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_builder-4.5.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.5.17/download"
+              ],
+              "strip_prefix": "clap_builder-4.5.17",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_builder-4.5.17.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_complete-4.5.26": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_complete/4.5.26/download"
+              ],
+              "strip_prefix": "clap_complete-4.5.26",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_complete-4.5.26.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_derive-4.5.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.5.13/download"
+              ],
+              "strip_prefix": "clap_derive-4.5.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_derive-4.5.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_lex-0.7.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.7.2/download"
+              ],
+              "strip_prefix": "clap_lex-0.7.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_lex-0.7.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__colorchoice-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.2/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.colorchoice-1.0.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__either-1.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__env_logger-0.10.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.2/download"
+              ],
+              "strip_prefix": "env_logger-0.10.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.env_logger-0.10.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__glob-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/glob/0.3.1/download"
+              ],
+              "strip_prefix": "glob-0.3.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.glob-0.3.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__heck-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__hermit-abi-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.4.0/download"
+              ],
+              "strip_prefix": "hermit-abi-0.4.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.hermit-abi-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__humantime-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__is-terminal-0.4.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.13/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.is-terminal-0.4.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__is_terminal_polyfill-1.70.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is_terminal_polyfill/1.70.1/download"
+              ],
+              "strip_prefix": "is_terminal_polyfill-1.70.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.is_terminal_polyfill-1.70.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__itertools-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__libc-0.2.158": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "rules_rust_bindgen__libloading-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libloading/0.8.5/download"
+              ],
+              "strip_prefix": "libloading-0.8.5",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.libloading-0.8.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__log-0.4.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "rules_rust_bindgen__memchr-2.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__minimal-lexical-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/minimal-lexical/0.2.1/download"
+              ],
+              "strip_prefix": "minimal-lexical-0.2.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.minimal-lexical-0.2.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__nom-7.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/nom/7.1.3/download"
+              ],
+              "strip_prefix": "nom-7.1.3",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.nom-7.1.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__prettyplease-0.2.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "rules_rust_bindgen__proc-macro2-1.0.86": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
+            }
+          },
+          "rules_rust_bindgen__quote-1.0.37": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-1.10.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-automata-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-syntax-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__rustc-hash-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+              ],
+              "strip_prefix": "rustc-hash-1.1.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__shlex-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shlex/1.3.0/download"
+              ],
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__strsim-0.11.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.11.1/download"
+              ],
+              "strip_prefix": "strsim-0.11.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.strsim-0.11.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__syn-2.0.77": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.77/download"
+              ],
+              "strip_prefix": "syn-2.0.77",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.syn-2.0.77.bazel"
+            }
+          },
+          "rules_rust_bindgen__termcolor-1.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.4.1/download"
+              ],
+              "strip_prefix": "termcolor-1.4.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.termcolor-1.4.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-ident-1.0.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.13/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-width-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.13/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.unicode-width-0.1.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__utf8parse-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.2/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.utf8parse-0.2.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-util-0.1.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.9/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.9",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-util-0.1.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-sys-0.52.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-sys-0.59.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-targets-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_aarch64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_aarch64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__yansi-term-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/yansi-term/0.1.2/download"
+              ],
+              "strip_prefix": "yansi-term-0.1.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.yansi-term-0.1.2.bazel"
+            }
+          },
+          "rrra__aho-corasick-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rrra__anstream-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.3.2/download"
+              ],
+              "strip_prefix": "anstream-0.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
+            }
+          },
+          "rrra__anstyle-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "rrra__anstyle-parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "rrra__anstyle-query-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
+              ],
+              "strip_prefix": "anstyle-query-1.0.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+            }
+          },
+          "rrra__anstyle-wincon-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "rrra__anyhow-1.0.71": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
+          "rrra__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rrra__cc-1.0.79": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.79/download"
+              ],
+              "strip_prefix": "cc-1.0.79",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.cc-1.0.79.bazel"
+            }
+          },
+          "rrra__clap-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.3.11/download"
+              ],
+              "strip_prefix": "clap-4.3.11",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap-4.3.11.bazel"
+            }
+          },
+          "rrra__clap_builder-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
+              ],
+              "strip_prefix": "clap_builder-4.3.11",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
+            }
+          },
+          "rrra__clap_derive-4.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+              ],
+              "strip_prefix": "clap_derive-4.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+            }
+          },
+          "rrra__clap_lex-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "rrra__colorchoice-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "rrra__either-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.either-1.8.1.bazel"
+            }
+          },
+          "rrra__env_logger-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.0/download"
+              ],
+              "strip_prefix": "env_logger-0.10.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
+            }
+          },
+          "rrra__errno-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rrra__errno-dragonfly-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rrra__heck-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "rrra__hermit-abi-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "rrra__humantime-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rrra__io-lifetimes-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rrra__is-terminal-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "rrra__itertools-0.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.11.0/download"
+              ],
+              "strip_prefix": "itertools-0.11.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.itertools-0.11.0.bazel"
+            }
+          },
+          "rrra__itoa-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "rrra__libc-0.2.147": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.147/download"
+              ],
+              "strip_prefix": "libc-0.2.147",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.libc-0.2.147.bazel"
+            }
+          },
+          "rrra__linux-raw-sys-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rrra__log-0.4.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rrra__memchr-2.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rrra__once_cell-1.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rrra__proc-macro2-1.0.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rrra__quote-1.0.29": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rrra__regex-1.9.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.9.1/download"
+              ],
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "rrra__regex-automata-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rrra__regex-syntax-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rrra__rustix-0.37.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "rrra__ryu-1.0.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "rrra__serde-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.171/download"
+              ],
+              "strip_prefix": "serde-1.0.171",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.serde-1.0.171.bazel"
+            }
+          },
+          "rrra__serde_derive-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rrra__serde_json-1.0.102": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
+              ],
+              "strip_prefix": "serde_json-1.0.102",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "rrra__strsim-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "rrra__syn-2.0.25": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.25/download"
+              ],
+              "strip_prefix": "syn-2.0.25",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.syn-2.0.25.bazel"
+            }
+          },
+          "rrra__termcolor-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
+              ],
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "rrra__unicode-ident-1.0.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rrra__utf8parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "rrra__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rrra__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rrra__winapi-util-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rrra__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rrra__windows-sys-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "rrra__windows-targets-0.48.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rrra__windows_aarch64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_aarch64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_i686_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_i686_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen_cli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "08f61e21873f51e3059a8c7c3eef81ede7513d161cfc60751c7b2ffa6ed28270",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-0.2.92.crate"
+              ],
+              "type": "tar.gz",
+              "strip_prefix": "wasm-bindgen-cli-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty:BUILD.wasm-bindgen-cli.bazel",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust+//wasm_bindgen/3rdparty/patches:resolver.patch"
+              ]
+            }
+          },
+          "rules_rust_wasm_bindgen__adler-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__aho-corasick-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__alloc-no-stdlib-2.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/alloc-no-stdlib/2.0.4/download"
+              ],
+              "strip_prefix": "alloc-no-stdlib-2.0.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.alloc-no-stdlib-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__alloc-stdlib-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/alloc-stdlib/0.2.2/download"
+              ],
+              "strip_prefix": "alloc-stdlib-0.2.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.alloc-stdlib-0.2.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android-tzdata-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
+              ],
+              "strip_prefix": "android-tzdata-0.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android_system_properties-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
+              ],
+              "strip_prefix": "android_system_properties-0.1.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__anyhow-1.0.71": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ascii-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ascii/1.1.0/download"
+              ],
+              "strip_prefix": "ascii-1.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ascii-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__assert_cmd-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/assert_cmd/1.0.8/download"
+              ],
+              "strip_prefix": "assert_cmd-1.0.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.assert_cmd-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__atty-0.2.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atty/0.2.14/download"
+              ],
+              "strip_prefix": "atty-0.2.14",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.atty-0.2.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__autocfg-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.13.1/download"
+              ],
+              "strip_prefix": "base64-0.13.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.base64-0.13.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.21.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.21.5/download"
+              ],
+              "strip_prefix": "base64-0.21.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.base64-0.21.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__brotli-decompressor-2.5.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/brotli-decompressor/2.5.1/download"
+              ],
+              "strip_prefix": "brotli-decompressor-2.5.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.brotli-decompressor-2.5.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bstr-0.2.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/0.2.17/download"
+              ],
+              "strip_prefix": "bstr-0.2.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.bstr-0.2.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__buf_redux-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/buf_redux/0.8.4/download"
+              ],
+              "strip_prefix": "buf_redux-0.8.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.buf_redux-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bumpalo-3.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+              ],
+              "strip_prefix": "bumpalo-3.13.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__cc-1.0.83": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.83/download"
+              ],
+              "strip_prefix": "cc-1.0.83",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.cc-1.0.83.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chrono-0.4.26": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono/0.4.26/download"
+              ],
+              "strip_prefix": "chrono-0.4.26",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chunked_transfer-1.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chunked_transfer/1.4.1/download"
+              ],
+              "strip_prefix": "chunked_transfer-1.4.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.chunked_transfer-1.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__core-foundation-sys-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
+              ],
+              "strip_prefix": "core-foundation-sys-0.8.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crc32fast-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-channel-0.5.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-deque-0.8.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.8.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-epoch-0.9.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.9.15",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-utils-0.8.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__diff-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/diff/0.1.13/download"
+              ],
+              "strip_prefix": "diff-0.1.13",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.diff-0.1.13.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difference-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difference/2.0.0/download"
+              ],
+              "strip_prefix": "difference-2.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.difference-2.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difflib-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difflib/0.4.0/download"
+              ],
+              "strip_prefix": "difflib-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.difflib-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__doc-comment-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/doc-comment/0.3.3/download"
+              ],
+              "strip_prefix": "doc-comment-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.doc-comment-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__docopt-1.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/docopt/1.1.1/download"
+              ],
+              "strip_prefix": "docopt-1.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.docopt-1.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__either-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.either-1.8.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__env_logger-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.8.4/download"
+              ],
+              "strip_prefix": "env_logger-0.8.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.env_logger-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__equivalent-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__errno-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__errno-dragonfly-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fallible-iterator-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fallible-iterator/0.2.0/download"
+              ],
+              "strip_prefix": "fallible-iterator-0.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.fallible-iterator-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fastrand-1.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/1.9.0/download"
+              ],
+              "strip_prefix": "fastrand-1.9.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.fastrand-1.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__filetime-0.2.21": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.21/download"
+              ],
+              "strip_prefix": "filetime-0.2.21",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.filetime-0.2.21.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__flate2-1.0.28": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/flate2/1.0.28/download"
+              ],
+              "strip_prefix": "flate2-1.0.28",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__float-cmp-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/float-cmp/0.8.0/download"
+              ],
+              "strip_prefix": "float-cmp-0.8.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.float-cmp-0.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__form_urlencoded-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__getrandom-0.2.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
+              ],
+              "strip_prefix": "getrandom-0.2.10",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__gimli-0.26.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.26.2/download"
+              ],
+              "strip_prefix": "gimli-0.26.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.gimli-0.26.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hashbrown-0.12.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.12.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hashbrown-0.14.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.0/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.14.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__heck-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.3.3/download"
+              ],
+              "strip_prefix": "heck-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.heck-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hermit-abi-0.1.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.1.19/download"
+              ],
+              "strip_prefix": "hermit-abi-0.1.19",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.1.19.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hermit-abi-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httparse-1.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.8.0/download"
+              ],
+              "strip_prefix": "httparse-1.8.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httpdate-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.2/download"
+              ],
+              "strip_prefix": "httpdate-1.0.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__humantime-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-0.1.57": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
+              ],
+              "strip_prefix": "iana-time-zone-0.1.57",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-haiku-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
+              ],
+              "strip_prefix": "iana-time-zone-haiku-0.1.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__id-arena-2.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/id-arena/2.2.1/download"
+              ],
+              "strip_prefix": "id-arena-2.2.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.id-arena-2.2.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__idna-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.4.0/download"
+              ],
+              "strip_prefix": "idna-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.idna-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-1.9.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.0.0/download"
+              ],
+              "strip_prefix": "indexmap-2.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.indexmap-2.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__instant-0.1.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/instant/0.1.12/download"
+              ],
+              "strip_prefix": "instant-0.1.12",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.instant-0.1.12.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__io-lifetimes-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__itertools-0.10.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.10.5/download"
+              ],
+              "strip_prefix": "itertools-0.10.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.itertools-0.10.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__itoa-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__js-sys-0.3.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
+              ],
+              "strip_prefix": "js-sys-0.3.64",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__lazy_static-1.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__leb128-0.2.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/leb128/0.2.5/download"
+              ],
+              "strip_prefix": "leb128-0.2.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.leb128-0.2.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__libc-0.2.150": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.150/download"
+              ],
+              "strip_prefix": "libc-0.2.150",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.libc-0.2.150.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__linux-raw-sys-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__log-0.4.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memchr-2.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memoffset-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
+              ],
+              "strip_prefix": "memoffset-0.9.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__mime-0.3.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime/0.3.17/download"
+              ],
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__mime_guess-2.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime_guess/2.0.4/download"
+              ],
+              "strip_prefix": "mime_guess-2.0.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.mime_guess-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__miniz_oxide-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__multipart-0.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multipart/0.18.0/download"
+              ],
+              "strip_prefix": "multipart-0.18.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.multipart-0.18.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__normalize-line-endings-0.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/normalize-line-endings/0.3.0/download"
+              ],
+              "strip_prefix": "normalize-line-endings-0.3.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.normalize-line-endings-0.3.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num-traits-0.2.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
+              ],
+              "strip_prefix": "num-traits-0.2.15",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num_cpus-1.16.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.16.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.16.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.num_cpus-1.16.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num_threads-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
+              ],
+              "strip_prefix": "num_threads-0.1.6",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__once_cell-1.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__percent-encoding-2.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ppv-lite86-0.2.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/1.0.8/download"
+              ],
+              "strip_prefix": "predicates-1.0.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-2.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/2.1.5/download"
+              ],
+              "strip_prefix": "predicates-2.1.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-2.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-core-1.0.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-core/1.0.6/download"
+              ],
+              "strip_prefix": "predicates-core-1.0.6",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-core-1.0.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-tree-1.0.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-tree/1.0.9/download"
+              ],
+              "strip_prefix": "predicates-tree-1.0.9",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-tree-1.0.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__proc-macro2-1.0.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quick-error-1.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quick-error/1.2.3/download"
+              ],
+              "strip_prefix": "quick-error-1.2.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.quick-error-1.2.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quote-1.0.29": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_chacha-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_core-0.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rayon-1.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon/1.7.0/download"
+              ],
+              "strip_prefix": "rayon-1.7.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rayon-1.7.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rayon-core-1.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon-core/1.11.0/download"
+              ],
+              "strip_prefix": "rayon-core-1.11.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rayon-core-1.11.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.2.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.2.16/download"
+              ],
+              "strip_prefix": "redox_syscall-0.2.16",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.2.16.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-1.9.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.9.1/download"
+              ],
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-automata-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.1.10/download"
+              ],
+              "strip_prefix": "regex-automata-0.1.10",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.1.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-automata-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-syntax-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ring-0.17.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ring/0.17.5/download"
+              ],
+              "strip_prefix": "ring-0.17.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ring-0.17.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rouille-3.6.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rouille/3.6.2/download"
+              ],
+              "strip_prefix": "rouille-3.6.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rouille-3.6.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustc-demangle-0.1.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.23/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.23",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustc-demangle-0.1.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustix-0.37.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustls-0.21.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustls/0.21.8/download"
+              ],
+              "strip_prefix": "rustls-0.21.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustls-0.21.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustls-webpki-0.101.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustls-webpki/0.101.7/download"
+              ],
+              "strip_prefix": "rustls-webpki-0.101.7",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustls-webpki-0.101.7.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ryu-1.0.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__safemem-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/safemem/0.3.3/download"
+              ],
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__scopeguard-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__sct-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sct/0.7.1/download"
+              ],
+              "strip_prefix": "sct-0.7.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.sct-0.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__semver-1.0.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.17/download"
+              ],
+              "strip_prefix": "semver-1.0.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.171/download"
+              ],
+              "strip_prefix": "serde-1.0.171",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.serde-1.0.171.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde_derive-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde_json-1.0.102": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
+              ],
+              "strip_prefix": "serde_json-1.0.102",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__sha1_smol-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
+              ],
+              "strip_prefix": "sha1_smol-1.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__spin-0.9.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spin/0.9.8/download"
+              ],
+              "strip_prefix": "spin-0.9.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.spin-0.9.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__stable_deref_trait-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/stable_deref_trait/1.2.0/download"
+              ],
+              "strip_prefix": "stable_deref_trait-1.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.stable_deref_trait-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__strsim-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__syn-1.0.109": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__syn-2.0.25": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.25/download"
+              ],
+              "strip_prefix": "syn-2.0.25",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.syn-2.0.25.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tempfile-3.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.6.0/download"
+              ],
+              "strip_prefix": "tempfile-3.6.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termcolor-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
+              ],
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termtree-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termtree/0.4.1/download"
+              ],
+              "strip_prefix": "termtree-0.4.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.termtree-0.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__threadpool-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/threadpool/1.8.1/download"
+              ],
+              "strip_prefix": "threadpool-1.8.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.threadpool-1.8.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__time-0.3.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time/0.3.23/download"
+              ],
+              "strip_prefix": "time-0.3.23",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.time-0.3.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__time-core-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-core/0.1.1/download"
+              ],
+              "strip_prefix": "time-core-0.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.time-core-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tiny_http-0.12.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tiny_http/0.12.0/download"
+              ],
+              "strip_prefix": "tiny_http-0.12.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tiny_http-0.12.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec_macros-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__twoway-0.1.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/twoway/0.1.8/download"
+              ],
+              "strip_prefix": "twoway-0.1.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.twoway-0.1.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicase-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicase/2.6.0/download"
+              ],
+              "strip_prefix": "unicase-2.6.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicase-2.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-bidi-0.3.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
+              ],
+              "strip_prefix": "unicode-bidi-0.3.13",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-ident-1.0.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-normalization-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-segmentation-1.10.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-segmentation/1.10.1/download"
+              ],
+              "strip_prefix": "unicode-segmentation-1.10.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-segmentation-1.10.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__untrusted-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/untrusted/0.9.0/download"
+              ],
+              "strip_prefix": "untrusted-0.9.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.untrusted-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ureq-2.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ureq/2.8.0/download"
+              ],
+              "strip_prefix": "ureq-2.8.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ureq-2.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__url-2.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.4.0/download"
+              ],
+              "strip_prefix": "url-2.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.url-2.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__version_check-0.9.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/version_check/0.9.4/download"
+              ],
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wait-timeout-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wait-timeout/0.2.0/download"
+              ],
+              "strip_prefix": "wait-timeout-0.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wait-timeout-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__walrus-0.20.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walrus/0.20.3/download"
+              ],
+              "strip_prefix": "walrus-0.20.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.walrus-0.20.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__walrus-macro-0.19.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walrus-macro/0.19.0/download"
+              ],
+              "strip_prefix": "walrus-macro-0.19.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.walrus-macro-0.19.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasi-0.11.0-wasi-snapshot-preview1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-backend-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca821da8c1ae6c87c5e94493939a206daa8587caff227c6032e0061a3d80817f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-cli-support-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-externref-xform-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "102582726b35a30d53157fbf8de3d0f0fed4c40c0c7951d69a034e9ef01da725",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-externref-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-externref-xform-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-support-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-support-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-multi-value-xform-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3498e4799f43523d780ceff498f04d882a8dbc9719c28020034822e5952f32a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-multi-value-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-multi-value-xform-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-shared-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2d5add359b7f7d09a55299a9d29be54414264f2b8cf84f8c8fda5be9269b5dd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-threads-xform-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8c04e3607b810e76768260db3a5f2e8beb477cb089ef8726da85c8eb9bd3b575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-interpreter-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9ea966593c8243a33eb4d643254eb97a69de04e89462f46cf6b4f506aae89b3a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-interpreter/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-interpreter-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-encoder-0.29.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-encoder/0.29.0/download"
+              ],
+              "strip_prefix": "wasm-encoder-0.29.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-encoder-0.29.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.102.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.102.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.102.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.102.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.108.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.108.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.108.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.108.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.80.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.80.2/download"
+              ],
+              "strip_prefix": "wasmparser-0.80.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.80.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmprinter-0.2.60": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b76cb909fe3d9b0de58cee1f4072247e680ff5cc1558ccad2790a9de14a23993",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmprinter/0.2.60/download"
+              ],
+              "strip_prefix": "wasmprinter-0.2.60",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmprinter-0.2.60.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__webpki-roots-0.25.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/webpki-roots/0.25.2/download"
+              ],
+              "strip_prefix": "webpki-roots-0.25.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.webpki-roots-0.25.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-util-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows/0.48.0/download"
+              ],
+              "strip_prefix": "windows-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-sys-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-targets-0.48.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_test_load_arbitrary_tool": {
+            "repoRuleId": "@@rules_rust+//test/load_arbitrary_tool:load_arbitrary_tool_test.bzl%_load_arbitrary_tool_test",
+            "attributes": {}
+          },
+          "generated_inputs_in_external_repo": {
+            "repoRuleId": "@@rules_rust+//test/generated_inputs:external_repo.bzl%_generated_inputs_in_external_repo",
+            "attributes": {}
+          },
+          "libc": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "load(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\nrust_library(\n    name = \"libc\",\n    srcs = glob([\"src/**/*.rs\"]),\n    edition = \"2015\",\n    rustc_flags = [\n        # In most cases, warnings in 3rd party crates are not interesting as\n        # they're out of the control of consumers. The flag here silences\n        # warnings. For more details see:\n        # https://doc.rust-lang.org/rustc/lints/levels.html\n        \"--cap-lints=allow\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "1ac4c2ac6ed5a8fb9020c166bc63316205f1dc78d4b964ad31f4f21eb73f0c6d",
+              "strip_prefix": "libc-0.2.20",
+              "urls": [
+                "https://mirror.bazel.build/github.com/rust-lang/libc/archive/0.2.20.zip",
+                "https://github.com/rust-lang/libc/archive/0.2.20.zip"
+              ]
+            }
+          },
+          "rules_rust_toolchain_test_target_json": {
+            "repoRuleId": "@@rules_rust+//test/unit/toolchain:toolchain_test_utils.bzl%rules_rust_toolchain_test_target_json_repository",
+            "attributes": {
+              "target_json": "@@rules_rust+//test/unit/toolchain:toolchain-test-triple.json"
+            }
+          },
+          "com_google_googleapis": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/googleapis/googleapis/archive/18becb1d1426feb7399db144d7beeb3284f1ccb0.zip"
+              ],
+              "strip_prefix": "googleapis-18becb1d1426feb7399db144d7beeb3284f1ccb0",
+              "sha256": "b8c487191eb942361af905e40172644eab490190e717c3d09bf83e87f3994fff"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
+              "strip_prefix": "rules_python-0.34.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "rules_rust_tinyjson",
+            "cui",
+            "cui__anyhow-1.0.75",
+            "cui__camino-1.1.6",
+            "cui__cargo-lock-9.0.0",
+            "cui__cargo-platform-0.1.4",
+            "cui__cargo_metadata-0.18.1",
+            "cui__cargo_toml-0.19.2",
+            "cui__cfg-expr-0.15.5",
+            "cui__clap-4.3.11",
+            "cui__crates-index-2.2.0",
+            "cui__hex-0.4.3",
+            "cui__indoc-2.0.4",
+            "cui__itertools-0.12.0",
+            "cui__normpath-1.1.1",
+            "cui__once_cell-1.19.0",
+            "cui__pathdiff-0.2.1",
+            "cui__regex-1.10.2",
+            "cui__semver-1.0.20",
+            "cui__serde-1.0.190",
+            "cui__serde_json-1.0.108",
+            "cui__serde_starlark-0.1.14",
+            "cui__sha2-0.10.8",
+            "cui__spdx-0.10.3",
+            "cui__tempfile-3.8.1",
+            "cui__tera-1.19.1",
+            "cui__textwrap-0.16.0",
+            "cui__toml-0.8.10",
+            "cui__tracing-0.1.40",
+            "cui__tracing-subscriber-0.3.17",
+            "cui__url-2.5.2",
+            "cui__maplit-1.0.2",
+            "cui__spectral-0.6.0",
+            "cargo_bazel.buildifier-darwin-amd64",
+            "cargo_bazel.buildifier-darwin-arm64",
+            "cargo_bazel.buildifier-linux-amd64",
+            "cargo_bazel.buildifier-linux-arm64",
+            "cargo_bazel.buildifier-linux-s390x",
+            "cargo_bazel.buildifier-windows-amd64.exe",
+            "rules_rust_prost__heck",
+            "rules_rust_prost",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust_proto__grpc-0.6.2",
+            "rules_rust_proto__grpc-compiler-0.6.2",
+            "rules_rust_proto__log-0.4.17",
+            "rules_rust_proto__protobuf-2.8.2",
+            "rules_rust_proto__protobuf-codegen-2.8.2",
+            "rules_rust_proto__tls-api-0.1.22",
+            "rules_rust_proto__tls-api-stub-0.1.22",
+            "llvm-raw",
+            "rules_rust_bindgen__bindgen-cli-0.70.1",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rrra__anyhow-1.0.71",
+            "rrra__clap-4.3.11",
+            "rrra__env_logger-0.10.0",
+            "rrra__itertools-0.11.0",
+            "rrra__log-0.4.19",
+            "rrra__serde-1.0.171",
+            "rrra__serde_json-1.0.102",
+            "rules_rust_wasm_bindgen_cli",
+            "rules_rust_wasm_bindgen__anyhow-1.0.71",
+            "rules_rust_wasm_bindgen__docopt-1.1.1",
+            "rules_rust_wasm_bindgen__env_logger-0.8.4",
+            "rules_rust_wasm_bindgen__log-0.4.19",
+            "rules_rust_wasm_bindgen__rouille-3.6.2",
+            "rules_rust_wasm_bindgen__serde-1.0.171",
+            "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+            "rules_rust_wasm_bindgen__serde_json-1.0.102",
+            "rules_rust_wasm_bindgen__ureq-2.8.0",
+            "rules_rust_wasm_bindgen__walrus-0.20.3",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+            "rules_rust_wasm_bindgen__diff-0.1.13",
+            "rules_rust_wasm_bindgen__predicates-1.0.8",
+            "rules_rust_wasm_bindgen__rayon-1.7.0",
+            "rules_rust_wasm_bindgen__tempfile-3.6.0",
+            "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+            "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+            "rules_rust_test_load_arbitrary_tool",
+            "generated_inputs_in_external_repo",
+            "libc",
+            "rules_rust_toolchain_test_target_json",
+            "com_google_googleapis",
+            "rules_python"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cui__anyhow-1.0.75",
+            "rules_rust++i+cui__anyhow-1.0.75"
+          ],
+          [
+            "rules_rust+",
+            "cui__camino-1.1.6",
+            "rules_rust++i+cui__camino-1.1.6"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo-lock-9.0.0",
+            "rules_rust++i+cui__cargo-lock-9.0.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo-platform-0.1.4",
+            "rules_rust++i+cui__cargo-platform-0.1.4"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo_metadata-0.18.1",
+            "rules_rust++i+cui__cargo_metadata-0.18.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo_toml-0.19.2",
+            "rules_rust++i+cui__cargo_toml-0.19.2"
+          ],
+          [
+            "rules_rust+",
+            "cui__cfg-expr-0.15.5",
+            "rules_rust++i+cui__cfg-expr-0.15.5"
+          ],
+          [
+            "rules_rust+",
+            "cui__clap-4.3.11",
+            "rules_rust++i+cui__clap-4.3.11"
+          ],
+          [
+            "rules_rust+",
+            "cui__crates-index-2.2.0",
+            "rules_rust++i+cui__crates-index-2.2.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__hex-0.4.3",
+            "rules_rust++i+cui__hex-0.4.3"
+          ],
+          [
+            "rules_rust+",
+            "cui__indoc-2.0.4",
+            "rules_rust++i+cui__indoc-2.0.4"
+          ],
+          [
+            "rules_rust+",
+            "cui__itertools-0.12.0",
+            "rules_rust++i+cui__itertools-0.12.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__maplit-1.0.2",
+            "rules_rust++i+cui__maplit-1.0.2"
+          ],
+          [
+            "rules_rust+",
+            "cui__normpath-1.1.1",
+            "rules_rust++i+cui__normpath-1.1.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__once_cell-1.19.0",
+            "rules_rust++i+cui__once_cell-1.19.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__pathdiff-0.2.1",
+            "rules_rust++i+cui__pathdiff-0.2.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__regex-1.10.2",
+            "rules_rust++i+cui__regex-1.10.2"
+          ],
+          [
+            "rules_rust+",
+            "cui__semver-1.0.20",
+            "rules_rust++i+cui__semver-1.0.20"
+          ],
+          [
+            "rules_rust+",
+            "cui__serde-1.0.190",
+            "rules_rust++i+cui__serde-1.0.190"
+          ],
+          [
+            "rules_rust+",
+            "cui__serde_json-1.0.108",
+            "rules_rust++i+cui__serde_json-1.0.108"
+          ],
+          [
+            "rules_rust+",
+            "cui__serde_starlark-0.1.14",
+            "rules_rust++i+cui__serde_starlark-0.1.14"
+          ],
+          [
+            "rules_rust+",
+            "cui__sha2-0.10.8",
+            "rules_rust++i+cui__sha2-0.10.8"
+          ],
+          [
+            "rules_rust+",
+            "cui__spdx-0.10.3",
+            "rules_rust++i+cui__spdx-0.10.3"
+          ],
+          [
+            "rules_rust+",
+            "cui__spectral-0.6.0",
+            "rules_rust++i+cui__spectral-0.6.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__tempfile-3.8.1",
+            "rules_rust++i+cui__tempfile-3.8.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__tera-1.19.1",
+            "rules_rust++i+cui__tera-1.19.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__textwrap-0.16.0",
+            "rules_rust++i+cui__textwrap-0.16.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__toml-0.8.10",
+            "rules_rust++i+cui__toml-0.8.10"
+          ],
+          [
+            "rules_rust+",
+            "cui__tracing-0.1.40",
+            "rules_rust++i+cui__tracing-0.1.40"
+          ],
+          [
+            "rules_rust+",
+            "cui__tracing-subscriber-0.3.17",
+            "rules_rust++i+cui__tracing-subscriber-0.3.17"
+          ],
+          [
+            "rules_rust+",
+            "cui__url-2.5.2",
+            "rules_rust++i+cui__url-2.5.2"
+          ],
+          [
+            "rules_rust+",
+            "rrra__anyhow-1.0.71",
+            "rules_rust++i+rrra__anyhow-1.0.71"
+          ],
+          [
+            "rules_rust+",
+            "rrra__clap-4.3.11",
+            "rules_rust++i+rrra__clap-4.3.11"
+          ],
+          [
+            "rules_rust+",
+            "rrra__env_logger-0.10.0",
+            "rules_rust++i+rrra__env_logger-0.10.0"
+          ],
+          [
+            "rules_rust+",
+            "rrra__itertools-0.11.0",
+            "rules_rust++i+rrra__itertools-0.11.0"
+          ],
+          [
+            "rules_rust+",
+            "rrra__log-0.4.19",
+            "rules_rust++i+rrra__log-0.4.19"
+          ],
+          [
+            "rules_rust+",
+            "rrra__serde-1.0.171",
+            "rules_rust++i+rrra__serde-1.0.171"
+          ],
+          [
+            "rules_rust+",
+            "rrra__serde_json-1.0.102",
+            "rules_rust++i+rrra__serde_json-1.0.102"
+          ],
+          [
+            "rules_rust+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust++i+rules_rust_bindgen__bindgen-0.70.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust++i+rules_rust_bindgen__clang-sys-1.8.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust++i+rules_rust_bindgen__clap-4.5.17"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust++i+rules_rust_bindgen__clap_complete-4.5.26"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rules_rust++i+rules_rust_bindgen__env_logger-0.10.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust++i+rules_rust_prost__h2-0.4.6"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust++i+rules_rust_prost__prost-0.13.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust++i+rules_rust_prost__prost-types-0.13.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust++i+rules_rust_prost__protoc-gen-prost-0.4.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust++i+rules_rust_prost__protoc-gen-tonic-0.4.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust++i+rules_rust_prost__tokio-1.39.3"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust++i+rules_rust_prost__tokio-stream-0.1.15"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust++i+rules_rust_prost__tonic-0.12.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__grpc-0.6.2",
+            "rules_rust++i+rules_rust_proto__grpc-0.6.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__grpc-compiler-0.6.2",
+            "rules_rust++i+rules_rust_proto__grpc-compiler-0.6.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__log-0.4.17",
+            "rules_rust++i+rules_rust_proto__log-0.4.17"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__protobuf-2.8.2",
+            "rules_rust++i+rules_rust_proto__protobuf-2.8.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__protobuf-codegen-2.8.2",
+            "rules_rust++i+rules_rust_proto__protobuf-codegen-2.8.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__tls-api-0.1.22",
+            "rules_rust++i+rules_rust_proto__tls-api-0.1.22"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__tls-api-stub-0.1.22",
+            "rules_rust++i+rules_rust_proto__tls-api-stub-0.1.22"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__anyhow-1.0.71",
+            "rules_rust++i+rules_rust_wasm_bindgen__anyhow-1.0.71"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+            "rules_rust++i+rules_rust_wasm_bindgen__assert_cmd-1.0.8"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__diff-0.1.13",
+            "rules_rust++i+rules_rust_wasm_bindgen__diff-0.1.13"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__docopt-1.1.1",
+            "rules_rust++i+rules_rust_wasm_bindgen__docopt-1.1.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__env_logger-0.8.4",
+            "rules_rust++i+rules_rust_wasm_bindgen__env_logger-0.8.4"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__log-0.4.19",
+            "rules_rust++i+rules_rust_wasm_bindgen__log-0.4.19"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__predicates-1.0.8",
+            "rules_rust++i+rules_rust_wasm_bindgen__predicates-1.0.8"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__rayon-1.7.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__rayon-1.7.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__rouille-3.6.2",
+            "rules_rust++i+rules_rust_wasm_bindgen__rouille-3.6.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__serde-1.0.171",
+            "rules_rust++i+rules_rust_wasm_bindgen__serde-1.0.171"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+            "rules_rust++i+rules_rust_wasm_bindgen__serde_derive-1.0.171"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__serde_json-1.0.102",
+            "rules_rust++i+rules_rust_wasm_bindgen__serde_json-1.0.102"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__tempfile-3.6.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__tempfile-3.6.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__ureq-2.8.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__ureq-2.8.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__walrus-0.20.3",
+            "rules_rust++i+rules_rust_wasm_bindgen__walrus-0.20.3"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasm-bindgen-0.2.92"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasmparser-0.102.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasmprinter-0.2.60"
+          ]
+        ]
+      }
+    },
     "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "r/zoigrb42fT/zIUCLua7Xptst5Dk96z/IyAElaPNf8=",
@@ -15862,6 +26904,34 @@
         "recordedRepoMappingEntries": [
           [
             "rules_swift+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@upb+//:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "MoDKeLK+fZfOC/Kn2bejs500LmbsWGEP2rGmPqFJaxo=",
+        "usagesDigest": "pZOZBYc8Kee/Hi8/EIf3SfYt6ar0unb9MMI2Tczhi6g=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "utf8_range": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/protocolbuffers/utf8_range/archive/de0b4a8ff9b5d4c98108bdfe723291a33c52c54f.zip"
+              ],
+              "strip_prefix": "utf8_range-de0b4a8ff9b5d4c98108bdfe723291a33c52c54f",
+              "sha256": "5da960e5e5d92394c809629a03af3c7709d2d3d0ca731dacb3a9fb4bf28f7702"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "upb+",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/lib/Dialect/BGV/Conversions/BGVToLWE/BGVToLWE.cpp
+++ b/lib/Dialect/BGV/Conversions/BGVToLWE/BGVToLWE.cpp
@@ -22,9 +22,12 @@ struct BGVToLWE : public impl::BGVToLWEBase<BGVToLWE> {
     auto *module = getOperation();
 
     RewritePatternSet patterns(context);
-    patterns.add<Convert<AddOp, lwe::RAddOp>, Convert<SubOp, lwe::RSubOp>,
-                 Convert<NegateOp, lwe::RNegateOp>, Convert<MulOp, lwe::RMulOp>,
-                 lwe::ConvertExtract<ExtractOp, MulPlainOp, RotateColumnsOp> >(
+    patterns.add<
+        Convert<AddOp, lwe::RAddOp>, Convert<AddPlainOp, lwe::RAddPlainOp>,
+        Convert<SubOp, lwe::RSubOp>, Convert<SubPlainOp, lwe::RSubPlainOp>,
+        Convert<NegateOp, lwe::RNegateOp>, Convert<MulOp, lwe::RMulOp>,
+        Convert<MulPlainOp, lwe::RMulPlainOp>,
+        lwe::ConvertExtract<ExtractOp, lwe::RMulPlainOp, RotateColumnsOp> >(
         context);
     walkAndApplyPatterns(module, std::move(patterns));
   }

--- a/lib/Dialect/CKKS/Conversions/CKKSToLWE/CKKSToLWE.cpp
+++ b/lib/Dialect/CKKS/Conversions/CKKSToLWE/CKKSToLWE.cpp
@@ -24,10 +24,13 @@ struct CKKSToLWE : public impl::CKKSToLWEBase<CKKSToLWE> {
     auto *module = getOperation();
 
     RewritePatternSet patterns(context);
-    patterns.add<Convert<AddOp, lwe::RAddOp>, Convert<SubOp, lwe::RSubOp>,
-                 Convert<NegateOp, lwe::RNegateOp>, Convert<MulOp, lwe::RMulOp>,
-                 lwe::ConvertExtract<ExtractOp, MulPlainOp, RotateOp> >(
-        context);
+    patterns
+        .add<Convert<AddOp, lwe::RAddOp>, Convert<AddPlainOp, lwe::RAddPlainOp>,
+             Convert<SubOp, lwe::RSubOp>, Convert<SubPlainOp, lwe::RSubPlainOp>,
+             Convert<NegateOp, lwe::RNegateOp>, Convert<MulOp, lwe::RMulOp>,
+             Convert<MulPlainOp, lwe::RMulPlainOp>,
+             lwe::ConvertExtract<ExtractOp, lwe::RMulPlainOp, RotateOp> >(
+            context);
     walkAndApplyPatterns(module, std::move(patterns));
   }
 };

--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -487,14 +487,14 @@ using ConvertBGVSubOp = ConvertRlweBinOp<lattigo::BGVEvaluatorType, lwe::RSubOp,
 using ConvertBGVMulOp = ConvertRlweBinOp<lattigo::BGVEvaluatorType, lwe::RMulOp,
                                          lattigo::BGVMulNewOp>;
 using ConvertBGVAddPlainOp =
-    ConvertRlweCommutativePlainOp<lattigo::BGVEvaluatorType, bgv::AddPlainOp,
+    ConvertRlweCommutativePlainOp<lattigo::BGVEvaluatorType, lwe::RAddPlainOp,
                                   lattigo::BGVAddNewOp>;
 using ConvertBGVSubPlainOp =
-    ConvertRlweSubPlainOp<lattigo::BGVEvaluatorType, bgv::SubPlainOp,
+    ConvertRlweSubPlainOp<lattigo::BGVEvaluatorType, lwe::RSubPlainOp,
                           lattigo::BGVSubNewOp, lattigo::BGVAddNewOp,
                           lattigo::RLWENegateNewOp>;
 using ConvertBGVMulPlainOp =
-    ConvertRlweCommutativePlainOp<lattigo::BGVEvaluatorType, bgv::MulPlainOp,
+    ConvertRlweCommutativePlainOp<lattigo::BGVEvaluatorType, lwe::RMulPlainOp,
                                   lattigo::BGVMulNewOp>;
 
 using ConvertBGVRelinOp =
@@ -534,14 +534,14 @@ using ConvertCKKSSubOp = ConvertRlweBinOp<lattigo::CKKSEvaluatorType,
 using ConvertCKKSMulOp = ConvertRlweBinOp<lattigo::CKKSEvaluatorType,
                                           lwe::RMulOp, lattigo::CKKSMulNewOp>;
 using ConvertCKKSAddPlainOp =
-    ConvertRlweCommutativePlainOp<lattigo::CKKSEvaluatorType, ckks::AddPlainOp,
+    ConvertRlweCommutativePlainOp<lattigo::CKKSEvaluatorType, lwe::RAddPlainOp,
                                   lattigo::CKKSAddNewOp>;
 using ConvertCKKSSubPlainOp =
-    ConvertRlweSubPlainOp<lattigo::CKKSEvaluatorType, ckks::SubPlainOp,
+    ConvertRlweSubPlainOp<lattigo::CKKSEvaluatorType, lwe::RSubPlainOp,
                           lattigo::CKKSSubNewOp, lattigo::CKKSAddNewOp,
                           lattigo::RLWENegateNewOp>;
 using ConvertCKKSMulPlainOp =
-    ConvertRlweCommutativePlainOp<lattigo::CKKSEvaluatorType, ckks::MulPlainOp,
+    ConvertRlweCommutativePlainOp<lattigo::CKKSEvaluatorType, lwe::RMulPlainOp,
                                   lattigo::CKKSMulNewOp>;
 
 using ConvertCKKSRelinOp =
@@ -622,6 +622,7 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
     target
         .addIllegalOp<lwe::RLWEEncryptOp, lwe::RLWEDecryptOp, lwe::RLWEEncodeOp,
                       lwe::RLWEDecodeOp, lwe::RAddOp, lwe::RSubOp, lwe::RMulOp,
+                      lwe::RMulPlainOp, lwe::RSubPlainOp, lwe::RAddPlainOp,
                       lwe::ReinterpretApplicationDataOp>();
 
     RewritePatternSet patterns(context);

--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -391,25 +391,22 @@ struct LWEToOpenfhe : public impl::LWEToOpenfheBase<LWEToOpenfhe> {
         ConvertLWEBinOp<lwe::RSubOp, openfhe::SubOp>,
         ConvertLWEBinOp<lwe::RMulOp, openfhe::MulNoRelinOp>,
         ConvertUnaryOp<lwe::RNegateOp, openfhe::NegateOp>,
+        ConvertCiphertextPlaintextOp<lwe::RAddPlainOp, openfhe::AddPlainOp>,
+        ConvertCiphertextPlaintextOp<lwe::RSubPlainOp, openfhe::SubPlainOp>,
+        ConvertCiphertextPlaintextOp<lwe::RMulPlainOp, openfhe::MulPlainOp>,
 
         ///////////////////////////////////
         // Scheme-Specific Op Patterns   //
         ///////////////////////////////////
-        // The Add/(Sub)/Mul-Plain ops are not really scheme-specific,
-        // but do not currently have an analogue in the LWE dialect.
-        // TODO (#1193): Extend "common lwe" to support ctxt-ptxt ops
 
         // AddPlain
-        ConvertCiphertextPlaintextOp<bgv::AddPlainOp, openfhe::AddPlainOp>,
-        ConvertCiphertextPlaintextOp<ckks::AddPlainOp, openfhe::AddPlainOp>,
+        ConvertCiphertextPlaintextOp<lwe::RAddPlainOp, openfhe::AddPlainOp>,
 
         // SubPlain
-        ConvertCiphertextPlaintextOp<bgv::SubPlainOp, openfhe::SubPlainOp>,
-        ConvertCiphertextPlaintextOp<ckks::SubPlainOp, openfhe::SubPlainOp>,
+        ConvertCiphertextPlaintextOp<lwe::RSubPlainOp, openfhe::SubPlainOp>,
 
         // MulPlain
-        ConvertCiphertextPlaintextOp<bgv::MulPlainOp, openfhe::MulPlainOp>,
-        ConvertCiphertextPlaintextOp<ckks::MulPlainOp, openfhe::MulPlainOp>,
+        ConvertCiphertextPlaintextOp<lwe::RMulPlainOp, openfhe::MulPlainOp>,
 
         // Rotate
         ConvertRotateOp<bgv::RotateColumnsOp, openfhe::RotOp>,

--- a/lib/Dialect/LWE/IR/BUILD
+++ b/lib/Dialect/LWE/IR/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "LWEAttributes.h",
         "LWEDialect.h",
         "LWEOps.h",
+        "LWEPatterns.h",
         "LWETraits.h",
         "LWETypes.h",
     ],
@@ -35,6 +36,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )
 

--- a/lib/Dialect/LWE/IR/LWEOps.cpp
+++ b/lib/Dialect/LWE/IR/LWEOps.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/LWE/IR/LWEPatterns.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
@@ -24,6 +25,8 @@ namespace lwe {
 //===----------------------------------------------------------------------===//
 
 LogicalResult RMulOp::verify() { return lwe::verifyMulOp(this); }
+
+LogicalResult RMulPlainOp::verify() { return lwe::verifyMulPlainOp(this); }
 
 LogicalResult TrivialEncryptOp::verify() {
   auto paramsAttr = this->getParamsAttr();
@@ -137,16 +140,44 @@ LogicalResult RAddOp::inferReturnTypes(
   return lwe::inferAddOpReturnTypes(ctx, adaptor, inferredReturnTypes);
 }
 
+LogicalResult RAddPlainOp::inferReturnTypes(
+    MLIRContext* ctx, std::optional<Location>, RAddPlainOp::Adaptor adaptor,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  return lwe::inferPlainOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
 LogicalResult RSubOp::inferReturnTypes(
     MLIRContext* ctx, std::optional<Location>, RSubOp::Adaptor adaptor,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   return lwe::inferAddOpReturnTypes(ctx, adaptor, inferredReturnTypes);
 }
 
+LogicalResult RSubPlainOp::inferReturnTypes(
+    MLIRContext* ctx, std::optional<Location>, RSubPlainOp::Adaptor adaptor,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  return lwe::inferPlainOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
 LogicalResult RMulOp::inferReturnTypes(
     MLIRContext* ctx, std::optional<Location>, RMulOp::Adaptor adaptor,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   return lwe::inferMulOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
+LogicalResult RMulPlainOp::inferReturnTypes(
+    MLIRContext* ctx, std::optional<Location>, RMulPlainOp::Adaptor adaptor,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  return lwe::inferMulPlainOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
+void RAddPlainOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                              MLIRContext* context) {
+  results.add<lwe::PutCiphertextInFirstOperand<RAddPlainOp>>(context);
+}
+
+void RMulPlainOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                              MLIRContext* context) {
+  results.add<lwe::PutCiphertextInFirstOperand<RMulPlainOp>>(context);
 }
 
 }  // namespace lwe

--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -99,6 +99,12 @@ class LWE_BinOp<string mnemonic, list<Trait> traits = []> :
   let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
+class LWE_CiphertextPlaintextOp<string mnemonic, list<Trait> traits = []> :
+        LWE_Op<mnemonic, traits #  [IsCiphertextPlaintextOp, InferTypeOpAdaptor]> {
+  let arguments = (ins NewLWEPlaintextOrCiphertext:$lhs, NewLWEPlaintextOrCiphertext:$rhs);
+  let results = (outs NewLWECiphertext:$output);
+}
+
 def LWE_EncodeOp : LWE_Op<"encode", [HasEncoding<"output", "encoding", "LWEPlaintextType">]> {
   let summary = "Encode an integer to yield an LWE plaintext";
   let description = [{
@@ -159,11 +165,20 @@ def LWE_RAddOp : LWE_BinOp<"radd", [SameOperandsAndResultRings, SameOperandsAndR
   }];
 }
 
+def LWE_RAddPlainOp : LWE_CiphertextPlaintextOp<"radd_plain", [Commutative, SameOperandsAndResultPlaintextTypes, InferTypeOpAdaptor]> {
+  let summary = "Addition between RLWE ciphertext-plaintext";
+  let hasCanonicalizer = 1;
+}
+
 def LWE_RSubOp : LWE_BinOp<"rsub", [SameOperandsAndResultRings, SameOperandsAndResultPlaintextTypes, InferTypeOpAdaptor]> {
   let summary = "Subtract two RLWE ciphertexts";
   let assemblyFormat = [{
     operands attr-dict `:`  functional-type(operands, results)
   }];
+}
+
+def LWE_RSubPlainOp : LWE_CiphertextPlaintextOp<"rsub_plain", [SameOperandsAndResultPlaintextTypes]> {
+  let summary = "Subtraction between RLWE ciphertext-plaintext";
 }
 
 def LWE_RMulOp : LWE_BinOp<"rmul", [SameOperandsAndResultRings, InferTypeOpAdaptor, Commutative]> {
@@ -172,6 +187,12 @@ def LWE_RMulOp : LWE_BinOp<"rmul", [SameOperandsAndResultRings, InferTypeOpAdapt
     operands attr-dict `:`  functional-type(operands, results)
   }];
   let hasVerifier = 1;
+}
+
+def LWE_RMulPlainOp : LWE_CiphertextPlaintextOp<"rmul_plain", [Commutative]> {
+  let summary = "Multiplication between RLWE ciphertext-plaintext";
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def LWE_RNegateOp : LWE_Op<"rnegate", [SameOperandsAndResultType, ElementwiseMappable]> {

--- a/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
@@ -27,15 +27,27 @@
 !ct1 = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_D3_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
 !ct2 = !lwe.new_lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
+!pt = !lwe.new_lwe_plaintext<application_data = <message_type = i3>, plaintext_space = #plaintext_space>
+
 // CHECK: module
 module attributes {scheme.bgv} {
   // CHECK: @test_ops
-  // CHECK-SAME: ([[C:%.+]]: [[S:.*evaluator]], [[X:%.+]]: [[T:!lattigo.rlwe.ciphertext]], [[Y:%.+]]: [[T]])
-  func.func @test_ops(%x : !ct, %y : !ct) {
+  // CHECK-SAME: ([[C:%.+]]: [[S:.*evaluator]], [[X:%.+]]: [[T:!lattigo.rlwe.ciphertext]], [[Y:%.+]]: [[T]], [[Z:%.+]]: [[P:!lattigo.rlwe.plaintext]])
+  func.func @test_ops(%x : !ct, %y : !ct, %z : !pt) {
     // CHECK: %[[v1:.*]] = lattigo.bgv.add_new [[C]], %[[x:.*]], %[[y:.*]]: ([[S]], [[T]], [[T]]) -> [[T]]
     %add = bgv.add %x, %y  : (!ct, !ct) -> !ct
+    // CHECK: %[[add_plain_rhs_ct:.*]] = lattigo.bgv.add_new [[C]], %[[x]], %[[z:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %add_plain_rhs_ct = bgv.add_plain %z, %x : (!pt, !ct) -> !ct
+    // CHECK: %[[add_plain_lhs_ct:.*]] = lattigo.bgv.add_new [[C]], %[[x]], %[[z:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %add_plain_lhs_ct = bgv.add_plain %x, %z : (!ct, !pt) -> !ct
+    // CHECK: %[[sub_plain:.*]] = lattigo.bgv.sub_new [[C]], %[[x]], %[[z:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %sub_plain = bgv.sub_plain %x, %z : (!ct, !pt) -> !ct
     // CHECK: %[[mul:.*]] = lattigo.bgv.mul_new [[C]], %[[x]], %[[y]]: ([[S]], [[T]], [[T]]) -> [[T]]
     %mul = bgv.mul %x, %y  : (!ct, !ct) -> !ct1
+    // CHECK: %[[mul_plain_rhs_ct:.*]] = lattigo.bgv.mul_new [[C]], %[[x]], %[[z]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %mul_plain_rhs_ct = bgv.mul_plain %z, %x : (!pt, !ct) -> !ct
+    // CHECK: %[[mul_plain_lhs_ct:.*]] = lattigo.bgv.mul_new [[C]], %[[x]], %[[z]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %mul_plain_lhs_ct = bgv.mul_plain %x, %z : (!ct, !pt) -> !ct
     // CHECK: %[[relin:.*]] = lattigo.bgv.relinearize_new [[C]], %[[mul]] : ([[S]], [[T]]) -> [[T]]
     %relin = bgv.relinearize %mul  {
       from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/bgv_to_openfhe.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/bgv_to_openfhe.mlir
@@ -1,5 +1,4 @@
 // RUN: heir-opt --mlir-print-local-scope --bgv-to-lwe --lwe-to-openfhe %s | FileCheck %s
-
 !Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
 !Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
 !Z65537_i64_ = !mod_arith.int<65537 : i64>
@@ -34,8 +33,8 @@
 // CHECK: module
 module {
   // CHECK: @test_ops
-  // CHECK-SAME: ([[C:%.+]]: [[S:.*crypto_context]], [[X:%.+]]: [[T:.*new_lwe_ciphertext.*]], [[Y:%.+]]: [[T]])
-  func.func @test_ops(%x : !ct, %y : !ct) -> (!ct, !ct, !ct, !ct_D3, !ct) {
+  // CHECK-SAME: ([[C:%.+]]: [[S:.*crypto_context]], [[X:%.+]]: [[T:.*new_lwe_ciphertext.*]], [[Y:%.+]]: [[T]], [[Z:%.+]]: [[P:.*new_lwe_plaintext.[^)]*]])
+  func.func @test_ops(%x : !ct, %y : !ct, %z : !pt) -> (!ct, !ct, !ct, !ct_D3, !ct, !ct, !ct, !ct) {
     // CHECK: %[[v1:.*]] = openfhe.negate [[C]], %[[x1:.*]] : ([[S]], [[T]]) -> [[T]]
     %negate = bgv.negate %x  : !ct
     // CHECK: %[[v2:.*]] = openfhe.add [[C]], %[[x2:.*]], %[[y2:.*]]: ([[S]], [[T]], [[T]]) -> [[T]]
@@ -47,7 +46,13 @@ module {
     // CHECK: %[[v5:.*]] = openfhe.rot [[C]], %[[x5:.*]] {index = 4 : i64}
     // CHECK-SAME: ([[S]], [[T]]) -> [[T]]
     %rot = bgv.rotate_cols %x { offset = 4 } : !ct
-    return %negate, %add, %sub, %mul, %rot : !ct, !ct, !ct, !ct_D3, !ct
+    // CHECK: %[[v6:.*]] = openfhe.add_plain [[C]], %[[x6:.*]], %[[z6:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %add_plain = bgv.add_plain %x, %z : (!ct, !pt) -> !ct
+    // CHECK: %[[v7:.*]] = openfhe.sub_plain [[C]], %[[x7:.*]], %[[z7:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %sub_plain = bgv.sub_plain %x, %z : (!ct, !pt) -> !ct
+    // CHECK: %[[v8:.*]] = openfhe.mul_plain [[C]], %[[x8:.*]], %[[z8:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %mul_plain = bgv.mul_plain %x, %z : (!ct, !pt) -> !ct
+    return %negate, %add, %sub, %mul, %rot, %add_plain, %sub_plain, %mul_plain : !ct, !ct, !ct, !ct_D3, !ct, !ct, !ct, !ct
   }
 
   // CHECK: @test_relin

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir
@@ -34,8 +34,8 @@
 // CHECK: module
 module {
   // CHECK: @test_ops
-  // CHECK-SAME: ([[C:%.+]]: [[S:.*crypto_context]], [[X:%.+]]: [[T:.*new_lwe_ciphertext.*]], [[Y:%.+]]: [[T]])
-  func.func @test_ops(%x : !ct, %y : !ct) -> (!ct, !ct, !ct, !ct_D3, !ct) {
+  // CHECK-SAME: ([[C:%.+]]: [[S:.*crypto_context]], [[X:%.+]]: [[T:.*new_lwe_ciphertext.*]], [[Y:%.+]]: [[T]], [[Z:%.+]]: [[P:.*new_lwe_plaintext[^)]*]])
+  func.func @test_ops(%x : !ct, %y : !ct, %z : !pt) -> (!ct, !ct, !ct, !ct_D3, !ct, !ct, !ct, !ct) {
     // CHECK: %[[v1:.*]] = openfhe.negate [[C]], %[[x1:.*]] : ([[S]], [[T]]) -> [[T]]
     %negate = ckks.negate %x  : !ct
     // CHECK: %[[v2:.*]] = openfhe.add [[C]], %[[x2:.*]], %[[y2:.*]]: ([[S]], [[T]], [[T]]) -> [[T]]
@@ -47,7 +47,13 @@ module {
     // CHECK: %[[v5:.*]] = openfhe.rot [[C]], %[[x5:.*]] {index = 4 : i64}
     // CHECK-SAME: ([[S]], [[T]]) -> [[T]]
     %rot = ckks.rotate %x { offset = 4 } : !ct
-    return %negate, %add, %sub, %mul, %rot : !ct, !ct, !ct, !ct_D3, !ct
+    // CHECK: %[[v6:.*]] = openfhe.add_plain [[C]], %[[x6:.*]], %[[z6:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %add_plain = ckks.add_plain %x, %z : (!ct, !pt) -> !ct
+    // CHECK: %[[v7:.*]] = openfhe.sub_plain [[C]], %[[x7:.*]], %[[z7:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %sub_plain = ckks.sub_plain %x, %z : (!ct, !pt) -> !ct
+    // CHECK: %[[v7:.*]] = openfhe.mul_plain [[C]], %[[x8:.*]], %[[z8:.*]]: ([[S]], [[T]], [[P]]) -> [[T]]
+    %mul_plain = ckks.mul_plain %x, %z : (!ct, !pt) -> !ct
+    return %negate, %add, %sub, %mul, %rot, %add_plain, %sub_plain, %mul_plain : !ct, !ct, !ct, !ct_D3, !ct, !ct, !ct, !ct
   }
 
   // CHECK: @test_relin

--- a/tests/Dialect/LWE/IR/canonicalize.mlir
+++ b/tests/Dialect/LWE/IR/canonicalize.mlir
@@ -1,0 +1,39 @@
+// RUN: heir-opt --canonicalize %s | FileCheck %s
+
+#encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#poly_1024 = #polynomial.int_polynomial<1 + x**1024>
+!plaintext_coefficient_modulus = !mod_arith.int<65537 : i64>
+#plaintext_ring = #polynomial.ring<
+  coefficientType=!plaintext_coefficient_modulus,
+  polynomialModulus=#poly_1024>
+#plaintext_space = #lwe.plaintext_space<
+  ring=#plaintext_ring,
+  encoding=#encoding>
+!ciphertext_coefficient_modulus = !mod_arith.int<1032955396097 : i64>
+#ciphertext_ring = #polynomial.ring<
+  coefficientType=!ciphertext_coefficient_modulus,
+  polynomialModulus=#poly_1024>
+#ciphertext_space = #lwe.ciphertext_space<
+  ring=#ciphertext_ring,
+  encryption_type=lsb,
+  size=2>
+
+!ct = !lwe.new_lwe_ciphertext<
+  application_data=<message_type=i3>,
+  plaintext_space=#plaintext_space,
+  ciphertext_space=#ciphertext_space,
+  key=#lwe.key<>>
+!pt = !lwe.new_lwe_plaintext<
+  application_data=<message_type=i3>,
+  plaintext_space=#plaintext_space>
+
+// CHECK: @test_ct_pt_canonicalize(
+// CHECK-SAME: [[X:%.[^:]+]]:
+// CHECK-SAME: , [[Y:%.[^:]+]]:
+func.func @test_ct_pt_canonicalize(%x: !ct, %y: !pt) -> (!ct, !ct) {
+    // CHECK: lwe.radd_plain [[X]], [[Y]]
+    %add_ct_rhs = lwe.radd_plain %y, %x : (!pt, !ct) -> !ct
+    // CHECK: lwe.rmul_plain [[X]], [[Y]]
+    %mul_ct_rhs = lwe.rmul_plain %y, %x : (!pt, !ct) -> !ct
+    return %add_ct_rhs, %mul_ct_rhs : !ct, !ct
+}

--- a/tests/Dialect/LWE/IR/rlwe_ops.mlir
+++ b/tests/Dialect/LWE/IR/rlwe_ops.mlir
@@ -33,6 +33,10 @@
   ciphertext_space=#post_mul_ciphertext_space,
   key=#lwe.key<>>
 
+!pt = !lwe.new_lwe_plaintext<
+  application_data=<message_type=i3>,
+  plaintext_space=#plaintext_space>
+
 // CHECK: test_radd
 func.func @test_radd(%0: !ct, %1: !ct) -> !ct {
   // CHECK: lwe.radd
@@ -59,4 +63,31 @@ func.func @test_rnegate(%0: !ct) -> !ct {
   // CHECK: lwe.rnegate
   %1 = lwe.rnegate %0 : !ct
   return %1 : !ct
+}
+
+// CHECK: test_radd_plain
+func.func @test_radd_plain(%0: !ct, %1: !pt) -> !ct {
+  // CHECK: lwe.radd_plain
+  %2 = lwe.radd_plain %0, %1 : (!ct, !pt) -> !ct
+  // CHECK: lwe.radd_plain
+  %3 = lwe.radd_plain %1, %0 : (!pt, !ct) -> !ct
+  return %2 : !ct
+}
+
+// CHECK: test_rsub_plain
+func.func @test_rsub_plain(%0: !ct, %1: !pt) -> !ct {
+  // CHECK: lwe.rsub_plain
+  %2 = lwe.rsub_plain %0, %1 : (!ct, !pt) -> !ct
+  // CHECK: lwe.rsub_plain
+  %3 = lwe.rsub_plain %1, %0 : (!pt, !ct) -> !ct
+  return %2 : !ct
+}
+
+// CHECK: test_rmul_plain
+func.func @test_rmul_plain(%0: !ct, %1: !pt) -> !ct {
+  // CHECK: lwe.rmul_plain
+  %2 = lwe.rmul_plain %0, %1 : (!ct, !pt) -> !ct
+  // CHECK: lwe.rmul_plain
+  %3 = lwe.rmul_plain %1, %0 : (!pt, !ct) -> !ct
+  return %2 : !ct
 }


### PR DESCRIPTION
Added lwe ciphertext-plaintext ops and their lowerings for bgv/ckks  (#1603)  

Also I can't fully test the `lwe-to-polynomial` lowering until #1199 but I did my best to add the functionality and tests.