### PR TITLE
implement RegionBranchOpInterface for secret.generic

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,10 @@ bazel_dep(name = "rules_python", version = "1.2.0")
 bazel_dep(name = "googletest", version = "1.16.0")
 bazel_dep(name = "google_benchmark", version = "1.9.1")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
-bazel_dep(name = "eigen", version = "4.0.0-20241125.bcr.1")
+
+# eigen 4.0.0-20241125.bcr.1 has issues with gitlab changing the checksum
+# Cf. https://github.com/google/heir/issues/1840
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "or-tools", version = "9.12", repo_name = "com_google_ortools")
 
 # needed as transitive deps of yosys

--- a/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h
+++ b/lib/Analysis/AddAndKeySwitchCountAnalysis/AddAndKeySwitchCountAnalysis.h
@@ -5,6 +5,7 @@
 #include <cassert>
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -113,6 +114,11 @@ class CountAnalysis
   friend class SecretnessAnalysisDependent<CountAnalysis>;
 
   void setToEntryState(CountLattice *lattice) override {
+    // one addition in Vfresh
+    if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+      propagateIfChanged(lattice, lattice->join(CountState(1, 0)));
+      return;
+    }
     propagateIfChanged(lattice, lattice->join(CountState()));
   }
 

--- a/lib/Analysis/DimensionAnalysis/BUILD
+++ b/lib/Analysis/DimensionAnalysis/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",

--- a/lib/Analysis/DimensionAnalysis/DimensionAnalysis.cpp
+++ b/lib/Analysis/DimensionAnalysis/DimensionAnalysis.cpp
@@ -7,11 +7,10 @@
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
-#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
-#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
-#include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
 #include "mlir/include/mlir/IR/Attributes.h"               // from @llvm-project
@@ -22,8 +21,6 @@
 #include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
 #include "mlir/include/mlir/Interfaces/CallInterfaces.h"   // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
