### PR TITLE
Add layout-optimization infrastructure to handle kernel changes during hoisting

### DIFF
--- a/lib/Dialect/BUILD
+++ b/lib/Dialect/BUILD
@@ -14,6 +14,8 @@ cc_library(
     hdrs = ["HEIRInterfaces.h"],
     deps = [
         ":interfaces_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:SecretAttributes",
+        "@heir//lib/Transforms/LayoutOptimization:InterfaceImpl",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:IR",
     ],

--- a/lib/Dialect/HEIRInterfaces.cpp
+++ b/lib/Dialect/HEIRInterfaces.cpp
@@ -1,16 +1,30 @@
 #include "lib/Dialect/HEIRInterfaces.h"
 
+#include "lib/Transforms/LayoutOptimization/InterfaceImpl.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/DialectRegistry.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/MLIRContext.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/DialectRegistry.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"          // from @llvm-project
 
 namespace mlir {
 namespace heir {
+
 #include "lib/Dialect/HEIRInterfaces.cpp.inc"
 
 void registerOperandAndResultAttrInterface(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, affine::AffineDialect *dialect) {
     affine::AffineForOp::attachInterface<OperandAndResultAttrInterface>(*ctx);
+  });
+}
+
+void registerLayoutConversionHoistableInterface(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, arith::ArithDialect *dialect) {
+    arith::AddFOp::attachInterface<DoNothingHoistingImpl<arith::AddFOp>>(*ctx);
+    arith::AddIOp::attachInterface<DoNothingHoistingImpl<arith::AddIOp>>(*ctx);
+    arith::MulFOp::attachInterface<DoNothingHoistingImpl<arith::MulFOp>>(*ctx);
+    arith::MulIOp::attachInterface<DoNothingHoistingImpl<arith::MulIOp>>(*ctx);
+    arith::SubFOp::attachInterface<DoNothingHoistingImpl<arith::SubFOp>>(*ctx);
+    arith::SubIOp::attachInterface<DoNothingHoistingImpl<arith::SubIOp>>(*ctx);
   });
 }
 

--- a/lib/Dialect/HEIRInterfaces.h
+++ b/lib/Dialect/HEIRInterfaces.h
@@ -2,6 +2,9 @@
 #define LIB_DIALECT_HEIRINTERFACES_H_
 
 // IWYU pragma: begin_keep
