### PR TITLE
frontend: add cggi scheme support up to cggi dialect

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -343,12 +343,11 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.6.3/MODULE.bazel": "e90505b7a931d194245ffcfb6ff4ca8ef9d46b4e830d12e64817752e0198e2ed",
+    "https://bcr.bazel.build/modules/rules_java/8.6.3/source.json": "8330cc5d277085bbcf93e9f1c85c24d06975585606a1215df4faf886a8d3cc9e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -2169,6 +2168,28 @@
         "recordedRepoMappingEntries": [
           [
             "rules_fuzzing+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "9SPkp75wN6dP9sKiOgU1uOCTNNA08v8PVBMYs+SZ27s=",
+        "usagesDigest": "ZsMvJZXTm/u0lYuq0P/yTF2h6FdynULVT3mwKA1SE5k=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java+",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -13619,7 +13640,7 @@
     },
     "@@rules_rust+//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "0XHSLimPR0yIi1HIZgsMrr67WhwiJ9YwNk9n4/D118s=",
+        "bzlTransitiveDigest": "u0AbcREuyXinWoLmuEjo7UWBx+Y+ROXvSITNXzSqOvo=",
         "usagesDigest": "ozx08ZbgRXTJw0zCaO/xtMUzgGLvwaQkZGnUo6tlyHM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/frontend/cggi_test.py
+++ b/frontend/cggi_test.py
@@ -1,0 +1,30 @@
+from heir import compile
+from heir.mlir import I8, Secret
+
+
+from absl.testing import absltest  # fmt: skip
+class EndToEndTest(absltest.TestCase):
+
+  def test_simple_arithmetic(self):
+
+    @compile(
+        scheme="cggi",
+        debug="True",
+    )
+    def foo(a: Secret[I8], b: Secret[I8]):
+      return a * a - b * b
+
+    # Test cleartext functionality
+    self.assertEqual(-15, foo.original(7, 8))
+
+    # Test FHE functionality
+    foo.setup()
+    enc_a = foo.encrypt_a(7)
+    enc_b = foo.encrypt_b(8)
+    result_enc = foo.eval(enc_a, enc_b)
+    result = foo.decrypt_result(result_enc)
+    self.assertEqual(-15, result)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/frontend/heir/pipeline.py
+++ b/frontend/heir/pipeline.py
@@ -1,5 +1,6 @@
 """The compilation pipeline."""
 
+import os
 import pathlib
 import shutil
 import tempfile
@@ -41,6 +42,12 @@ def run_pipeline(
   """Run the pipeline."""
   if not heir_config:
     heir_config = heir_cli_config.from_os_env()
+
+  # Set environment variables from HEIR config
+  os.environ["HEIR_ABC_BINARY"] = os.path.abspath(str(heir_config.abc_path))
+  os.environ["HEIR_YOSYS_SCRIPTS_DIR"] = os.path.abspath(
+      str(heir_config.techmap_dir_path)
+  )
 
   # The temporary workspace dir is so that heir-opt and the backend
   # can have places to write their output files. It is cleaned up once
@@ -183,6 +190,12 @@ def run_pipeline(
       )
 
     # Run backend (which will call heir_translate and other tools, e.g., clang, as needed)
+    if "--mlir-to-cggi" in heir_opt_options:
+      raise NotImplementedError(
+          "Backend compilation is unsupported for CGGI scheme, check CGGI"
+          f" output at {mlirpath}"
+      )
+
     result = backend.run_backend(
         workspace_dir,
         heir_opt,


### PR DESCRIPTION
no backend is supported right now, so the cggi_test will fail at:

In the future, we should decide how to pass options to the compiler - I would actually just like to wait until the backend is selected and decide based on that. 
  - e.g. for tfhe-rs, use lookup tables
  - for binFHE, use boolean gates

```
asraa@asraali:~/git/heir/frontend$ python -m cggi_test
Running tests under Python 3.12.9: /usr/local/google/home/asraa/git/heir/frontend/venv/bin/python
[ RUN      ] EndToEndTest.test_simple_arithmetic
HEIR Debug: Writing raw input MLIR to /tmp/tmpbwe19k0o/foo.raw.mlir
HEIR Debug: Writing input MLIR w/ shape inference to /tmp/tmpbwe19k0o/foo.in.mlir
HEIR Debug: Writing secretness-annotated MLIR to /tmp/tmpbwe19k0o/foo.annotated.mlir
HEIR Debug: Writing secretness-annotated graph to /tmp/tmpbwe19k0o/foo.annotated.dot
HEIR Debug: Running heir-opt --canonicalize --mlir-to-cggi --mlir-print-debuginfo --view-op-graph
HEIR Debug: Writing output MLIR to /tmp/tmpbwe19k0o/foo.out.mlir
HEIR Debug: Writing output graph to /tmp/tmpbwe19k0o/foo.out.dot
HEIR Debug: Leaving workspace_dir /tmp/tmpbwe19k0o for manual inspection.

[  FAILED  ] EndToEndTest.test_simple_arithmetic
======================================================================
ERROR: test_simple_arithmetic (__main__.EndToEndTest.test_simple_arithmetic)
EndToEndTest.test_simple_arithmetic
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/asraa/git/heir/frontend/cggi_test.py", line 10, in test_simple_arithmetic
    @compile(
     ^^^^^^^^
  File "/usr/local/google/home/asraa/git/heir/frontend/heir/pipeline.py", line 268, in decorator
    return run_pipeline(
           ^^^^^^^^^^^^^
  File "/usr/local/google/home/asraa/git/heir/frontend/heir/pipeline.py", line 194, in run_pipeline
    raise NotImplementedError(f"Backend compilation is unsupported for CGGI scheme, check CGGI output at {mlirpath}")
NotImplementedError: Backend compilation is unsupported for CGGI scheme, check CGGI output at /tmp/tmpbwe19k0o/foo.out.mlir
```