-
-#define DEBUG_TYPE "DimensionAnalysis"
 
 namespace mlir {
 namespace heir {
@@ -42,13 +39,6 @@ LogicalResult DimensionAnalysis::visitOperation(
   };
 
   llvm::TypeSwitch<Operation &>(*op)
-      .Case<secret::GenericOp>([&](auto genericOp) {
-        Block *body = genericOp.getBody();
-        for (auto i = 0; i != body->getNumArguments(); ++i) {
-          auto blockArg = body->getArgument(i);
-          propagate(blockArg, DimensionState(2));
-        }
-      })
       .Case<mgmt::RelinearizeOp>([&](auto relinearizeOp) {
         // implicitly ensure that the operand is secret
         propagate(relinearizeOp.getResult(), DimensionState(2));
@@ -110,15 +100,14 @@ void DimensionAnalysis::visitExternalCall(
 // Utils
 //===----------------------------------------------------------------------===//
 
-int getDimension(Value value, DataFlowSolver *solver) {
+std::optional<DimensionState::DimensionType> getDimension(
+    Value value, DataFlowSolver *solver) {
   auto *lattice = solver->lookupState<DimensionLattice>(value);
   if (!lattice) {
-    assert(false && "DimensionLattice not found");
-    return 2;
+    return std::nullopt;
   }
   if (!lattice->getValue().isInitialized()) {
-    assert(false && "DimensionLattice not initialized");
-    return 2;
+    return std::nullopt;
   }
   return lattice->getValue().getDimension();
 }
@@ -136,28 +125,26 @@ void annotateDimension(Operation *top, DataFlowSolver *solver) {
     return IntegerAttr::get(IntegerType::get(top->getContext(), 64), dimension);
   };
 
-  top->walk<WalkOrder::PreOrder>([&](mgmt::InitOp initOp) {
-    auto dimension = 2;
-    // plaintext actually has no dimension, use 2 as a placeholder
-    initOp->setAttr(kArgDimensionAttrName, getIntegerAttr(dimension));
-  });
+  walkValues(top, [&](Value value) {
+    std::optional<int> dimension = getDimension(value, solver);
 
-  top->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {
-    for (auto blockArg : genericOp.getBody()->getArguments()) {
-      genericOp.setOperandAttr(blockArg.getArgNumber(), kArgDimensionAttrName,
-                               getIntegerAttr(getDimension(blockArg, solver)));
+    if (mgmt::shouldHaveMgmtAttribute(value, solver)) {
+      // Other analyses will backprop to mgmt.init, and hence mgmt.init will
+      // have a lattice value. Here we don't backprop, though perhaps we should
+      // in case a mgmt.init is used for a ct-pt op at dimension-3.
+      //
+      // In that case, we can avoid the default value_or(2) below and properly
+      // err whenever an analysis result is not present and
+      // shouldHaveMgmtAttribute is true.
+      //
+      // TODO(#1847): backpropagate dimension analysis to mgmt.init.
+      if (!dimension.has_value() && isSecret(value, solver)) {
+        assert(false &&
+               "secret-typed value not processed by dimension analysis!");
+      }
+      setAttributeAssociatedWith(value, kArgDimensionAttrName,
+                                 getIntegerAttr(dimension.value_or(2)));
     }
-
-    genericOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
-      if (op->getNumResults() == 0) {
-        return;
-      }
-      if (!isSecret(op->getResult(0), solver)) {
-        return;
-      }
-      op->setAttr(kArgDimensionAttrName,
-                  getIntegerAttr(getDimension(op->getResult(0), solver)));
-    });
   });
 }
 

--- a/lib/Analysis/DimensionAnalysis/DimensionAnalysis.h
+++ b/lib/Analysis/DimensionAnalysis/DimensionAnalysis.h
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -81,6 +82,10 @@ class DimensionAnalysis
   friend class SecretnessAnalysisDependent<DimensionAnalysis>;
 
   void setToEntryState(DimensionLattice *lattice) override {
+    if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+      propagateIfChanged(lattice, lattice->join(DimensionState(2)));
+      return;
+    }
     propagateIfChanged(lattice, lattice->join(DimensionState()));
   }
 
@@ -99,7 +104,8 @@ class DimensionAnalysis
 
 // this function will assert false when Lattice does not exist or not
 // initialized
-DimensionState::DimensionType getDimension(Value value, DataFlowSolver *solver);
+std::optional<DimensionState::DimensionType> getDimension(
+    Value value, DataFlowSolver *solver);
 
 DimensionState::DimensionType getDimensionFromMgmtAttr(Value value);
 

--- a/lib/Analysis/LevelAnalysis/BUILD
+++ b/lib/Analysis/LevelAnalysis/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
@@ -7,9 +7,9 @@
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
-#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
-#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
 #include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -40,14 +40,10 @@ LogicalResult LevelAnalysis::visitOperation(
     propagateIfChanged(lattice, changed);
   };
 
+  LLVM_DEBUG(llvm::dbgs() << "Forward Propagate visiting " << op->getName()
+                          << "\n");
+
   llvm::TypeSwitch<Operation &>(*op)
-      .Case<secret::GenericOp>([&](auto genericOp) {
-        Block *body = genericOp.getBody();
-        for (auto i = 0; i != body->getNumArguments(); ++i) {
-          auto blockArg = body->getArgument(i);
-          propagate(blockArg, LevelState(0));
-        }
-      })
       .Case<mgmt::ModReduceOp>([&](auto modReduceOp) {
         // implicitly ensure that the operand is secret
         const auto *operandLattice = operands[0];
@@ -156,22 +152,18 @@ LogicalResult LevelAnalysisBackward::visitOperation(
 // Utils
 //===----------------------------------------------------------------------===//
 
+// Walk the entire IR and return the maximum assigned level of all secret
+// Values.
 static int getMaxLevel(Operation *top, DataFlowSolver *solver) {
   auto maxLevel = 0;
-  top->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {
-    genericOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
-      if (op->getNumResults() == 0) {
-        return;
+  walkValues(top, [&](Value value) {
+    if (mgmt::shouldHaveMgmtAttribute(value, solver)) {
+      auto levelState = solver->lookupState<LevelLattice>(value)->getValue();
+      if (levelState.isInitialized()) {
+        auto level = levelState.getLevel();
+        maxLevel = std::max(maxLevel, level);
       }
-      if (!isSecret(op->getResult(0), solver)) {
-        return;
-      }
-      // ensure result is secret
-      auto level = solver->lookupState<LevelLattice>(op->getResult(0))
-                       ->getValue()
-                       .getLevel();
-      maxLevel = std::max(maxLevel, level);
-    });
+    }
   });
   return maxLevel;
 }
@@ -185,34 +177,23 @@ void annotateLevel(Operation *top, DataFlowSolver *solver, int baseLevel) {
   };
 
   // use L to 0 instead of 0 to L
-  auto getLevel = [&](Value value) {
-    return maxLevel -
-           solver->lookupState<LevelLattice>(value)->getValue().getLevel() +
-           baseLevel;
+  auto getLevel = [&](Value value) -> int {
+    LevelState levelState =
+        solver->lookupState<LevelLattice>(value)->getValue();
+    // The analysis uses 0 to L for ease of analysis, and then we materialize
+    // it in the IR in reverse, from L to 0.
+    if (!levelState.isInitialized()) {
+      return maxLevel + baseLevel;
+    }
+    return maxLevel - levelState.getLevel() + baseLevel;
   };
 
-  top->walk<WalkOrder::PreOrder>([&](mgmt::InitOp initOp) {
-    auto level = getLevel(initOp.getResult());
-    initOp->setAttr(kArgLevelAttrName, getIntegerAttr(level));
-  });
-
-  top->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {
-    for (auto i = 0; i != genericOp.getBody()->getNumArguments(); ++i) {
-      auto blockArg = genericOp.getBody()->getArgument(i);
-      auto level = getLevel(blockArg);
-      genericOp.setOperandAttr(i, kArgLevelAttrName, getIntegerAttr(level));
+  walkValues(top, [&](Value value) {
+    if (mgmt::shouldHaveMgmtAttribute(value, solver)) {
+      int level = getLevel(value);
+      setAttributeAssociatedWith(value, kArgLevelAttrName,
+                                 getIntegerAttr(level));
     }
-
-    genericOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
-      if (op->getNumResults() == 0) {
-        return;
-      }
-      if (!isSecret(op->getResult(0), solver)) {
-        return;
-      }
-      auto level = getLevel(op->getResult(0));
-      op->setAttr(kArgLevelAttrName, getIntegerAttr(level));
-    });
   });
 }
 

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -97,6 +98,10 @@ class LevelAnalysis
   friend class SecretnessAnalysisDependent<LevelAnalysis>;
 
   void setToEntryState(LevelLattice *lattice) override {
+    if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+      propagateIfChanged(lattice, lattice->join(LevelState(0)));
+      return;
+    }
     propagateIfChanged(lattice, lattice->join(LevelState()));
   }
 

--- a/lib/Analysis/MulDepthAnalysis/MulDepthAnalysis.h
+++ b/lib/Analysis/MulDepthAnalysis/MulDepthAnalysis.h
@@ -5,6 +5,7 @@
 #include <optional>
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -79,6 +80,10 @@ class MulDepthAnalysis
   friend class SecretnessAnalysisDependent<MulDepthAnalysis>;
 
   void setToEntryState(MulDepthLattice *lattice) override {
+    if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+      propagateIfChanged(lattice, lattice->join(MulDepthState(0)));
+      return;
+    }
     propagateIfChanged(lattice, lattice->join(MulDepthState()));
   }
 

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
@@ -28,7 +28,15 @@ namespace heir {
 // explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
 template <typename NoiseModel>
 void NoiseAnalysis<NoiseModel>::setToEntryState(LatticeType *lattice) {
-  // At an entry point, we have no information about the noise.
+  if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+    Value value = lattice->getAnchor();
+    auto localParam = LocalParamType(&schemeParam, getLevelFromMgmtAttr(value),
+                                     getDimensionFromMgmtAttr(value));
+    NoiseState encrypted = noiseModel.evalEncrypt(localParam);
+    this->propagateIfChanged(lattice, lattice->join(encrypted));
+    return;
+  }
+
   this->propagateIfChanged(lattice, lattice->join(NoiseState::uninitialized()));
 }
 

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
@@ -29,7 +29,15 @@ namespace heir {
 // explicit specialization of NoiseAnalysis for NoiseByBoundCoeffModel
 template <typename NoiseModel>
 void NoiseAnalysis<NoiseModel>::setToEntryState(LatticeType *lattice) {
-  // At an entry point, we have no information about the noise.
+  if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+    Value value = lattice->getAnchor();
+    auto localParam = LocalParamType(&schemeParam, getLevelFromMgmtAttr(value),
+                                     getDimensionFromMgmtAttr(value));
+    NoiseState encrypted = noiseModel.evalEncrypt(localParam);
+    this->propagateIfChanged(lattice, lattice->join(encrypted));
+    return;
+  }
+
   this->propagateIfChanged(lattice, lattice->join(NoiseState::uninitialized()));
 }
 

--- a/lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.cpp
+++ b/lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.cpp
@@ -166,7 +166,7 @@ LogicalResult OptimizeRelinearizationAnalysis::solve() {
   for (auto &[value, var] : keyBasisVars) {
     if (llvm::isa<BlockArgument>(value)) {
       // If the dimension is 3, the key basis is [0, 1, 2] and the degree is 2.
-      auto constrainedDegree = getDimension(value, solver) - 1;
+      auto constrainedDegree = getDimension(value, solver).value_or(2) - 1;
       model.AddLinearConstraint(var == constrainedDegree, "");
     }
   }

--- a/lib/Analysis/ScaleAnalysis/ScaleAnalysis.h
+++ b/lib/Analysis/ScaleAnalysis/ScaleAnalysis.h
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "lib/Parameters/BGV/Params.h"
 #include "lib/Parameters/CKKS/Params.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
@@ -132,6 +133,10 @@ class ScaleAnalysis
         inputScale(inputScale) {}
 
   void setToEntryState(ScaleLattice *lattice) override {
+    if (isa<secret::SecretType>(lattice->getAnchor().getType())) {
+      propagateIfChanged(lattice, lattice->join(ScaleState(inputScale)));
+      return;
+    }
     propagateIfChanged(lattice, lattice->join(ScaleState()));
   }
 

--- a/lib/Dialect/Mgmt/IR/BUILD
+++ b/lib/Dialect/Mgmt/IR/BUILD
@@ -25,6 +25,7 @@ cc_library(
         ":MgmtAttributes",
         ":MgmtOps",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
     ],
@@ -40,8 +41,10 @@ cc_library(
         "MgmtDialect.h",
     ],
     deps = [
+        ":MgmtOps",
         ":attributes_inc_gen",
         ":dialect_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Utils:AttributeUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",

--- a/lib/Dialect/Mgmt/IR/MgmtAttributes.cpp
+++ b/lib/Dialect/Mgmt/IR/MgmtAttributes.cpp
@@ -2,10 +2,13 @@
 
 #include <cstdint>
 
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Utils/AttributeUtils.h"
-#include "mlir/include/mlir/IR/Value.h"      // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -36,6 +39,11 @@ MgmtAttr findMgmtAttrAssociatedWith(Value value) {
 void setMgmtAttrAssociatedWith(Value value, MgmtAttr mgmtAttr) {
   setAttributeAssociatedWith(value, mgmt::MgmtDialect::kArgMgmtAttrName,
                              mgmtAttr);
+}
+
+bool shouldHaveMgmtAttribute(Value value, DataFlowSolver *solver) {
+  return isSecret(value, solver) ||
+         (isa_and_nonnull<mgmt::InitOp>(value.getDefiningOp()));
 }
 
 }  // namespace mgmt

--- a/lib/Dialect/Mgmt/IR/MgmtAttributes.h
+++ b/lib/Dialect/Mgmt/IR/MgmtAttributes.h
@@ -4,7 +4,8 @@
 #include <cstdint>
 
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
-#include "mlir/include/mlir/IR/Value.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
 
 #define GET_ATTRDEF_CLASSES
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h.inc"
@@ -28,6 +29,13 @@ MgmtAttr findMgmtAttrAssociatedWith(Value value);
 
 /// set the MgmtAttr associated with the given Value
 void setMgmtAttrAssociatedWith(Value value, MgmtAttr mgmtAttr);
+
+/// Determine if a Value should have an associated mgmt attribute. This is
+/// intended to be used by various analyses that populate attributes to be used
+/// by later conversion passes, and it includes secret values (which become
+/// ciphertexts) as well as some non-secret values (e.g., the result of a
+/// mgmt.init op) which become plaintexts with specific encoding details.
+bool shouldHaveMgmtAttribute(Value value, DataFlowSolver *solver);
 
 }  // namespace mgmt
 }  // namespace heir

--- a/lib/Dialect/Mgmt/Transforms/AnnotateMgmt.cpp
+++ b/lib/Dialect/Mgmt/Transforms/AnnotateMgmt.cpp
@@ -6,10 +6,8 @@
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
-#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
-#include "lib/Dialect/Secret/IR/SecretOps.h"
-#include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/Utils.h"
 #include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -39,73 +37,38 @@ void annotateMgmtAttr(Operation *top) {
     auto scale = cast<IntegerAttr>(scaleAttr).getInt();
     return MgmtAttr::get(top->getContext(), level, dimension, scale);
   };
+
+  walkValues(top, [&](Value value) {
+    if (succeeded(findAttributeAssociatedWith(value,
+                                              MgmtDialect::kArgMgmtAttrName))) {
+      return;
+    }
+
+    FailureOr<Attribute> levelAttr =
+        findAttributeAssociatedWith(value, kArgLevelAttrName);
+    FailureOr<Attribute> dimensionAttr =
+        findAttributeAssociatedWith(value, kArgDimensionAttrName);
+    if (failed(levelAttr) || failed(dimensionAttr)) {
+      return;
+    }
+    Attribute scaleAttr =
+        findAttributeAssociatedWith(value, kArgScaleAttrName).value_or(nullptr);
+    Attribute mgmtAttr =
+        mergeIntoMgmtAttr(levelAttr.value(), dimensionAttr.value(), scaleAttr);
+    setAttributeAssociatedWith(value, MgmtDialect::kArgMgmtAttrName, mgmtAttr);
+  });
+
+  // Function declarations have no values and must be handled manually
   top->walk<WalkOrder::PreOrder>([&](func::FuncOp funcOp) {
-    // handle plaintext
-    funcOp->walk<WalkOrder::PreOrder>([&](mgmt::InitOp initOp) {
-      auto levelAttr = initOp->removeAttr(kArgLevelAttrName);
-      auto dimensionAttr = initOp->removeAttr(kArgDimensionAttrName);
-      if (!levelAttr || !dimensionAttr) {
-        return;
-      }
-      auto scaleAttr = initOp->removeAttr(kArgScaleAttrName);
-      auto mgmtAttr = mergeIntoMgmtAttr(levelAttr, dimensionAttr, scaleAttr);
-      initOp->setAttr(MgmtDialect::kArgMgmtAttrName, mgmtAttr);
-    });
-
-    bool bodyContainsSecretGeneric = false;
-    funcOp->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {
-      bodyContainsSecretGeneric = true;
-      for (auto i = 0; i != genericOp.getBody()->getNumArguments(); ++i) {
-        auto levelAttr = genericOp.removeOperandAttr(i, kArgLevelAttrName);
-        auto dimensionAttr =
-            genericOp.removeOperandAttr(i, kArgDimensionAttrName);
-        auto scaleAttr = genericOp.removeOperandAttr(i, kArgScaleAttrName);
-        auto mgmtAttr = mergeIntoMgmtAttr(levelAttr, dimensionAttr, scaleAttr);
-        genericOp.setOperandAttr(i, MgmtDialect::kArgMgmtAttrName, mgmtAttr);
-      }
-
-      genericOp.getBody()->walk<WalkOrder::PreOrder>([&](Operation *op) {
-        if (op->getNumResults() == 0) {
-          return;
-        }
-        auto levelAttr = op->removeAttr(kArgLevelAttrName);
-        auto dimensionAttr = op->removeAttr(kArgDimensionAttrName);
-        if (!levelAttr || !dimensionAttr) {
-          return;
-        }
-        auto scaleAttr = op->removeAttr(kArgScaleAttrName);
-        op->setAttr(MgmtDialect::kArgMgmtAttrName,
-                    mergeIntoMgmtAttr(levelAttr, dimensionAttr, scaleAttr));
-      });
-
-      // Add yielded result as attribute on secret.generic
-      secret::YieldOp yieldOp = genericOp.getYieldOp();
-      for (auto &opOperand : yieldOp->getOpOperands()) {
-        FailureOr<Attribute> attrResult = findAttributeAssociatedWith(
-            opOperand.get(), MgmtDialect::kArgMgmtAttrName);
-
-        if (failed(attrResult)) continue;
-        genericOp.setResultAttr(opOperand.getOperandNumber(),
-                                MgmtDialect::kArgMgmtAttrName,
-                                attrResult.value());
-      }
-    });
-
-    // handle generic-less function body
-    // default to level 0 and dimension 2
-    // otherwise secret-to-<scheme> won't find the mgmt attr
-    if (!bodyContainsSecretGeneric) {
-      for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
-        auto argumentTy = funcOp.getFunctionType().getInput(i);
-        if (isa<secret::SecretType>(argumentTy)) {
-          funcOp.setArgAttr(i, MgmtDialect::kArgMgmtAttrName,
-                            MgmtAttr::get(top->getContext(), 0, 2));
-        }
+    if (!funcOp.isExternal()) return;
+    for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
+      auto argumentTy = funcOp.getFunctionType().getInput(i);
+      if (isa<secret::SecretType>(argumentTy)) {
+        funcOp.setArgAttr(i, MgmtDialect::kArgMgmtAttrName,
+                          MgmtAttr::get(top->getContext(), 0, 2));
       }
     }
   });
-
-  populateOperandAttrInterface(top, MgmtDialect::kArgMgmtAttrName);
 }
 
 struct AnnotateMgmt : impl::AnnotateMgmtBase<AnnotateMgmt> {
@@ -127,6 +90,7 @@ struct AnnotateMgmt : impl::AnnotateMgmtBase<AnnotateMgmt> {
       return;
     }
 
+    clearAttrs(getOperation(), MgmtDialect::kArgMgmtAttrName);
     annotateLevel(getOperation(), &solver, baseLevel);
     annotateDimension(getOperation(), &solver);
     // Combine level and dimension (and optional scale) into MgmtAttr
@@ -134,6 +98,16 @@ struct AnnotateMgmt : impl::AnnotateMgmtBase<AnnotateMgmt> {
     // The optional scale is passed by annotateScale() when calling
     // this pass.
     annotateMgmtAttr(getOperation());
+
+    clearAttrs(getOperation(), kArgLevelAttrName);
+    clearAttrs(getOperation(), kArgDimensionAttrName);
+    clearAttrs(getOperation(), kArgScaleAttrName);
+
+    // Dataflow analyses don't assign anything to function results because they
+    // don't have a corresponding Value. So we have to manually copy it from
+    // the func terminator.
+    copyReturnOperandAttrsToFuncResultAttrs(getOperation(),
+                                            MgmtDialect::kArgMgmtAttrName);
   }
 };
 

