### PR TITLE
SelectVariableNames: Make a Wrapper for DataflowAnalysis

### DIFF
--- a/lib/Analysis/SelectVariableNames/BUILD
+++ b/lib/Analysis/SelectVariableNames/BUILD
@@ -10,6 +10,7 @@ cc_library(
     hdrs = ["SelectVariableNames.h"],
     deps = [
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",

--- a/lib/Analysis/SelectVariableNames/SelectVariableNames.h
+++ b/lib/Analysis/SelectVariableNames/SelectVariableNames.h
@@ -4,14 +4,53 @@
 #include <cassert>
 #include <string>
 
-#include "llvm/include/llvm/ADT/DenseMap.h"          // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"          // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"              // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"          // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMap.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
 
 namespace mlir {
 namespace heir {
+
+class VariableName {
+ public:
+  VariableName() = default;
+  VariableName(const std::string &name, int integer)
+      : initialized(true), name(name), integer(integer) {}
+  ~VariableName() = default;
+
+  bool operator==(const VariableName &other) const {
+    return initialized == other.initialized && name == other.name &&
+           integer == other.integer;
+  }
+
+  // For Lattice in DataFlowFramework
+  static VariableName join(const VariableName &lhs, const VariableName &rhs) {
+    if (!lhs.isInitialized() || lhs.getName().empty()) return rhs;
+    if (!rhs.isInitialized() || rhs.getName().empty()) return lhs;
+
+    if (lhs.getName() == rhs.getName()) return lhs;
+
+    // If the names are different, we can just return the first one
+    return lhs;
+  }
+
+  void print(raw_ostream &os) const {
+    os << "Name: " << name << " Int: " << integer;
+  }
+
+  bool isInitialized() const { return initialized; }
+  std::string getName() const { return name; }
+  int getInteger() const { return integer; }
+
+ private:
+  bool initialized = false;
+  std::string name;
+  int integer;
+};
 
 class SelectVariableNames {
  public:
@@ -22,31 +61,66 @@ class SelectVariableNames {
   /// value was not assigned a name (suggesting the value was not in the IR
   /// tree that this class was constructed with).
   std::string getNameForValue(Value value) const {
-    assert(variableNames.contains(value));
-    return variableNames.lookup(value);
+    return lookup(value).getName();
   }
 
-  // Return the unique integer assigned to a given value.
-  int getIntForValue(Value value) const {
-    assert(variableToInteger.contains(value));
-    return variableToInteger.lookup(value);
+  /// Return the unique integer assigned to a given value.
+  int getIntForValue(Value value) const { return lookup(value).getInteger(); }
+
+  /// returns the internal VariableName struct
+  VariableName lookup(Value value) const {
+    assert(variableNames.contains(value));
+    return variableNames.lookup(value);
   }
 
   // Map from one value's name to another value's name.
   void mapValueNameToValue(Value fromValue, Value toValue) {
     assert(variableNames.contains(toValue));
     variableNames[fromValue] = variableNames[toValue];
-    variableToInteger[fromValue] = variableToInteger[toValue];
   }
 
   bool contains(Value value) const { return variableNames.contains(value); }
 
  private:
-  std::string suggestNameForValue(Value value);
+  std::string suggestPrefixForValue(Value value);
 
   std::string defaultPrefix{"v"};
-  llvm::DenseMap<Value, std::string> variableNames;
-  llvm::DenseMap<Value, int> variableToInteger;
+  llvm::DenseMap<Value, VariableName> variableNames;
+};
+
+//===----------------------------------------------------------------------===//
+// DataFlowAnalysis Wrapper
+//===----------------------------------------------------------------------===//
+
+class VariableNameLattice : public dataflow::Lattice<VariableName> {
+ public:
+  using Lattice::Lattice;
+};
+
+/// This analysis does not update the Lattice when IR changes!
+class SelectVariableNameAnalysis
+    : public dataflow::SparseForwardDataFlowAnalysis<VariableNameLattice> {
+ public:
+  explicit SelectVariableNameAnalysis(
+      DataFlowSolver &solver, const SelectVariableNames &selectVariableNames)
+      : SparseForwardDataFlowAnalysis(solver),
+        selectVariableNames(selectVariableNames) {}
+
+  void setToEntryState(VariableNameLattice *lattice) override {
+    propagateIfChanged(
+        lattice,
+        lattice->join(selectVariableNames.lookup(lattice->getAnchor())));
+  }
+
+  // does nothing
+  LogicalResult visitOperation(
+      Operation *operation, ArrayRef<const VariableNameLattice *> operands,
+      ArrayRef<VariableNameLattice *> results) override {
+    return success();
+  };
+
+ private:
+  SelectVariableNames selectVariableNames;
 };
 
 }  // namespace heir

--- a/lib/Transforms/GenerateParam/BUILD
+++ b/lib/Transforms/GenerateParam/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Analysis/SelectVariableNames",
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/CKKS/IR:Dialect",

--- a/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
@@ -3,6 +3,7 @@
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
@@ -145,6 +146,9 @@ struct GenerateParamBFV : impl::GenerateParamBFVBase<GenerateParamBFV> {
     solver.load<dataflow::SparseConstantPropagation>();
     // NoiseAnalysis depends on SecretnessAnalysis
     solver.load<SecretnessAnalysis>();
+    // NoiseAnalysis depends on SelectVariableNameAnalysis
+    SelectVariableNames selectVariableNames(getOperation());
+    solver.load<SelectVariableNameAnalysis>(selectVariableNames);
     solver.load<NoiseAnalysis<NoiseModel>>(schemeParam, model);
     if (failed(solver.initializeAndRun(getOperation()))) {
       getOperation()->emitOpError() << "Failed to run the analysis.\n";

--- a/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
@@ -5,6 +5,7 @@
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
@@ -170,6 +171,9 @@ struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
     solver.load<dataflow::SparseConstantPropagation>();
     // NoiseAnalysis depends on SecretnessAnalysis
     solver.load<SecretnessAnalysis>();
+    // NoiseAnalysis depends on SelectVariableNameAnalysis
+    SelectVariableNames selectVariableNames(getOperation());
+    solver.load<SelectVariableNameAnalysis>(selectVariableNames);
     solver.load<NoiseAnalysis<NoiseModel>>(schemeParam, model);
     if (failed(solver.initializeAndRun(getOperation()))) {
       getOperation()->emitOpError() << "Failed to run the analysis.\n";

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Analysis/SelectVariableNames",
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:MgmtOps",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -14,6 +14,7 @@
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
@@ -172,6 +173,9 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
     solver.load<dataflow::SparseConstantPropagation>();
     // NoiseAnalysis depends on SecretnessAnalysis
     solver.load<SecretnessAnalysis>();
+    // NoiseAnalysis depends on SelectVariableNameAnalysis
+    SelectVariableNames selectVariableNames(getOperation());
+    solver.load<SelectVariableNameAnalysis>(selectVariableNames);
 
     solver.load<NoiseAnalysis<NoiseModel>>(schemeParam, model);
 


### PR DESCRIPTION
NoiseAnalysis (and also other analysis) may want to get unique name of a `Value`, e.g. for symbolic way of analysis (see #1817)

I do not know if this way of providing name for analysis is favorable (so requesting opinions from @j2kun before more technical details). I used to have another `NameAnalysis` so that NoiseAnalysis could access `NameLattice`, turned out that is a duplicate of `SelectVariableNames` so I modified this analysis to have a dataflow framework wrapper.

Notice that other ways of solving it include

* Pass `SelectVariableName` struct to every analysis, which is inconvenient if we get more analysis. Passing it to the DataFlowSolver might be more convenient.
* Pass it in `LocalParam`, which is essentially constructed from the IR, which requires annotating the IR with HEIR generated name (quite strange)

<summary>solved now</summary>
<details>
It was me that used reference for destroyed struct. 
</details>

Other problem involves loop-carried variable which has the same name but does not have the same analysis state, which we (and also MLIR) are quite unable to handle. One way is to force the invariant for these variables via bootstrapping, but then we need to think about what "reset the Symbolic State" means for bootstrapping inside a loop.