### PR TITLE
Revert "Openfhe: CKKS: Avoid MulDepth of 0"

### DIFF
--- a/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.cpp
@@ -284,11 +284,6 @@ struct ConfigureCryptoContext
       config.mulDepth += bootstrapDepth;
     }
 
-    // OpenFHE CKKS with mulDepth 0 has bug, set it to 1
-    if (config.mulDepth == 0 && moduleIsCKKS(module)) {
-      config.mulDepth = 1;
-    }
-
     // pass option could override mulDepth
     if (mulDepth != 0) {
       config.mulDepth = mulDepth;


### PR DESCRIPTION
After #1905, CKKS with muldepth of 0 in OpenFHE should not contain bug.

> An update on CKKS multiplicativeDepth = 0, after updating openfhe to v1.3 (we used to have v1.1.4), this problem should be resolved as the default scaling mod size becomes 50. The fix is [here](https://github.com/openfheorg/openfhe-development/commit/2589b2cae0612d3f0613c9e65a34c65222ccfd71#diff-d8f4230f48ebe243fd05d74577e6d4c90ec228441b13b0cbfb556c4d981b7031R62) introduced in v1.2

Though we indeed need range analysis for CKKS, as the firstModSize of 60 and scalingModSize of 50 only allow the input up to 2^{10} (roughly sense, need to consider encoding), if the user want to compute 10000 + 10000, the default parameter may fail.