### PR TITLE
enhance propagate-annotation to reverse-propagate

### DIFF
--- a/lib/Transforms/PropagateAnnotation/PropagateAnnotation.cpp
+++ b/lib/Transforms/PropagateAnnotation/PropagateAnnotation.cpp
@@ -1,7 +1,14 @@
 #include "lib/Transforms/PropagateAnnotation/PropagateAnnotation.h"
 
+#include "lib/Dialect/HEIRInterfaces.h"
 #include "lib/Utils/AttributeUtils.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Iterators.h"    // from @llvm-project
+#include "mlir/include/mlir/Interfaces/FunctionInterfaces.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+#define DEBUG_TYPE "propagate-annotation"
 
 namespace mlir {
 namespace heir {
@@ -9,39 +16,103 @@ namespace heir {
 #define GEN_PASS_DEF_PROPAGATEANNOTATION
 #include "lib/Transforms/PropagateAnnotation/PropagateAnnotation.h.inc"
 
+void forwardPropagateAnnotation(Operation *root, StringRef attrName) {
+  if (attrName.empty()) {
+    return;
+  }
+  root->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (op->hasAttr(attrName)) {
+      return;
+    }
+
+    for (Value operand : op->getOperands()) {
+      Attribute attr;
+      if (dyn_cast<BlockArgument>(operand)) {
+        auto res = findAttributeAssociatedWith(operand, attrName);
+        if (failed(res)) {
+          continue;
+        }
+        attr = *res;
+      } else {
+        // findAttributeAssociatedWith works not so well for ArrayAttr
+        attr = operand.getDefiningOp()->getAttr(attrName);
+        if (!attr) {
+          continue;
+        }
+      }
+      op->setAttr(attrName, attr);
+      // short-circuit if we found an attribute
+      return;
+    }
+  });
+}
+
+void setAttrIfMissing(Value value, StringRef attrName, Attribute attr) {
+  if (failed(findAttributeAssociatedWith(value, attrName))) {
+    setAttributeAssociatedWith(value, attrName, attr);
+  }
+}
+
+void backwardPropagateAnnotation(Operation *root, StringRef attrName) {
+  if (attrName.empty()) {
+    return;
+  }
+
+  root->walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
+    LLVM_DEBUG(llvm::dbgs() << "BackProp(" << attrName << ") visiting op "
+                            << op->getName() << "\n");
+    if (op->hasAttr(attrName)) {
+      // The attr is assumed to be associated with the op's results.
+      Attribute attrToPropagate = op->getAttr(attrName);
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Using op's result attr " << attrToPropagate << "\n");
+      for (auto operand : op->getOperands()) {
+        setAttrIfMissing(operand, attrName, attrToPropagate);
+      }
+      return WalkResult::advance();
+    }
+
+    if (op->hasTrait<OpTrait::IsTerminator>()) {
+      LLVM_DEBUG(llvm::dbgs() << "Op is a terminator\n");
+      // Terminators try to inherit their attribute from the parent op's return
+      // attr.
+      auto *parentOp = op->getParentOp();
+
+      // An op like `return %0, %1` can inherit multiple attributes from the
+      // parent's multiple result attrs.
+      for (int i = 0; i < op->getNumOperands(); ++i) {
+        Attribute attr =
+            llvm::TypeSwitch<Operation *, Attribute>(parentOp)
+                .Case<FunctionOpInterface, OperandAndResultAttrInterface>(
+                    [&](auto interface) {
+                      return interface.getResultAttr(i, attrName);
+                    })
+                .Default([&](Operation *op) { return op->getAttr(attrName); });
+        if (attr) {
+          LLVM_DEBUG(llvm::dbgs() << "Propagating result attr " << i << " ("
+                                  << attr << ") to operand " << i << "\n");
+          setAttrIfMissing(op->getOperand(i), attrName, attr);
+        }
+      }
+      return WalkResult::advance();
+    }
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Skipping op because no suitable cases found.\n");
+    return WalkResult::advance();
+  });
+}
+
 struct PropagateAnnotation
     : impl::PropagateAnnotationBase<PropagateAnnotation> {
   using PropagateAnnotationBase::PropagateAnnotationBase;
 
   void runOnOperation() override {
-    if (attrName.empty()) {
-      return;
+    if (reverse) {
+      backwardPropagateAnnotation(getOperation(), attrName);
+    } else {
+      forwardPropagateAnnotation(getOperation(), attrName);
     }
-    getOperation()->walk<WalkOrder::PreOrder>([&](Operation *op) {
-      if (op->hasAttr(attrName)) {
-        return;
-      }
-
-      for (Value operand : op->getOperands()) {
-        Attribute attr;
-        if (dyn_cast<BlockArgument>(operand)) {
-          auto res = findAttributeAssociatedWith(operand, attrName);
-          if (failed(res)) {
-            continue;
-          }
-          attr = *res;
-        } else {
-          // findAttributeAssociatedWith works not so well for ArrayAttr
-          attr = operand.getDefiningOp()->getAttr(attrName);
-          if (!attr) {
-            continue;
-          }
-        }
-        op->setAttr(attrName, attr);
-        // short-circuit if we found an attribute
-        return;
-      }
-    });
   }
 };
 

--- a/lib/Transforms/PropagateAnnotation/PropagateAnnotation.h
+++ b/lib/Transforms/PropagateAnnotation/PropagateAnnotation.h
@@ -12,6 +12,12 @@ namespace heir {
 #define GEN_PASS_REGISTRATION
 #include "lib/Transforms/PropagateAnnotation/PropagateAnnotation.h.inc"
 
+/// Forward-propagate an annotation through the IR.
+void forwardPropagateAnnotation(Operation *root, StringRef attrName);
+
+/// Backward-propagate an annotation through the IR.
+void backwardPropagateAnnotation(Operation *root, StringRef attrName);
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/lib/Transforms/PropagateAnnotation/PropagateAnnotation.td
+++ b/lib/Transforms/PropagateAnnotation/PropagateAnnotation.td
@@ -33,6 +33,8 @@ def PropagateAnnotation : Pass<"propagate-annotation"> {
   let options = [
     Option<"attrName", "attr-name", "std::string", /*default=*/"\"\"",
            "The attribute name to propagate with.">,
+    Option<"reverse", "reverse", "bool", /*default=*/"false",
+           "Whether to propagate in reverse">,
   ];
 }
 

--- a/tests/Transforms/propagate_annotation/reverse.mlir
+++ b/tests/Transforms/propagate_annotation/reverse.mlir
@@ -1,0 +1,16 @@
+// RUN: heir-opt %s --propagate-annotation="attr-name=test.attr reverse=true" | FileCheck %s
+
+// CHECK: @mul
+// CHECK-SAME: (%[[arg0:.*]]: i16 {test.attr = 3
+// CHECK-SAME: ) -> (i16 {test.attr = 3
+func.func @mul(%arg0 : i16) -> (i16 {test.attr = 3}) {
+  // CHECK: arith.muli
+  // CHECK-SAME: {test.attr = 3
+  %1 = arith.muli %arg0, %arg0 : i16
+  // Only the first muli is used later, so the other two muli's don't get
+  // propagated to.
+  // CHECK-NOT: test.attr
+  %2 = arith.muli %1, %1 : i16
+  %3 = arith.muli %2, %1 : i16
+  return %1 : i16
+}


### PR DESCRIPTION
This PR enhances the propagate-annotation pass to support reverse propagation. It also slightly refactors that pass so that the propagation helpers can be used as independent utility functions in other passes.

This is needed for the lowering of the new add-client-interface pass, because now when we lower secret to scheme, we need to convert secret types of the client interface functions. (Previously we generated them after lowering to scheme). The main obstacle here is that the mgmt attrs are on the original function, not the client helpers, and the type converter fails without a mgmt attr.

My plan for this is essentially to copy the mgmt attr from the original function to the client helpers, and then to propagate those attributes through the body of the helper functions. For decryption this is a forward propagation (the secret type is a func arg) but for encryption this propagation must happen in reverse, since only the return value has a secret type. If I use this utility then the remaining work for lowering the client helper is to copy the attribute from the original function's arg/resultAttrs to the client helper's arg/resultAttrs.

For the reviewer: `forwardPropagateAnnotation` is an unchanged copy of the original pass, while `reversePropagateAnnotation` is new code. The diff makes that hard to see.