--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -46,6 +46,7 @@ cc_library(
         ":ops_inc_gen",
         ":types_inc_gen",
         "@heir//lib/Dialect:HEIRInterfaces",
+        "@heir//lib/Utils:AttributeUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:AffineDialect",

--- a/lib/Dialect/Secret/IR/SecretDialect.td
+++ b/lib/Dialect/Secret/IR/SecretDialect.td
@@ -26,6 +26,8 @@ def Secret_Dialect : Dialect {
         kArgMissingAttrName = "secret.missing";
     constexpr const static ::llvm::StringLiteral
         kArgUnknownAttrName = "secret.unknown";
+    constexpr const static ::llvm::StringLiteral
+        kSecretInitsAttrName = "secret.secret_inits";
 
     // Name of the attribute for plaintext backend execution result.
     constexpr const static ::llvm::StringLiteral

--- a/lib/Dialect/Secret/IR/SecretOps.cpp
+++ b/lib/Dialect/Secret/IR/SecretOps.cpp
@@ -549,7 +549,7 @@ void populateGenericCanonicalizers(RewritePatternSet &patterns,
                                    MLIRContext *ctx) {
   patterns.add<CollapseSecretlessGeneric, RemoveUnusedYieldedValues,
                RemoveUnusedGenericArgs, RemoveNonSecretGenericArgs,
-               HoistPlaintextOps, FixSecretInFunctionType>(ctx);
+               HoistPlaintextOps, ConcealThenGeneric>(ctx);
 }
 
 // When replacing a generic op with a new one, and given an op in the original
@@ -714,6 +714,45 @@ void GenericOp::inlineInPlaceDroppingSecrets(PatternRewriter &rewriter,
 void GenericOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
   populateGenericCanonicalizers(results, context);
+}
+
+// RegionBranchOpInterface implementation for generic/yield
+
+OperandRange GenericOp::getEntrySuccessorOperands(RegionBranchPoint point) {
+  return getInputs();
+}
+
+void GenericOp::getSuccessorRegions(RegionBranchPoint point,
+                                    SmallVectorImpl<RegionSuccessor> &regions) {
+  if (point == RegionBranchPoint::parent()) {
+    regions.push_back(RegionSuccessor(&getRegion(), getBody()->getArguments()));
+  } else {
+    regions.push_back(RegionSuccessor(getResults()));
+  }
+}
+
+void GenericOp::getRegionInvocationBounds(
+    ArrayRef<Attribute> operands, SmallVectorImpl<InvocationBounds> &bounds) {
+  // The sole region is invoked exactly once
+  bounds.push_back(InvocationBounds(/*lb=*/1, /*ub=*/1));
+}
+
+bool GenericOp::areTypesCompatible(Type t1, Type t2) {
+  // The default check enforces type equality, whereas we switch from
+  // secret<foo> to foo and vice versa
+  SecretType s1 = dyn_cast<SecretType>(t1);
+  SecretType s2 = dyn_cast<SecretType>(t2);
+  if (s1) {
+    return t2 == s1.getValueType();
+  }
+
+  if (s2) {
+    return t1 == s2.getValueType();
+  }
+
+  // Generic operands need not be secret, so in this case the types must be
+  // equal.
+  return t1 == t2;
 }
 
 }  // namespace secret

--- a/lib/Dialect/Secret/IR/SecretOps.td
+++ b/lib/Dialect/Secret/IR/SecretOps.td
@@ -95,6 +95,8 @@ def Secret_RevealOp : Secret_Op<"reveal", [Pure]> {
 
 
 def Secret_YieldOp : Secret_Op<"yield", [
+    // ReturnLike provides a default implementation of
+    // RegionBranchTerminatorOpInterface::getMutableSuccessorOperands
     Pure, ReturnLike, Terminator, HasParent<"GenericOp">
 ]>,
   Arguments<(ins Variadic<AnyType>:$values)> {
@@ -114,7 +116,25 @@ def Secret_GenericOp : Secret_Op<"generic", [
   SingleBlock,
   SingleBlockImplicitTerminator<"YieldOp">,
   OpAsmOpInterface,
-  OperandAndResultAttrInterface
+  OperandAndResultAttrInterface,
+  DeclareOpInterfaceMethods<RegionBranchOpInterface, [
+    // Generic operands forward to the body's block arguments with a type change
+    "getEntrySuccessorOperands",
+
+    // getEntrySuccessorRegions is not needed because we always enter the region
+    // this is used for other operations that may not execute the body (e.g.,
+    // a loop with statically-determined zero iterations.
+
+    // RegionBranchPoint::parent() -> body,
+    // body -> RegionBranchPoint::parent()
+    "getSuccessorRegions",
+
+    // Generic runs exactly once.
+    "getRegionInvocationBounds",
+
+    // Cleartext types are compatible to forward to secret region results.
+    "areTypesCompatible"
+  ]>
 ]> {
   let summary = "Lift a plaintext computation to operate on secrets.";
   let description = [{

--- a/lib/Dialect/Secret/Transforms/DistributeGeneric.cpp
+++ b/lib/Dialect/Secret/Transforms/DistributeGeneric.cpp
@@ -79,6 +79,45 @@ struct FoldSecretSeparators : public OpRewritePattern<GenericOp> {
   }
 };
 
+// Uses the dataflow analysis to persist an ArrayAttr of BoolAttr on each
+// LoopLikeOp to denote which of its iter args should be promoted to secrets.
+void persistSecretAnalysisResultsOnLoopInits(Operation *operation,
+                                             DataFlowSolver *solver) {
+  operation->walk([&](LoopLikeOpInterface loop) {
+    SmallVector<Attribute> initSecretness(
+        loop.getInits().size(), BoolAttr::get(operation->getContext(), false));
+    // If the iter arg is secret, then a non-secret init must be concealed
+    // later to be lifted outside of the generic.
+    for (auto [i, iterArg] : llvm::enumerate(loop.getRegionIterArgs())) {
+      if (isSecret(iterArg, solver)) {
+        initSecretness[i] = BoolAttr::get(operation->getContext(), true);
+      }
+    }
+
+    loop->setAttr(secret::SecretDialect::kSecretInitsAttrName,
+                  ArrayAttr::get(operation->getContext(), initSecretness));
+    LLVM_DEBUG(loop.emitRemark()
+               << "Persisted secret init analysis results: " << loop);
+  });
+}
+
+bool shouldLoopInitBeLiftedToSecret(LoopLikeOpInterface loop,
+                                    size_t initIndex) {
+  LLVM_DEBUG(loop.emitRemark() << "Looking up lifting decision for index "
+                               << initIndex << " for loop: " << loop);
+  ArrayAttr initLiftDecision = loop->getAttrOfType<ArrayAttr>(
+      secret::SecretDialect::kSecretInitsAttrName);
+  if (!initLiftDecision) {
+    return false;
+  }
+
+  if (auto boolAttr = llvm::dyn_cast<BoolAttr>(initLiftDecision[initIndex])) {
+    return boolAttr.getValue();
+  }
+
+  return false;
+}
+
 // Split a secret.generic containing multiple ops into multiple secret.generics.
 //
 // E.g.,
@@ -109,11 +148,9 @@ struct FoldSecretSeparators : public OpRewritePattern<GenericOp> {
 // block, and will always create two secret.generics.
 struct SplitGeneric : public OpRewritePattern<GenericOp> {
   SplitGeneric(mlir::MLIRContext *context,
-               llvm::ArrayRef<std::string> opsToDistribute,
-               DataFlowSolver *solver)
+               llvm::ArrayRef<std::string> opsToDistribute)
       : OpRewritePattern<GenericOp>(context, /*benefit=*/1),
-        opsToDistribute(opsToDistribute),
-        solver(solver) {}
+        opsToDistribute(opsToDistribute) {}
 
   LogicalResult distributeThroughRegionHoldingOp(
       GenericOp genericOp, Operation &opToDistribute,
@@ -201,14 +238,20 @@ struct SplitGeneric : public OpRewritePattern<GenericOp> {
       // Update the cloned loop's iter_args to be secret types if corresponded
       // to secret types in the original generic.
       DenseMap<Value, Value> newInitsToOperands;
-      for (auto [operand, blockArg] : llvm::zip(
+      for (const auto &[operand, blockArg] : llvm::zip(
                clonedLoop.getInitsMutable(), clonedLoop.getRegionIterArgs())) {
-        auto *yieldedIterValue = clonedLoop.getTiedLoopYieldedValue(blockArg);
+        BlockArgument iterArg = clonedLoop.getTiedLoopRegionIterArg(&operand);
+        // The index of the iterArg to pass to shouldLoopInitBeLiftedToSecret
+        // must account for the induction variables additionally passed to the
+        // loop as block arguments.
+        auto inductionVars = clonedLoop.getLoopInductionVars();
+        size_t numInductionVars =
+            inductionVars.has_value() ? inductionVars.value().size() : 0;
+        size_t initIndex = iterArg.getArgNumber() - numInductionVars;
+
         if (isa<SecretType>(operand.get().getType())) {
           blockArg.setType(operand.get().getType());
-        } else if (isSecret(loop.getYieldedValues()[yieldedIterValue
-                                                        ->getOperandNumber()],
-                            solver) &&
+        } else if (shouldLoopInitBeLiftedToSecret(clonedLoop, initIndex) &&
                    !isa<SecretType>(operand.get().getType())) {
           // The initial value of an iter_arg yielded by the original loop must
           // be promoted to a secret and added to the new generic's operands if
@@ -600,14 +643,7 @@ struct SplitGeneric : public OpRewritePattern<GenericOp> {
         return failure();
       }
     } else if (first) {
-      auto newGeneric = splitGenericAfterFirstOp(op, rewriter);
-      // We must re-run the secretness analysis on the new generic to populate
-      // the secretness of the operations inside the new generic. Since the
-      // generic is new, pre-existing values in the secretness analysis are
-      // unaffected and do not affect the new generic's body.
-      if (failed(solver->initializeAndRun(newGeneric.getOperation()))) {
-        return failure();
-      }
+      splitGenericAfterFirstOp(op, rewriter);
     } else {
       splitGenericBeforeOp(op, *opToDistribute, rewriter);
     }
@@ -617,54 +653,7 @@ struct SplitGeneric : public OpRewritePattern<GenericOp> {
 
  private:
   llvm::ArrayRef<std::string> opsToDistribute;
-  DataFlowSolver *solver;
 };
-
-// should be called right before all splitting
-void moveMgmtAttrAnnotationToFuncArgument(Operation *top) {
-  top->walk([&](secret::GenericOp genericOp) {
-    for (auto i = 0; i != genericOp->getNumOperands(); ++i) {
-      auto operand = genericOp.getOperand(i);
-      auto funcBlockArg = dyn_cast<BlockArgument>(operand);
-      if (isa<SecretType>(operand.getType()) && funcBlockArg) {
-        auto funcOp =
-            dyn_cast<func::FuncOp>(funcBlockArg.getOwner()->getParentOp());
-        auto mgmtAttr =
-            genericOp.removeOperandAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName);
-        if (mgmtAttr) {
-          funcOp.setArgAttr(funcBlockArg.getArgNumber(),
-                            mgmt::MgmtDialect::kArgMgmtAttrName, mgmtAttr);
-        }
-      }
-    }
-  });
-  // some unused func secret type arg should also be annotated with mgmt attr,
-  // inferred from other used arg
-  top->walk([&](func::FuncOp funcOp) {
-    if (funcOp.isDeclaration()) {
-      return;
-    }
-    Attribute firstMgmtAttr;
-    for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
-      firstMgmtAttr = funcOp.getArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName);
-      if (firstMgmtAttr) {
-        break;
-      }
-    }
-    for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
-      auto arg = funcOp.getArgument(i);
-      if (firstMgmtAttr && mlir::isa<SecretType>(arg.getType()) &&
-          !funcOp.getArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName)) {
-        funcOp.setArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName,
-                          firstMgmtAttr);
-      }
-    }
-  });
-
-  // Now handle returned values -> func op result attrs
-  copyReturnOperandAttrsToFuncResultAttrs(top,
-                                          mgmt::MgmtDialect::kArgMgmtAttrName);
-}
 
 // should be called right before all splitting, after
 // moveMgmtAttrAnnotationToFuncArgument
@@ -738,12 +727,14 @@ struct DistributeGeneric
       return;
     }
 
-    // used by secret-to-<scheme> lowering
-    moveMgmtAttrAnnotationToFuncArgument(getOperation());
     // move dialect attrs from secret generic op arg to func arg
     moveDialectAttrsToFuncArgument(getOperation());
 
-    patterns.add<SplitGeneric>(context, opsToDistribute, &solver);
+    // This replaces the need to re-run secretness analysis after each
+    // SplitGeneric.
+    persistSecretAnalysisResultsOnLoopInits(getOperation(), &solver);
+
+    patterns.add<SplitGeneric>(context, opsToDistribute);
     // These patterns are shared with canonicalization
     patterns.add<FoldSecretSeparators, CollapseSecretlessGeneric,
                  RemoveUnusedGenericArgs, RemoveNonSecretGenericArgs>(context);
@@ -753,6 +744,7 @@ struct DistributeGeneric
 
     // used by secret-to-<scheme> lowering
     moveMgmtAttrAnnotationFromInnerToOuter(getOperation());
+    clearAttrs(getOperation(), secret::SecretDialect::kSecretInitsAttrName);
   }
 };
 

--- a/lib/Utils/AttributeUtils.h
+++ b/lib/Utils/AttributeUtils.h
@@ -3,6 +3,7 @@
 
 #include "llvm/include/llvm/Support/LogicalResult.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Attributes.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
 
@@ -40,6 +41,14 @@ void copyReturnOperandAttrsToFuncResultAttrs(Operation *op, StringRef attrName);
 // Walk the op and copy attributes associated with
 // OperandAndResultAttrInterface op operands to the operand attrs of that op.
 void populateOperandAttrInterface(Operation *op, StringRef attrName);
+
+// For each attribute name in arrayOfDicts, extract an ArrayAttr of the values
+// for that name and add it to result.
+//
+// If there is only one dictionary in the array, extract the attributes
+// directly without wrapping them in array attrs
+void convertArrayOfDicts(ArrayAttr arrayOfDicts,
+                         SmallVector<NamedAttribute> &result);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Utils/BUILD
+++ b/lib/Utils/BUILD
@@ -76,6 +76,7 @@ cc_library(
     srcs = ["ContextAwareConversionUtils.cpp"],
     hdrs = ["ContextAwareConversionUtils.h"],
     deps = [
+        ":AttributeUtils",
         ":ContextAwareDialectConversion",
         ":ContextAwareTypeConversion",
         "@heir//lib/Dialect/LWE/IR:Dialect",

--- a/lib/Utils/ContextAwareConversionUtils.cpp
+++ b/lib/Utils/ContextAwareConversionUtils.cpp
@@ -94,33 +94,6 @@ static LogicalResult convertFuncOpTypes(
   return success();
 }
 
-void convertArrayOfDicts(ArrayAttr arrayOfDicts,
-                         SmallVector<NamedAttribute> &result) {
-  if (!arrayOfDicts) return;
-
-  if (arrayOfDicts.size() == 1) {
-    for (auto &namedAttr : cast<DictionaryAttr>(arrayOfDicts[0]))
-      result.push_back(namedAttr);
-    return;
-  }
-
-  DenseMap<StringAttr, SmallVector<Attribute>> arrayAttrs;
-  arrayAttrs.reserve(arrayOfDicts.size());
-  for (auto arrayOfDict : arrayOfDicts) {
-    ::mlir::DictionaryAttr attrs = cast<DictionaryAttr>(arrayOfDict);
-    for (NamedAttribute namedAttr : attrs) {
-      auto key = namedAttr.getName();
-      arrayAttrs[key].push_back(namedAttr.getValue());
-    }
-  }
-
-  for (auto &[name, attributes] : arrayAttrs) {
-    NamedAttribute attr(name,
-                        ArrayAttr::get(arrayOfDicts.getContext(), attributes));
-    result.push_back(attr);
-  }
-}
-
 LogicalResult ContextAwareFuncConversion::matchAndRewrite(
     func::FuncOp op, OpAdaptor adaptor,
     ContextAwareConversionPatternRewriter &rewriter) const {

--- a/lib/Utils/Utils.h
+++ b/lib/Utils/Utils.h
@@ -17,13 +17,14 @@
 namespace mlir {
 namespace heir {
 
-typedef std::function<bool(Operation *)> OpPredicate;
-typedef std::function<LogicalResult(const Type &)> IsValidTypeFn;
-typedef std::function<LogicalResult(const Value &)> IsValidValueFn;
+using OpPredicate = std::function<bool(Operation *)>;
+using IsValidTypeFn = std::function<LogicalResult(const Type &)>;
+using IsValidValueFn = std::function<LogicalResult(const Value &)>;
+using ValueProcessor = std::function<void(const Value &)>;
 
-typedef std::function<bool(const Type &)> TypePredicate;
+using TypePredicate = std::function<bool(const Type &)>;
 
-typedef std::function<bool(Dialect *)> DialectPredicate;
+using DialectPredicate = std::function<bool(Dialect *)>;
 
 using IndexTupleConsumer = std::function<void(const std::vector<int64_t> &)>;
 
@@ -69,6 +70,12 @@ LogicalResult validateValues(Operation *op, IsValidValueFn isValidValue);
 LogicalResult walkAndValidateValues(
     Operation *op, IsValidValueFn isValidValue,
     std::optional<std::string> err = std::nullopt);
+
+/// Walk the IR and apply a predicate to all SSA values and produced values.
+/// Values will be visited once for the operation that defines them, and once
+/// for each use. The valueProcessor must be aware that it may be called
+/// multiple times for the same value.
+void walkValues(Operation *op, ValueProcessor valueProcessor);
 
 /// Walk the IR and apply a predicate to all argument and result types
 /// encountered, returning failure if any type is invalid. Invalidity is

--- a/tests/Dialect/Mgmt/Transforms/BUILD
+++ b/tests/Dialect/Mgmt/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Mgmt/Transforms/annotate_mgmt.mlir
+++ b/tests/Dialect/Mgmt/Transforms/annotate_mgmt.mlir
@@ -1,0 +1,12 @@
+// RUN: heir-opt --annotate-mgmt %s | FileCheck %s
+
+func.func @main(%arg0: !secret.secret<tensor<8xi8>>) -> !secret.secret<tensor<8xi8>> {
+  %b = secret.generic(%arg0: !secret.secret<tensor<8xi8>>) {
+  ^body(%clear_a: tensor<8xi8>):
+    %c = mgmt.modreduce %clear_a : tensor<8xi8>
+    secret.yield %c : tensor<8xi8>
+  // %b here should have level _annotation_ of 0 instead of 1.
+  // CHECK: } -> (!secret.secret<tensor<8xi8>> {mgmt.mgmt = #mgmt.mgmt<level = 0>})
+  } -> !secret.secret<tensor<8xi8>>
+  func.return %b : !secret.secret<tensor<8xi8>>
+}

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_add.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_add.mlir
@@ -1,8 +1,8 @@
 // RUN: heir-opt %s --mlir-print-local-scope --secret-distribute-generic --secret-to-bgv=poly-mod-degree=8 | FileCheck %s
 
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [1152921504606994433, 1097729], P = [1152921504607191041], plaintextModulus = 65537>, scheme.bfv} {
-  func.func @mixed_add(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) -> !secret.secret<tensor<8xi16>> {
-    %0 = secret.generic(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) attrs = {__argattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}, {mgmt.mgmt = #mgmt.mgmt<level = 1>}], __resattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}]} {
+  func.func @mixed_add(%arg0: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}, %arg1: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) -> (!secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
+    %0 = secret.generic(%arg0: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}, %arg1: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
     ^body(%input0: tensor<8xi16>, %input1: tensor<8xi16>):
       // CHECK: bgv.mul
       // CHECK-SAME: size = 3
@@ -15,7 +15,7 @@ module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [115292150
       // CHECK-SAME: from_basis = array<i32: 0, 1, 2>
       %3 = mgmt.relinearize %2 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
       secret.yield %3 : tensor<8xi16>
-    } -> !secret.secret<tensor<8xi16>>
+    } -> (!secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>})
     return %0 : !secret.secret<tensor<8xi16>>
   }
 }

--- a/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_mul.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_bgv/mixed_degree_mul.mlir
@@ -1,8 +1,8 @@
 // RUN: heir-opt %s --mlir-print-local-scope --secret-distribute-generic --secret-to-bgv=poly-mod-degree=8 | FileCheck %s
 
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [1152921504606994433, 17179967489], P = [1152921504607191041], plaintextModulus = 65537>, scheme.bfv} {
-  func.func @two_mul(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) -> !secret.secret<tensor<8xi16>> {
-    %0 = secret.generic(%arg0: !secret.secret<tensor<8xi16>>, %arg1: !secret.secret<tensor<8xi16>>) attrs = {__argattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}, {mgmt.mgmt = #mgmt.mgmt<level = 1>}], __resattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 1>}]} {
+  func.func @two_mul(%arg0: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}, %arg1: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) -> (!secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
+    %0 = secret.generic(%arg0: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}, %arg1: !secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
     ^body(%input0: tensor<8xi16>, %input1: tensor<8xi16>):
       // CHECK: bgv.mul
       // CHECK-SAME: size = 3
@@ -15,7 +15,7 @@ module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [115292150
       // CHECK-SAME: from_basis = array<i32: 0, 1, 2, 3>
       %3 = mgmt.relinearize %2 {mgmt.mgmt = #mgmt.mgmt<level = 1>} : tensor<8xi16>
       secret.yield %3 : tensor<8xi16>
-    } -> !secret.secret<tensor<8xi16>>
+    } -> (!secret.secret<tensor<8xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>})
     return %0 : !secret.secret<tensor<8xi16>>
   }
 }

--- a/tests/Dialect/Secret/Conversions/secret_to_cggi/add_one.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_cggi/add_one.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --secret-distribute-generic --secret-to-cggi -cse %s | FileCheck %s
+// RUN: heir-opt --secret-distribute-generic --canonicalize --secret-to-cggi -cse %s | FileCheck %s
 
 // This test was produced by running
 //   heir-opt --yosys-optimizer --canonicalize tests/yosys_optimizer/add_one.mlir

--- a/tests/Dialect/Secret/Conversions/secret_to_cggi/truth_table.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_cggi/truth_table.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-print-local-scope --secret-distribute-generic --split-input-file --secret-to-cggi --cse %s | FileCheck %s
+// RUN: heir-opt --mlir-print-local-scope --secret-distribute-generic --canonicalize --split-input-file --secret-to-cggi --cse %s | FileCheck %s
 
 // CHECK-NOT: secret
 // CHECK: @truth_table_all_secret([[ARG:%.*]]: [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]) -> [[LWET:!lwe.lwe_ciphertext<.* = 3>>]]

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --annotate-module="backend=openfhe scheme=ckks" --secret-insert-mgmt-ckks=slot-number=1024 --generate-param-ckks --secret-distribute-generic --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --annotate-module="backend=openfhe scheme=ckks" --secret-insert-mgmt-ckks=slot-number=1024 --generate-param-ckks --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
 
 module {
 // CHECK: func @hv_matmul

--- a/tests/Dialect/Secret/Transforms/canonicalize/canonicalize.mlir
+++ b/tests/Dialect/Secret/Transforms/canonicalize/canonicalize.mlir
@@ -32,3 +32,36 @@ func.func @remove_pass_through_args(
   // CHECK: return %[[out1]], %[[arg2]]
   return %out1, %out2 : !secret.secret<i32>, !secret.secret<i32>
 }
+
+// CHECK: func @hoist_plaintext
+// CHECK-SAME: (%arg0: !secret.secret<i16>) -> !secret.secret<i16>
+func.func @hoist_plaintext(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {
+    // CHECK: arith.constant
+    // CHECK: secret.generic
+    // CHECK: arith.muli
+    // CHECK: secret.yield
+    %0 = secret.generic(%arg0 : !secret.secret<i16>) {
+    ^bb0(%arg1: i16):
+        %c7 = arith.constant 7 : i16
+        %0 = arith.muli %arg1, %c7 : i16
+         secret.yield %0 : i16
+    } -> !secret.secret<i16>
+    //CHECK: return %[[S:.*]] : !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+}
+
+// -----
+
+// CHECK: func @preserve_attrs
+func.func @preserve_attrs(%arg0: tensor<1x1024xf32>) -> !secret.secret<tensor<1x1024xf32>> {
+  // CHECK: mgmt.init
+  // CHECK-SAME: {mgmt.mgmt = #mgmt.mgmt<level = 1>}
+    %6 = secret.conceal %arg0 : tensor<1x1024xf32> -> !secret.secret<tensor<1x1024xf32>>
+    %7 = secret.generic(%6: !secret.secret<tensor<1x1024xf32>>) {
+    ^body(%input0: tensor<1x1024xf32>):
+      %10 = mgmt.init %input0 : tensor<1x1024xf32>
+      secret.yield %10 : tensor<1x1024xf32>
+    } -> (!secret.secret<tensor<1x1024xf32>> {mgmt.mgmt = #mgmt.mgmt<level = 1>})
+    //CHECK: return %[[S:.*]] : !secret.secret<tensor<1x1024xf32>>
+    return %7 : !secret.secret<tensor<1x1024xf32>>
+}

--- a/tests/Dialect/Secret/Transforms/canonicalize/secretless.mlir
+++ b/tests/Dialect/Secret/Transforms/canonicalize/secretless.mlir
@@ -1,14 +1,73 @@
-// RUN: heir-opt --canonicalize %s | FileCheck %s
+// RUN: heir-opt --canonicalize --split-input-file %s | FileCheck %s
 
 // CHECK: func @func
-// CHECK-SAME: (%arg0: !secret.secret<i16>) -> i16
+// CHECK-SAME: (%arg0: !secret.secret<i16>) -> !secret.secret<i16>
 func.func @func(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {
-    // CHECK-NOT: secret.generic
+    // CHECK: %[[c1:.*]] = arith.constant 1 : i16
+    // CHECK: %[[v0:.*]] = secret.conceal %[[c1]] : i16 -> !secret.secret<i16>
+    // CHECK: return %[[v0]] : !secret.secret<i16>
     %0 = secret.generic(%arg0 : !secret.secret<i16>) {
     ^bb0(%arg1: i16):
         %c1_i16 = arith.constant 1 : i16
         secret.yield %c1_i16 : i16
     } -> !secret.secret<i16>
-    //CHECK: return %[[S:.*]] : i16
     return %0 : !secret.secret<i16>
+}
+
+// -----
+
+// CHECK: func @constant_false
+// CHECK-SAME: () -> !secret.secret<i2>
+func.func @constant_false() -> !secret.secret<i2> {
+  // CHECK: %[[cst:.*]] = arith.constant dense<false> : tensor<2xi1>
+  // CHECK: %[[v0:.*]] = secret.conceal %[[cst]] : tensor<2xi1> -> !secret.secret<tensor<2xi1>>
+  // CHECK: %[[v1:.*]] = secret.cast %[[v0]] : !secret.secret<tensor<2xi1>> to !secret.secret<i2>
+  // CHECK: return %[[v1]] : !secret.secret<i2>
+  %false = arith.constant false
+  %0 = secret.generic(%false : i1) {
+  ^bb0(%arg1: i1):
+      %1 = tensor.from_elements %arg1, %arg1 : tensor<2xi1>
+      secret.yield %1 : tensor<2xi1>
+  } -> !secret.secret<tensor<2xi1>>
+  %1 = secret.cast %0 : !secret.secret<tensor<2xi1>> to !secret.secret<i2>
+  return %1 : !secret.secret<i2>
+}
+
+// -----
+
+// CHECK: func @no_conceal
+// CHECK-SAME: (%[[arg0:.*]]: !secret.secret<i2>) -> !secret.secret<i2>
+func.func @no_conceal(%arg0: !secret.secret<i2>) -> !secret.secret<i2> {
+  // CHECK-NEXT: %[[cst:.*]] = arith.constant -1 : i2
+  // CHECK-NEXT: %[[v1:.*]] = secret.generic(%[[arg0]]: !secret.secret<i2>)
+  // CHECK-NEXT: ^body(%[[input0:.*]]: i2):
+  // CHECK-NEXT: %[[v2:.*]] = arith.muli %[[input0]], %[[cst]] : i2
+  // CHECK-NEXT: secret.yield %[[v2]] : i2
+  // CHECK: return %[[v1]] : !secret.secret<i2>
+  %false = arith.constant 3 : i2
+  %secret_false = secret.conceal %false : i2 -> !secret.secret<i2>
+  %0 = secret.generic(%arg0 : !secret.secret<i2>, %secret_false : !secret.secret<i2>) {
+  ^bb0(%arg1: i2, %arg2: i2):
+      %1 = arith.muli %arg1, %arg2 : i2
+      secret.yield %1 : i2
+  } -> !secret.secret<i2>
+  return %0 : !secret.secret<i2>
+}
+
+// -----
+
+// CHECK: func @no_conceal_from_elements
+// CHECK-SAME: (%[[pt:.*]]: i1) -> !secret.secret<i1>
+func.func @no_conceal_from_elements(%pt: i1) -> !secret.secret<i1> {
+  // CHECK: %[[v0:.*]] = secret.conceal %[[pt]] : i1 -> !secret.secret<i1>
+  // CHECK: return %[[v0]] : !secret.secret<i1>
+  %false = arith.constant false
+  %c0 = arith.constant 0 : index
+  %0 = secret.generic(%pt : i1) {
+  ^bb0(%arg1: i1):
+      %1 = tensor.from_elements %arg1, %arg1 : tensor<2xi1>
+      %2 = tensor.extract %1[%c0] : tensor<2xi1>
+      secret.yield %2 : i1
+  } -> !secret.secret<i1>
+  return %0 : !secret.secret<i1>
 }

--- a/tests/Regression/issue_1086.mlir
+++ b/tests/Regression/issue_1086.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s --yosys-optimizer --secret-distribute-generic --secret-to-cggi | FileCheck %s
+// RUN: heir-opt %s --yosys-optimizer --secret-distribute-generic --canonicalize --secret-to-cggi | FileCheck %s
 
 // CHECK-NOT: secret
 func.func @sum(%arr: !secret.secret<memref<8xi8>>) -> !secret.secret<i8> {

--- a/tests/Regression/issue_1406_minimal.mlir
+++ b/tests/Regression/issue_1406_minimal.mlir
@@ -1,0 +1,16 @@
+// RUN: heir-opt %s "--annotate-mgmt" | FileCheck %s
+
+module attributes {backend.openfhe, scheme.bfv} {
+  // CHECK: @add
+  // CHECK-SAME: (%[[arg0:[^:]*]]: !secret.secret<i16> {mgmt.mgmt =
+  // CHECK-SAME: %[[arg1:[^:]*]]: !secret.secret<i16> {mgmt.mgmt =
+  // CHECK-SAME: -> (!secret.secret<i16> {mgmt.mgmt =
+  func.func @add(%arg0: !secret.secret<i16>, %arg1: !secret.secret<i16>) -> !secret.secret<i16> {
+    %0 = secret.generic(%arg0: !secret.secret<i16>) {
+    ^body(%input0: i16):
+      %1 = arith.addi %input0, %input0 : i16
+      secret.yield %1 : i16
+    } -> !secret.secret<i16>
+    return %0 : !secret.secret<i16>
+  }
+}

--- a/tests/Transforms/secret_insert_mgmt/func_call.mlir
+++ b/tests/Transforms/secret_insert_mgmt/func_call.mlir
@@ -1,7 +1,7 @@
 // RUN: heir-opt --secret-insert-mgmt-ckks --split-input-file %s | FileCheck %s
 
 // CHECK: func.func private @extract_plaintext(f32) -> f32
-// CHECK: func.func @call_plaintext(%[[arg0:.*]]: !secret.secret<f32>) -> !secret.secret<f32>
+// CHECK: func.func @call_plaintext(%[[arg0:.*]]: !secret.secret<f32> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) -> (!secret.secret<f32>  {mgmt.mgmt = #mgmt.mgmt<level = 0>})
 // CHECK-NEXT:  %[[v0:.*]] = secret.generic(%[[arg0]]: !secret.secret<f32> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
 // CHECK-NEXT:     ^body(%[[input0:.*]]: f32)
 // CHECK-NEXT:       %[[v1:.*]] = func.call @extract_plaintext(%[[input0]]) {mgmt.mgmt = #mgmt.mgmt<level = 0>} : (f32) -> f32
@@ -23,7 +23,7 @@ module {
 // -----
 
 // CHECK: func.func private @external_secret(!secret.secret<f32> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) -> !secret.secret<f32>
-// CHECK: func.func @call_secret(%[[arg0:.*]]: !secret.secret<f32> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) -> !secret.secret<f32>
+// CHECK: func.func @call_secret(%[[arg0:.*]]: !secret.secret<f32> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) -> (!secret.secret<f32> {mgmt.mgmt = #mgmt.mgmt<level = 0>})
 // CHECK-NEXT:  %[[v0:.*]] = call @external_secret(%[[arg0]])
 // CHECK-NEXT:  return %[[v0]]
 module {

--- a/tests/Transforms/validate_noise/validate_noise_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_fail.mlir
@@ -17,7 +17,7 @@
 #original_type = #tensor_ext.original_type<originalType = i16, layout = #layout>
 // expected-error@below {{'builtin.module' op Noise validation failed.}}
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113, 35184376184833], P = [35184376545281, 35184376578049], plaintextModulus = 4295294977>, scheme.bgv} {
-  func.func @dot_product(%arg0: !secret.secret<tensor<1024xi16>>) -> (!secret.secret<tensor<1024xi16>>) {
+  func.func @dot_product(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 5>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %0 = secret.generic(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 5>}) {
     ^body(%input0: tensor<1024xi16>):
       %1 = arith.muli %input0, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 5, dimension = 3>} : tensor<1024xi16>

--- a/tests/Transforms/validate_noise/validate_noise_pass.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_pass.mlir
@@ -8,7 +8,7 @@
 
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [134250497, 33832961, 140737488486401], P = [140737488928769, 140737489256449], plaintextModulus = 65537>, scheme.bgv} {
   // CHECK: @dot_product
-  func.func @dot_product(%arg0: !secret.secret<tensor<1024xi16>>, %arg1: !secret.secret<tensor<1024xi16>>) -> (!secret.secret<tensor<1024xi16>>) {
+  func.func @dot_product(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}, %arg1: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %c7 = arith.constant 7 : index
     %c1_i16 = arith.constant 1 : i16
     %cst = arith.constant dense<0> : tensor<1024xi16>

--- a/tests/Transforms/validate_noise/validate_noise_preserve_user_param.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_preserve_user_param.mlir
@@ -3,7 +3,7 @@
 // CHECK: module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [2148728833, 2148794369, 1152921504607338497], P = [1152921504608747521, 1152921504609239041], plaintextModulus = 65537>, scheme.bgv} {
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [2148728833, 2148794369, 1152921504607338497], P = [1152921504608747521, 1152921504609239041], plaintextModulus = 65537>, scheme.bgv} {
   // CHECK: @return
-  func.func @return(%arg0: !secret.secret<tensor<1024xi16>>) -> (!secret.secret<tensor<1024xi16>>) {
+  func.func @return(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}) {
     return %arg0 : !secret.secret<tensor<1024xi16>>
   }
 }

--- a/tests/Transforms/validate_noise/validate_noise_preserve_user_param_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_preserve_user_param_fail.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@below {{'builtin.module' op The level in the scheme param is smaller than the max level.}}
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 11, Q = [17], P = [1093633], plaintextModulus = 65537>} {
-  func.func @main(%arg0: !secret.secret<tensor<1024xi16>>) -> !secret.secret<tensor<1024xi16>> {
+  func.func @main(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %0 = secret.generic(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
     ^body(%input0: tensor<1024xi16>):
       %13 = arith.muli %input0, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3>} : tensor<1024xi16>
@@ -18,7 +18,7 @@ module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 11, Q = [17], P = 
 
 // expected-error@below {{'builtin.module' op Noise validation failed.}}
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 11, Q = [17, 23], P = [1093633], plaintextModulus = 65537>} {
-  func.func @main(%arg0: !secret.secret<tensor<1024xi16>>) -> !secret.secret<tensor<1024xi16>> {
+  func.func @main(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %0 = secret.generic(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
     ^body(%input0: tensor<1024xi16>):
       %13 = arith.muli %input0, %input0 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3>} : tensor<1024xi16>


### PR DESCRIPTION
This PR implements RegionBranchOpInterface for `secret.generic`. Though `generic` does not have any "real" branching (single-directional control flow), this interface is the easiest way to enhance the dataflow analysis passes, so that the lattice operands of a `secret.yield` op are propagated to the results of the enclosing `secret.generic` op.

Note, the part of the interface that has `secret.yield` say which operands are forwarded is automatically generated by the `ReturnLike` trait on `secret.yield`.