### PR TITLE
Mgmt: Add MemoryEffect for InitOp to prevent CSE

### DIFF
--- a/lib/Dialect/Mgmt/IR/MgmtOps.cpp
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.cpp
@@ -7,6 +7,10 @@ namespace mlir {
 namespace heir {
 namespace mgmt {
 
+//===----------------------------------------------------------------------===//
+// Canonicalization Patterns
+//===----------------------------------------------------------------------===//
+
 // Kept inside a namespace because it generates a function called
 // populateWithGenerated, which can conflict with other generated patterns.
 #include "lib/Dialect/Mgmt/IR/MgmtCanonicalization.cpp.inc"
@@ -26,6 +30,16 @@ void LevelReduceOp::getCanonicalizationPatterns(RewritePatternSet &results,
 void AdjustScaleOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                 MLIRContext *context) {
   results.add<ModReduceAfterAdjustScale>(context);
+}
+
+//===----------------------------------------------------------------------===//
+// Utils
+//===----------------------------------------------------------------------===//
+
+void cleanupInitOp(Operation *top) {
+  top->walk([&](mgmt::InitOp initOp) {
+    if (initOp->use_empty()) initOp.erase();
+  });
 }
 
 }  // namespace mgmt

--- a/lib/Dialect/Mgmt/IR/MgmtOps.h
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.h
@@ -12,4 +12,15 @@
 #define GET_OP_CLASSES
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h.inc"
 
+namespace mlir {
+namespace heir {
+namespace mgmt {
+
+/// Remove all unused mgmt.init ops from the top operation.
+void cleanupInitOp(Operation *top);
+
+}  // namespace mgmt
+}  // namespace heir
+}  // namespace mlir
+
 #endif  // LIB_DIALECT_MGMT_IR_MGMTOPS_H_

--- a/lib/Dialect/Mgmt/IR/MgmtOps.td
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.td
@@ -143,7 +143,9 @@ def Mgmt_AdjustScaleOp : Mgmt_Op<"adjust_scale"> {
   let hasCanonicalizer = 1;
 }
 
-def Mgmt_InitOp : Mgmt_Op<"init"> {
+def Mgmt_InitOp : Mgmt_Op<"init",
+    [MemoryEffects<[MemWrite]>, ElementwiseMappable, SameOperandsAndResultType, ConditionallySpeculatable]> {
+
   let summary = "Init the plaintext with mgmt attributes";
 
   let description = [{
@@ -161,6 +163,16 @@ def Mgmt_InitOp : Mgmt_Op<"init"> {
 
     To address the problem, for each _use_ of the plaintext, we insert an `mgmt.init`
     operation to initialize the plaintext with `mgmt` attributes.
+
+    Technical reasons for registering memory effects:
+
+    Register a (bogus) memory effect to prevent CSE from merging this op.
+    Two mgmt.init ops could be seen as equivalent only if they have the same
+    MgmtAttr with *level/dimension/scale* annotated, otherwise we could not
+    judge whether they are equivalent or not. In practice, we create the op first
+    and only in later analyses we know whether they are equivalent or not.
+
+    ConditionallySpeculatable is for isSpeculatable check in hoisting canonicalization.
   }];
 
   let arguments = (ins
@@ -168,6 +180,13 @@ def Mgmt_InitOp : Mgmt_Op<"init"> {
   );
   let results = (outs AnyType:$output);
   let assemblyFormat = "operands attr-dict `:` type($output)";
+
+  let extraClassDeclaration = [{
+    /// Interface method for ConditionallySpeculatable.
+    Speculation::Speculatability getSpeculatability() {
+      return Speculation::Speculatable;
+    }
+  }];
 }
 
 #endif  // LIB_DIALECT_MGMT_IR_MGMTOPS_TD_

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -274,6 +274,7 @@ struct SecretToBGV : public impl::SecretToBGVBase<SecretToBGV> {
     }
 
     clearAttrs(getOperation(), mgmt::MgmtDialect::kArgMgmtAttrName);
+    mgmt::cleanupInitOp(getOperation());
   }
 };
 

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -407,6 +407,7 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
     }
 
     clearAttrs(getOperation(), mgmt::MgmtDialect::kArgMgmtAttrName);
+    mgmt::cleanupInitOp(getOperation());
   }
 };
 

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBFV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBFV.cpp
@@ -93,9 +93,9 @@ struct SecretInsertMgmtBFV
     (void)walkAndApplyPatterns(getOperation(), std::move(patternsRelinearize));
 
     auto level = maxMulDepth;