+#include "lib/Dialect/Secret/IR/SecretAttributes.h"      // from @llvm-project
+#include "lib/Dialect/Secret/IR/SecretDialect.h"         // from @llvm-project
+#include "lib/Transforms/LayoutOptimization/Hoisting.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
@@ -16,7 +19,8 @@
 namespace mlir {
 namespace heir {
 
-void registerOperandAndResultAttrInterface(DialectRegistry &registry);
+void registerOperandAndResultAttrInterface(DialectRegistry& registry);
+void registerLayoutConversionHoistableInterface(DialectRegistry& registry);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/HEIRInterfaces.td
+++ b/lib/Dialect/HEIRInterfaces.td
@@ -3,7 +3,7 @@ include "mlir/IR/OpBase.td"
 def LUTOpInterface : OpInterface<"LUTOpInterface"> {
   let cppNamespace = "::mlir::heir";
   let description = [{
-    This is an example interface definition.
+    An interface that represents a general lookup table operation.
   }];
 
   let methods = [
@@ -12,6 +12,40 @@ def LUTOpInterface : OpInterface<"LUTOpInterface"> {
       "std::optional<mlir::ValueRange>", "getLookupTableInputs"
     >,
   ];
+}
+
+def LayoutConversionHoistableOpInterface : OpInterface<"LayoutConversionHoistableOpInterface"> {
+  let cppNamespace = "::mlir::heir";
+  let description = [{
+    An interface that abstracts the common information required for the
+    `layout-optimization` pass to evaluate the feasibility and cost of hoisting
+    a `convert_layout` op through a given operation.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Get hoisters for the op.",
+      "std::vector<::mlir::heir::Hoister>",
+      "getHoisters",
+      (ins "::mlir::heir::tensor_ext::ConvertLayoutOp":$convertLayoutOp)
+    >,
+  ];
+
+  // TODO(#1888): figure out how to get OpInterface verifier to run
+  // automatically.
+  // let verify = [{
+  //   ::mlir::heir::KernelName kernelName = ::mlir::heir::KernelName::Trivial;
+  //   auto attrName = ::mlir::heir::secret::SecretDialect::kKernelAttrName;
+  //   if ($_op->hasAttr(attrName)) {
+  //     auto attr = $_op->getAttrOfType<::mlir::heir::secret::KernelAttr>(attrName);
+  //     kernelName = attr.getName();
+  //   }
+  //   if (!::mlir::heir::isSupportedKernel($_op, kernelName)) {
+  //     return $_op->emitOpError()
+  //            << "has unsupported kernel '" << kernelName << "'";
+  //   }
+  //   return success();
+  // }];
 }
 
 def OperandAndResultAttrInterface : OpInterface<"OperandAndResultAttrInterface"> {

--- a/lib/Dialect/Secret/IR/BUILD
+++ b/lib/Dialect/Secret/IR/BUILD
@@ -12,11 +12,13 @@ cc_library(
         "SecretDialect.cpp",
     ],
     hdrs = [
+        "SecretAttributes.h",
         "SecretDialect.h",
         "SecretOps.h",
         "SecretTypes.h",
     ],
     deps = [
+        ":SecretAttributes",
         ":SecretOps",
         ":SecretPatterns",
         ":dialect_inc_gen",
@@ -63,6 +65,22 @@ cc_library(
 )
 
 cc_library(
+    name = "SecretAttributes",
+    hdrs = [
+        "SecretAttributes.h",
+        "SecretDialect.h",
+    ],
+    deps = [
+        ":attributes_inc_gen",
+        ":dialect_inc_gen",
+        "@heir//lib/Kernel",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
     name = "SecretOps",
     srcs = [
         "SecretOps.cpp",
@@ -89,6 +107,7 @@ cc_library(
 td_library(
     name = "td_files",
     srcs = [
+        "SecretAttributes.td",
         "SecretDialect.td",
         "SecretOps.td",
         "SecretTypes.td",
@@ -108,6 +127,16 @@ add_heir_dialect_library(
     dialect = "Secret",
     kind = "dialect",
     td_file = "SecretDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "Secret",
+    kind = "attribute",
+    td_file = "SecretAttributes.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/Secret/IR/SecretAttributes.h
+++ b/lib/Dialect/Secret/IR/SecretAttributes.h
@@ -1,0 +1,12 @@
+#ifndef LIB_DIALECT_SECRET_IR_SECRETATTRIBUTES_H_
+#define LIB_DIALECT_SECRET_IR_SECRETATTRIBUTES_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Kernel/Kernel.h"
+#include "mlir/include/mlir/IR/OpImplementation.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/Secret/IR/SecretAttributes.h.inc"
+
+#endif  // LIB_DIALECT_SECRET_IR_SECRETATTRIBUTES_H_

--- a/lib/Dialect/Secret/IR/SecretAttributes.td
+++ b/lib/Dialect/Secret/IR/SecretAttributes.td
@@ -1,0 +1,41 @@
+#ifndef LIB_DIALECT_SECRET_IR_SECRETATTRIBUTES_TD_
+#define LIB_DIALECT_SECRET_IR_SECRETATTRIBUTES_TD_
+
+include "lib/Dialect/Secret/IR/SecretDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/IR/OpAsmInterface.td"
+
+class Secret_Attr<string name, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<Secret_Dialect, name, traits # [OpAsmAttrInterface]> {
+  let mnemonic = attrMnemonic;
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let extraClassDeclaration = [{
+    // OpAsmAttrInterface methods.
+    ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
+      os << "}] # attrMnemonic # [{";
+      return ::mlir::OpAsmDialectInterface::AliasResult::FinalAlias;
+    }
+  }];
+}
+
+def Secret_KernelAttr : Secret_Attr<"Kernel", "kernel"> {
+  let summary = "An annotation describing an implementation kernel for a given op.";
+  let description = [{
+    This attribute is used for two purposes:
+
+    1. To allow the input IR to annotate fixed kernels on ops that the rest of the
+    compiler must respect.
+    2. To allow the layout optimization pipeline to materialize its kernel selection
+    decisions to the IR.
+
+    The `name` field corresponds to an internally-defined kernel name, and if
+    `force` is set to `true`, then the kernel may not be overridden by HEIR's
+    internal passes.
+  }];
+  let parameters = (ins "::mlir::heir::KernelName":$name, "bool":$force);
+}
+
+#endif  // LIB_DIALECT_SECRET_IR_SECRETATTRIBUTES_TD_

--- a/lib/Dialect/Secret/IR/SecretDialect.cpp
+++ b/lib/Dialect/Secret/IR/SecretDialect.cpp
@@ -1,11 +1,17 @@
 #include "lib/Dialect/Secret/IR/SecretDialect.h"
 
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Secret/IR/SecretAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretDialect.cpp.inc"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/Secret/IR/SecretTypes.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/Secret/IR/SecretAttributes.cpp.inc"
 #define GET_TYPEDEF_CLASSES
 #include "lib/Dialect/Secret/IR/SecretTypes.cpp.inc"
 #define GET_OP_CLASSES
@@ -22,6 +28,10 @@ namespace secret {
 // Dialect construction: there is one instance per context and it registers its
 // operations, types, and interfaces here.
 void SecretDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "lib/Dialect/Secret/IR/SecretAttributes.cpp.inc"
+      >();
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "lib/Dialect/Secret/IR/SecretTypes.cpp.inc"

--- a/lib/Dialect/Secret/IR/SecretDialect.td
+++ b/lib/Dialect/Secret/IR/SecretDialect.td
@@ -28,6 +28,8 @@ def Secret_Dialect : Dialect {
         kArgUnknownAttrName = "secret.unknown";
     constexpr const static ::llvm::StringLiteral
         kSecretInitsAttrName = "secret.secret_inits";
+    constexpr const static ::llvm::StringLiteral
+        kKernelAttrName = "secret.kernel";
 
     // Name of the attribute for plaintext backend execution result.
     constexpr const static ::llvm::StringLiteral
@@ -36,6 +38,7 @@ def Secret_Dialect : Dialect {
 
   let cppNamespace = "::mlir::heir::secret";
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif  // LIB_DIALECT_SECRET_IR_SECRETDIALECT_TD_

--- a/lib/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -5,6 +5,7 @@
 #include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
 #include "llvm/include/llvm/ADT/ArrayRef.h"              // from @llvm-project
 #include "llvm/include/llvm/ADT/STLFunctionalExtras.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project

--- a/lib/Kernel/BUILD
+++ b/lib/Kernel/BUILD
@@ -1,0 +1,13 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Kernel",
+    srcs = ["Kernel.cpp"],
+    hdrs = ["Kernel.h"],
+    deps = [
+        "@llvm-project//mlir:IR",
+    ],
+)

--- a/lib/Kernel/Kernel.cpp
+++ b/lib/Kernel/Kernel.cpp
@@ -1,0 +1,40 @@
+#include "Kernel.h"
+
+#include <set>
+#include <string>
+#include <unordered_map>
+
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/OperationSupport.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+namespace {
+static std::unordered_map<KernelName, std::string> correspondingOp = {
+    {KernelName::MatvecNaive, "linalg.matvec"},
+    {KernelName::MatvecDiagonal, "linalg.matvec"},
+};
+
+std::set<std::string> requiredNontrivial = {"linalg"};
+}  // namespace
+
+bool isSupportedKernel(Operation *op, KernelName name) {
+  std::string dialect = std::string(op->getDialect()->getNamespace());
+  if (name == KernelName::Trivial) {
+    return requiredNontrivial.count(dialect) == 0;
+  }
+
+  if (correspondingOp.find(name) == correspondingOp.end()) {
+    return false;
+  }
+
+  std::string actual;
+  llvm::raw_string_ostream ss(actual);
+  ss << op->getDialect()->getNamespace() << "." << op->getName().getStringRef();
+  return correspondingOp.at(name) == actual;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Kernel/Kernel.h
+++ b/lib/Kernel/Kernel.h
@@ -1,0 +1,56 @@
+#ifndef LIB_KERNEL_KERNEL_H_
+#define LIB_KERNEL_KERNEL_H_
+
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/OperationSupport.h"       // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+enum class KernelName {
+  // A trivial kernel is one for which there is only a single known option
+  // (e.g., an elementwise addition).
+  Trivial,
+  MatvecNaive,
+  MatvecDiagonal,
+};
+
+bool isSupportedKernel(Operation *op, KernelName name);
+
+inline raw_ostream &operator<<(raw_ostream &os,
+                               const heir::KernelName &kernelName) {
+  switch (kernelName) {
+    case heir::KernelName::Trivial:
+      os << "Trivial";
+      break;
+    case heir::KernelName::MatvecNaive:
+      os << "MatvecNaive";
+      break;
+    case heir::KernelName::MatvecDiagonal:
+      os << "MatvecDiagonal";
+      break;
+    default:
+      os << "Unknown";
+  }
+  return os;
+}
+
+}  // namespace heir
+
+template <>
+struct FieldParser<heir::KernelName> {
+  static FailureOr<heir::KernelName> parse(AsmParser &parser) {
+    std::string kernelName;
+    if (parser.parseString(&kernelName)) return failure();
+
+    if (kernelName == "Trivial") return heir::KernelName::Trivial;
+    if (kernelName == "MatvecNaive") return heir::KernelName::MatvecNaive;
+    if (kernelName == "MatvecDiagonal") return heir::KernelName::MatvecDiagonal;
+
+    return failure();
+  }
+};
+
+}  // namespace mlir
+#endif  // LIB_KERNEL_KERNEL_H_

--- a/lib/Transforms/LayoutOptimization/BUILD
+++ b/lib/Transforms/LayoutOptimization/BUILD
@@ -10,6 +10,7 @@ cc_library(
     srcs = ["LayoutOptimization.cpp"],
     hdrs = ["LayoutOptimization.h"],
     deps = [
+        ":Hoisting",
         ":Patterns",
         ":pass_inc_gen",
         "@heir//lib/Dialect/Secret/IR:Dialect",
@@ -25,6 +26,30 @@ cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+cc_library(
+    name = "Hoisting",
+    srcs = ["Hoisting.h"],
+    hdrs = [],
+    deps = [
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Kernel",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "InterfaceImpl",
+    srcs = ["InterfaceImpl.cpp"],
+    hdrs = ["InterfaceImpl.h"],
+    deps = [
+        ":Hoisting",
+        "@heir//lib/Kernel",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:LinalgDialect",
     ],
 )
 

--- a/lib/Transforms/LayoutOptimization/Hoisting.h
+++ b/lib/Transforms/LayoutOptimization/Hoisting.h
@@ -1,0 +1,33 @@
+#ifndef LIB_TRANSFORMS_LAYOUTOPTIMIZATION_HOISTING_H_
+#define LIB_TRANSFORMS_LAYOUTOPTIMIZATION_HOISTING_H_
+
+#include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Kernel/Kernel.h"
+
+namespace mlir {
+namespace heir {
+
+struct HoistResult {
+  // A new required layout for each operand
+  SmallVector<::mlir::heir::tensor_ext::LayoutAttr> newInputLayouts;
+
+  // A new result layout
+  ::mlir::heir::tensor_ext::LayoutAttr newOutputLayout;
+
+  // A new result layout
+  ::mlir::heir::KernelName newKernel;
+
+  // The convert_layout op hoisted.
+  ::mlir::heir::tensor_ext::ConvertLayoutOp convertLayoutOp;
+};
+
+// A Hoister maps convert_layout to HoistResult, returning failure if the hoist
+// is impossible.
+using Hoister = std::function<::llvm::FailureOr<::mlir::heir::HoistResult>(
+    ::mlir::heir::tensor_ext::ConvertLayoutOp)>;
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_LAYOUTOPTIMIZATION_HOISTING_H_

--- a/lib/Transforms/LayoutOptimization/InterfaceImpl.cpp
+++ b/lib/Transforms/LayoutOptimization/InterfaceImpl.cpp
@@ -1,0 +1,25 @@
+
+#include "lib/Transforms/LayoutOptimization/Hoisting.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+using tensor_ext::ConvertLayoutOp;
+using tensor_ext::LayoutAttr;
+
+Hoister createTrivialHoister(Operation* op) {
+  return [op](ConvertLayoutOp convertLayoutOp) -> llvm::FailureOr<HoistResult> {
+    HoistResult result;
+    auto outputLayout = convertLayoutOp.getToLayout();
+    result.convertLayoutOp = convertLayoutOp;
+    result.newInputLayouts =
+        SmallVector<LayoutAttr>(op->getNumOperands(), outputLayout);
+    result.newKernel = KernelName::Trivial;
+    result.newOutputLayout = outputLayout;
+    return result;
+  };
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/LayoutOptimization/InterfaceImpl.h
+++ b/lib/Transforms/LayoutOptimization/InterfaceImpl.h
@@ -1,0 +1,28 @@
+#ifndef LIB_TRANSFORMS_LAYOUTOPTIMIZATION_INTERFACEIMPL_H_
+#define LIB_TRANSFORMS_LAYOUTOPTIMIZATION_INTERFACEIMPL_H_
+
+#include "lib/Dialect/HEIRInterfaces.h"
+#include "lib/Transforms/LayoutOptimization/Hoisting.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+/// Construct a trivial hoister for which all layouts can be hoisted without
+/// any kernel change or difference in the output layout.
+Hoister createTrivialHoister(Operation* op);
+
+template <typename OpTy>
+struct DoNothingHoistingImpl
+    : public LayoutConversionHoistableOpInterface::ExternalModel<
+          DoNothingHoistingImpl<OpTy>, OpTy> {
+  std::vector<::mlir::heir::Hoister> getHoisters(
+      Operation* op, tensor_ext::ConvertLayoutOp convertLayoutOp) const {
+    return {createTrivialHoister(op)};
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_LAYOUTOPTIMIZATION_INTERFACEIMPL_H_

--- a/tests/Dialect/Secret/IR/kernel.mlir
+++ b/tests/Dialect/Secret/IR/kernel.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// CHECK: #secret.kernel<name = MatvecNaive, force = true>
+#alignment = #tensor_ext.alignment<in = [16], out = [8192]>
+#alignment1 = #tensor_ext.alignment<in = [16, 16], out = [16, 16]>
+#layout = #tensor_ext.layout<map = (d0) -> (d0 mod 8192), alignment = #alignment>
+#layout1 = #tensor_ext.layout<map = (d0, d1) -> ((-d0 + d1) mod 16, (d0 + ((-d0 + d1) floordiv 16) * 16) mod 8192), alignment = #alignment1>
+func.func @matvec(%arg0: !secret.secret<tensor<16xf32>> {tensor_ext.layout = #layout}) -> (!secret.secret<tensor<16xf32>> {tensor_ext.layout = #layout}) {
+  %cst = arith.constant dense<0.0> : tensor<16xf32>
+  %cst_0 = arith.constant dense<0.0> : tensor<16x16xf32>
+  %1 = tensor_ext.assign_layout %cst_0 {layout = #layout1, tensor_ext.layout = #layout1} : tensor<16x16xf32>
+  %2 = tensor_ext.assign_layout %cst {layout = #layout, tensor_ext.layout = #layout} : tensor<16xf32>
+  %0 = secret.generic(%arg0 : !secret.secret<tensor<16xf32>>) attrs = {__argattrs = [{tensor_ext.layout = #layout}], __resattrs = [{tensor_ext.layout = #layout}]} {
+  ^body(%input0: tensor<16xf32>):
+    %3 = linalg.matvec {tensor_ext.layout = #layout, secret.kernel = #secret.kernel<name="MatvecNaive", force=true>}
+        ins(%1, %input0 : tensor<16x16xf32>, tensor<16xf32>) outs(%2 : tensor<16xf32>) -> tensor<16xf32>
+    secret.yield %3 : tensor<16xf32>
+  } -> !secret.secret<tensor<16xf32>>
+  return %0 : !secret.secret<tensor<16xf32>>
+}

--- a/tests/Transforms/layout_optimization/mnist.mlir
+++ b/tests/Transforms/layout_optimization/mnist.mlir
@@ -1,0 +1,50 @@
+// RUN: heir-opt --layout-optimization %s | FileCheck %s
+// TODO(#1888): assert layout hoisting is correct
+
+#alignment = #tensor_ext.alignment<in = [1, 10], out = [1, 1024], padding = [0, 6], paddingValue = 0.000000e+00 : f32>
+#alignment1 = #tensor_ext.alignment<in = [1, 784], out = [1, 1024], padding = [0, 240], paddingValue = 0.000000e+00 : f32>
+#alignment2 = #tensor_ext.alignment<in = [784], out = [1024], padding = [240], paddingValue = 0.000000e+00 : f32>
+#alignment3 = #tensor_ext.alignment<in = [784, 512], out = [1024, 512], padding = [240, 0], paddingValue = 0.000000e+00 : f32>
+#alignment4 = #tensor_ext.alignment<in = [512], out = [1024]>
+#alignment5 = #tensor_ext.alignment<in = [512, 10], out = [512, 16], padding = [0, 6], paddingValue = 0.000000e+00 : f32>
+#alignment6 = #tensor_ext.alignment<in = [10], out = [1024], padding = [6], paddingValue = 0.000000e+00 : f32>
+#layout = #tensor_ext.layout<map = (d0, d1) -> (d1 mod 1024), alignment = #alignment>
+#layout1 = #tensor_ext.layout<map = (d0, d1) -> (d1 mod 1024), alignment = #alignment1>
+#layout2 = #tensor_ext.layout<map = (d0) -> (d0 mod 1024), alignment = #alignment2>
+#layout3 = #tensor_ext.layout<map = (d0, d1) -> (((d0 * 512 + d1) floordiv 1024) mod 512, (d0 * 512 + d1) mod 1024), alignment = #alignment3>
+#layout4 = #tensor_ext.layout<map = (d0) -> (d0 mod 1024), alignment = #alignment4>
+#layout5 = #tensor_ext.layout<map = (d0, d1) -> (((d0 * 16 + d1) floordiv 1024) mod 8, (d0 * 16 + d1) mod 1024), alignment = #alignment5>
+#layout6 = #tensor_ext.layout<map = (d0) -> (d0 mod 1024), alignment = #alignment6>
+module attributes {backend.openfhe, scheme.bgv} {
+
+  // CHECK: @main
+  func.func @main(%arg0: tensor<512x784xf32> {debug.name = "layer1_weights"}, %arg1: tensor<512xf32> {debug.name = "layer1_bias"}, %arg2: tensor<10x512xf32> {debug.name = "layer2_weights"}, %arg3: tensor<10xf32> {debug.name = "layer2_bias"}, %arg4: !secret.secret<tensor<1x784xf32>> {debug.name = "input", tensor_ext.layout = #layout1}) -> (!secret.secret<tensor<1x10xf32>> {debug.name = "result", tensor_ext.layout = #layout}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<512xf32>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<10xf32>
+    %0 = tensor.empty() : tensor<784x512xf32>
+    %1 = tensor.empty() : tensor<512x10xf32>
+    %2 = secret.generic(%arg4: !secret.secret<tensor<1x784xf32>> {tensor_ext.layout = #layout1}) {
+    ^body(%input0: tensor<1x784xf32>):
+      %transposed = linalg.transpose ins(%arg0 : tensor<512x784xf32>) outs(%0 : tensor<784x512xf32>) permutation = [1, 0]
+      %collapsed = tensor.collapse_shape %input0 [[0, 1]] {tensor_ext.layout = #layout2} : tensor<1x784xf32> into tensor<784xf32>
+      %3 = tensor_ext.assign_layout %transposed {layout = #layout3, tensor_ext.layout = #layout3} : tensor<784x512xf32>
+      %4 = tensor_ext.assign_layout %cst {layout = #layout4, tensor_ext.layout = #layout4} : tensor<512xf32>
+      %5 = linalg.vecmat {tensor_ext.layout = #layout2} ins(%collapsed, %3 : tensor<784xf32>, tensor<784x512xf32>) outs(%4 : tensor<512xf32>) -> tensor<512xf32>
+      %6 = tensor_ext.assign_layout %arg1 {layout = #layout4, tensor_ext.layout = #layout4} : tensor<512xf32>
+      %7 = tensor_ext.convert_layout %5 {from_layout = #layout2, tensor_ext.layout = #layout4, to_layout = #layout4} : tensor<512xf32>
+      %8 = arith.addf %6, %7 {tensor_ext.layout = #layout4} : tensor<512xf32>
+      %9 = tensor_ext.assign_layout %cst {layout = #layout4, tensor_ext.layout = #layout4} : tensor<512xf32>
+      %10 = arith.maximumf %8, %9 {tensor_ext.layout = #layout4} : tensor<512xf32>
+      %transposed_1 = linalg.transpose ins(%arg2 : tensor<10x512xf32>) outs(%1 : tensor<512x10xf32>) permutation = [1, 0]
+      %11 = tensor_ext.assign_layout %transposed_1 {layout = #layout5, tensor_ext.layout = #layout5} : tensor<512x10xf32>
+      %12 = tensor_ext.assign_layout %cst_0 {layout = #layout6, tensor_ext.layout = #layout6} : tensor<10xf32>
+      %13 = linalg.vecmat {tensor_ext.layout = #layout4} ins(%10, %11 : tensor<512xf32>, tensor<512x10xf32>) outs(%12 : tensor<10xf32>) -> tensor<10xf32>
+      %14 = tensor_ext.assign_layout %arg3 {layout = #layout6, tensor_ext.layout = #layout6} : tensor<10xf32>
+      %15 = tensor_ext.convert_layout %13 {from_layout = #layout4, tensor_ext.layout = #layout6, to_layout = #layout6} : tensor<10xf32>
+      %16 = arith.addf %14, %15 {tensor_ext.layout = #layout6} : tensor<10xf32>
+      %expanded = tensor.expand_shape %16 [[0, 1]] output_shape [1, 10] {tensor_ext.layout = #layout} : tensor<10xf32> into tensor<1x10xf32>
+      secret.yield %expanded : tensor<1x10xf32>
+    } -> (!secret.secret<tensor<1x10xf32>> {tensor_ext.layout = #layout})
+    return %2 : !secret.secret<tensor<1x10xf32>>
+  }
+}

--- a/tests/Transforms/layout_optimization/verifier.mlir
+++ b/tests/Transforms/layout_optimization/verifier.mlir
@@ -1,0 +1,40 @@
+// RUN: heir-opt --split-input-file --layout-optimization --verify-diagnostics %s
+
+// Valid
+func.func @main(%arg0: tensor<512xf32>) -> tensor<512xf32> {
+  %0 = arith.addf %arg0, %arg0 {secret.kernel = #secret.kernel<name="Trivial", force=false>} : tensor<512xf32>
+  func.return %0 : tensor<512xf32>
+}
+
+// -----
+
+// Bad kernel name
+func.func @main(%arg0: tensor<512xf32>) -> tensor<512xf32> {
+  // expected-error@below {{has unsupported kernel}}
+  %0 = arith.addf %arg0, %arg0 {secret.kernel = #secret.kernel<name="MatvecNaive", force=false>} : tensor<512xf32>
+  func.return %0 : tensor<512xf32>
+}
+
+// -----
+
+// Good kernel name
+func.func @main(%arg0: tensor<512x512xf32>, %arg1: tensor<512xf32>) -> tensor<512xf32> {
+  %cst = tensor.empty() : tensor<512xf32>
+  %0 = linalg.matvec
+    {secret.kernel = #secret.kernel<name="MatvecDiagonal", force=false>}
+    ins(%arg0, %arg1 : tensor<512x512xf32>, tensor<512xf32>)
+    outs(%cst : tensor<512xf32>) -> tensor<512xf32>
+  func.return %0 : tensor<512xf32>
+}
+// -----
+
+// TODO(#1888): re-enable when matvec is hoistable
+// Missing required kernel
+// func.func @main(%arg0: tensor<512x512xf32>, %arg1: tensor<512xf32>) -> tensor<512xf32> {
+//   %cst = tensor.empty() : tensor<512xf32>
+//   // expected-error@REENABLEME {{has unsupported kernel}}
+//   %0 = linalg.matvec
+//     ins(%arg0, %arg1 : tensor<512x512xf32>, tensor<512xf32>)
+//     outs(%cst : tensor<512xf32>) -> tensor<512xf32>
+//   func.return %0 : tensor<512xf32>
+// }

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -350,6 +350,7 @@ int main(int argc, char **argv) {
   secret::registerBufferizableOpInterfaceExternalModels(registry);
   rns::registerExternalRNSTypeInterfaces(registry);
   registerOperandAndResultAttrInterface(registry);
+  registerLayoutConversionHoistableInterface(registry);
 
   PassPipelineRegistration<TosaToArithOptions>(
       "heir-tosa-to-arith",


### PR DESCRIPTION
Rebased on https://github.com/google/heir/pull/1889

Partial progress toward https://github.com/google/heir/issues/1888

This PR adds:

- An attribute to specify the chosen kernel for layout-optimizer
- A new op interface that allows layout-optimizer to handle all convert_layout op hoisting generically
- converting existing hoisters for arith ops to use the interface
- expansion of the layout-optimizer to incorporate the cost of the kernel

For next PR:

- an implementation of the interface for matvec when alignment is unchanged
- baseline selection of kernel costs