### PR TITLE
Copy mgmt attr to client helpers

### DIFF
--- a/lib/Dialect/Mgmt/Transforms/AnnotateMgmt.cpp
+++ b/lib/Dialect/Mgmt/Transforms/AnnotateMgmt.cpp
@@ -6,6 +6,7 @@
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "lib/Dialect/Mgmt/Transforms/Utils.h"
 #include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "lib/Utils/AttributeUtils.h"
 #include "lib/Utils/Utils.h"
@@ -110,6 +111,11 @@ struct AnnotateMgmt : impl::AnnotateMgmtBase<AnnotateMgmt> {
     // the func terminator.
     copyReturnOperandAttrsToFuncResultAttrs(getOperation(),
                                             MgmtDialect::kArgMgmtAttrName);
+
+    if (failed(copyMgmtAttrToClientHelpers(getOperation()))) {
+      signalPassFailure();
+      return;
+    }
   }
 };
 

--- a/lib/Dialect/Mgmt/Transforms/BUILD
+++ b/lib/Dialect/Mgmt/Transforms/BUILD
@@ -16,10 +16,28 @@ cc_library(
 )
 
 cc_library(
+    name = "Utils",
+    srcs = ["Utils.cpp"],
+    hdrs = ["Utils.h"],
+    deps = [
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Transforms/PropagateAnnotation",
+        "@heir//lib/Utils:AttributeUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
     name = "AnnotateMgmt",
     srcs = ["AnnotateMgmt.cpp"],
     hdrs = ["AnnotateMgmt.h"],
     deps = [
+        ":Utils",
         ":pass_inc_gen",
         "@heir//lib/Analysis/DimensionAnalysis",
         "@heir//lib/Analysis/LevelAnalysis",

--- a/lib/Dialect/Mgmt/Transforms/Utils.cpp
+++ b/lib/Dialect/Mgmt/Transforms/Utils.cpp
@@ -1,0 +1,73 @@
+#include "lib/Dialect/Mgmt/Transforms/Utils.h"
+
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
+#include "lib/Transforms/PropagateAnnotation/PropagateAnnotation.h"
+#include "lib/Utils/AttributeUtils.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+LogicalResult copyMgmtAttrToClientHelpers(Operation *op) {
+  auto &kArgMgmtAttrName = mgmt::MgmtDialect::kArgMgmtAttrName;
+
+  ModuleOp moduleOp = cast<ModuleOp>(op);
+  WalkResult result = op->walk([&](func::FuncOp funcOp) {
+    // Check for the helper attributes
+    auto clientEncAttr =
+        funcOp->getAttrOfType<mlir::DictionaryAttr>(kClientEncFuncAttrName);
+    auto clientDecAttr =
+        funcOp->getAttrOfType<mlir::DictionaryAttr>(kClientDecFuncAttrName);
+
+    if (!clientEncAttr && !clientDecAttr) return WalkResult::advance();
+
+    DictionaryAttr attr = clientEncAttr ? clientEncAttr : clientDecAttr;
+    llvm::StringRef originalFuncName =
+        cast<StringAttr>(attr.get(kClientHelperFuncName));
+
+    Operation *maybeFunc = moduleOp.lookupSymbol(originalFuncName);
+    if (!maybeFunc) {
+      op->emitError() << "module missing func with name " << originalFuncName;
+      return WalkResult::interrupt();
+    }
+
+    func::FuncOp originalFunc = cast<func::FuncOp>(maybeFunc);
+    int index = cast<IntegerAttr>(attr.get(kClientHelperIndex)).getInt();
+
+    auto shouldPropagate = [&](Type type) {
+      return isa<secret::SecretType>(type);
+    };
+
+    if (clientEncAttr) {
+      auto mgmtAttr = originalFunc.getArgAttr(index, kArgMgmtAttrName);
+      if (!mgmtAttr) {
+        originalFunc.emitError()
+            << "expected mgmt attribute on original function argument";
+        return WalkResult::interrupt();
+      }
+      funcOp.setResultAttr(0, kArgMgmtAttrName, mgmtAttr);
+      backwardPropagateAnnotation(funcOp, kArgMgmtAttrName, shouldPropagate);
+    } else {
+      auto mgmtAttr = originalFunc.getResultAttr(index, kArgMgmtAttrName);
+      if (!mgmtAttr) {
+        originalFunc.emitError()
+            << "expected mgmt attribute on original function argument";
+        return WalkResult::interrupt();
+      }
+      funcOp.setArgAttr(0, kArgMgmtAttrName, mgmtAttr);
+      forwardPropagateAnnotation(funcOp, kArgMgmtAttrName, shouldPropagate);
+    }
+
+    return WalkResult::advance();
+  });
+
+  return result.wasInterrupted() ? failure() : success();
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Mgmt/Transforms/Utils.h
+++ b/lib/Dialect/Mgmt/Transforms/Utils.h
@@ -1,0 +1,46 @@
+#ifndef LIB_DIALECT_MGMT_TRANSFORMS_UTILS_H_
+#define LIB_DIALECT_MGMT_TRANSFORMS_UTILS_H_
+
+#include "mlir/include/mlir/IR/Operation.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// Client helper functions require mgmt attributes in order for the type
+// converter to convert them. The correct mgmt attribute to use is
+// determined by the function the helpers are made for, and so
+// this method copies the relevant mgmt attributes from
+// the original function to the client helper function arg/result attrs
+// so they can be propagated through those IRs. Any existing mgmt attributes
+// on the client helpers are replaced.
+//
+// E.g., given the following functions
+//
+//   func.func @foo(
+//      %arg0: !secret.secret<tensor<8xi16>> {mgmt.mgmt = ...})
+//         -> (!secret.secret<tensor<8xi16>> {mgmt.mgmt = ...}) {
+//     ...
+//   }
+//   func.func @foo__encrypt__arg0(
+//      %arg0: tensor<8xi16>) -> !secret.secret<tensor<8xi16>>
+//      attributes {client_enc_func = {func_name = "foo", index = 0 : i64}} {
+//     ...
+//   }
+//   func.func @foo__decrypt__result0(
+//      %arg0: !secret.secret<tensor<8xi16>>) -> i16
+//       attributes {client_dec_func = {func_name = "foo", index = 0 : i64}} {
+//     ...
+//   }
+//
+// The encrypt function needs its result annotated with a mgmt attr that
+// matches the mgmt attr of @foo's 0th argument, and the decrypt function's
+// argument needs a mgmt attr that matches the mgmt attr of @foo's 0th result.
+// Then the mgmt attr needs to be backward propagated in the encryption
+// function and forward propagated in the decryption function.
+LogicalResult copyMgmtAttrToClientHelpers(Operation *op);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_MGMT_TRANSFORMS_UTILS_H_

--- a/lib/Transforms/PropagateAnnotation/PropagateAnnotation.cpp
+++ b/lib/Transforms/PropagateAnnotation/PropagateAnnotation.cpp
@@ -16,13 +16,71 @@ namespace heir {
 #define GEN_PASS_DEF_PROPAGATEANNOTATION
 #include "lib/Transforms/PropagateAnnotation/PropagateAnnotation.h.inc"
 
-void forwardPropagateAnnotation(Operation *root, StringRef attrName) {
+static void setAttrIfMissing(Value value, StringRef attrName, Attribute attr) {
+  if (failed(findAttributeAssociatedWith(value, attrName))) {
+    setAttributeAssociatedWith(value, attrName, attr);
+  }
+}
+
+void forwardPropagateAnnotation(Operation *root, StringRef attrName,
+                                function_ref<bool(Type)> shouldPropagate) {
+  LLVM_DEBUG(llvm::dbgs() << "Forward propagation of " << attrName << "\n");
   if (attrName.empty()) {
     return;
   }
   root->walk<WalkOrder::PreOrder>([&](Operation *op) {
     if (op->hasAttr(attrName)) {
-      return;
+      return WalkResult::advance();
+    }
+
+    // A terminator propagates to parent's result attrs, if the op implements
+    // the OperandAndResultAttrInterface or is a func.func.
+    if (op->hasTrait<OpTrait::IsTerminator>()) {
+      LLVM_DEBUG(llvm::dbgs() << "Op is a terminator\n");
+      // Terminators try to inherit their attribute from the parent op's return
+      // attr.
+      auto *parentOp = op->getParentOp();
+
+      // An op like `return %0, %1` propagates multiple attributes forward to
+      // the parent's multiple result attrs.
+      for (int i = 0; i < op->getNumOperands(); ++i) {
+        auto operand = op->getOperand(i);
+        FailureOr<Attribute> attr =
+            findAttributeAssociatedWith(operand, attrName);
+        if (failed(attr)) continue;
+        if (!shouldPropagate(operand.getType())) {
+          LLVM_DEBUG(llvm::dbgs() << "Skipping propagation of " << attrName
+                                  << " to operand " << operand << "\n");
+          continue;
+        }
+
+        llvm::TypeSwitch<Operation *>(parentOp)
+            .Case<FunctionOpInterface, OperandAndResultAttrInterface>(
+                [&](auto interface) {
+                  LLVM_DEBUG(llvm::dbgs()
+                             << "Propagating terminator operand attr " << i
+                             << " (" << attr << ") to parent result attr " << i
+                             << "\n");
+                  return interface.setResultAttr(i, attrName, attr.value());
+                })
+            .Default([&](Operation *op) {
+              LLVM_DEBUG(llvm::dbgs()
+                         << "Warning: propagating terminator operand attr " << i
+                         << " (" << attr
+                         << ") to unsupported parent result attr\n");
+              return op->setAttr(attrName, attr.value());
+            });
+      }
+      return WalkResult::advance();
+    }
+
+    // Otherwise, operands propagate to result attributes of the op, unless
+    // the results should not be propagated to.
+    if (llvm::all_of(op->getResultTypes(),
+                     [&](Type type) { return !shouldPropagate(type); })) {
+      LLVM_DEBUG(llvm::dbgs() << "Skipping propagation of " << attrName
+                              << " through op " << op->getName() << "\n");
+      return WalkResult::advance();
     }
 
     for (Value operand : op->getOperands()) {
@@ -40,20 +98,17 @@ void forwardPropagateAnnotation(Operation *root, StringRef attrName) {
           continue;
         }
       }
+
       op->setAttr(attrName, attr);
       // short-circuit if we found an attribute
-      return;
+      break;
     }
+    return WalkResult::advance();
   });
 }
 
-void setAttrIfMissing(Value value, StringRef attrName, Attribute attr) {
-  if (failed(findAttributeAssociatedWith(value, attrName))) {
-    setAttributeAssociatedWith(value, attrName, attr);
-  }
-}
-
-void backwardPropagateAnnotation(Operation *root, StringRef attrName) {
+void backwardPropagateAnnotation(Operation *root, StringRef attrName,
+                                 function_ref<bool(Type)> shouldPropagate) {
   if (attrName.empty()) {
     return;
   }
@@ -61,15 +116,38 @@ void backwardPropagateAnnotation(Operation *root, StringRef attrName) {
   root->walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
     LLVM_DEBUG(llvm::dbgs() << "BackProp(" << attrName << ") visiting op "
                             << op->getName() << "\n");
+
     if (op->hasAttr(attrName)) {
       // The attr is assumed to be associated with the op's results.
       Attribute attrToPropagate = op->getAttr(attrName);
       LLVM_DEBUG(llvm::dbgs()
                  << "Using op's result attr " << attrToPropagate << "\n");
       for (auto operand : op->getOperands()) {
+        if (!shouldPropagate(operand.getType())) {
+          LLVM_DEBUG(llvm::dbgs() << "Skipping propagation of " << attrName
+                                  << " to operand " << operand << "\n");
+          continue;
+        }
         setAttrIfMissing(operand, attrName, attrToPropagate);
       }
       return WalkResult::advance();
+    }
+
+    if (auto attrInterface = dyn_cast<OperandAndResultAttrInterface>(op)) {
+      // The attr is attached to the op's operands and can be propagated
+      // backward to the op's defining op.
+      for (OpOperand &operand : op->getOpOperands()) {
+        if (!shouldPropagate(operand.get().getType())) {
+          LLVM_DEBUG(llvm::dbgs() << "Skipping propagation of " << attrName
+                                  << " to operand " << operand.get() << "\n");
+          continue;
+        }
+        auto attr =
+            attrInterface.getOperandAttr(operand.getOperandNumber(), attrName);
+        if (attr) {
+          setAttrIfMissing(operand.get(), attrName, attr);
+        }
+      }
     }
 
     if (op->hasTrait<OpTrait::IsTerminator>()) {
@@ -89,9 +167,15 @@ void backwardPropagateAnnotation(Operation *root, StringRef attrName) {
                     })
                 .Default([&](Operation *op) { return op->getAttr(attrName); });
         if (attr) {
+          auto operand = op->getOperand(i);
+          if (!shouldPropagate(operand.getType())) {
+            LLVM_DEBUG(llvm::dbgs() << "Skipping propagation of " << attrName
+                                    << " to operand " << operand << "\n");
+            continue;
+          }
           LLVM_DEBUG(llvm::dbgs() << "Propagating result attr " << i << " ("
                                   << attr << ") to operand " << i << "\n");
-          setAttrIfMissing(op->getOperand(i), attrName, attr);
+          setAttrIfMissing(operand, attrName, attr);
         }
       }
       return WalkResult::advance();

--- a/lib/Transforms/PropagateAnnotation/PropagateAnnotation.h
+++ b/lib/Transforms/PropagateAnnotation/PropagateAnnotation.h
@@ -12,11 +12,27 @@ namespace heir {
 #define GEN_PASS_REGISTRATION
 #include "lib/Transforms/PropagateAnnotation/PropagateAnnotation.h.inc"
 
+/// Forward propagate an annotation, with a callable determining when it's
+/// OK to propagate based on the type.
+void forwardPropagateAnnotation(Operation *root, StringRef attrName,
+                                function_ref<bool(Type)> shouldPropagate);
+
 /// Forward-propagate an annotation through the IR.
 void forwardPropagateAnnotation(Operation *root, StringRef attrName);
+inline void forwardPropagateAnnotation(Operation *root, StringRef attrName) {
+  return forwardPropagateAnnotation(root, attrName, [](Type) { return true; });
+}
+
+/// Backward propagate an annotation, with a callable determining when it's
+/// OK to propagate based on the type.
+void backwardPropagateAnnotation(Operation *root, StringRef attrName,
+                                 function_ref<bool(Type)> shouldPropagate);
 
 /// Backward-propagate an annotation through the IR.
 void backwardPropagateAnnotation(Operation *root, StringRef attrName);
+inline void backwardPropagateAnnotation(Operation *root, StringRef attrName) {
+  return backwardPropagateAnnotation(root, attrName, [](Type) { return true; });
+}
 
 }  // namespace heir
 }  // namespace mlir

--- a/tests/Transforms/annotate_mgmt/BUILD
+++ b/tests/Transforms/annotate_mgmt/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/annotate_mgmt/client_helpers.mlir
+++ b/tests/Transforms/annotate_mgmt/client_helpers.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt --annotate-mgmt %s | FileCheck %s
+
+// CHECK: @main
+func.func @main(%arg0: !secret.secret<i16> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) -> (!secret.secret<i16> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
+  return %arg0 : !secret.secret<i16>
+}
+
+// CHECK: @encrypt_helper
+// CHECK-SAME: (%[[arg0:.*]]: i16) -> (!secret.secret<i16> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) attributes
+func.func @encrypt_helper(%arg0: i16) -> !secret.secret<i16> attributes {client.enc_func = {func_name = "main", index = 0 : i64}} {
+  // CHECK: secret.conceal
+  // CHECK-SAME: {mgmt.mgmt = #mgmt.mgmt<level = 0>
+  %0 = secret.conceal %arg0 : i16 -> !secret.secret<i16>
+  return %0 : !secret.secret<i16>
+}
+// CHECK: @decrypt_helper
+// CHECK-SAME: (%[[arg0:.*]]: !secret.secret<i16> {mgmt.mgmt = #mgmt.mgmt<level = 0>
+func.func @decrypt_helper(%arg0: !secret.secret<i16>) -> i16 attributes {client.dec_func = {func_name = "main", index = 0 : i64}} {
+  %0 = secret.reveal %arg0 : !secret.secret<i16> -> i16
+  return %0 : i16
+}

--- a/tests/Transforms/propagate_annotation/pass.mlir
+++ b/tests/Transforms/propagate_annotation/pass.mlir
@@ -10,12 +10,13 @@ func.func @mul(%arg0 : i16 {secret.secret}) -> i16 {
 
 // -----
 
-// CHECK-COUNT-2: test.attr = 2
+// 3 because one is an argAttr, one is a resultAttr, and one is on the first
+// muli op.
+// CHECK-COUNT-3: test.attr = 2
 func.func @mul(%arg0 : i16 {secret.secret, test.attr = 2}) -> i16 {
   %1 = arith.muli %arg0, %arg0 : i16
   // CHECK-COUNT-2: test.attr = 1
   %2 = arith.muli %1, %1 {test.attr = 1} : i16
   %3 = arith.muli %2, %1 : i16
-// CHECK: test.attr = 2
   return %1 : i16
 }


### PR DESCRIPTION
Copies the mgmt attr from the main compiled function to the client helpers. This is required to lower them from secret to scheme in https://github.com/google/heir/pull/1633

The main idea is to copy the mgmt attrs to the function arg attrs and result attrs, and then rely on the attribute propagation utilities to populate the client helper function bodies with mgmt attrs. This last step is necessary for two reasons:

- secret-to-scheme requires mgmt attrs for type conversion, and at least, the last op in the client encryption step (secret.conceal) produces a secret type that needs to be lowered
- the various analysis passes work on the entire IR and will fail if mgmt attrs are not found. It's simpler to ensure the mgmt attrs are consistent across the entire IR than to have the analyses have special cases to know about client helpers.