### PR TITLE
BGV: Symbolic Noise Analysis for Dependency Tracking

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BGV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BGV/BUILD
@@ -78,3 +78,45 @@ cc_library(
         "@heir//lib/Utils:MathUtils",
     ],
 )
+
+cc_library(
+    name = "NoiseBySymbolCoeffModelAnalysis",
+    srcs = [
+        "NoiseBySymbolCoeffModelAnalysis.cpp",
+    ],
+    hdrs = [
+    ],
+    deps = [
+        ":NoiseBySymbolCoeffModel",
+        "@heir//lib/Analysis:Utils",
+        "@heir//lib/Analysis/DimensionAnalysis",
+        "@heir//lib/Analysis/LevelAnalysis",
+        "@heir//lib/Analysis/NoiseAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:CallOpInterfaces",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+    # required for gcc to link properly
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "NoiseBySymbolCoeffModel",
+    srcs = [
+        "NoiseBySymbolCoeffModel.cpp",
+    ],
+    hdrs = [
+        "NoiseBySymbolCoeffModel.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/NoiseAnalysis:Symbolic",
+        "@heir//lib/Parameters/BGV:Params",
+        "@heir//lib/Utils:MathUtils",
+    ],
+)

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.cpp
@@ -1,0 +1,118 @@
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.h"
+
+#include <cassert>
+#include <cmath>
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "lib/Utils/MathUtils.h"
+
+namespace mlir {
+namespace heir {
+namespace bgv {
+
+using namespace mlir::heir::noise;
+
+double NoiseBySymbolCoeffModel::toLogBound(const LocalParamType &param,
+                                           const StateType &noise) const {
+  double alpha = pow(2.0, -32);
+  auto ringDim = param.getSchemeParam()->getRingDim();
+  // variance is log2(Var(e))
+  auto variance = noise.getVariance(ringDim);
+  double bound = (1. / 2.) * (1 + variance) +
+                 log2(erfinv(pow(1.0 - alpha, 1.0 / ringDim)));
+  return bound;
+}
+
+double NoiseBySymbolCoeffModel::toLogBudget(const LocalParamType &param,
+                                            const StateType &noise) const {
+  return toLogTotal(param) - toLogBound(param, noise);
+}
+
+double NoiseBySymbolCoeffModel::toLogTotal(const LocalParamType &param) const {
+  double total = 0;
+  auto logqi = param.getSchemeParam()->getLogqi();
+  for (auto i = 0; i <= param.getCurrentLevel(); ++i) {
+    total += logqi[i];
+  }
+  return total - 1.0;
+}
+
+std::string NoiseBySymbolCoeffModel::toLogBoundString(
+    const LocalParamType &param, const StateType &noise) const {
+  auto logBound = toLogBound(param, noise);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logBound;
+  return stream.str();
+}
+
+std::string NoiseBySymbolCoeffModel::toLogBudgetString(
+    const LocalParamType &param, const StateType &noise) const {
+  auto logBudget = toLogBudget(param, noise);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logBudget;
+  return stream.str();
+}
+
+std::string NoiseBySymbolCoeffModel::toLogTotalString(
+    const LocalParamType &param) const {
+  auto logTotal = toLogTotal(param);
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(2) << logTotal;
+  return stream.str();
+}
+
+typename NoiseBySymbolCoeffModel::StateType
+NoiseBySymbolCoeffModel::evalEncryptPk(const LocalParamType &param,
+                                       unsigned index) const {
+  auto stderr = param.getSchemeParam()->getStd0();
+  Expr ei = Symbol(Symbol::GAUSSIAN, "e" + std::to_string(index), stderr);
+  Expr s = Symbol(Symbol::UNIFORM_TERNARY, "s", 0);
+  Expr epk = Symbol(Symbol::GAUSSIAN, "epk", stderr);
+  Expr ui = Symbol(Symbol::UNIFORM_TERNARY, "u" + std::to_string(index), 0);
+
+  Expr t = Symbol(Symbol::CONSTANT, "t",
+                  param.getSchemeParam()->getPlaintextModulus());
+  return t * (ei * s + epk * ui);
+}
+
+typename NoiseBySymbolCoeffModel::StateType
+NoiseBySymbolCoeffModel::evalEncryptSk(const LocalParamType &param,
+                                       unsigned index) const {
+  auto stderr = param.getSchemeParam()->getStd0();
+  Expr ei = Symbol(Symbol::GAUSSIAN, "e" + std::to_string(index), stderr);
+
+  Expr t = Symbol(Symbol::CONSTANT, "t",
+                  param.getSchemeParam()->getPlaintextModulus());
+  return t * ei;
+}
+
+typename NoiseBySymbolCoeffModel::StateType
+NoiseBySymbolCoeffModel::evalEncrypt(const LocalParamType &param,
+                                     unsigned index) const {
+  auto usePublicKey = param.getSchemeParam()->getUsePublicKey();
+  if (usePublicKey) {
+    return evalEncryptPk(param, index);
+  }
+  return evalEncryptSk(param, index);
+}
+
+typename NoiseBySymbolCoeffModel::StateType NoiseBySymbolCoeffModel::evalMul(
+    const LocalParamType &resultParam, const StateType &lhs,
+    const StateType &rhs) const {
+  return lhs * rhs;
+}
+
+typename NoiseBySymbolCoeffModel::StateType NoiseBySymbolCoeffModel::evalAdd(
+    const StateType &lhs, const StateType &rhs) const {
+  return lhs + rhs;
+}
+
+}  // namespace bgv
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.h
@@ -1,0 +1,55 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_BGV_NOISEBYSYMBOLCOEFFMODEL_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_BGV_NOISEBYSYMBOLCOEFFMODEL_H_
+
+#include <cassert>
+#include <string>
+
+#include "lib/Analysis/NoiseAnalysis/Symbolic.h"
+#include "lib/Parameters/BGV/Params.h"
+
+namespace mlir {
+namespace heir {
+namespace bgv {
+
+// coefficient embedding noise model using variance
+class NoiseBySymbolCoeffModel {
+ public:
+  // for MP24, NoiseState stores the variance var for the one coefficient of
+  // critical quantity v = m + t * e, assuming coefficients are IID.
+  //
+  // MP24 states that for two polynomial multipication, the variance of one
+  // coefficient of the result can be approximated by ringDim * var_0 * var_1,
+  // because the polynomial multipication is a convolution.
+  using StateType = noise::Expression;
+  using SchemeParamType = SchemeParam;
+  using LocalParamType = LocalParam;
+
+ private:
+  StateType evalEncryptPk(const LocalParamType &param, unsigned index) const;
+  StateType evalEncryptSk(const LocalParamType &param, unsigned index) const;
+
+ public:
+  StateType evalEncrypt(const LocalParamType &param, unsigned index) const;
+  StateType evalAdd(const StateType &lhs, const StateType &rhs) const;
+  StateType evalMul(const LocalParamType &resultParam, const StateType &lhs,
+                    const StateType &rhs) const;
+
+  // logTotal: log(Ql / 2)
+  // logBound: bound on ||m + t * e|| predicted by the model
+  // logBudget: logTotal - logBound
+  // as ||m + t * e|| < Ql / 2 for correct decryption
+  double toLogBound(const LocalParamType &param, const StateType &noise) const;
+  std::string toLogBoundString(const LocalParamType &param,
+                               const StateType &noise) const;
+  double toLogBudget(const LocalParamType &param, const StateType &noise) const;
+  std::string toLogBudgetString(const LocalParamType &param,
+                                const StateType &noise) const;
+  double toLogTotal(const LocalParamType &param) const;
+  std::string toLogTotalString(const LocalParamType &param) const;
+};
+
+}  // namespace bgv
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_BGV_NOISEBYSYMBOLCOEFFMODEL_H_

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModelAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModelAnalysis.cpp
@@ -1,0 +1,115 @@
+#include <functional>
+#include <iomanip>
+
+#include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+#include "lib/Analysis/Utils.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"             // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"              // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"     // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                   // from @llvm-project
+#include "mlir/include/mlir/Interfaces/CallInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"               // from @llvm-project
+
+#define DEBUG_TYPE "NoiseAnalysis"
+
+namespace mlir {
+namespace heir {
+
+// explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
+template <typename NoiseModel>
+void NoiseAnalysis<NoiseModel>::setToEntryState(LatticeType *lattice) {
+  // At an entry point, we have no information about the noise.
+  this->propagateIfChanged(lattice, lattice->join(NoiseState()));
+}
+
+// explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
+template <typename NoiseModel>
+void NoiseAnalysis<NoiseModel>::visitExternalCall(
+    CallOpInterface call, ArrayRef<const LatticeType *> argumentLattices,
+    ArrayRef<LatticeType *> resultLattices) {
+  auto callback =
+      std::bind(&NoiseAnalysis<NoiseModel>::propagateIfChangedWrapper, this,
+                std::placeholders::_1, std::placeholders::_2);
+  ::mlir::heir::visitExternalCall<NoiseState, LatticeType>(
+      call, argumentLattices, resultLattices, callback);
+}
+
+// explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
+template <typename NoiseModel>
+LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
+    Operation *op, ArrayRef<const LatticeType *> operands,
+    ArrayRef<LatticeType *> results) {
+  auto getLocalParam = [&](Value value) {
+    auto level = getLevelFromMgmtAttr(value);
+    auto dimension = getDimensionFromMgmtAttr(value);
+    return LocalParamType(&schemeParam, level, dimension);
+  };
+
+  auto propagate = [&](Value value, NoiseState noise) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Propagating "
+               << noiseModel.toLogBoundString(getLocalParam(value), noise)
+               << " " << noise.toString() << " to " << value << "\n");
+    LatticeType *lattice = this->getLatticeElement(value);
+    auto changeResult = lattice->join(noise);
+    this->propagateIfChanged(lattice, changeResult);
+  };
+
+  auto res =
+      llvm::TypeSwitch<Operation &, LogicalResult>(*op)
+          .Case<secret::GenericOp>([&](auto genericOp) {
+            Block *body = genericOp.getBody();
+            for (BlockArgument &arg : body->getArguments()) {
+              auto localParam = getLocalParam(arg);
+              NoiseState encrypted =
+                  noiseModel.evalEncrypt(localParam, arg.getArgNumber());
+              propagate(arg, encrypted);
+            }
+            return success();
+          })
+          .template Case<arith::MulIOp>([&](auto mulOp) {
+            SmallVector<OpResult> secretResults;
+            this->getSecretResults(mulOp, secretResults);
+            if (secretResults.empty()) {
+              return success();
+            }
+
+            auto localParam = getLocalParam(mulOp.getResult());
+            NoiseState mult = noiseModel.evalMul(
+                localParam, operands[0]->getValue(), operands[1]->getValue());
+            propagate(mulOp.getResult(), mult);
+            return success();
+          })
+          .template Case<arith::AddIOp>([&](auto addOp) {
+            SmallVector<OpResult> secretResults;
+            this->getSecretResults(addOp, secretResults);
+            if (secretResults.empty()) {
+              return success();
+            }
+
+            NoiseState add = noiseModel.evalAdd(operands[0]->getValue(),
+                                                operands[1]->getValue());
+            propagate(addOp.getResult(), add);
+            return success();
+          })
+          .template Case<mgmt::RelinearizeOp>([&](auto relinearizeOp) {
+            propagate(relinearizeOp.getResult(), operands[0]->getValue());
+            return success();
+          })
+          .Default([&](auto &op) { return success(); });
+  return res;
+}
+
+// template instantiation
+template class NoiseAnalysis<bgv::NoiseBySymbolCoeffModel>;
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BUILD
@@ -32,3 +32,16 @@ cc_library(
         "@llvm-project//mlir:IR",
     ],
 )
+
+cc_library(
+    name = "Symbolic",
+    srcs = ["Symbolic.cpp"],
+    hdrs = [
+        "Symbolic.h",
+    ],
+    deps = [
+        ":Noise",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/lib/Analysis/NoiseAnalysis/Noise.h
+++ b/lib/Analysis/NoiseAnalysis/Noise.h
@@ -89,6 +89,11 @@ class NoiseState {
   // as if we are doing e1 + e2 using log(e1) and log(e2)
   NoiseState operator+(const NoiseState& rhs) const;
 
+  NoiseState& operator+=(const NoiseState& rhs) {
+    assert(isKnown());
+    return *this = *this + rhs;
+  }
+
   // for int/double
   template <typename T>
   NoiseState operator+(const T& rhs) const {
@@ -96,15 +101,32 @@ class NoiseState {
     return *this + NoiseState::of(rhs);
   }
 
+  template <typename T>
+  NoiseState& operator+=(const T& rhs) {
+    assert(isKnown());
+    return *this += NoiseState::of(rhs);
+  }
+
   // Although NoiseState stores log(e), we expose the operation
   // as if we are doing e1 * e2 using log(e1) and log(e2)
   NoiseState operator*(const NoiseState& rhs) const;
+
+  NoiseState& operator*=(const NoiseState& rhs) {
+    assert(isKnown());
+    return *this = *this * rhs;
+  }
 
   // for int/double
   template <typename T>
   NoiseState operator*(const T& rhs) const {
     assert(isKnown());
     return *this * NoiseState::of(rhs);
+  }
+
+  template <typename T>
+  NoiseState& operator*=(const T& rhs) {
+    assert(isKnown());
+    return *this *= NoiseState::of(rhs);
   }
 
   static NoiseState join(const NoiseState& lhs, const NoiseState& rhs) {

--- a/lib/Analysis/NoiseAnalysis/Symbolic.cpp
+++ b/lib/Analysis/NoiseAnalysis/Symbolic.cpp
@@ -1,0 +1,199 @@
+#include "lib/Analysis/NoiseAnalysis/Symbolic.h"
+
+#include <cmath>
+
+#include "lib/Analysis/NoiseAnalysis/Noise.h"
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+
+#define DEBUG_TYPE "Symbolic"
+
+namespace mlir {
+namespace heir {
+namespace noise {
+
+//===------------------------------------------------------------------------===//
+// Monomial
+//===------------------------------------------------------------------------===//
+
+Monomial Monomial::operator*(const Monomial &rhs) const {
+  SymbolsType newSymbols;
+  auto updateSymbols = [&](const SymbolsType &symbols) {
+    for (auto &[symbol, exponent] : symbols) {
+      auto find = newSymbols.find(symbol);
+      if (find != newSymbols.end()) {
+        find->second += exponent;
+      } else {
+        newSymbols[symbol] = exponent;
+      }
+    }
+  };
+  updateSymbols(this->getSymbols());
+  updateSymbols(rhs.getSymbols());
+  return newSymbols;
+}
+
+std::string Monomial::toString() const {
+  std::string ret;
+  bool firstTime = true;
+  for (auto &[symbol, exponent] : symbols) {
+    if (!firstTime) {
+      ret += " * ";
+    }
+    ret += symbol.getName();
+    if (exponent != 1) {
+      ret += "^" + std::to_string(exponent);
+    }
+    firstTime = false;
+  }
+  return ret;
+}
+
+//===------------------------------------------------------------------------===//
+// Expression
+//===------------------------------------------------------------------------===//
+
+Expression Expression::operator+(const Expression &rhs) const {
+  MonomialsType newMonomials;
+  auto updateMonomials = [&](const MonomialsType &monomials) {
+    for (auto &[monomial, coefficient] : monomials) {
+      auto find = newMonomials.find(monomial);
+      if (find != newMonomials.end()) {
+        find->second += coefficient;
+      } else {
+        newMonomials[monomial] = coefficient;
+      }
+    }
+  };
+  updateMonomials(this->getMonomials());
+  updateMonomials(rhs.getMonomials());
+  return newMonomials;
+}
+
+Expression Expression::operator*(const Expression &rhs) const {
+  MonomialsType newMonomials;
+  for (auto &[lhsMonomial, lhsCoefficient] : this->monomials) {
+    for (auto &[rhsMonomial, rhsCoefficient] : rhs.monomials) {
+      auto newMonomial = lhsMonomial * rhsMonomial;
+      auto newCoefficient = lhsCoefficient * rhsCoefficient;
+      auto find = newMonomials.find(newMonomial);
+      if (find != newMonomials.end()) {
+        find->second += newCoefficient;
+      } else {
+        newMonomials[newMonomial] = newCoefficient;
+      }
+    }
+  }
+  return Expression(newMonomials);
+}
+
+std::string Expression::toString() const {
+  std::string ret;
+  bool firstTime = true;
+  for (auto &[monomial, coefficient] : monomials) {
+    if (!firstTime) {
+      ret += " + ";
+    }
+    if (coefficient != 1.0) {
+      ret += std::to_string(coefficient) + " * ";
+    }
+    ret += monomial.toString();
+    firstTime = false;
+  }
+  return ret;
+}
+
+//===------------------------------------------------------------------------===//
+// Constant and Random Variable
+//===------------------------------------------------------------------------===//
+
+double Symbol::getVariance() const {
+  assert(isRandomVariable());
+  switch (kind) {
+    case SymbolKind::GAUSSIAN:
+      return param * param;
+    case SymbolKind::UNIFORM_TERNARY:
+      return 2.0 / 3.0;
+    case SymbolKind::UNIFORM:
+      return param * param / 12.;
+    default:
+      llvm_unreachable("Unknown symbol kind");
+  }
+}
+
+double Expression::getVariance(int ringDim) const {
+  // Group monomials by sharing the same random variables with same order
+  // e.g. c1 * s^i * e^j and c2 * s^i * e^j
+  // because they should have been merged as (c1 + c2) * s^i * e^j.
+  // Technically, this is done by filling all Constant Symbols.
+  // We use NoiseState to do log-arithmetic.
+  std::map<Monomial, NoiseState> randomVariableToCoefficient;
+  for (auto &[monomial, coefficient] : getMonomials()) {
+    Monomial randomVariables;
+    auto instantiatedCoefficient = NoiseState::of(coefficient);
+    for (auto &[symbol, exponent] : monomial.getSymbols()) {
+      if (symbol.isConstant()) {
+        // multiply constant for exponent times
+        for (auto i = 0; i != exponent; ++i) {
+          // this happens using log-arithmetic
+          instantiatedCoefficient *= symbol.getConstant();
+        }
+      } else {
+        if (randomVariables.getSymbols().empty()) {
+          // first time
+          randomVariables = Monomial(symbol, exponent);
+        } else {
+          randomVariables = randomVariables * Monomial(symbol, exponent);
+        }
+      }
+    }
+    // update the map
+    auto find = randomVariableToCoefficient.find(randomVariables);
+    if (find != randomVariableToCoefficient.end()) {
+      find->second = find->second + instantiatedCoefficient;
+    } else {
+      randomVariableToCoefficient[randomVariables] = instantiatedCoefficient;
+    }
+  }
+
+  LLVM_DEBUG({
+    for (auto &[monomial, coefficient] : randomVariableToCoefficient) {
+      llvm::dbgs() << "Monomial: " << monomial.toString()
+                   << " Coeff: " << coefficient << "\n";
+    }
+  });
+
+  auto variance = NoiseState::of(0.0);
+
+  // then we can use the map to calculate variance
+  for (auto &[monomial, coefficient] : randomVariableToCoefficient) {
+    // in Var(), c -> c^2
+    auto currentVariance = coefficient * coefficient;
+
+    // calculate s^j e^k using the following formula
+    // Var(s^j e^k) = j! * k! * N^{j+k-1} Var(s)^j * Var(e)^k
+    int64_t exponentSum = 0;
+    for (auto &[symbol, exponent] : monomial.getSymbols()) {
+      exponentSum += exponent;
+      if (symbol.isRandomVariable()) {
+        // multiply variance for exponent times
+        // also calculate j!
+        for (auto i = 1; i <= exponent; ++i) {
+          currentVariance *= symbol.getVariance() * (i);
+        }
+      }
+    }
+    // multiply N^{j+k-1}
+    if (exponentSum > 0) {
+      for (auto i = 0; i != exponentSum - 1; ++i) {
+        currentVariance *= ringDim;
+      }
+    }
+    variance += currentVariance;
+  }
+  // return log-scale value
+  return variance.getValue();
+}
+
+}  // namespace noise
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/Symbolic.h
+++ b/lib/Analysis/NoiseAnalysis/Symbolic.h
@@ -1,0 +1,134 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_SYMBOLIC_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_SYMBOLIC_H_
+
+#include <cassert>
+#include <map>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"         // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace noise {
+
+// User should ensure "name" is unique
+class Symbol {
+ public:
+  enum SymbolKind {
+    CONSTANT = 0,  // param is constant
+    RANDOMVARIABLE,
+    /*RV*/ GAUSSIAN,  // param is stderr
+    /*RV*/ UNIFORM,
+    /*RV*/ UNIFORM_TERNARY,  // [-param/2, param/2]
+    END_OF_RV,
+  };
+  SymbolKind getKind() const { return kind; }
+  bool isConstant() const { return kind == CONSTANT; }
+  bool isRandomVariable() const {
+    return kind >= RANDOMVARIABLE && kind < END_OF_RV;
+  }
+  double getConstant() const {
+    assert(isConstant());
+    return param;
+  }
+  double getVariance() const;
+
+ private:
+  const SymbolKind kind;
+
+ public:
+  Symbol(SymbolKind kind, const std::string &name, double param)
+      : kind(kind), name(name), param(param) {}
+
+  bool operator<(const Symbol &rhs) const { return name < rhs.name; }
+  bool operator==(const Symbol &rhs) const { return name == rhs.name; }
+
+  std::string getName() const { return name; }
+  double getParam() const { return param; }
+
+ private:
+  std::string name;
+  // interpreted differently for different symbol
+  double param;
+};
+
+class Monomial {
+ public:
+  using ExponentType = int64_t;
+  using SymbolsType = std::map<Symbol, ExponentType>;
+
+  Monomial() = default;
+  Monomial(const Symbol &symbol) { symbols[symbol] = 1; }
+
+  Monomial(const Symbol &symbol, ExponentType exponent)
+      : symbols({{symbol, exponent}}) {}
+
+  Monomial(const SymbolsType &symbols) : symbols(symbols) {}
+
+  bool operator<(const Monomial &rhs) const { return symbols < rhs.symbols; }
+  bool operator==(const Monomial &rhs) const { return symbols == rhs.symbols; }
+
+  const SymbolsType &getSymbols() const { return symbols; }
+
+  Monomial operator*(const Monomial &rhs) const;
+
+  std::string toString() const;
+
+ private:
+  SymbolsType symbols;
+};
+
+class Expression {
+ public:
+  using CoefficientType = int64_t;
+  using MonomialsType = std::map<Monomial, CoefficientType>;
+
+  Expression() = default;
+  Expression(const Symbol &symbol) { monomials.insert({Monomial(symbol), 1}); }
+  Expression(const Monomial &monomial) { monomials.insert({monomial, 1}); }
+
+  Expression(const MonomialsType &monomials) : monomials(monomials) {}
+
+  const MonomialsType &getMonomials() const { return monomials; }
+
+  bool operator==(const Expression &rhs) const {
+    return monomials == rhs.monomials;
+  }
+
+  Expression operator+(const Expression &rhs) const;
+
+  Expression operator*(const Expression &rhs) const;
+
+  std::string toString() const;
+
+  void print(raw_ostream &os) const { os << toString(); }
+
+  // for Lattice in DataFlowFramework
+  static Expression join(const Expression &lhs, const Expression &rhs) {
+    // prefer lhs when equal
+    if (lhs.monomials.size() >= rhs.monomials.size()) {
+      return lhs;
+    }
+    return rhs;
+  }
+
+  // for compatibility with other Noise Lattice
+  bool isInitialized() const { return !monomials.empty(); }
+
+  // random variable related
+  double getVariance(int ringDim) const;
+
+ private:
+  MonomialsType monomials;
+};
+
+using Expr = Expression;
+
+}  // namespace noise
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_SYMBOLIC_H_

--- a/lib/Transforms/GenerateParam/BUILD
+++ b/lib/Transforms/GenerateParam/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseCanEmbModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseBySymbolCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
         "@heir//lib/Analysis/RangeAnalysis",

--- a/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
@@ -7,6 +7,7 @@
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/Noise.h"
@@ -223,6 +224,9 @@ struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
     } else if (model == "bgv-noise-mono") {
       bgv::NoiseCanEmbModel model;
       run<bgv::NoiseCanEmbModel>(model);
+    } else if (model == "bgv-noise-symbol") {
+      bgv::NoiseBySymbolCoeffModel model;
+      run<bgv::NoiseBySymbolCoeffModel>(model);
     } else {
       emitWarning(getOperation()->getLoc()) << "Unknown noise model.\n";
       generateFallbackParam();

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseCanEmbModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseBySymbolCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
         "@heir//lib/Analysis/SecretnessAnalysis",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -8,6 +8,7 @@
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BGV/NoiseBySymbolCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/Noise.h"
@@ -192,6 +193,9 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
     } else if (model == "bgv-noise-mono") {
       bgv::NoiseCanEmbModel model;
       run<bgv::NoiseCanEmbModel>(model);
+    } else if (model == "bgv-noise-symbol") {
+      bgv::NoiseBySymbolCoeffModel model;
+      run<bgv::NoiseBySymbolCoeffModel>(model);
     } else if (model == "bfv-noise-by-bound-coeff-worst-case") {
       bfv::NoiseByBoundCoeffModel model(NoiseModelVariant::WORST_CASE);
       run<bfv::NoiseByBoundCoeffModel>(model);

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -38,6 +38,7 @@ cc_binary(
         "@heir//lib/Analysis/NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseAnalysis",  # buildcleaner: keep
+        "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseBySymbolCoeffModelAnalysis",  # buildcleaner: keep
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGI",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGIQuart",


### PR DESCRIPTION
### Status

This PR is intended for the symbolic part `Symbolic.h/Symbolic.cpp`, as this part is big enough.

Also it should be rebased after #1816 is in.

The BGV adoption of it is not comprehensive as it only supports addition/multiplication but it is enough to demonstrate along with (#1782, which would be another PR). Its complete version supporting modulus switching/key switching needs another PR regarding `SelectVariableNames`. Its extension to BFV is already in a branch (also need `SelectVariableNames`). CKKS noise analysis could also benefit from it but lets wait until all the TODOs in #1685.

### Backgrounds

Recent attacks like [GNSJ24](https://www.usenix.org/conference/usenixsecurity24/presentation/guo-qian), [CCP+24](eprint.iacr.org/2024/127), [CSBB24](eprint.iacr.org/2024/116) demonstrated that the ability for noise analysis to handle dependent ciphertext is crucial for security.

These attacks exploited the fact that dependency among ciphertext will lead to faster noise growth, and former average-case analysis is not so able to handle them (strong independency assumption).

This approach could handle it but there are some issues. One obvious issue is that is could not scale-up as the number of symbolic terms grows exponentially with the number of multiplication (though there are some optimizations).

HEIR formerly has a pass called `openfhe-count-add-and-key-switch` in #1254 that could in spirit handle those attacks but it is standalone and not connected to the NoiseAnalysis inside HEIR.

### Some experiments

#### Multiplication of Independent ciphertext

```mlir
func.func @mul(%arg0 : i16 {secret.secret}, %arg1 : i16 {secret.secret}) -> i16 {
  %1 = arith.muli %arg0, %arg1 : i16
  return %1 : i16
}
```

MP24 model

```
Propagating 28.05 to <block argument> of type 'i16' at index: 0
Propagating 28.05 to <block argument> of type 'i16' at index: 1
Propagating 58.94 to %1 = arith.muli %input0, %input1
Propagating 58.94 to %2 = mgmt.relinearize %1
Propagating 24.08 to %3 = mgmt.modreduce %2
```

Symbol model: able to handle common dependency like secret key and error in public key (namely #1782)

```
Propagating 28.05 ... block arg
Propagating 28.05 ... block arg
Propagating 59.23 ... muli
```

#### Multiplication of same ciphertext

```mlir
func.func @mul(%arg0 : i16 {secret.secret}) -> i16 {
  %1 = arith.muli %arg0, %arg0 : i16
  return %1 : i16
}
```

MP24: the same as above

Symbol: even higher noise

```
Propagating 59.73 ... muli
```

#### Addition of 4 indep ciphertext

```mlir
func.func @mul(
  %arg0 : i16 {secret.secret},
  %arg1 : i16 {secret.secret},
  %arg2 : i16 {secret.secret},
  %arg3 : i16 {secret.secret}
  ) -> i16 {
  %1 = arith.addi %arg0, %arg1 : i16
  %2 = arith.addi %1, %arg2 : i16
  %3 = arith.addi %2, %arg3 : i16
  return %3 : i16
}
```

MP24

```
Propagating 28.05 to <block argument> of type 'i16' at index: 0
Propagating 28.55 to %1 = arith.addi %input0, %input1
Propagating 28.55 to %2 = arith.addi %input2, %input3 
Propagating 29.05 to %3 = arith.addi %1, %2 
```

Symbol (should align with MP24)

```
Propagating 28.05 <block argument>
Propagating 28.55 ... to %1 = arith.addi %input0, %input1 
Propagating 28.55 ... to %2 = arith.addi %input2, %input3
Propagating 29.05 ... to %3 = arith.addi %1, %2
```

#### Addition of same ciphertext 4 times

```mlir
func.func @mul(%arg0 : i16 {secret.secret}) -> i16 {
  %1 = arith.addi %arg0, %arg0 : i16
  %2 = arith.addi %1, %1 : i16
  return %2 : i16
}
```

MP24 (unable to handle faster growth)

```
Propagating 28.05 to <block argument>
Propagating 28.55 to %1 = arith.addi %input0, %input0
Propagating 29.05 to %2 = arith.addi %1, %1
```

Symbol

```
Propagating 28.05 block arg
Propagating 29.05 addi
Propagating 30.05 addi
```