### PR TITLE
NoiseAnalysis: Refactor noise to string

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BFV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BFV/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:CallOpInterfaces",

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
@@ -10,6 +10,7 @@
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"             // from @llvm-project
 #include "llvm/include/llvm/Support/Debug.h"              // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"     // from @llvm-project
@@ -55,10 +56,10 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
   };
 
   auto propagate = [&](Value value, NoiseState noise) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Propagating "
-               << noiseModel.toLogBoundString(getLocalParam(value), noise)
-               << " to " << value << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Propagating "
+                            << doubleToString2Prec(noiseModel.toLogBound(
+                                   getLocalParam(value), noise))
+                            << " to " << value << "\n");
     LatticeType *lattice = this->getLatticeElement(value);
     auto changeResult = lattice->join(noise);
     this->propagateIfChanged(lattice, changeResult);

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.cpp
@@ -40,30 +40,6 @@ double NoiseByBoundCoeffModel::toLogTotal(const LocalParamType &param) const {
   return total - logT - 1.0;
 }
 
-std::string NoiseByBoundCoeffModel::toLogBoundString(
-    const LocalParamType &param, const StateType &noise) const {
-  auto logBound = toLogBound(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBound;
-  return stream.str();
-}
-
-std::string NoiseByBoundCoeffModel::toLogBudgetString(
-    const LocalParamType &param, const StateType &noise) const {
-  auto logBudget = toLogBudget(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBudget;
-  return stream.str();
-}
-
-std::string NoiseByBoundCoeffModel::toLogTotalString(
-    const LocalParamType &param) const {
-  auto logTotal = toLogTotal(param);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logTotal;
-  return stream.str();
-}
-
 double NoiseByBoundCoeffModel::getExpansionFactor(
     const LocalParamType &param) const {
   auto n = param.getSchemeParam()->getRingDim();

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h
@@ -47,13 +47,8 @@ class NoiseByBoundCoeffModel {
   // logBudget: logTotal - logBound
   // as ||e|| < Q / (t * 2) for correct decryption
   double toLogBound(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBoundString(const LocalParamType &param,
-                               const StateType &noise) const;
   double toLogBudget(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBudgetString(const LocalParamType &param,
-                                const StateType &noise) const;
   double toLogTotal(const LocalParamType &param) const;
-  std::string toLogTotalString(const LocalParamType &param) const;
 
  private:
   NoiseModelVariant variant;

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.cpp
@@ -52,30 +52,6 @@ double NoiseByVarianceCoeffModel::toLogTotal(
   return total - logT - 1.0;
 }
 
-std::string NoiseByVarianceCoeffModel::toLogBoundString(
-    const LocalParamType &param, const StateType &noise) const {
-  auto logBound = toLogBound(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBound;
-  return stream.str();
-}
-
-std::string NoiseByVarianceCoeffModel::toLogBudgetString(
-    const LocalParamType &param, const StateType &noise) const {
-  auto logBudget = toLogBudget(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBudget;
-  return stream.str();
-}
-
-std::string NoiseByVarianceCoeffModel::toLogTotalString(
-    const LocalParamType &param) const {
-  auto logTotal = toLogTotal(param);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logTotal;
-  return stream.str();
-}
-
 double NoiseByVarianceCoeffModel::getVarianceErr(
     const LocalParamType &param) const {
   auto std0 = param.getSchemeParam()->getStd0();

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h
@@ -59,13 +59,8 @@ class NoiseByVarianceCoeffModel {
   // logBudget: logTotal - logBound
   // as ||e|| < Q / (t * 2) for correct decryption
   double toLogBound(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBoundString(const LocalParamType &param,
-                               const StateType &noise) const;
   double toLogBudget(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBudgetString(const LocalParamType &param,
-                                const StateType &noise) const;
   double toLogTotal(const LocalParamType &param) const;
-  std::string toLogTotalString(const LocalParamType &param) const;
 };
 
 }  // namespace bfv

--- a/lib/Analysis/NoiseAnalysis/BGV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BGV/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:CallOpInterfaces",

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
@@ -11,6 +11,7 @@
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"             // from @llvm-project
 #include "llvm/include/llvm/Support/Debug.h"              // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"     // from @llvm-project
@@ -56,10 +57,10 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
   };
 
   auto propagate = [&](Value value, NoiseState noise) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Propagating "
-               << noiseModel.toLogBoundString(getLocalParam(value), noise)
-               << " to " << value << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Propagating "
+                            << doubleToString2Prec(noiseModel.toLogBound(
+                                   getLocalParam(value), noise))
+                            << " to " << value << "\n");
     LatticeType *lattice = this->getLatticeElement(value);
     auto changeResult = lattice->join(noise);
     this->propagateIfChanged(lattice, changeResult);

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.cpp
@@ -43,30 +43,6 @@ double NoiseByBoundCoeffModel::toLogTotal(const LocalParamType &param) const {
   return total - 1.0;
 }
 
-std::string NoiseByBoundCoeffModel::toLogBoundString(
-    const LocalParamType &param, const StateType &noise) const {
-  auto logBound = toLogBound(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBound;
-  return stream.str();
-}
-
-std::string NoiseByBoundCoeffModel::toLogBudgetString(
-    const LocalParamType &param, const StateType &noise) const {
-  auto logBudget = toLogBudget(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBudget;
-  return stream.str();
-}
-
-std::string NoiseByBoundCoeffModel::toLogTotalString(
-    const LocalParamType &param) const {
-  auto logTotal = toLogTotal(param);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logTotal;
-  return stream.str();
-}
-
 double NoiseByBoundCoeffModel::getExpansionFactor(
     const LocalParamType &param) const {
   auto n = param.getSchemeParam()->getRingDim();

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h
@@ -50,13 +50,8 @@ class NoiseByBoundCoeffModel {
   // logBudget: logTotal - logBound
   // as ||m + t * e|| < Ql / 2 for correct decryption
   double toLogBound(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBoundString(const LocalParamType &param,
-                               const StateType &noise) const;
   double toLogBudget(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBudgetString(const LocalParamType &param,
-                                const StateType &noise) const;
   double toLogTotal(const LocalParamType &param) const;
-  std::string toLogTotalString(const LocalParamType &param) const;
 
  private:
   NoiseModelVariant variant;

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.cpp
@@ -51,29 +51,6 @@ double Model::toLogTotal(const LocalParamType &param) const {
   return total - 1.0;
 }
 
-std::string Model::toLogBoundString(const LocalParamType &param,
-                                    const StateType &noise) const {
-  auto logBound = toLogBound(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBound;
-  return stream.str();
-}
-
-std::string Model::toLogBudgetString(const LocalParamType &param,
-                                     const StateType &noise) const {
-  auto logBudget = toLogBudget(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBudget;
-  return stream.str();
-}
-
-std::string Model::toLogTotalString(const LocalParamType &param) const {
-  auto logTotal = toLogTotal(param);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logTotal;
-  return stream.str();
-}
-
 double Model::getVarianceErr(const LocalParamType &param) const {
   auto std0 = param.getSchemeParam()->getStd0();
   return std0 * std0;

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h
@@ -49,13 +49,8 @@ class NoiseByVarianceCoeffModel {
   // logBudget: logTotal - logBound
   // as ||m + t * e|| < Ql / 2 for correct decryption
   double toLogBound(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBoundString(const LocalParamType &param,
-                               const StateType &noise) const;
   double toLogBudget(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBudgetString(const LocalParamType &param,
-                                const StateType &noise) const;
   double toLogTotal(const LocalParamType &param) const;
-  std::string toLogTotalString(const LocalParamType &param) const;
 };
 
 }  // namespace bgv

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.cpp
@@ -43,29 +43,6 @@ double Model::toLogTotal(const LocalParamType &param) const {
   return total - 1.0;
 }
 
-std::string Model::toLogBoundString(const LocalParamType &param,
-                                    const StateType &noise) const {
-  auto logBound = toLogBound(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBound;
-  return stream.str();
-}
-
-std::string Model::toLogBudgetString(const LocalParamType &param,
-                                     const StateType &noise) const {
-  auto logBudget = toLogBudget(param, noise);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logBudget;
-  return stream.str();
-}
-
-std::string Model::toLogTotalString(const LocalParamType &param) const {
-  auto logTotal = toLogTotal(param);
-  std::stringstream stream;
-  stream << std::fixed << std::setprecision(2) << logTotal;
-  return stream.str();
-}
-
 double Model::getVarianceErr(const LocalParamType &param) const {
   auto std0 = param.getSchemeParam()->getStd0();
   return std0 * std0;

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h
@@ -51,13 +51,8 @@ class NoiseCanEmbModel {
   // logBudget: logTotal - logBound
   // as ||m + t * e|| < Ql / 2 for correct decryption
   double toLogBound(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBoundString(const LocalParamType &param,
-                               const StateType &noise) const;
   double toLogBudget(const LocalParamType &param, const StateType &noise) const;
-  std::string toLogBudgetString(const LocalParamType &param,
-                                const StateType &noise) const;
   double toLogTotal(const LocalParamType &param) const;
-  std::string toLogTotalString(const LocalParamType &param) const;
 };
 
 }  // namespace bgv

--- a/lib/Parameters/BUILD
+++ b/lib/Parameters/BUILD
@@ -9,6 +9,7 @@ cc_library(
     hdrs = ["RLWEParams.h"],
     deps = [
         ":RLWESecurityParams",
+        "@heir//lib/Utils",
         "@llvm-project//llvm:Support",
         "@openfhe//:core",
     ],

--- a/lib/Parameters/RLWEParams.cpp
+++ b/lib/Parameters/RLWEParams.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "lib/Parameters/RLWESecurityParams.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "src/core/include/openfhecore.h"           // from @openfhe
 
@@ -151,17 +152,11 @@ RLWESchemeParam RLWESchemeParam::getConcreteRLWESchemeParam(
 }
 
 void RLWESchemeParam::print(llvm::raw_ostream &os) const {
-  auto doubleToString = [](double d) {
-    std::stringstream stream;
-    stream << std::fixed << std::setprecision(2) << d;
-    return stream.str();
-  };
-
   os << "ringDim: " << ringDim << "\n";
   os << "level: " << level << "\n";
   os << "logqi: ";
   for (auto qi : logqi) {
-    os << doubleToString(qi) << " ";
+    os << doubleToString2Prec(qi) << " ";
   }
   os << "\n";
   os << "qi: ";
@@ -172,7 +167,7 @@ void RLWESchemeParam::print(llvm::raw_ostream &os) const {
   os << "dnum: " << dnum << "\n";
   os << "logpi: ";
   for (auto pi : logpi) {
-    os << doubleToString(pi) << " ";
+    os << doubleToString2Prec(pi) << " ";
   }
   os << "\n";
   os << "pi: ";

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:MgmtOps",
         "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Utils",
         "@heir//lib/Utils:AttributeUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -20,6 +20,7 @@
 #include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
@@ -86,11 +87,13 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
 
     auto budget = model.toLogBudget(localParam, noiseState);
 
-    auto boundString = model.toLogBoundString(localParam, noiseState);
-    auto budgetString = model.toLogBudgetString(localParam, noiseState);
-    auto totalString = model.toLogTotalString(localParam);
+    auto boundString =
+        doubleToString2Prec(model.toLogBound(localParam, noiseState));
 
     LLVM_DEBUG({
+      auto budgetString =
+          doubleToString2Prec(model.toLogBudget(localParam, noiseState));
+      auto totalString = doubleToString2Prec(model.toLogTotal(localParam));
       llvm::dbgs() << "Noise Bound: " << boundString
                    << " Budget: " << budgetString << " Total: " << totalString
                    << " for value: " << value << " " << "\n";

--- a/lib/Utils/Utils.cpp
+++ b/lib/Utils/Utils.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <map>
 #include <optional>
 #include <string>
@@ -129,6 +130,12 @@ void iterateIndices(ArrayRef<int64_t> shape, const IndexTupleConsumer &process,
       done = true;
     }
   }
+}
+
+std::string doubleToString2Prec(double value) {
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << value;
+  return stream.str();
 }
 
 }  // namespace heir

--- a/lib/Utils/Utils.h
+++ b/lib/Utils/Utils.h
@@ -121,6 +121,9 @@ void iterateIndices(ArrayRef<int64_t> shape, const IndexTupleConsumer &process,
                     ArrayRef<int64_t> fixedIndices = {},
                     ArrayRef<int64_t> fixedIndexValues = {});
 
+/// Convert a double to a string with 2 decimal precision.
+std::string doubleToString2Prec(double value);
+
 }  // namespace heir
 }  // namespace mlir
 


### PR DESCRIPTION
The old API `toLogXXXString` is quite redundant given there are now so many noise models in HEIR, this PR refactors them out.