### PR TITLE
NoiseAnalysis: Update average-case expansion factor for modulus switching

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseByBoundCoeffModel.h
@@ -22,6 +22,8 @@ class NoiseByBoundCoeffModel {
 
  private:
   double getExpansionFactor(const LocalParamType &param) const;
+  double getExpansionFactorForModulusSwitching(
+      const LocalParamType &param) const;
   double getBoundErr(const LocalParamType &param) const;
   double getBoundKey(const LocalParamType &param) const;
 

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.h
@@ -23,6 +23,8 @@ class NoiseByBoundCoeffModel {
 
  private:
   double getExpansionFactor(const LocalParamType &param) const;
+  double getExpansionFactorForModulusSwitching(
+      const LocalParamType &param) const;
   double getBoundErr(const LocalParamType &param) const;
   double getBoundKey(const LocalParamType &param) const;
 


### PR DESCRIPTION
See https://github.com/openfheorg/openfhe-development/pull/1007

After experiments, we found that the 2\sqrt{N} expansion factor is not enough for modulus switching error, and 4\sqrt{N} should be used instead. For the case of modulus switching, 4\sqrt{N} gives at most 2^{-30} failing probability, which is enough (see theory in https://github.com/openfheorg/openfhe-development/issues/1004)

The old code in HEIR knew that 2\sqrt{N} is not enough, some of them already uses 4\sqrt {N}; this time the underestimation comments are deleted. Other changes are made according to 1007.

Cc @yspolyakov