### PR TITLE
annotate enc/dec funcs for cross-pass matching

### DIFF
--- a/lib/Dialect/ModuleAttributes.h
+++ b/lib/Dialect/ModuleAttributes.h
@@ -48,6 +48,25 @@ void moduleClearBackend(Operation *moduleOp);
 void moduleSetOpenfhe(Operation *moduleOp);
 void moduleSetLattigo(Operation *moduleOp);
 
+// Func attributes for client helpers
+//
+// This corresponds to a named attribute client.enc_func whose
+// value is a dictionary {func_name = "foo", index = 2 : i64}
+//
+// This means that the function with this attribute is an encryption
+// helper for the function "foo" and the argument at index 2.
+
+constexpr const static ::llvm::StringLiteral kClientEncFuncAttrName =
+    "client.enc_func";
+constexpr const static ::llvm::StringLiteral kClientDecFuncAttrName =
+    "client.dec_func";
+
+// The name of the function this client helper is made for.
+constexpr const static ::llvm::StringLiteral kClientHelperFuncName =
+    "func_name";
+// The argument or operand index the client helper function is for.
+constexpr const static ::llvm::StringLiteral kClientHelperIndex = "index";
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/lib/Transforms/AddClientInterface/BUILD
+++ b/lib/Transforms/AddClientInterface/BUILD
@@ -11,6 +11,7 @@ cc_library(
     hdrs = ["AddClientInterface.h"],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Transforms/ConvertToCiphertextSemantics:AssignLayout",

--- a/tests/Transforms/add_client_interface/add_client_interface.mlir
+++ b/tests/Transforms/add_client_interface/add_client_interface.mlir
@@ -41,7 +41,7 @@ func.func @simple_sum(
 
 // CHECK: @simple_sum__encrypt
 // CHECK-SAME: (%[[arg0:[^:]*]]: tensor<32xi16>
-// CHECK-SAME:     -> [[ct_ty]] {
+// CHECK-SAME:     -> [[ct_ty]] attributes {client.enc_func = {func_name = "simple_sum", index = 0 : i64}} {
 // CHECK-NEXT:   %[[laidout:[^ ]*]] = tensor.concat
 //               ...many operands... omitted for brevity
 // CHECK-SAME:   %[[arg0]], %[[arg0]], %[[arg0]], %[[arg0]]
@@ -51,7 +51,7 @@ func.func @simple_sum(
 
 // CHECK: @simple_sum__decrypt
 // CHECK-SAME: (%[[arg1:[^:]*]]: [[ct_ty]]
-// CHECK-SAME:     -> i16 {
+// CHECK-SAME:     -> i16 attributes {client.dec_func = {func_name = "simple_sum", index = 0 : i64}} {
 // CHECK-NEXT:   %[[decrypted:.*]] = secret.reveal %[[arg1]]
 // CHECK:        %[[extracted:.*]] = tensor.extract %[[decrypted]]
 // CHECK:        return %[[extracted]]


### PR DESCRIPTION
This allows one to use the annotation on the encryption func to identify the original function the cilent helper is for, as well as the argument/result index.

I needed this in https://github.com/google/heir/pull/1633/files because I need a way to copy mgmt attributes from the main function to the client helpers before lowering secret to scheme.