### PR TITLE
bazel: bump compile-commands-extractor commit

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,7 +117,7 @@ use_repo(
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 git_override(
     module_name = "hedron_compile_commands",
-    commit = "f5fbd4cee671d8d908f37c83abaf70fba5928fc7",
+    commit = "02d15621b528efd877f5d5657c4b738523a0eb17",
     remote = "https://github.com/mikael-s-persson/bazel-compile-commands-extractor",
 )
 


### PR DESCRIPTION
My colleague encountered this error when getting `compile_commands.json`

```
AssertionError: No source files found in compile args: ['external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh'

'-c', 'external/boost.spirit+/include/boost/spirit/home/classic/utility/impl/chset/basic_chset.ipp', '-o', 'bazel-out/k8-dbg/bin/external/boost.spirit+/_objs/boost.spirit/1/basic_chset.h.processed', '-no-canonical-prefixes', '-Wno-builtin-macro-redefined', '-D__DATE__="redacted"', '-D__TIMESTAMP__="redacted"', '-D__TIME__="redacted"'].
Please file an issue with this information!
```

Seems like `mikael-s-persson` repo has a new fix for it (two months ago)

Ref to https://github.com/hedronvision/bazel-compile-commands-extractor/pull/219 in case other people encounter it.