### PR TITLE
fix HEIR config path typo

### DIFF
--- a/frontend/heir/heir_cli/heir_cli_config.py
+++ b/frontend/heir/heir_cli/heir_cli_config.py
@@ -37,7 +37,7 @@ def development_heir_config() -> HEIRConfig:
       / "yosys"
   )
   if not techmap_dir_path.exists():
-    techmap_path = ""
+    techmap_dir_path = ""
 
   abc_path = (
       repo_root


### PR DESCRIPTION
Played around with [Codex](https://chatgpt.com/codex/tasks/task_e_6840c0a608a08328aa3a829641fa4d2c) and it actually found a legitimate (if super minor) bug!