### PR TITLE
OpenFHE: BFV: Count Add and KeySwitch Op

### DIFF
--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -341,6 +341,23 @@ struct ConfigureCryptoContext
     config.scalingTechniqueFixedManual = scalingTechniqueFixedManual;
     config.levelBudgetDecode = levelBudgetDecode;
     config.levelBudgetEncode = levelBudgetEncode;
+
+    // for BFV, keep only one of MulDepth/EvalAddCount/KeySwitchCount
+    // If MulDepth != 0, clean EvalAddCount/KeySwitchCount
+    // If MulDepth == 0, and both Count are non-zero, emit warning
+    //
+    // https://github.com/openfheorg/openfhe-development/blob/v1.3.0/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp
+    if (moduleIsBFV(module)) {
+      if (config.mulDepth != 0) {
+        config.evalAddCount = 0;
+        config.keySwitchCount = 0;
+      } else if (config.evalAddCount != 0 && config.keySwitchCount != 0) {
+        module->emitWarning(
+            "MulDepth is 0, but EvalAddCount and KeySwitchCount are both "
+            "non-zero. This may not satisfy the correctness requirement of "
+            "OpenFHE BFV Parameter Generation");
+      }
+    }
     return success();
   }
 

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -313,9 +313,9 @@ void mlirToRLWEPipeline(OpPassManager &pm,
       exit(EXIT_FAILURE);
   }
 
-  if (scheme == RLWEScheme::bgvScheme) {
+  if (scheme == RLWEScheme::bgvScheme || scheme == RLWEScheme::bfvScheme) {
     // count add and keyswitch for Openfhe
-    // this pass only works for BGV now
+    // this pass only works for BGV/BFV
     pm.addPass(openfhe::createCountAddAndKeySwitch());
   }
 

--- a/tests/Dialect/Openfhe/Transforms/eval_add_count_other.mlir
+++ b/tests/Dialect/Openfhe/Transforms/eval_add_count_other.mlir
@@ -1,0 +1,8 @@
+// RUN: heir-opt --annotate-module="backend=openfhe scheme=bfv" --mlir-to-bfv --scheme-to-openfhe %s | FileCheck %s
+
+// CHECK: evalAddCount = 3
+func.func @add_other(%arg0 : i16 {secret.secret}, %arg1 : i16 {secret.secret}) -> i16 {
+    %0 = arith.addi %arg0, %arg1 : i16
+    %1 = arith.addi %0, %arg1 : i16
+    return %1 : i16
+}

--- a/tests/Dialect/Openfhe/Transforms/eval_add_count_self.mlir
+++ b/tests/Dialect/Openfhe/Transforms/eval_add_count_self.mlir
@@ -1,0 +1,8 @@
+// RUN: heir-opt --annotate-module="backend=openfhe scheme=bfv" --mlir-to-bfv --scheme-to-openfhe %s | FileCheck %s
+
+// CHECK: evalAddCount = 4
+func.func @add_self(%arg0 : i16 {secret.secret}) -> i16 {
+    %0 = arith.addi %arg0, %arg0 : i16
+    %1 = arith.addi %0, %0 : i16
+    return %1 : i16
+}


### PR DESCRIPTION
We used to correctly set EvalAddCount and KeySwitchCount for BGV in OpenFHE *for security reasons*. See #1254 for background.

For BFV, the case when mulDepth = 0 also needs setting EvalAddCount and KeySwitchCount. However, the requirement is that

* Only one of them could be non-zero

```
// throw an exception if at least 2 variables are not zero
```

* Only one of them takes the responsibility to ensure correctness

```
mulDepth != 0
// Only EvalMult operations are used in the correctness constraint
// the correctness constraint from Section 3.1 of https://eprint.iacr.org/2021/204.pdf
// is used

keyswitchCount != 0
// this case supports automorphism w/o any other operations
// base for relinearization

addCount != 0
// only public key encryption and EvalAdd (optional when evalAddCount = 0)
// operations are supported the correctness constraint from section 3.5 of
// https://eprint.iacr.org/2014/062.pdf is used
```

The case when there is no mul but there are mixed adds/keyswitchs remains unclear.

See https://github.com/openfheorg/openfhe-development/blob/v1.3.0/src/pke/lib/scheme/bfvrns/bfvrns-parametergeneration.cpp for detail.