### PR TITLE
Refactor Log2Arithmetic into standalone file

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BUILD
+++ b/lib/Analysis/NoiseAnalysis/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "Noise.h",
     ],
     deps = [
+        "@heir//lib/Utils:LogArithmetic",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
     ],

--- a/lib/Analysis/NoiseAnalysis/Noise.cpp
+++ b/lib/Analysis/NoiseAnalysis/Noise.cpp
@@ -29,44 +29,19 @@ std::string NoiseState::toString() const {
 NoiseState NoiseState::operator+(const NoiseState &rhs) const {
   assert(isKnown() && rhs.isKnown());
 
+  auto value = getLog2Arithmetic() + rhs.getLog2Arithmetic();
   auto degree = std::max(getDegree(), rhs.getDegree());
 
-  // give sum of two log value
-  double log2a = getValue();
-  double log2b = rhs.getValue();
-  // make a >= b
-  if (log2b > log2a) {
-    std::swap(log2a, log2b);
-  }
-  // if a >>> b, do not call std::exp2 to avoid overflow
-  if (log2b == NEGATIVE_INFINITY || log2a - log2b > 512.0) {
-    return NoiseState(NoiseType::SET, log2a, degree);
-  }
-  // log2(a + b) = log2(a) + log2(1 + pow(2, (log2(b) - log2(a))))
-  // More numerically stable than direct computation
-  double log2Sum;
-  if (log2a == log2b) {
-    // Special case when equal: log2(2a) = 1 + log2a
-    log2Sum = 1.0 + log2a;
-  } else {
-    double exponent = log2b - log2a;
-    // For small exponents, use more accurate approximation
-    log2Sum = log2a + std::log1p(std::exp2(exponent)) / std::log(2);
-  }
-  return NoiseState(NoiseType::SET, log2Sum, degree);
+  return NoiseState(NoiseType::SET, value, degree);
 }
 
 NoiseState NoiseState::operator*(const NoiseState &rhs) const {
   assert(isKnown() && rhs.isKnown());
 
+  auto value = getLog2Arithmetic() * rhs.getLog2Arithmetic();
   auto degree = std::max(getDegree(), rhs.getDegree());
 
-  // give product of two log value
-  auto log2a = getValue();
-  auto log2b = rhs.getValue();
-  // log2(a * b) = log2(a) + log2(b)
-  // this works for negative infinity
-  return NoiseState(NoiseType::SET, log2a + log2b, degree);
+  return NoiseState(NoiseType::SET, value, degree);
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const NoiseState &noise) {

--- a/lib/Analysis/NoiseAnalysis/Noise.h
+++ b/lib/Analysis/NoiseAnalysis/Noise.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 
+#include "lib/Utils/LogArithmetic.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"       // from @llvm-project
 
@@ -39,21 +40,20 @@ class NoiseState {
   static NoiseState uninitialized() {
     return NoiseState(NoiseType::UNINITIALIZED, std::nullopt);
   }
+  /// value in normal scale
   static NoiseState of(double value) {
     return NoiseState::of(value, /*degree*/ 0);
   }
+  /// value in normal scale
   static NoiseState of(double value, int degree) {
-    if (value == 0.0) {
-      return NoiseState(NoiseType::SET, NEGATIVE_INFINITY, degree);
-    }
-    return NoiseState(NoiseType::SET, log2(value), degree);
+    return NoiseState(NoiseType::SET, Log2Arithmetic::of(value), degree);
   }
 
   /// Create an integer value range lattice value.
   /// The default constructor must be equivalent to the "entry state" of the
   /// lattice, i.e., an uninitialized noise.
   NoiseState(NoiseType noiseType = NoiseType::UNINITIALIZED,
-             std::optional<double> value = std::nullopt, int degree = 0)
+             std::optional<Log2Arithmetic> value = std::nullopt, int degree = 0)
       : noiseType(noiseType), value(value), degree(degree) {}
 
   bool isKnown() const { return noiseType == NoiseType::SET; }
@@ -61,7 +61,12 @@ class NoiseState {
   bool isInitialized() const { return noiseType != NoiseType::UNINITIALIZED; }
 
   // this returns log2(e) instead of e, use with caution
-  const double &getValue() const {
+  double getValue() const {
+    assert(isKnown());
+    return value->getLog2Value();
+  }
+
+  Log2Arithmetic getLog2Arithmetic() const {
     assert(isKnown());
     return *value;
   }
@@ -115,11 +120,13 @@ class NoiseState {
     }
 
     assert(lhs.noiseType == NoiseType::SET && rhs.noiseType == NoiseType::SET);
-    return NoiseState(NoiseType::SET, std::max(lhs.getValue(), rhs.getValue()),
-                      std::max(lhs.getDegree(), rhs.getDegree()));
+    return NoiseState(
+        NoiseType::SET,
+        std::max(lhs.getLog2Arithmetic(), rhs.getLog2Arithmetic()),
+        std::max(lhs.getDegree(), rhs.getDegree()));
   }
 
-  void print(llvm::raw_ostream &os) const { os << value; }
+  void print(llvm::raw_ostream &os) const { os << toString(); }
 
   std::string toString() const;
 
@@ -135,13 +142,9 @@ class NoiseState {
   // 3523 bits and could not be represented in double.
   // To mitigate such problem we store log2(Noise) as only the order of
   // magnititude is important
-  std::optional<double> value;
+  std::optional<Log2Arithmetic> value;
   // for some analysis a degree is tracked
   int degree;
-
-  // value may be negative infinity
-  static constexpr double NEGATIVE_INFINITY =
-      -std::numeric_limits<double>::infinity();
 };
 
 }  // namespace heir

--- a/lib/Utils/BUILD
+++ b/lib/Utils/BUILD
@@ -142,6 +142,21 @@ cc_library(
 )
 
 cc_library(
+    name = "LogArithmetic",
+    srcs = ["LogArithmetic.cpp"],
+    hdrs = ["LogArithmetic.h"],
+)
+
+cc_test(
+    name = "LogArithmeticTest",
+    srcs = ["LogArithmeticTest.cpp"],
+    deps = [
+        ":LogArithmetic",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "TargetUtils",
     srcs = ["TargetUtils.cpp"],
     hdrs = ["TargetUtils.h"],

--- a/lib/Utils/LogArithmetic.cpp
+++ b/lib/Utils/LogArithmetic.cpp
@@ -1,0 +1,44 @@
+#include "lib/Utils/LogArithmetic.h"
+
+namespace mlir {
+namespace heir {
+
+Log2Arithmetic Log2Arithmetic::operator+(const Log2Arithmetic &rhs) const {
+  // give sum of two log value
+  double log2a = getLog2Value();
+  double log2b = rhs.getLog2Value();
+  // make a >= b
+  if (log2b > log2a) {
+    std::swap(log2a, log2b);
+  }
+  // if a >>> b, do not call std::exp2 to avoid overflow
+  if (log2b == NEGATIVE_INFINITY || log2a - log2b > 512.0) {
+    // Use internal constructor to avoid confusion with double
+    return Log2Arithmetic(log2a);
+  }
+  // log2(a + b) = log2(a) + log2(1 + pow(2, (log2(b) - log2(a))))
+  // More numerically stable than direct computation
+  double log2Sum;
+  if (log2a == log2b) {
+    // Special case when equal: log2(2a) = 1 + log2a
+    log2Sum = 1.0 + log2a;
+  } else {
+    double exponent = log2b - log2a;
+    // For small exponents, use more accurate approximation
+    log2Sum = log2a + std::log1p(std::exp2(exponent)) / std::log(2);
+  }
+  // Use internal constructor to avoid confusion with double
+  return Log2Arithmetic(log2Sum);
+}
+
+Log2Arithmetic Log2Arithmetic::operator*(const Log2Arithmetic &rhs) const {
+  // give product of two log value
+  auto log2a = getLog2Value();
+  auto log2b = rhs.getLog2Value();
+  // log2(a * b) = log2(a) + log2(b)
+  // this works for negative infinity
+  return Log2Arithmetic(log2a + log2b);
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/LogArithmetic.h
+++ b/lib/Utils/LogArithmetic.h
@@ -1,0 +1,72 @@
+#ifndef LIB_UTILS_LOGARITHMETIC_H_
+#define LIB_UTILS_LOGARITHMETIC_H_
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace mlir {
+namespace heir {
+
+class Log2Arithmetic {
+ public:
+  /// User-facing constructor that creates a Log2Arithmetic instance
+  /// from a double value.
+  static Log2Arithmetic of(double value) {
+    double log2value;
+    if (value == 0.0) {
+      log2value = NEGATIVE_INFINITY;
+    } else {
+      log2value = std::log2(value);
+    }
+    return Log2Arithmetic(log2value);
+  }
+
+  Log2Arithmetic() : log2value(NEGATIVE_INFINITY) {}
+
+  Log2Arithmetic operator+(const Log2Arithmetic &rhs) const;
+
+  Log2Arithmetic operator*(const Log2Arithmetic &rhs) const;
+
+  bool operator==(const Log2Arithmetic &rhs) const {
+    return log2value == rhs.log2value;
+  }
+
+  bool operator<(const Log2Arithmetic &rhs) const {
+    if (log2value == NEGATIVE_INFINITY) {
+      return rhs.log2value != NEGATIVE_INFINITY;
+    }
+    if (rhs.log2value == NEGATIVE_INFINITY) {
+      return false;  // this.log2value > NEGATIVE_INFINITY
+    }
+    return log2value < rhs.log2value;
+  }
+
+  /// Returns the storage value of this Log2Arithmetic instance.
+  double getLog2Value() const { return log2value; }
+
+  /// Caution: This may overflow if the value is too large.
+  double getValue() const {
+    if (log2value == NEGATIVE_INFINITY) {
+      return 0.0;
+    }
+    return std::exp2(log2value);
+  }
+
+ private:
+  /// Internal constructor that initializes the Log2Arithmetic instance
+  /// with a precomputed log2 value.
+  /// This is used internally to prevent user mixing up the semantics of
+  /// Log2Arithmetic and double.
+  Log2Arithmetic(double log2value) : log2value(log2value) {}
+
+  // value may be negative infinity
+  static constexpr double NEGATIVE_INFINITY =
+      -std::numeric_limits<double>::infinity();
+  double log2value;
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_UTILS_LOGARITHMETIC_H_

--- a/lib/Utils/LogArithmeticTest.cpp
+++ b/lib/Utils/LogArithmeticTest.cpp
@@ -1,0 +1,70 @@
+#include <cmath>
+#include <iomanip>
+#include <ios>
+#include <sstream>
+#include <string>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Utils/LogArithmetic.h"
+
+namespace mlir {
+namespace heir {
+namespace {
+
+TEST(ArithmeticDagTest, TestStorage) {
+  auto zero = Log2Arithmetic::of(0.0);
+  // Check the storage value
+  EXPECT_EQ(zero.getLog2Value(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(zero.getValue(), 0.0);
+
+  auto one = Log2Arithmetic::of(1.0);
+  // Check the storage value
+  EXPECT_EQ(one.getLog2Value(), 0.0);
+  EXPECT_EQ(one.getValue(), 1.0);
+}
+
+TEST(ArithmeticDagTest, TestZeroArith) {
+  auto zero = Log2Arithmetic::of(0.0);
+  EXPECT_EQ(zero + zero, zero);
+  EXPECT_EQ(zero * zero, zero);
+}
+
+TEST(ArithmeticDagTest, TestOneArith) {
+  auto zero = Log2Arithmetic::of(0.0);
+  auto one = Log2Arithmetic::of(1.0);
+  auto two = Log2Arithmetic::of(2.0);
+  EXPECT_EQ(zero + one, one);
+  EXPECT_EQ(zero * one, zero);
+  EXPECT_EQ(one + one, two);
+  EXPECT_EQ(one * one, one);
+}
+
+TEST(ArithmeticDagTest, TestLargeArith) {
+  auto l512 = Log2Arithmetic::of(std::pow(2, 512));
+  // Check the storage value
+  EXPECT_EQ((l512 * l512 * l512 * l512).getLog2Value(), 2048.0);
+  EXPECT_EQ((l512 + l512 + l512 + l512).getLog2Value(), 514.0);
+}
+
+TEST(ArithmeticDagTest, TestNearZeroArith) {
+  auto l512 = Log2Arithmetic::of(std::pow(2, -512));
+  // Check the storage value
+  EXPECT_EQ((l512 * l512 * l512 * l512).getLog2Value(), -2048.0);
+  EXPECT_EQ((l512 + l512 + l512 + l512).getLog2Value(), -510.0);
+}
+
+TEST(ArithmeticDagTest, TestZeroCompareOne) {
+  auto zero = Log2Arithmetic::of(0.0);
+  auto one = Log2Arithmetic::of(1.0);
+  EXPECT_LT(zero, one);
+  EXPECT_FALSE(one < zero);
+}
+
+TEST(ArithmeticDagTest, TestZeroCompareZero) {
+  auto zero = Log2Arithmetic::of(0.0);
+  EXPECT_FALSE(zero < zero);
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
This PR refactors the arithmetic in log scale code in `Noise.h` into a standalone file so that others can benefit from it, e.g. CKKS Range Analysis which also needs to record the range in log scale.