### PR TITLE
frontend: add tensor support

### DIFF
--- a/frontend/BUILD
+++ b/frontend/BUILD
@@ -70,6 +70,24 @@ frontend_test(
     ],
 )
 
+frontend_test(
+    name = "tensor_test",
+    srcs = ["tensor_test.py"],
+    tags = [
+        # copybara: manual
+        "notap",
+    ],
+)
+
+frontend_test(
+    name = "tensor_loop_test",
+    srcs = ["tensor_loop_test.py"],
+    tags = [
+        # copybara: manual
+        "notap",
+    ],
+)
+
 bzl_library(
     name = "testing_bzl",
     srcs = ["testing.bzl"],

--- a/frontend/tensor_loop_test.py
+++ b/frontend/tensor_loop_test.py
@@ -1,0 +1,31 @@
+from heir import compile
+from heir.mlir import I16, Secret, Tensor
+import numpy as np
+from numpy.testing import assert_array_equal
+
+
+from absl.testing import absltest  # fmt: skip
+class TensorLoopTest(absltest.TestCase):
+
+  def test_tensor_loop(self):
+
+    @compile()  # defaults to scheme="bgv", OpenFHE backend, and debug=False
+    def func(x: Secret[Tensor[[1024], I16]], y: Secret[Tensor[[1024], I16]]):
+      result = x
+      for i in range(10):
+        result = result + y
+      return result * result
+
+    a = np.array([7] * 1024, dtype=np.int16)
+    b = np.array([8] * 1024, dtype=np.int16)
+    expected = (a + 10 * b) ** 2
+
+    # Test cleartext functionality
+    assert_array_equal(expected, func.original(a, b))
+
+    # Test FHE functionality
+    assert_array_equal(expected, func(a, b))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/frontend/tensor_test.py
+++ b/frontend/tensor_test.py
@@ -1,0 +1,28 @@
+from heir import compile
+from heir.mlir import I16, Secret, Tensor
+import numpy as np
+from numpy.testing import assert_array_equal
+
+
+from absl.testing import absltest  # fmt: skip
+class TensorTest(absltest.TestCase):
+
+  def test_basic_tensors(self):
+
+    @compile()  # defaults to BGV and OpenFHE
+    def foo(a: Secret[Tensor[[1024], I16]], b: Secret[Tensor[[1024], I16]]):
+      return a * a - b * b
+
+    a = np.array([7] * 1024, dtype=np.int16)
+    b = np.array([8] * 1024, dtype=np.int16)
+    expected = a * a - b * b
+
+    # Test cleartext functionality
+    assert_array_equal(expected, foo.original(a, b))
+
+    # Test FHE functionality
+    assert_array_equal(expected, foo(a, b))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/lib/Transforms/ShapeInference/BUILD
+++ b/lib/Transforms/ShapeInference/BUILD
@@ -1,0 +1,29 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ShapeInference",
+    srcs = ["ShapeInference.cpp"],
+    hdrs = ["ShapeInference.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ShapeInference",
+    td_file = "ShapeInference.td",
+)

--- a/lib/Transforms/ShapeInference/ShapeInference.cpp
+++ b/lib/Transforms/ShapeInference/ShapeInference.cpp
@@ -1,0 +1,425 @@
+#include "lib/Transforms/ShapeInference/ShapeInference.h"
+
+#include <llvm/Support/Debug.h>
+
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/FormatVariadic.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Verifier.h"              // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+#define DEBUG_TYPE "shape-inference"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_SHAPEINFERENCE
+#include "lib/Transforms/ShapeInference/ShapeInference.h.inc"
+
+namespace {
+FailureOr<SmallVector<int64_t>> getShapeFromArrayAttr(ArrayAttr shapeAttr,
+                                                      ShapedType shapedType,
+                                                      Location loc) {
+  SmallVector<int64_t> shape;
+  for (auto attr : shapeAttr) {
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+      shape.emplace_back(intAttr.getInt());
+    else
+      return emitError(loc,
+                       "Invalid shape attribute (expected ArrayAttr of "
+                       "only IntegerAttr)");
+  }
+
+  if (shape.size() != shapedType.getRank())
+    return emitError(
+        loc, llvm::formatv("Shape annotation has wrong number of elements "
+                           "(expected {0}, got {1}).",
+                           shapedType.getRank(), shape.size()));
+  return shape;
+}
+
+/// Helper function to handle RegionBranchOpInterface operations
+// (e.g., scf.while, scf.if, affine.for)
+void handleInterface(RegionBranchOpInterface regionBranchOp) {
+  LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\t\tcurrent op has "
+                             "RegionBranchOpInterface.\n");
+
+  // Get all successors that can be reached from the current op
+  // (starting from current op is indicated by passing
+  // RegionBranchPoint::parent() as the branch point. Successors can
+  // be either regions, or "parent", i.e., the regionBranchOp itself
+  SmallVector<RegionSuccessor> successors;
+
+  // Note: the RegionBranchOpInterface allows ops to omit successors
+  // that are not reachable, in which case unresolved type
+  // mismatches might remain in those regions.
+  regionBranchOp.getSuccessorRegions(RegionBranchPoint::parent(), successors);
+
+  for (auto &successor : successors) {
+    // We are interested in successor _regions_ here,
+    // so ignore if the op has a control-flow edge loop to itself
+    if (successor.isParent()) continue;
+
+    LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\t\tfound region successor: "
+                            << successor.getSuccessor()->getLoc() << "\n");
+    // We have a region successor, so we want to update
+    // the block argument types of the successor
+    // based on the types of the operands of the regionBranchOp
+    // that will be forwarded to this region.
+
+    // The "inputs" (block arguments) of the current successor
+    // that are defined by the "forwarded" operands of the op
+    auto successorInputs = successor.getSuccessorInputs();
+    // Note: the block arguments might also contain "produced"
+    // values (e.g., the index in a loop), the types of which
+    // could technically also somehow depend on the updated
+    // types of the other operands. However, this isn't the case
+    // for the ops we're currently focused on (scf/affine)
+    // and there doesn't seem to be a good way to handle this
+
+    // The operands of the op that are forwarded to the successor
+    auto succesorOperands = regionBranchOp.getEntrySuccessorOperands(successor);
+
+    for (auto [input, operand] : llvm::zip(successorInputs, succesorOperands)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "ShapeInference:\t\t\tupdating successor input: " << input
+                 << " with type of successor operand: " << operand << "\n");
+      input.setType(operand.getType());
+    }
+  }
+}
+
+void handleInterface(RegionBranchTerminatorOpInterface terminator) {
+  LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\t\tcurrent op has "
+                             "RegionBranchTerminatorOpInterface.\n");
+
+  // All potential potential successors of the terminator
+  // This can be the parent op or other regions (e.g., in scf.while)
+  SmallVector<RegionSuccessor> successors;
+
+  // the terminator interface doesn't have the
+  // getSuccessorRegions/getSuccessorEntryRegions distinction.
+  // This seems to be one of several oversights around this
+  // interface when RegionBranchPoint was introduced.
+  // https://github.com/llvm/llvm-project/commit/4dd744ac9c0f772a61dd91c84bc14d17e69aec51
+  SmallVector<Attribute> operands(terminator->getNumOperands());
+  terminator.getSuccessorRegions(operands, successors);
+
+  for (auto successor : successors) {
+    // the terminator operands that are "passed" to the successor
+    auto succesorOperands =
+        terminator.getSuccessorOperands(RegionBranchPoint::parent());
+
+    // Special case: the "return/yield" back to the parent op
+    if (successor.isParent()) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "ShapeInference:\t\t\tfound parent successor\n");
+      /// The RegionBranchTerminatorOpInterface requires that
+      /// the successor operands and the parent's results match
+      for (auto [operand, result] : llvm::zip(
+               succesorOperands, terminator->getParentOp()->getResults())) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "ShapeInference:\t\t\tupdating parent result " << result
+                   << " with type of successor operand " << operand << "\n");
+        result.setType(operand.getType());
+      }
+    } else {
+      LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\t\t"
+                                 "found region successor: "
+                              << successor.getSuccessor()->getLoc() << "\n");
+      for (auto [operand, input] :
+           llvm::zip(succesorOperands, successor.getSuccessorInputs())) {
+        LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\t\t"
+                                   "updating successor input: "
+                                << input << " with type of successor operand: "
+                                << operand << "\n");
+        input.setType(operand.getType());
+      }
+    }
+  }
+}
+
+}  // namespace
+
+struct InferShape : public OpRewritePattern<func::FuncOp> {
+  InferShape(MLIRContext *context)
+      : OpRewritePattern<func::FuncOp>(context, /*benefit=*/1) {}
+
+ public:
+  LogicalResult matchAndRewrite(func::FuncOp funcOp,
+                                PatternRewriter &rewriter) const override {
+    /// Helper to determine whether any IR modifications are necessary
+    bool changed = false;
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "ShapeInference: running shape inference on function "
+               << funcOp.getName() << "\n");
+
+    /////////////////////////////////////////////////////////////////////
+    //// Step 1: Resolve any shape-annotated args in Function Type   ////
+    /////////////////////////////////////////////////////////////////////
+    SmallVector<Type> inferredInputTypes;
+    for (auto [idx, type] :
+         llvm::enumerate(funcOp.getFunctionType().getInputs())) {
+      auto shapedType = dyn_cast<ShapedType>(type);
+
+      bool isDynamicShapedType = shapedType && !shapedType.hasStaticShape();
+      auto shapeAttr = funcOp.getArgAttrOfType<ArrayAttr>(idx, "shape.shape");
+
+      // Shape annotation on ShapedType type -> push back new type
+      if (isDynamicShapedType && shapeAttr) {
+        auto shape =
+            getShapeFromArrayAttr(shapeAttr, shapedType, funcOp.getLoc());
+        if (failed(shape)) return shape;
+        // save the newly inferred argument type
+        inferredInputTypes.emplace_back(
+            shapedType.clone(shape.value(), shapedType.getElementType()));
+        changed = true;
+        continue;
+      }
+
+      // Dynamic ShapedType but no {shape.shape} annotation
+      if (isDynamicShapedType && !shapeAttr) {
+        emitWarning(funcOp.getLoc(),
+                    "Found argument with dynamic shaped type but no shape "
+                    "annotation.");
+      }
+
+      // Shape annotation on non-ShapedType type
+      if (shapeAttr && !shapedType) {
+        emitWarning(
+            funcOp.getLoc(),
+            "Ignoring shape annotation on argument with non-ShapedType type");
+      }
+
+      // Shape annotation on non-dynamic ShapedType type
+      if (!isDynamicShapedType && shapeAttr) {
+        emitWarning(funcOp.getLoc(),
+                    "Ignoring shape annotation on argument with non-dynamic "
+                    "shaped type");
+      }
+
+      inferredInputTypes.emplace_back(type);
+    }
+
+    /////////////////////////////////////////////////////////////////////
+    //// Step 2: Walk the body, inferring and updating new types     ////
+    /////////////////////////////////////////////////////////////////////
+
+    // Only do this if there's been an annotated type and there's a body
+    if (changed && !funcOp.isDeclaration()) {
+      rewriter.startOpModification(funcOp);
+
+      //// Update Block Argument types based on Annotations
+      for (auto [type, arg] :
+           llvm::zip(inferredInputTypes, funcOp.getArguments())) {
+        arg.setType(type);
+      }
+
+      // WalkOrder::PreOrder is essential so that we can handle mapping
+      // operands to block arguments for region-bearing ops before
+      // the region itself is walked.
+      auto walkResult =
+          funcOp.getBody().walk<WalkOrder::PreOrder>([&](Operation *op) {
+            LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\twalking op: "
+                                    << op->getName() << "\n");
+
+            // for RegionBranchOps, we need to forward the types of their
+            // operands to the block arguments of their successor regions
+            if (auto regionBranchOp = dyn_cast<RegionBranchOpInterface>(op)) {
+              // While some ops might have both RegionBranchOpInterface and
+              // other interfaces, such as InferTypeOpInterface, we cannot rely
+              // on those since the body and terminators have not yet been
+              // updated and the op is therefore potentially invalid.
+              // -> return early and skip other interface handling code
+              handleInterface(regionBranchOp);
+              return WalkResult::advance();
+            }
+
+            // We focus on operations with return type inference,
+            // as these will likely complain if their operands' types change
+            // but their return type hasn't been updated.
+            // Technically, other ops could also cause issues,
+            // For example, an op could allow only dynamically shaped tensors,
+            // which means it would fail to verify after shape inference,
+            // but failing on those is probably the right thing to do for the
+            // compiler
+            if (auto inferOp = dyn_cast<InferTypeOpInterface>(op)) {
+              LLVM_DEBUG(llvm::dbgs() << "ShapeInference:\t\t\tcurrent op has "
+                                         "InferTypeOpInterface.\n");
+              SmallVector<Type> inferredReturnTypes;
+              if (failed(inferOp.inferReturnTypes(
+                      rewriter.getContext(), op->getLoc(), op->getOperands(),
+                      op->getAttrDictionary(), op->getPropertiesStorage(),
+                      op->getRegions(), inferredReturnTypes))) {
+                emitError(op->getLoc(), "Failed to infer return types.");
+                return WalkResult::interrupt();
+              }
+
+              assert(inferredReturnTypes.size() == op->getNumResults() &&
+                     "Number of inferred return types must match the number of "
+                     "results");
+
+              for (size_t i = 0; i < inferredReturnTypes.size(); ++i) {
+                if (inferredReturnTypes[i] == op->getResult(i).getType())
+                  continue;
+                op->getResult(i).setType(inferredReturnTypes[i]);
+              }
+
+              if (failed(verify(op))) {
+                emitError(op->getLoc(),
+                          "Operation failed to verify with its newly inferred "
+                          "return type(s) after its operands' types were "
+                          "updated during shape inference.");
+                return WalkResult::interrupt();
+              }
+            }
+
+            // If an operation is a (RegionBranch) terminator, we need to update
+            // the return types of the results of the parent operation to match
+            // the types of the terminators operands.
+            if (auto terminator =
+                    dyn_cast<RegionBranchTerminatorOpInterface>(op)) {
+              // Skip the func.return of the funcOp we're currently walking
+              // since we handle that separately at the end of this pass
+              if (terminator->getParentOp() == funcOp) {
+                LLVM_DEBUG(llvm::dbgs()
+                           << "ShapeInference:\t\t\t skipping terminator of "
+                              "current function since function return types "
+                              "are handled separately\n");
+
+              } else {
+                handleInterface(terminator);
+              }
+            }
+
+            // TODO (#1784): support additional operations/interfaces
+
+            return WalkResult::advance();
+          });
+      if (walkResult.wasInterrupted()) {
+        rewriter.cancelOpModification(funcOp);
+        return failure();
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////
+    ////  Step 3: Handle function return types                       ////
+    /////////// /////////////////////////////////////////////////////////
+
+    // Terminator return types (only if they exist, i.e., not a declaration)
+    SmallVector<Type> terminatorOperandTypes;
+    if (!funcOp.isDeclaration()) {
+      terminatorOperandTypes = llvm::to_vector(funcOp.getBody()
+                                                   .getBlocks()
+                                                   .front()
+                                                   .getTerminator()
+                                                   ->getOperandTypes());
+
+      if (terminatorOperandTypes.size() !=
+          funcOp.getFunctionType().getResults().size())
+        return emitError(funcOp.getLoc(),
+                         "Mismatch between inferred number of returns from "
+                         "function body and function signature.");
+    }
+
+    SmallVector<Type> inferredReturnTypes;
+
+    for (auto [idx, t] : enumerate(funcOp.getFunctionType().getResults())) {
+      auto shapedType = dyn_cast<ShapedType>(t);
+      bool isDynamicShapedType = shapedType && !shapedType.hasStaticShape();
+      auto shapeAttr = funcOp.getResultAttrOfType<ArrayAttr>(0, "shape.shape");
+
+      if (isDynamicShapedType) {
+        Type newType = Type();
+        bool isAnnotated = false;
+        if (shapeAttr) {
+          auto shape =
+              getShapeFromArrayAttr(shapeAttr, shapedType, funcOp.getLoc());
+          if (failed(shape)) return shape;
+          isAnnotated = true;
+          newType =
+              shapedType.clone(shape.value(), shapedType.getElementType());
+        }
+        if (!funcOp.isDeclaration()) {
+          auto terminatorType = terminatorOperandTypes[idx];
+          if (isAnnotated && terminatorType != newType) {
+            return emitError(
+                funcOp.getLoc(),
+                "Mismatch between inferred return type and annotated "
+                "return type.");
+          }
+          newType = terminatorType;
+        }
+        changed = true;
+        inferredReturnTypes.emplace_back(newType);
+      } else {
+        // Dynamic ShapedType but no {shape.shape} annotation
+        if (isDynamicShapedType && !shapeAttr) {
+          emitWarning(funcOp.getLoc(),
+                      "Found result with dynamic shaped type but no shape "
+                      "annotation.");
+        }
+
+        // Shape annotation on non-ShapedType type
+        if (shapeAttr && !shapedType) {
+          emitWarning(
+              funcOp.getLoc(),
+              "Ignoring shape annotation on result with non-ShapedType type");
+        }
+
+        // Shape annotation on non-dynamic ShapedType type
+        if (!isDynamicShapedType && shapeAttr) {
+          emitWarning(funcOp.getLoc(),
+                      "Ignoring shape annotation on result with non-dynamic "
+                      "shaped type");
+        }
+        inferredReturnTypes.emplace_back(t);
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////
+    ////  Step 4: Update the function type                            ////
+    /////////////////////////////////////////////////////////////////////
+
+    // If no types changed, we don't need to do anything
+    if (!changed) return failure();
+
+    // If the function had no body, we did not yet signal a modification
+    // Otherwise, we did so already in Step 2
+    if (funcOp.isDeclaration()) rewriter.startOpModification(funcOp);
+
+    // We need to update the function type to reflect the new types
+    funcOp.setFunctionType(
+        rewriter.getFunctionType(inferredInputTypes, inferredReturnTypes));
+
+    // Also remove the attribute argument from the signature
+    // (primarily for better readability of the IR after shape inference).
+    // N.B.: these fail gracefully/silently if there's no such attribute
+    for (int i = 0; i < inferredInputTypes.size(); ++i) {
+      funcOp.removeArgAttr(i, "shape.shape");
+    }
+    for (int i = 0; i < inferredReturnTypes.size(); ++i) {
+      funcOp.removeResultAttr(i, "shape.shape");
+    }
+
+    // Signal that we have successfully modified the op
+    rewriter.finalizeOpModification(funcOp);
+    return success();
+  }
+};
+
+struct ShapeInference : impl::ShapeInferenceBase<ShapeInference> {
+  using ShapeInferenceBase::ShapeInferenceBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<InferShape>(context);
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/ShapeInference/ShapeInference.h
+++ b/lib/Transforms/ShapeInference/ShapeInference.h
@@ -1,0 +1,20 @@
+#ifndef LIB_TRANSFORMS_SHAPEINFERENCE_SHAPEINFERENCE_H_
+#define LIB_TRANSFORMS_SHAPEINFERENCE_SHAPEINFERENCE_H_
+
+// IWYU pragma: begin_keep
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/ShapeInference/ShapeInference.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/ShapeInference/ShapeInference.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_SHAPEINFERENCE_SHAPEINFERENCE_H_

--- a/lib/Transforms/ShapeInference/ShapeInference.td
+++ b/lib/Transforms/ShapeInference/ShapeInference.td
@@ -1,0 +1,23 @@
+#ifndef LIB_TRANSFORMS_SHAPEINFERENCE_SHAPEINFERENCE_TD_
+#define LIB_TRANSFORMS_SHAPEINFERENCE_SHAPEINFERENCE_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ShapeInference : Pass<"shape-inference"> {
+  let summary = "Infer shapes for shaped types";
+
+  let description = [{
+    This pass infers the shapes of shaped types in a function,
+    starting from function arguments annotated with a {shape.shape} attribute.
+    Shape inference is only supported for operations that implement InferTypeOpInterface.
+
+    This is primarily intended to be used in conjunction with the Python frontend,
+    which infers the rank, but not the length of each dimension, for tensor types.
+  }];
+
+  let dependentDialects = [
+  ];
+}
+
+
+#endif // LIB_TRANSFORMS_SHAPEINFERENCE_SHAPEINFERENCE_TD_

--- a/tests/Transforms/shape_inference/BUILD
+++ b/tests/Transforms/shape_inference/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/shape_inference/shape_inference.mlir
+++ b/tests/Transforms/shape_inference/shape_inference.mlir
@@ -1,0 +1,80 @@
+// RUN: heir-opt --shape-inference  %s | FileCheck %s
+
+//CHECK: func @ignore_redundant_attribute
+//CHECK-SAME:(%[[X:.*]]: tensor<42xi16> {shape.shape = [111]}, %[[Y:.*]]: tensor<42xi16> {shape.shape = [111]}) -> tensor<42xi16>
+func.func @ignore_redundant_attribute(%x: tensor<42xi16> {shape.shape=[111]} , %y: tensor<42xi16> {shape.shape=[111]}) -> (tensor<42xi16>) {
+    //CHECK-NEXT: %[[ADD:.*]] = arith.addi %[[X]], %[[Y]] : tensor<42xi16>
+    %0 = arith.addi %x, %y : tensor<42xi16>
+    //CHECK-NEXT: return %[[ADD]] : tensor<42xi16>
+    func.return %0 : tensor<42xi16>
+}
+
+//CHECK: func @one_dimensional
+//CHECK-SAME:(%[[X:.*]]: tensor<42xi16>, %[[Y:.*]]: tensor<42xi16>) -> tensor<42xi16>
+func.func @one_dimensional(%x: tensor<?xi16> {shape.shape=[42]} , %y: tensor<?xi16> {shape.shape=[42]}) -> (tensor<?xi16>) {
+    //CHECK-NEXT: %[[ADD:.*]] = arith.addi %[[X]], %[[Y]] : tensor<42xi16>
+    %0 = arith.addi %x, %y : tensor<?xi16>
+    //CHECK-NEXT: return %[[ADD]] : tensor<42xi16>
+    func.return %0 : tensor<?xi16>
+}
+
+//CHECK: func @two_dimensional
+//CHECK-SAME:(%[[X:.*]]: tensor<2x3xi16>, %[[Y:.*]]: tensor<2x3xi16>) -> tensor<2x3xi16>
+func.func @two_dimensional(%x: tensor<?x?xi16> {shape.shape=[2, 3]} , %y: tensor<?x?xi16> {shape.shape=[2, 3]}) -> (tensor<?x?xi16>) {
+    //CHECK-NEXT: %[[ADD:.*]] = arith.addi %[[X]], %[[Y]] : tensor<2x3xi16>
+    %0 = arith.addi %x, %y : tensor<?x?xi16>
+    //CHECK-NEXT: return %[[ADD]] : tensor<2x3xi16>
+    func.return %0 : tensor<?x?xi16>
+}
+
+//CHECK: func private @decl_only
+//CHECK-SAME:(tensor<42xi16>, tensor<42xi16>) -> tensor<42xi16>
+func.func private @decl_only(%x: tensor<?xi16> {shape.shape=[42]} , %y: tensor<?xi16> {shape.shape=[42]}) -> (tensor<?xi16> {shape.shape=[42]})
+
+//CHECK: func @affine_for
+//CHECK-SAME:(%[[X:.*]]: tensor<42xi16>, %[[Y:.*]]: tensor<42xi16>) -> tensor<42xi16>
+func.func @affine_for(%x: tensor<?xi16> {shape.shape=[42]} , %y: tensor<?xi16> {shape.shape=[42]}) -> (tensor<?xi16>) {
+    //CHECK-NEXT: %[[FOR:.*]] = affine.for %[[I:.*]] = 0 to 10 iter_args(%[[SUM:.*]] = %[[X]]) -> (tensor<42xi16>) {
+    %0 = affine.for %i= 0 to 10 iter_args(%sum = %x) -> (tensor<?xi16>) {
+        //CHECK-NEXT: %[[NEW_SUM:.*]] = arith.addi %[[SUM]], %[[Y]] : tensor<42xi16>
+        %new_sum = arith.addi %sum, %y : tensor<?xi16>
+        //CHECK-NEXT: affine.yield %[[NEW_SUM]] : tensor<42xi16>
+        affine.yield %new_sum : tensor<?xi16>
+    }
+    //CHECK: return %[[FOR]] : tensor<42xi16>
+    func.return %0 : tensor<?xi16>
+}
+
+//CHECK: func @scf_if
+//CHECK-SAME:(%[[X:.*]]: tensor<42xi16>, %[[Y:.*]]: tensor<42xi16>, %[[COND:.*]]: i1) -> tensor<42xi16>
+func.func @scf_if(%x: tensor<?xi16> {shape.shape=[42]} , %y: tensor<?xi16> {shape.shape=[42]}, %cond : i1) -> (tensor<?xi16>) {
+    //CHECK-NEXT: %[[IF:.*]] = scf.if %[[COND:.*]] -> (tensor<42xi16>) {
+    %0 = scf.if %cond -> (tensor<?xi16>) {
+        //CHECK-NEXT: %[[ADD:.*]] = arith.addi %[[X]], %[[Y]] : tensor<42xi16>
+        %add = arith.addi %x, %y : tensor<?xi16>
+        //CHECK-NEXT: scf.yield %[[ADD]] : tensor<42xi16>
+        scf.yield %add : tensor<?xi16>
+    //CHECK-NEXT: } else {
+    } else {
+        //CHECK-NEXT: scf.yield %[[X]] : tensor<42xi16>
+        scf.yield %x : tensor<?xi16>
+    }
+    //CHECK: return %[[IF]] : tensor<42xi16>
+    func.return %0 : tensor<?xi16>
+}
+
+//CHECK: func @scf_while
+//CHECK-SAME:(%[[X:.*]]: tensor<42xi16>, %[[Y:.*]]: tensor<42xi16>, %[[COND:.*]]: i1) -> tensor<42xi16>
+func.func @scf_while(%x: tensor<?xi16> {shape.shape=[42]} , %y: tensor<?xi16> {shape.shape=[42]}, %cond : i1) -> (tensor<?xi16>) {
+    %0 = scf.while (%arg1 = %x) : (tensor<?xi16>) -> tensor<?xi16> {
+        %add = arith.addi %arg1, %y : tensor<?xi16>
+        scf.condition(%cond) %add : tensor<?xi16>
+    } do {
+        ^bb0(%arg2: tensor<?xi16>):
+            %next = arith.addi %arg2, %y : tensor<?xi16>
+            scf.yield %next : tensor<?xi16>
+    }
+    func.return %0 : tensor<?xi16>
+}
+
+// TODO (#1784): Add tests for linalg.generic and similar region carrying non-control-flow ops

--- a/tests/Transforms/shape_inference/shape_inference_invalid.mlir
+++ b/tests/Transforms/shape_inference/shape_inference_invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: heir-opt --shape-inference --split-input-file --verify-diagnostics %s 2>&1
+
+// expected-error@+1 {{must match the type of the corresponding argument in function signature}}
+func.func @mismatched_shape(%x: tensor<?xi16> {shape.shape=[42]} , %y: tensor<?xi16> {shape.shape=[44]}) -> (tensor<?xi16>) {
+    // expected-error@+2 {{Operation failed to verify with its newly inferred return type(s) after its operands' types were updated during shape inference.}}
+    // expected-error@+1 {{op requires the same type for all operands and results}}
+    %0 = arith.addi %x, %y : tensor<?xi16>
+    func.return %0 : tensor<?xi16>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -133,6 +133,7 @@ cc_binary(
         "@heir//lib/Transforms/SecretInsertMgmt",
         "@heir//lib/Transforms/Secretize",
         "@heir//lib/Transforms/SelectRewrite",
+        "@heir//lib/Transforms/ShapeInference",
         "@heir//lib/Transforms/StraightLineVectorizer",
         "@heir//lib/Transforms/TensorLinalgToAffineLoops",
         "@heir//lib/Transforms/TensorToScalars",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -84,6 +84,7 @@
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/Secretize/Passes.h"
 #include "lib/Transforms/SelectRewrite/SelectRewrite.h"
+#include "lib/Transforms/ShapeInference/ShapeInference.h"
 #include "lib/Transforms/StraightLineVectorizer/StraightLineVectorizer.h"
 #include "lib/Transforms/TensorLinalgToAffineLoops/TensorLinalgToAffineLoops.h"
 #include "lib/Transforms/TensorToScalars/TensorToScalars.h"
@@ -285,6 +286,7 @@ int main(int argc, char **argv) {
   registerLowerUnpackPasses();
   registerTensorToScalarsPasses();
   registerTensorLinalgToAffineLoops();
+  registerShapeInferencePasses();
   // Register yosys optimizer pipeline if configured.
 #ifndef HEIR_NO_YOSYS
 #ifndef HEIR_ABC_BINARY


### PR DESCRIPTION
From python, we convert
```Python
@compile()
def func(x: Secret[Tensor[2, 3, 4, I16]], y: Tensor[2, 3, 4, I16]):
  ....
 ```
 
 into 
 ```llvm
func.func @func(%x: tensor<?x?x?xi16> {secret.secret, shape.shape=[2,3,4]} loc("example.py":10:0),
                 %y: tensor<?x?x?xi16> {shape.shape=[2,3,4]} loc("example.py":10:0)) -> (tensor<?x?x?xi16>) {
 ```

Saving the shape into a function argument attribute on the func is easier than actually emitting a shaped tensor type, as it avoids the need to either cast the argument back to `tensor<?x?x?xi16>` later or try to do shape inference in Python/Numba.

I've also added a `--shape-inference` pass which will (a) update the actual argument types based on the annotations (b) walk the function body (using `inferOpTypeInterface`'s `inferResultTypes` to update types) , and (c) update the return type(s) of the function based on the inferred type(s) of the return op.

(Re-creating this PR since a change in the GH account used in #1594 confused the CLA system) 