-    // call Canonicalizer here because mgmt.init ops need to be moved out of the
-    // secret.generic.
-    // annotate mgmt attribute with all levels set to mulDepth
+    // 1. Canonicalizer moves mgmt::InitOp out of secret.generic.
+    // 2. AnnotateMgmt will merge level and dimension into MgmtAttr, for further
+    //   lowering. For B/FV, all levels should be set to mulDepth.
     OpPassManager pipeline("builtin.module");
     pipeline.addPass(createCanonicalizerPass());
     mgmt::AnnotateMgmtOptions annotateMgmtOptions;

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
@@ -126,12 +126,12 @@ struct SecretInsertMgmtBGV
       (void)walkAndApplyPatterns(getOperation(), std::move(patternsMulDepth));
     }
 
-    // call Canonicalizer here because mgmt ops need to be ordered
-    // call CSE here because there may be redundant mod reduce
-    // one Value may get mod reduced multiple times in
-    // multiple Uses
-    //
-    // also run annotate-mgmt for lowering
+    // 1. Canonicalizer reorders mgmt ops like Rescale/LevelReduce/AdjustScale.
+    //    This is important for AnnotateMgmt.
+    //    Canonicalizer also moves mgmt::InitOp out of secret.generic.
+    // 2. CSE removes redundant mgmt::ModReduceOp.
+    // 3. AnnotateMgmt will merge level and dimension into MgmtAttr, for further
+    //   lowering.
     OpPassManager pipeline("builtin.module");
     pipeline.addPass(createCanonicalizerPass());
     pipeline.addPass(createCSEPass());

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
@@ -226,12 +226,12 @@ struct SecretInsertMgmtCKKS
       (void)walkAndApplyPatterns(getOperation(), std::move(patternsMulDepth));
     }
 
-    // call Canonicalizer here because mgmt ops need to be ordered
-    // call CSE here because there may be redundant mod reduce
-    // one Value may get mod reduced multiple times in
-    // multiple Uses
-    //
-    // also run annotate-mgmt for lowering
+    // 1. Canonicalizer reorders mgmt ops like Rescale/LevelReduce/AdjustScale.
+    //    This is important for AnnotateMgmt.
+    //    Canonicalizer also moves mgmt::InitOp out of secret.generic.
+    // 2. CSE removes redundant mgmt::ModReduceOp.
+    // 3. AnnotateMgmt will merge level and dimension into MgmtAttr, for further
+    //   lowering.
     OpPassManager pipeline("builtin.module");
     pipeline.addPass(createCanonicalizerPass());
     pipeline.addPass(createCSEPass());


### PR DESCRIPTION
Inspired by #1904. The problem is that when mgmt.init has multiple uses, the back-prop should not propagate to the same mgmt.init; so from the begining we need to ensure mgmt.init only has one use.

Currently, this invariant is implicitly maintained by

* `UseInitOpForPlaintextOperand` in `insert-mgmt` that create mgmt.init for each _Use_
* `ConvertAdjustScaleToMulPlain` in `populate-scale` that create ad-hoc mgmt.init for each mulconst.

However, CSE does not respect this and merge them together since the op was marked as `Pure`. We could not judge the equivalence among init ops unless we have finished all the chain `--insert-mgmt --optimize-relinearation --populate-scale`, where all these MgmtAttr attached to the mgmt.init op could change.

So instead we could manually manage init op by registering bogus momery effect, and manually clean them up in `secret-to-<scheme>`.

Another idea would be attach `id` attr to each mgmt init op, but this counter should be maintained across passes so it is not so convenient.

Also, for secret.generic canonicalization, mgmt.init op attaches a ConditionallySpeculatable trait to tell the canonicalizer that it could be moved out of the secret generic body.