### PR TITLE
include abc/yosys/techmaps in pypi wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,7 @@ jobs:
           platforms: all
 
       - name: Build wheels on ${{ matrix.os }} using cibuildwheel
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_BUILD: "cp311-* cp312-* cp313-*"
           CIBW_BUILD_FRONTEND: "build[uv]"

--- a/frontend/heir/heir_cli/heir_cli_config.py
+++ b/frontend/heir/heir_cli/heir_cli_config.py
@@ -114,4 +114,7 @@ def from_pip_installation() -> HEIRConfig:
   return HEIRConfig(
       heir_opt_path=package_path / "heir-opt",
       heir_translate_path=package_path / "heir-translate",
+      # These paths are configured in setup.py
+      techmap_dir_path=package_path / "techmaps",
+      abc_path=package_path / "abc",
   )

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ class BuildBazelExtension(build_ext.build_ext):
 
     # bazel-heir -> /home/user/.cache/bazel/_bazel_j2kun/<hash>/execroot/_main
     bazel_out = (Path(self.build_temp) / "bazel-out").resolve()
+    bazel_heir = bazel_out.parent
     out_root = bazel_out.parent.parent.parent
     external = out_root / "external"
     libdir = Path(self.build_lib) / "heir"
@@ -156,7 +157,13 @@ class BuildBazelExtension(build_ext.build_ext):
     ]
     dirs_to_copy = {external / subdir: libdir / subdir for subdir in subdirs}
 
+    # Include yosys techmaps.
+    dirs_to_copy[
+        bazel_heir / "lib" / "Transforms" / "YosysOptimizer" / "yosys"
+    ] = (libdir / "techmaps")
+
     patterns = (
+        "*.v",  # techmap files
         "*.h",
         "*.hpp",
         "LICENSE",
@@ -279,6 +286,14 @@ setuptools.setup(
             bazel_target="//tools:heir-translate",
             generated_so_file=Path("tools") / "heir-translate",
             target_file="heir-translate",
+            py_limited_api=py_limited_api,
+            is_binary=True,
+        ),
+        BazelExtension(
+            name="heir_py._abc",
+            bazel_target="@edu_berkeley_abc//:abc",
+            generated_so_file=Path("external") / "edu_berkeley_abc" / "abc",
+            target_file="abc",
             py_limited_api=py_limited_api,
             is_binary=True,
         ),


### PR DESCRIPTION
The recent change to enable CGGI in the frontend did not include the configuration for the PyPI wheels.

This PR also updates to the latest cibuildwheel to get a more recent manylinux container image, which I think will fix the build failures in https://github.com/google/heir/actions/runs/16016007003/job/45182673687