### PR TITLE
BFV: Add Canonical Embedding based Noise Model

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BFV/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BFV/BUILD
@@ -13,6 +13,7 @@ cc_library(
     deps = [
         ":NoiseByBoundCoeffModel",
         ":NoiseByVarianceCoeffModel",
+        ":NoiseCanEmbModel",
         "@heir//lib/Analysis:Utils",
         "@heir//lib/Analysis/DimensionAnalysis",
         "@heir//lib/Analysis/LevelAnalysis",
@@ -59,5 +60,19 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis:Noise",
         "@heir//lib/Parameters/BGV:Params",
         "@heir//lib/Utils:MathUtils",
+    ],
+)
+
+cc_library(
+    name = "NoiseCanEmbModel",
+    srcs = [
+        "NoiseCanEmbModel.cpp",
+    ],
+    hdrs = [
+        "NoiseCanEmbModel.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/NoiseAnalysis:Noise",
+        "@heir//lib/Parameters/BGV:Params",
     ],
 )

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
@@ -6,6 +6,7 @@
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h"
 #include "lib/Analysis/Utils.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
@@ -35,6 +36,10 @@ void NoiseAnalysis<NoiseModel>::setToEntryState(LatticeType *lattice) {
                                      getDimensionFromMgmtAttr(value));
     NoiseState encrypted = noiseModel.evalEncrypt(localParam);
     this->propagateIfChanged(lattice, lattice->join(encrypted));
+    LLVM_DEBUG(llvm::dbgs() << "Initializing "
+                            << doubleToString2Prec(
+                                   noiseModel.toLogBound(localParam, encrypted))
+                            << " to " << value << "\n");
     return;
   }
 
@@ -214,6 +219,9 @@ template class NoiseAnalysis<bfv::NoiseByBoundCoeffModel>;
 
 // for variance
 template class NoiseAnalysis<bfv::NoiseByVarianceCoeffModel>;
