### PR TITLE
frontend: fix support for reassigning values in binary ops

### DIFF
--- a/frontend/heir/pipeline.py
+++ b/frontend/heir/pipeline.py
@@ -190,9 +190,9 @@ def run_pipeline(
       )
 
     # Run backend (which will call heir_translate and other tools, e.g., clang, as needed)
-    if "--mlir-to-cggi" in heir_opt_options and not isinstance(
-        backend, CleartextBackend
-    ):
+    if any(
+        opt.startswith("--mlir-to-cggi") for opt in heir_opt_options
+    ) and not isinstance(backend, CleartextBackend):
       raise NotImplementedError(
           "Backend compilation is unsupported for CGGI scheme, check CGGI"
           f" output at {mlirpath}"

--- a/frontend/loop_test.py
+++ b/frontend/loop_test.py
@@ -34,6 +34,19 @@ class LoopTest(absltest.TestCase):
 
     self.assertEqual(32, one_iter_arg(2))
 
+  def test_loop_assign(self):
+
+    @compile()
+    def reassign(x: Secret[I64]):
+      a = x
+      for _ in range(2):
+        a0 = a
+        a1 = a + 1
+        a = a0 + a1
+      return a
+
+    self.assertEqual(7, reassign(1))
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
This fixes an issue with parsing the numba IR to MLIR. Vars in numba IR can be reassigned and this would cause MLIR to complain that SSA values were re-defined.

I'm not sure why this only happens with some reassignments, but I added a testcase where this does happen.