### PR TITLE
centralize getMaxLevel

### DIFF
--- a/lib/Analysis/LevelAnalysis/BUILD
+++ b/lib/Analysis/LevelAnalysis/BUILD
@@ -10,6 +10,7 @@ cc_library(
     deps = [
         "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Utils",

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
@@ -7,11 +7,13 @@
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Utils/AttributeUtils.h"
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
 #include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/Attributes.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"        // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"             // from @llvm-project
@@ -202,6 +204,23 @@ LevelState::LevelType getLevelFromMgmtAttr(Value value) {
     assert(false && "MgmtAttr not found");
   }
   return mgmtAttr.getLevel();
+}
+
+std::optional<int> getMaxLevel(Operation *root) {
+  int maxLevel = 0;
+  root->walk([&](func::FuncOp funcOp) {
+    // Skip client helpers
+    if (isClientHelper(funcOp)) {
+      return;
+    }
+
+    for (BlockArgument arg : funcOp.getArguments()) {
+      if (isa<secret::SecretType>(arg.getType())) {
+        maxLevel = std::max(maxLevel, getLevelFromMgmtAttr(arg));
+      }
+    }
+  });
+  return maxLevel;
 }
 
 }  // namespace heir

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -154,6 +154,10 @@ constexpr StringRef kArgLevelAttrName = "mgmt.level";
 /// baseLevel is for B/FV scheme, where all the analysis result would be 0
 void annotateLevel(Operation *top, DataFlowSolver *solver, int baseLevel = 0);
 
+// Get the maximum annotated level from mgmt attributes.
+// Assumes max level at the entrypoint to the main compiled function.
+std::optional<int> getMaxLevel(Operation *root);
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/lib/Dialect/ModuleAttributes.h
+++ b/lib/Dialect/ModuleAttributes.h
@@ -61,6 +61,11 @@ constexpr const static ::llvm::StringLiteral kClientEncFuncAttrName =
 constexpr const static ::llvm::StringLiteral kClientDecFuncAttrName =
     "client.dec_func";
 
