### PR TITLE
docs: Add design of Noise Analysis

### DIFF
--- a/docs/content/en/docs/Design/noise.md
+++ b/docs/content/en/docs/Design/noise.md
@@ -1,0 +1,70 @@
+---
+title: Noise Analysis
+weight: 9
+---
+
+Homomorphic Encryption (HE) schemes based on Learning-With-Errors (LWE) and
+Ring-LWE naturally need to deal with *noises*. HE compilers, in particular, need
+to understand the noise behavior to ensure correctness and security while
+pursuing efficiency and optimizaiton.
+
+The noise analysis in HEIR has the following central task: Given an HE circuit,
+analyse the noise growth for each operation. HEIR then uses noise analysis for
+parameter selection, but the details of that are beyond the scope of this
+document.
+
+Noise analysis and parameter generation are still under active researching and
+HEIR does not have a one-size-fits-all solution for now. Noise analyses and
+(especially) parameter generation in HEIR should be viewed as experimental.
+*There is no guarantee that they are correct or secure* and the HEIR authors do
+not take responsibility. Please consult experts before putting them into
+production.
+
+## Two Flavors of Noise Analysis
+
+Each HE ciphertext contains *noise*. A noise analysis determines a *bound* on
+the noise and tracks its evolution after each HE operation. The noise should not
+exceed certain bounds imposed by HE schemes.
+
+There are two flavors of noise analyses: worst-case and average-case. Worst-case
+noise analyses always track the bound, while some average-case noise analyses
+use intermediate quantity like the variance to track their evolution, and derive
+a bound when needed.
+
+Currently, worst-case methods are often too conservative, while average-case
+methods often give underestimation.
+
+## Noise Analysis Framework
+
+HEIR implements noise analysis based on the `DataFlowFramework` in MLIR.
+
+In the `DataFlowFramework`, the main function of an `Analysis` is
+`visitOperation`, where it determines the `AnalysisState` for each SSA `Value`.
+Usually it computes a transfer function deriving the `AnalysisState` for each
+operation result based on the states of the operation's operands.
+
+As there are various HE schemes in HEIR, the detailed transfer function is
+defined by a `NoiseModel` class, which parameterizes the `NoiseAnalysis`.
+
+The `AnalysisState`, depending on whether we are using worst-case noise model or
+average-case, could be interpreted as the bound or the variance.
+
+A typical way to use noise analysis:
+
+```cpp
+DataFlowSolver solver;
+solver.load<dataflow::DeadCodeAnalysis>();
+solver.load<dataflow::SparseConstantPropagation>();
+// load other dependent analyses
+
+// schemeParam and model determined by other methods
+solver.load<NoiseAnalysis<NoiseModel>>(schemeParam, model);
+
+// run the analysis on the op
+solver.initializeAndRun(op)
+```
+
+## Implemented Noise Models
+
+See the [Passes](/docs/passes) page for details. Example passes include
+`generate-param-bgv` and `validate-noise`.


### PR DESCRIPTION
Before pushing forward my other noise analysis PRs (they would be new researches), I think it might be necessary, and it is the time to summarize what we have now. Ultimately, I think the security implication of noise analysis code should be made clear.

Disclaimer: I recently have a [critique](https://eprint.iacr.org/2025/1036) on average-case noise analyses, and I think we should be cautious about our code. I write this doc in pessimistic tone, because I am afraid we are not confident that the code is 100% secure. We might need further research/auditing. When people use the parameter generation/noise analysis functionality, they would assume it is well done and *the compiler has taken the responsibility*.

We are actually unclear about how much security the compiler has offered. While the open-source license already states the project offers no warranty, we need a clear definition of what HEIR can offer so people will know what they should care when actually using it. 