### PR TITLE
Openfhe: CKKS: Avoid MulDepth of 0

### DIFF
--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -278,6 +278,11 @@ struct ConfigureCryptoContext
       config.mulDepth += bootstrapDepth;
     }
 
+    // OpenFHE CKKS with mulDepth 0 has bug, set it to 1
+    if (config.mulDepth == 0 && moduleIsCKKS(module)) {
+      config.mulDepth = 1;
+    }
+
     // pass option could override mulDepth
     if (mulDepth != 0) {
       config.mulDepth = mulDepth;


### PR DESCRIPTION
As reported in discord, Openfhe with mulplicative depth of 0 has bug, we can mitigate it by setting it to 1.

See also https://openfhe.discourse.group/t/turn-off-rns-in-ckks/952/5