+inline bool isClientHelper(Operation *op) {
+  return op->hasAttr(kClientDecFuncAttrName) ||
+         op->hasAttr(kClientDecFuncAttrName);
+}
+
 // The name of the function this client helper is made for.
 constexpr const static ::llvm::StringLiteral kClientHelperFuncName =
     "func_name";

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -161,24 +161,6 @@ LogicalResult disallowFloatlike(const Type &type) {
 struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
   using SecretToBGVBase::SecretToBGVBase;
 
-  // assume only one main func
-  // also assume max level at entry
-  int getMaxLevel() {
-    int maxLevel = 0;
-    getOperation()->walk([&](func::FuncOp funcOp) {
-      // get mgmtattr from funcop argument
-      for (auto i = 0; i != funcOp.getNumArguments(); ++i) {
-        auto mgmtAttr =
-            funcOp.getArgAttr(i, mgmt::MgmtDialect::kArgMgmtAttrName);
-        if (mgmtAttr) {
-          maxLevel = cast<mgmt::MgmtAttr>(mgmtAttr).getLevel();
-          break;
-        }
-      }
-    });
-    return maxLevel;
-  }
-
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     auto *module = getOperation();

--- a/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
@@ -15,7 +15,6 @@
 #include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
 #include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
@@ -32,21 +31,6 @@ namespace heir {
 
 struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
   using GenerateParamBGVBase::GenerateParamBGVBase;
-
-  // assume only one main func
-  // also assume max level at entry
-  // also assume first genericOp arg is secret
-  int getMaxLevel() {
-    int maxLevel = 0;
-    getOperation()->walk([&](func::FuncOp funcOp) {
-      funcOp->walk([&](secret::GenericOp genericOp) {
-        if (genericOp.getBody()->getNumArguments() > 0) {
-          maxLevel = getLevelFromMgmtAttr(genericOp.getBody()->getArgument(0));
-        }
-      });
-    });
-    return maxLevel;
-  }
 
   template <typename NoiseAnalysis>
   typename NoiseAnalysis::SchemeParamType generateParamByGap(
@@ -155,11 +139,11 @@ struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
 
   template <typename NoiseModel>
   void run(const NoiseModel &model) {
-    int maxLevel = getMaxLevel();
+    std::optional<int> maxLevel = getMaxLevel(getOperation());
 
     // plaintext modulus from command line option
     auto schemeParam = NoiseModel::SchemeParamType::getConservativeSchemeParam(
-        maxLevel, plaintextModulus, slotNumber, usePublicKey,
+        maxLevel.value_or(0), plaintextModulus, slotNumber, usePublicKey,
         encryptionTechniqueExtended);
 
     LLVM_DEBUG(llvm::dbgs() << "Conservative Scheme Param:\n"
@@ -188,8 +172,9 @@ struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
 
   void generateFallbackParam() {
     // generate fallback scheme parameters
-    auto maxLevel = getMaxLevel();
-    std::vector<double> logPrimes(maxLevel + 1, 45);  // all primes of 45 bits
+    std::optional<int> maxLevel = getMaxLevel(getOperation());
+    std::vector<double> logPrimes(maxLevel.value_or(0) + 1,
+                                  45);  // all primes of 45 bits
 
     auto schemeParam = bgv::SchemeParam::getConcreteSchemeParam(
         logPrimes, plaintextModulus, slotNumber, usePublicKey,

--- a/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
@@ -1,15 +1,13 @@
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
-#include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Parameters/CKKS/Params.h"
 #include "lib/Transforms/GenerateParam/GenerateParam.h"
-#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
-#include "mlir/include/mlir/Transforms/Passes.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"       // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
 
 #define DEBUG_TYPE "GenerateParamCKKS"
 
@@ -22,23 +20,8 @@ namespace heir {
 struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
   using GenerateParamCKKSBase::GenerateParamCKKSBase;
 
-  // assume only one main func
-  // also assume max level at entry
-  // also assume first genericOp arg is secret
-  int getMaxLevel() {
-    int maxLevel = 0;
-    getOperation()->walk([&](func::FuncOp funcOp) {
-      funcOp->walk([&](secret::GenericOp genericOp) {
-        if (genericOp.getBody()->getNumArguments() > 0) {
-          maxLevel = getLevelFromMgmtAttr(genericOp.getBody()->getArgument(0));
-        }
-      });
-    });
-    return maxLevel;
-  }
-
   void runOnOperation() override {
-    auto maxLevel = getMaxLevel();
+    std::optional<int> maxLevel = getMaxLevel(getOperation());
 
     if (auto schemeParamAttr =
             getOperation()->getAttrOfType<ckks::SchemeParamAttr>(
@@ -46,7 +29,7 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
       // TODO: put this in validate-noise once CKKS noise model is in
       auto schemeParam =
           ckks::SchemeParam::getSchemeParamFromAttr(schemeParamAttr);
-      if (schemeParam.getLevel() < maxLevel) {
+      if (schemeParam.getLevel() < maxLevel.value_or(0)) {
         getOperation()->emitOpError()
             << "The level in the scheme param is smaller than the max level.\n";
         signalPassFailure();
@@ -56,7 +39,7 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
     }
 
     // generate scheme parameters
-    std::vector<double> logPrimes(maxLevel + 1, scalingModBits);
+    std::vector<double> logPrimes(maxLevel.value_or(0) + 1, scalingModBits);
     logPrimes[0] = firstModBits;
 
     auto schemeParam = ckks::SchemeParam::getConcreteSchemeParam(

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -1,7 +1,5 @@
 #include "lib/Transforms/ValidateNoise/ValidateNoise.h"
 
-#include <cmath>
-
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
@@ -14,14 +12,12 @@
 #include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/ModuleAttributes.h"
-#include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Utils/AttributeUtils.h"
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"        // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
@@ -38,21 +34,6 @@ namespace heir {
 
 struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
   using ValidateNoiseBase::ValidateNoiseBase;
-
-  // assume only one main func
-  // also assume max level at entry
-  // also assume first genericOp arg is secret
-  int getMaxLevel() {
-    int maxLevel = 0;
-    getOperation()->walk([&](func::FuncOp funcOp) {
-      funcOp->walk([&](secret::GenericOp genericOp) {
-        if (genericOp.getBody()->getNumArguments() > 0) {
-          maxLevel = getLevelFromMgmtAttr(genericOp.getBody()->getArgument(0));
-        }
-      });
-    });
-    return maxLevel;
-  }
 
   template <typename NoiseAnalysis>
   LogicalResult validateNoiseForValue(
@@ -125,7 +106,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
 
   template <typename NoiseModel>
   void run(const NoiseModel &model) {
-    int maxLevel = getMaxLevel();
+    std::optional<int> maxLevel = getMaxLevel(getOperation());
 
     auto schemeParamAttr = getOperation()->getAttrOfType<bgv::SchemeParamAttr>(
         bgv::BGVDialect::kSchemeParamAttrName);
@@ -142,7 +123,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
 
     auto schemeParam =
         NoiseModel::SchemeParamType::getSchemeParamFromAttr(schemeParamAttr);
-    if (schemeParam.getLevel() < maxLevel) {
+    if (schemeParam.getLevel() < maxLevel.value_or(0)) {
       getOperation()->emitOpError()
           << "The level in the scheme param is smaller than the max level.\n";
       signalPassFailure();


### PR DESCRIPTION
This also makes some slight simplifications to allow a failed getMaxLevel to be handled by the callers as they see fit. I chose to have it default to zero because I looked at each of the cases and it seemed to me that instances where maxlevel = 0 because it was not set properly would be caught when it mattered, and otherwise all level values can be zero.

Extracted from https://github.com/google/heir/pull/1633