### PR TITLE
allow skipping arithmetization (and, therefore, packing) pipeline

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -194,7 +194,16 @@ void mlirToPlaintextPipelineBuilder(OpPassManager &pm,
 void mlirToRLWEPipeline(OpPassManager &pm,
                         const MlirToRLWEPipelineOptions &options,
                         const RLWEScheme scheme) {
-  mlirToSecretArithmeticPipelineBuilder(pm, options);
+  if (options.enableArithmetization) {
+    mlirToSecretArithmeticPipelineBuilder(pm, options);
+  } else {
+    // Replicate the non-arithmetization related parts of the pipeline
+    pm.addPass(createWrapGeneric());
+    AddClientInterfaceOptions addClientInterfaceOptions;
+    addClientInterfaceOptions.ciphertextSize = options.ciphertextDegree;
+    addClientInterfaceOptions.enableLayoutAssignment = false;
+    pm.addPass(createAddClientInterface(addClientInterfaceOptions));
+  }
 
   // Only for debugging purpose.
   if (!options.plaintextExecutionResultFileName.empty()) {

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -28,6 +28,12 @@ void heirSIMDVectorizerPipelineBuilder(OpPassManager &manager,
                                        bool disableLoopUnroll);
 
 struct MlirToRLWEPipelineOptions : public SimdVectorizerOptions {
+  PassOptions::Option<bool> enableArithmetization{
+      *this, "enable-arithmetization",
+      llvm::cl::desc(
+          "If false, skip the arithmetization pipeline and try to directly "
+          "lower to RLWE scheme (default to true)"),
+      llvm::cl::init(true)};
   PassOptions::Option<int> ciphertextDegree{
       *this, "ciphertext-degree",
       llvm::cl::desc("The degree of the polynomials to use for ciphertexts; "

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -38,7 +38,8 @@ namespace openfhe {
 ::mlir::LogicalResult translateToOpenFhePke(::mlir::Operation *op,
                                             llvm::raw_ostream &os,
                                             const OpenfheImportType &importType,
-                                            const std::string &weightsFile);
+                                            const std::string &weightsFile,
+                                            bool skipVectorResizing);
 
 // A map from the SSA value name of a 1-D dense element constants to its value.
 // Note that multidimensional shapes are handled as flattened 1-D vectors.
@@ -61,7 +62,7 @@ class OpenFhePkeEmitter {
  public:
   OpenFhePkeEmitter(raw_ostream &os, SelectVariableNames *variableNames,
                     const OpenfheImportType &importType,
-                    const std::string &weightsFile);
+                    const std::string &weightsFile, bool skipVectorResizing);
 
   LogicalResult translate(::mlir::Operation &operation);
 
@@ -82,6 +83,9 @@ class OpenFhePkeEmitter {
   Weights weightsMap_;
 
   const std::string &weightsFile_;
+
+  // Whether to skip resizing vectors to ring dimension / 2
+  bool skipVectorResizing_;
 
   // Functions for printing individual ops
   LogicalResult printOperation(::mlir::ModuleOp op);

--- a/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
+++ b/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
@@ -51,6 +51,12 @@ struct TranslateOptions {
   llvm::cl::opt<std::string> weightsFile{
       "weights-file",
       llvm::cl::desc("Emit all dense elements attributes to this binary file")};
+  llvm::cl::opt<bool> skipVectorResizing{
+      "skip-vector-resizing",
+      llvm::cl::desc("Skip resizing vectors to ringdimension/2 when emitting "
+                     "OpenFHE PKE code, i.e., assume the dimensions in the "
+                     "input IR are correct already."),
+      llvm::cl::init(false)};
 };
 static llvm::ManagedStatic<TranslateOptions> options;
 
@@ -78,7 +84,8 @@ void registerToOpenFhePkeTranslation() {
       "translate the openfhe dialect to C++ code against the OpenFHE pke API",
       [](Operation *op, llvm::raw_ostream &output) {
         return translateToOpenFhePke(op, output, options->openfheImportType,
-                                     options->weightsFile);
+                                     options->weightsFile,
+                                     options->skipVectorResizing);
       },
       [](DialectRegistry &registry) {
         registry.insert<arith::ArithDialect, func::FuncDialect,

--- a/lib/Transforms/AddClientInterface/AddClientInterface.td
+++ b/lib/Transforms/AddClientInterface/AddClientInterface.td
@@ -16,7 +16,7 @@ def AddClientInterface : Pass<"add-client-interface"> {
   backends like the plaintext backend don't actually encrypt, but still require
   the ciphertext layout/packing logic to convert cleartexts to plaintexts.
   }];
-  let dependentDialects = ["mlir::heir::secret::SecretDialect"];
+  let dependentDialects = ["mlir::heir::secret::SecretDialect", "mlir::heir::tensor_ext::TensorExtDialect"];
 
   let options = [
     Option<
@@ -25,6 +25,13 @@ def AddClientInterface : Pass<"add-client-interface"> {
       "int",
       /*default=*/"1024",
       "Power of two length of the ciphertexts the data is packed in."
+    >,
+    Option<
+      "enableLayoutAssignment",
+      "enable-layout-assignment",
+      "bool",
+      /*default=*/"true",
+      "If false, skips the emission of layout assignment operations, essentially assuming that the input was already using correctly (ciphertext-)sized tensors."
     >
   ];
 }

--- a/tests/Dialect/Openfhe/Emitters/emit_client_interface.mlir
+++ b/tests/Dialect/Openfhe/Emitters/emit_client_interface.mlir
@@ -1,0 +1,85 @@
+// RUN: heir-translate %s --emit-openfhe-pke --skip-vector-resizing=false  | FileCheck %s --check-prefix=CHECK --check-prefix=RESIZE
+// RUN: heir-translate %s --emit-openfhe-pke --skip-vector-resizing=true | FileCheck %s --check-prefix=CHECK --check-prefix=NO-RESIZE
+
+
+!Z36028797019389953_i64 = !mod_arith.int<36028797019389953 : i64>
+!cc = !openfhe.crypto_context
+!params = !openfhe.cc_params
+!pk = !openfhe.public_key
+!sk = !openfhe.private_key
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 45>
+#key = #lwe.key<>
+#modulus_chain_L0_C0 = #lwe.modulus_chain<elements = <36028797019389953 : i64>, current = 0>
+#ring_f64_1_x1024 = #polynomial.ring<coefficientType = f64, polynomialModulus = <1 + x**1024>>
+!rns_L0 = !rns.rns<!Z36028797019389953_i64>
+!pt = !lwe.new_lwe_plaintext<application_data = <message_type = tensor<1024xf32>>, plaintext_space = <ring = #ring_f64_1_x1024, encoding = #inverse_canonical_encoding>>
+#ring_rns_L0_1_x1024 = #polynomial.ring<coefficientType = !rns_L0, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L0 = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024, encryption_type = mix>
+!ct_L0 = !lwe.new_lwe_ciphertext<application_data = <message_type = tensor<1024xf32>>, plaintext_space = <ring = #ring_f64_1_x1024, encoding = #inverse_canonical_encoding>, ciphertext_space = #ciphertext_space_L0, key = #key, modulus_chain = #modulus_chain_L0_C0>
+module attributes {scheme.ckks} {
+
+  // CHECK: CiphertextT foo(CryptoContextT cc, CiphertextT ct)
+  func.func @foo(%cc: !cc, %ct: !ct_L0) -> !ct_L0 {
+    return %ct : !ct_L0
+  }
+
+  // CHECK: CiphertextT foo__encrypt__arg0(CryptoContextT cc, std::vector<float> v0, PublicKeyT pk)
+  func.func @foo__encrypt__arg0(%cc: !cc, %arg0: tensor<1024xf32>, %pk: !pk) -> !ct_L0 attributes {client.enc_func = {func_name = "foo", index = 0 : i64}} {
+    //CHECK: std::vector<double> v1(std::begin(v0), std::end(v0));
+    %0 = arith.extf %arg0 : tensor<1024xf32> to tensor<1024xf64>
+
+    //RESIZE: auto pt_filled_n = cc->GetCryptoParameters()->GetElementParams()->GetRingDimension() / 2;
+    //RESIZE: auto pt_filled = v1;
+    //RESIZE: pt_filled.clear();
+    //RESIZE: pt_filled.reserve(pt_filled_n);
+    //RESIZE: for (auto i = 0; i < pt_filled_n; ++i) {
+    //RESIZE:   pt_filled.push_back(v1[i % v1.size()]);
+    //RESIZE: }
+    //NO-RESIZE-NOT: auto pt_filled
+
+    //RESIZE: const auto& pt = cc->MakeCKKSPackedPlaintext(pt_filled);
+    //NO-RESIZE: const auto& pt = cc->MakeCKKSPackedPlaintext(v1);
+    %pt = openfhe.make_ckks_packed_plaintext %cc, %0 : (!cc, tensor<1024xf64>) -> !pt
+
+    //CHECK: const auto& ct = cc->Encrypt(pk, pt
+    %ct = openfhe.encrypt %cc, %pt, %pk : (!cc, !pt, !pk) -> !ct_L0
+
+    // CHECK: return ct;
+    return %ct : !ct_L0
+  }
+
+  // CHECK: std::vector<float> foo__decrypt__result0(CryptoContextT cc, CiphertextT ct, PrivateKeyT sk)
+  func.func @foo__decrypt__result0(%cc: !cc, %ct: !ct_L0, %sk: !sk) -> tensor<1024xf32> attributes {client.dec_func = {func_name = "foo", index = 0 : i64}} {
+    // CHECK: PlaintextT pt;
+    // CHECK: cc->Decrypt(sk, ct, &pt);
+    %pt = openfhe.decrypt %cc, %ct, %sk : (!cc, !ct_L0, !sk) -> !pt
+    // CHECK: pt->SetLength(1024);
+    // CHECK: const auto& v0_cast = pt->GetCKKSPackedValue();
+    // CHECK: std::vector<float> v0(v0_cast.size());
+    // CHECK: std::transform(std::begin(v0_cast), std::end(v0_cast), std::begin(v0), [](const std::complex<double>& c) { return c.real(); });
+    %0 = lwe.rlwe_decode %pt {encoding = #inverse_canonical_encoding, ring = #ring_f64_1_x1024} : !pt -> tensor<1024xf32>
+    // CHECK: return v0;
+    return %0 : tensor<1024xf32>
+  }
+
+  // CHECK: CryptoContextT foo__generate_crypto_context()
+  func.func @foo__generate_crypto_context() -> !cc {
+    // CHECK: CCParamsT params;
+    // CHECK: params.SetMultiplicativeDepth(1);
+    // CHECK: params.SetKeySwitchTechnique(HYBRID);
+    %params = openfhe.gen_params  {mulDepth = 1 : i64, plainMod = 0 : i64} : () -> !params
+    // CHECK: CryptoContextT cc = GenCryptoContext(params);
+    // CHECK: cc->Enable(PKE);
+    // CHECK: cc->Enable(KEYSWITCH);
+    // CHECK: cc->Enable(LEVELEDSHE);
+    %cc = openfhe.gen_context %params {supportFHE = false} : (!params) -> !cc
+    // CHECK: return cc;
+    return %cc : !cc
+  }
+
+  // CHECK: CryptoContextT foo__configure_crypto_context(CryptoContextT cc, PrivateKeyT sk)
+  func.func @foo__configure_crypto_context(%cc: !cc, %sk: !sk) -> !cc {
+    // CHECK: return cc;
+    return %cc : !cc
+  }
+}

--- a/tests/Examples/openfhe/ckks/custom_arithmetization/BUILD
+++ b/tests/Examples/openfhe/ckks/custom_arithmetization/BUILD
@@ -1,0 +1,19 @@
+# See README.md for setup required to run these tests
+
+load("@heir//tests/Examples/openfhe:test.bzl", "openfhe_end_to_end_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+openfhe_end_to_end_test(
+    name = "custom_arithmetization_test",
+    generated_lib_header = "custom_arithmetization_lib.h",
+    heir_opt_flags = [
+        "--annotate-module=backend=openfhe scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=16 enable-arithmetization=false",
+        "--scheme-to-openfhe",
+    ],
+    heir_translate_flags = [],
+    mlir_src = "@heir//tests/Examples/openfhe/ckks/custom_arithmetization:custom_arithmetization.mlir",
+    tags = ["notap"],
+    test_src = "custom_arithmetization_test.cpp",
+)

--- a/tests/Examples/openfhe/ckks/custom_arithmetization/custom_arithmetization.mlir
+++ b/tests/Examples/openfhe/ckks/custom_arithmetization/custom_arithmetization.mlir
@@ -1,0 +1,14 @@
+func.func @matmul(%arg0: tensor<16xf32> {secret.secret}, %arg1: tensor<16xf32>, %arg2: tensor<16xf32>, %arg3: tensor<16xf32>, %arg4: tensor<16xf32>) -> tensor<16xf32> {
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  %0 = arith.mulf %arg0, %arg1 : tensor<16xf32>
+  %1 = tensor_ext.rotate %arg0, %c4 : tensor<16xf32>, index
+  %2 = arith.mulf %1, %arg2 : tensor<16xf32>
+  %3 = arith.addf %0, %2 : tensor<16xf32>
+  %4 = arith.mulf %arg0, %arg3 : tensor<16xf32>
+  %5 = arith.mulf %1, %arg4 : tensor<16xf32>
+  %6 = arith.addf %4, %5 : tensor<16xf32>
+  %7 = tensor_ext.rotate %6, %c8 : tensor<16xf32>, index
+  %8 = arith.addf %3, %7 : tensor<16xf32>
+  return %8 : tensor<16xf32>
+}

--- a/tests/Examples/openfhe/ckks/custom_arithmetization/custom_arithmetization_test.cpp
+++ b/tests/Examples/openfhe/ckks/custom_arithmetization/custom_arithmetization_test.cpp
@@ -1,0 +1,85 @@
+#include <vector>
+
+#include "gtest/gtest.h"  // from @googletest
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/ckks/custom_arithmetization/custom_arithmetization_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(CustomArithmetizationTest, RunTest) {
+  auto cryptoContext = matmul__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext = matmul__configure_crypto_context(cryptoContext, secretKey);
+
+  // ct is a [4,4] input matrix that is packed column-wise
+  // [
+  //  [0 1 2 3]
+  //  [4 5 6 7]
+  //  [8 9 10 11]
+  //  [12 13 14 15]
+  // ]
+  // =>
+  // [0 4 8 12 1 5 9 13 2 6 10 14 3 7 11 15]
+  std::vector<float> m;
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      m.push_back((float)(j * 4 + i));
+    }
+  }
+
+  // pt is a [4,4] input matrix that is packed in repeated diagonals
+  // [
+  //  [0 1 2 3]
+  //  [4 5 6 7]
+  //  [8 9 10 11]
+  //  [12 13 14 15]
+  // ]
+  // =>
+  // d0:[0 0 0 0 5 5 5 5 10 10 10 10 15 15 15 15]
+  // d1:[4 4 4 4 9 9 9 9 13 13 13 13 3 3 3 3 3]
+  std::vector<float> d0 = {0.0,  0.0,  0.0,  0.0,  5.0,  5.0,  5.0,  5.0,
+                           10.0, 10.0, 10.0, 10.0, 15.0, 15.0, 15.0, 15.0};
+  std::vector<float> d1 = {4.0,  4.0,  4.0,  4.0,  9.0, 9.0, 9.0, 9.0,
+                           14.0, 14.0, 14.0, 14.0, 3.0, 3.0, 3.0, 3.0};
+
+  // rotated by 8 for baby-step giant-step
+  // d2:[2 2 2 2 7 7 7 7 8 8 8 8 13 13 13 13]
+  // d3:[6 6 6 6 11 11 11 11 12 12 12 12 1 1 1 1]
+  std::vector<float> d2 = {2.0, 2.0, 2.0, 2.0, 7.0,  7.0,  7.0,  7.0,
+                           8.0, 8.0, 8.0, 8.0, 13.0, 13.0, 13.0, 13.0};
+  std::vector<float> d3 = {6.0,  6.0,  6.0,  6.0,  11.0, 11.0, 11.0, 11.0,
+                           12.0, 12.0, 12.0, 12.0, 1.0,  1.0,  1.0,  1.0};
+
+  // expected is the result of the matrix multiplication packed column-wise
+  // [
+  //  [ 56  62  68  74]
+  //  [152 174 196 218]
+  //  [248 286 324 362]
+  //  [344 398 452 506]
+  // ]
+  std::vector<float> expected = {56.0,  152.0, 248.0, 344.0, 62.0,  174.0,
+                                 286.0, 398.0, 68.0,  196.0, 324.0, 452.0,
+                                 74.0,  218.0, 362.0, 506.0};
+
+  auto ctEncrypted = matmul__encrypt__arg0(cryptoContext, m, keyPair.publicKey);
+
+  auto result = matmul(cryptoContext, ctEncrypted, d0, d1, d2, d3);
+
+  auto actual =
+      matmul__decrypt__result0(cryptoContext, result, keyPair.secretKey);
+
+  ASSERT_EQ(actual.size(), expected.size());
+
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_NEAR(expected[i], actual[i], 1e-3);
+  }
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/Regression/issue_1919.mlir
+++ b/tests/Regression/issue_1919.mlir
@@ -1,0 +1,23 @@
+// RUN: heir-opt %s "--mlir-to-bgv=enable-arithmetization=false" | FileCheck %s
+
+// A program that does not require any kind of arithmetization (i.e., already consists purely of operations that we can lower directly to FHE)
+// should be able to be lowered to FHE successfully without running the arithmetization stage.
+
+// CHECK: @foo
+func.func @foo(%x: tensor<1024xi16> {secret.secret}, %y: tensor<1024xi16> {secret.secret}) -> tensor<1024xi16> {
+    // CHECK: bgv.add
+    %add = arith.addi %x, %y : tensor<1024xi16>
+    // CHECK: bgv.sub
+    %sub = arith.subi %x, %y : tensor<1024xi16>
+    // CHECK: bgv.mul
+    %mul = arith.muli %add, %sub : tensor<1024xi16>
+    return %mul : tensor<1024xi16>
+}
+
+// CHECK: @foo__encrypt__
+// CHECK-NOT: affine.for
+// CHECK-NOT: tensor.extract
+
+// CHECK: @foo__decrypt__
+// CHECK-NOT: affine.for
+// CHECK-NOT: tensor.insert


### PR DESCRIPTION
Work towards
* #1919 

As a a first step, I added a `skip-arithmetization` flag to `--mlir-to-<bgv/ckks>` to skip the entire `--mlir-to-secret-arithmetic` pipeline. However, this runs into two issues

1. The compiler just crashes with 
```heir-opt: lib/Analysis/NoiseAnalysis/Noise.cpp:30: NoiseState mlir::heir::NoiseState::operator+(const NoiseState &) const: Assertion `isKnown() && rhs.isKnown()' failed``` so it seems like there's some noise-analysis initialization happening in the arithmetization pipeline that we're missing? @ZenithalHourlyRate ?

2. Currently, the generation of (the MLIR version of) the client-side functions (encrypt/decrypt/etc) happens at the end of the arithmetization phase, but in most cases we'll still need those. That should be simple to fix with another flag, though.