+
+// for canon emb bounds
+template class NoiseAnalysis<bfv::NoiseCanEmbModel>;
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.cpp
@@ -1,0 +1,222 @@
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <iomanip>
+#include <ios>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace mlir {
+namespace heir {
+namespace bfv {
+
+// canonical embedding noise model adapted
+// from MMLGA22 https://eprint.iacr.org/2022/706
+// from BMCM23 table 5 https://eprint.iacr.org/2023/600
+// and from BGV/NoiseCanEmbModel
+
+using Model = NoiseCanEmbModel;
+
+double Model::toLogBound(const LocalParamType &param,
+                         const StateType &noise) const {
+  auto cm = getRingExpansionFactor(param);
+  // ||a|| <= c_m * ||a||^{can}
+  // noise.getValue stores log2(||a||^{can})
+  return log2(cm) + noise.getValue();
+}
+
+double Model::toLogBudget(const LocalParamType &param,
+                          const StateType &noise) const {
+  return toLogTotal(param) - toLogBound(param, noise);
+}
+
+double Model::toLogTotal(const LocalParamType &param) const {
+  double total = 0;
+  auto logqi = param.getSchemeParam()->getLogqi();
+  for (auto i = 0; i <= param.getCurrentLevel(); ++i) {
+    total += logqi[i];
+  }
+  return total - 1.0;
+}
+
+double Model::getVarianceErr(const LocalParamType &param) const {
+  auto std0 = param.getSchemeParam()->getStd0();
+  return std0 * std0;
+}
+
+double Model::getVarianceKey(const LocalParamType &param) const {
+  // assume UNIFORM_TERNARY
+  return 2.0 / 3.0;
+}
+
+double Model::getRingExpansionFactor(const LocalParamType &param) const {
+  [[maybe_unused]] auto N = param.getSchemeParam()->getRingDim();
+  // Assert that N is a power of 2
+  assert((N > 0) && ((N & (N - 1)) == 0) && "N must be a power of 2");
+  // In power-of-two rings c_m = 1
+  return 1.;
+}
+
+double Model::getAssuranceFactor(const LocalParamType &param) const {
+  // probability that a exceeds its standard deviation by more than a factor of
+  // D is roughly erfc(D) with erfc(6) = 2^-55, erfc(5) = 2^-40, erfc(4.5) =
+  // 2^-32
+  return 6.;
+}
+
+double Model::getBScale(const LocalParamType &param) const {
+  auto varianceKey = getVarianceKey(param);
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // B_scale = D * sqrt(phi(m)/12 * (1 + phi(m) * V_key)
+  double innerTerm = (phi / 12.) * (1 + phi * varianceKey);
+  return d * sqrt(innerTerm);
+}
+
+double Model::getPhi(const LocalParamType &param) const {
+  return param.getSchemeParam()->getRingDim();
+}
+
+typename Model::StateType Model::evalEncryptPk(
+    const LocalParamType &param) const {
+  auto varianceError = getVarianceErr(param);
+  // uniform ternary
+  auto varianceKey = getVarianceKey(param);
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // public key (-as + e, a)
+  // public key encryption (-aus + u * e + e_0 + Delta * m, au + e_1)
+  // ||u * e + e_1 * s + e_0||
+  // <= D * sqrt(phi(m) * (2 * phi(m) * V_err * V_key + V_err))
+  double innerTerm =
+      phi * (2. * phi * varianceError * varianceKey + varianceKey);
+  double fresh = d * sqrt(innerTerm);
+  return StateType::of(fresh);
+}
+
+typename Model::StateType Model::evalEncryptSk(
+    const LocalParamType &param) const {
+  auto varianceError = getVarianceErr(param);
+  auto d = getAssuranceFactor(param);
+  auto phi = getPhi(param);
+
+  // secret key s
+  // secret key encryption (-as + Delta * m + e, a)
+  // ||e|| <= D * sqrt(phi(m) * (V_err))
+  double innerTerm = phi * (varianceError);
+  double fresh = d * sqrt(innerTerm);
+  return StateType::of(fresh);
+}
+
+typename Model::StateType Model::evalEncrypt(
+    const LocalParamType &param) const {
+  auto usePublicKey = param.getSchemeParam()->getUsePublicKey();
+  auto isEncryptionTechniqueExtended =
+      param.getSchemeParam()->isEncryptionTechniqueExtended();
+  if (isEncryptionTechniqueExtended) {
+    // for extended encryption technique, namely encrypt at Qp then mod reduce
+    // back to Q, the noise is modreduce(encrypt)
+    return evalModReduce(param, evalEncryptPk(param));
+  }
+  if (usePublicKey) {
+    return evalEncryptPk(param);
+  }
+  return evalEncryptSk(param);
+}
+
+typename Model::StateType Model::evalConstant(
+    const LocalParamType &param) const {
+  auto t = param.getSchemeParam()->getPlaintextModulus();
+  auto phi = getPhi(param);
+
+  // noise part of the plaintext in a pt-ct multiplication
+  // v_const <= t * sqrt(phi(m) / 12)
+  return StateType::of(t * sqrt(phi / 12.0));
+}
+
+typename Model::StateType Model::evalAdd(const StateType &lhs,
+                                         const StateType &rhs) const {
+  // v_add <= v_0 + v_1
+  return lhs + rhs;
+}
+
+typename Model::StateType Model::evalMul(const LocalParamType &resultParam,
+                                         const StateType &lhs,
+                                         const StateType &rhs) const {
+  // for canonical embedding, ||e1 * e2||^can <= ||e1||^can * ||e2||^can
+  auto v0 = lhs;
+  auto v1 = rhs;
+  auto phi = getPhi(resultParam);
+  auto t = resultParam.getSchemeParam()->getPlaintextModulus();
+  auto logqi = resultParam.getSchemeParam()->getLogqi();
+  auto logQ = std::accumulate(logqi.begin(), logqi.end(), 0.0);
+  // we hope double is big enough...
+  // if logQ > 1024... we may have a problem
+  auto Q = pow(2.0, logQ);
+  auto d = getAssuranceFactor(resultParam);
+
+  // c0 + c1s = (Q/t)m + v + hQ
+  // h is the high term, and has form (c1s + c0 - (Q/t)m - v)/Q
+  // so its variance is (phi * Vkey + 4) / 12
+  // B_h = D * sqrt(phi(m)/12 * (4 + phi(m) * V_key)
+  auto varianceKey = getVarianceKey(resultParam);
+  double innerH = (phi / 12.) * (1 + phi * varianceKey);
+  auto bH = d * sqrt(innerH);
+
+  // The rounding error is ignorable
+  // Bscale could not be used here as it has the form
+  // delta0 + delta1 * s + delta2 * s^2
+
+  // See KPZ21
+  auto term1 = v0 * v1 * t * (1. / Q);
+  // See also BMCM23 Table 5
+  auto term2 = (v0 + v1) * t * bH;
+  return term1 + term2;
+}
+
+typename Model::StateType Model::evalModReduce(const LocalParamType &inputParam,
+                                               const StateType &input) const {
+  auto currentLogqi =
+      inputParam.getSchemeParam()->getLogqi()[inputParam.getCurrentLevel()];
+  double modulus = pow(2.0, currentLogqi);
+
+  // modulus switching is essentially a scaling operation
+  // so the original error is scaled by the modulus
+  // ||v_scaled|| = ||v_input|| / modulus
+  auto scaled = input * (1. / modulus);
+  // in the meantime, it will introduce a rounding error
+  // (tau_0, tau_1) to (ct_0, ct_1)
+  // ||tau_0 + tau_1 * s|| <= D * sqrt(phi(m)/12 * (1 + phi(m) * V_key) =
+  // B_scale
+  // ||v_ms|| <= ||v_scaled|| + B_scale
+  auto bScale = StateType::of(getBScale(inputParam));
+  return scaled + bScale;
+}
+
+typename Model::StateType Model::evalRelinearizeHYBRID(
+    const LocalParamType &inputParam, const StateType &input) const {
+  // assume HYBRID and noise is negligible
+  // compared with noise of multiplication
+  // TODO: assert this happens after multiplication
+  return input;
+}
+
+typename Model::StateType Model::evalRelinearize(
+    const LocalParamType &inputParam, const StateType &input) const {
+  // assume HYBRID
+  // if we further introduce BV to SchemeParam we can have alternative
+  // implementation.
+  return evalRelinearizeHYBRID(inputParam, input);
+}
+
+}  // namespace bfv
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h
@@ -1,0 +1,63 @@
+#ifndef INCLUDE_ANALYSIS_NOISEANALYSIS_BFV_NOISECANEMBMODEL_H_
+#define INCLUDE_ANALYSIS_NOISEANALYSIS_BFV_NOISECANEMBMODEL_H_
+
+#include <cassert>
+#include <string>
+
+#include "lib/Analysis/NoiseAnalysis/Noise.h"
+#include "lib/Parameters/BGV/Params.h"
+
+namespace mlir {
+namespace heir {
+namespace bfv {
+
+// canonical embedding noise model adapted
+// from MMLGA22 https://eprint.iacr.org/2022/706
+// from BMCM23 table 5 https://eprint.iacr.org/2023/600
+// and from BGV/NoiseCanEmbModel
+class NoiseCanEmbModel {
+ public:
+  // NoiseState stores the bound log2||e||^{can} for error e.
+  using StateType = NoiseState;
+  using SchemeParamType = bgv::SchemeParam;
+  using LocalParamType = bgv::LocalParam;
+
+ private:
+  double getVarianceErr(const LocalParamType &param) const;
+  double getVarianceKey(const LocalParamType &param) const;
+  double getBScale(const LocalParamType &param) const;
+  double getBKs(const LocalParamType &param) const;
+  double getAssuranceFactor(const LocalParamType &param) const;
+  double getPhi(const LocalParamType &param) const;
+  double getRingExpansionFactor(const LocalParamType &param) const;
+
+  StateType evalEncryptPk(const LocalParamType &param) const;
+  StateType evalEncryptSk(const LocalParamType &param) const;
+  StateType evalRelinearizeHYBRID(const LocalParamType &inputParam,
+                                  const StateType &input) const;
+
+ public:
+  StateType evalEncrypt(const LocalParamType &param) const;
+  StateType evalConstant(const LocalParamType &param) const;
+  StateType evalAdd(const StateType &lhs, const StateType &rhs) const;
+  StateType evalMul(const LocalParamType &resultParam, const StateType &lhs,
+                    const StateType &rhs) const;
+  StateType evalRelinearize(const LocalParamType &inputParam,
+                            const StateType &input) const;
+  StateType evalModReduce(const LocalParamType &inputParam,
+                          const StateType &input) const;
+
+  // logTotal: log(Ql / 2)
+  // logBound: bound on ||m + t * e|| predicted by the model
+  // logBudget: logTotal - logBound
+  // as ||m + t * e|| < Ql / 2 for correct decryption
+  double toLogBound(const LocalParamType &param, const StateType &noise) const;
+  double toLogBudget(const LocalParamType &param, const StateType &noise) const;
+  double toLogTotal(const LocalParamType &param) const;
+};
+
+}  // namespace bfv
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // INCLUDE_ANALYSIS_NOISEANALYSIS_BFV_NOISECANEMBMODEL_H_

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
@@ -36,6 +36,10 @@ void NoiseAnalysis<NoiseModel>::setToEntryState(LatticeType *lattice) {
                                      getDimensionFromMgmtAttr(value));
     NoiseState encrypted = noiseModel.evalEncrypt(localParam);
     this->propagateIfChanged(lattice, lattice->join(encrypted));
+    LLVM_DEBUG(llvm::dbgs() << "Initializing "
+                            << doubleToString2Prec(
+                                   noiseModel.toLogBound(localParam, encrypted))
+                            << " to " << value << "\n");
     return;
   }
 

--- a/lib/Transforms/GenerateParam/BUILD
+++ b/lib/Transforms/GenerateParam/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis:Noise",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseCanEmbModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",

--- a/lib/Transforms/GenerateParam/GenerateParam.td
+++ b/lib/Transforms/GenerateParam/GenerateParam.td
@@ -90,10 +90,11 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
   let description = [{
     The pass generates the BFV scheme parameter using a given noise model.
 
-    There are three noise models available:
+    There are four noise models available:
     - `bfv-noise-by-bound-coeff-average-case`
     - `bfv-noise-by-bound-coeff-worst-case` or `bfv-noise-kpz21`
     - `bfv-noise-by-variance-coeff` or `bfv-noise-bmcm23`
+    - `bfv-noise-canon-emb`
 
     To use public-key encryption/secret-key encryption in the model, the option
     `usePublicKey` could be set accordingly.
@@ -108,6 +109,10 @@ def GenerateParamBFV : Pass<"generate-param-bfv"> {
     of the coefficient embedding of the ciphertexts. This gives a much tighter
     noise estimate for independent ciphertext input, but may give underestimation
     for dependent ciphertext input. See [the paper](https://ia.cr/2023/600) for more details.
+
+    The last model is adapted from MMLGA22 with mixes from BMCM23 and KPZ21.
+    It uses the canonical embedding to bound the critical quantity of a ciphertext
+    that defines whether c can be decrypted correctly.
 
     This pass then generates the moduli chain consisting of primes
     of bits specified by the `mod-bits` field.

--- a/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
@@ -7,6 +7,7 @@
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/Noise.h"
 #include "lib/Analysis/NoiseAnalysis/NoiseAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
@@ -201,6 +202,9 @@ struct GenerateParamBFV : impl::GenerateParamBFVBase<GenerateParamBFV> {
                model == "bfv-noise-bmcm23") {
       bfv::NoiseByVarianceCoeffModel model;
       run<bfv::NoiseByVarianceCoeffModel>(model);
+    } else if (model == "bfv-noise-canon-emb") {
+      bfv::NoiseCanEmbModel model;
+      run<bfv::NoiseCanEmbModel>(model);
     } else {
       getOperation()->emitWarning() << "Unknown noise model.\n";
       generateFallbackParam();

--- a/lib/Transforms/ValidateNoise/BUILD
+++ b/lib/Transforms/ValidateNoise/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "@heir//lib/Analysis/NoiseAnalysis:Noise",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseByVarianceCoeffModel",
+        "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseCanEmbModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByBoundCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseByVarianceCoeffModel",
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseCanEmbModel",

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -6,6 +6,7 @@
 #include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BFV/NoiseByVarianceCoeffModel.h"
+#include "lib/Analysis/NoiseAnalysis/BFV/NoiseCanEmbModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseByVarianceCoeffModel.h"
 #include "lib/Analysis/NoiseAnalysis/BGV/NoiseCanEmbModel.h"
@@ -204,6 +205,9 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
                model == "bfv-noise-bmcm23") {
       bfv::NoiseByVarianceCoeffModel model;
       run<bfv::NoiseByVarianceCoeffModel>(model);
+    } else if (model == "bfv-noise-canon-emb") {
+      bfv::NoiseCanEmbModel model;
+      run<bfv::NoiseCanEmbModel>(model);
     } else {
       getOperation()->emitOpError() << "Unknown noise model.\n";
       signalPassFailure();


### PR DESCRIPTION
This PR adds a noise model for BFV using canonical embedding model. It is similar to the BGV one.