### PR TITLE
Implement a layout conversion cost analysis

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
@@ -33,13 +33,6 @@ namespace tensor_ext {
 #define GEN_PASS_DEF_IMPLEMENTSHIFTNETWORK
 #include "lib/Dialect/TensorExt/Transforms/Passes.h.inc"
 
-// A permutation of 0..n-1. This vector should always have size n and contain
-// each integer from 0 to n-1 exactly once.
-using Permutation = FrozenVector<int64_t>;
-
-// A group of indices to rotate together
-using RotationGroup = DenseSet<int64_t>;
-
 // Convert an input->output index mapping to a canonical left-shift amount for
 // a given tensor size.
 // Example: 1 -> 13 with a 64-size tensor should produce a rotation of 52
@@ -54,194 +47,150 @@ inline int64_t normalizeShift(int64_t input, int64_t output,
   return shift;
 }
 
-// The ShiftStrategy class applies power-of-two shifts to each set bit in
-// LSB-to-MSB order, 1, 2, 4, 8, .... Each shift amount is considered a "round"
-// in which a group of indices are attempted to be shifted together. This can be
-// used both to identify conflicts for the graph coloring technique of
-// Vos-Vos-Erkin, and also to construct the concrete shift network after a
-// partition has been decided by Vos-Vos-Erkin.
-struct ShiftRound {
-  // Maps the index of the original input to its current position in the
-  // tensor. This may contain multiple indices mapping to the same slot due to
-  // conflicts in the shifting strategy.
-  SmallVector<int64_t> positions;
-  // The set of indices that are rotated left in this round. This can be used
-  // to generate a mask to select the indices that need rotating.
-  SmallVector<int64_t> rotatedIndices;
-  // The amount rotated left;
-  int64_t rotationAmount;
-};
+SmallVector<ShiftRound> ShiftStrategy::getRounds() const { return rounds; }
 
-class ShiftStrategy {
- public:
-  ShiftStrategy() = default;
+void ShiftStrategy::evaluate(const Permutation &permutation,
+                             const RotationGroup &group) {
+  int64_t ciphertextSize = permutation.size();
 
-  SmallVector<ShiftRound> getRounds() const { return rounds; }
+  // Stores the amount that each ciphertext index is shifted left. The
+  // RotationGroup might be a subset of indices, so we have to populate the
+  // entire set of shifts with zeros except possibly for those in the
+  // RotationGroup (some of those may also be zero if they're fixed points of
+  // the permutation).
+  SmallVector<int64_t> shifts;
+  shifts.resize(ciphertextSize, 0);
+  for (int64_t index : group) {
+    shifts[index] = normalizeShift(index, permutation[index], ciphertextSize);
+  }
 
-  // Run the shifting strategy and populate the `rounds` member variable.
-  void evaluate(const Permutation &permutation, const RotationGroup &group) {
-    int64_t ciphertextSize = permutation.size();
-
-    // Stores the amount that each ciphertext index is shifted left. The
-    // RotationGroup might be a subset of indices, so we have to populate the
-    // entire set of shifts with zeros except possibly for those in the
-    // RotationGroup (some of those may also be zero if they're fixed points of
-    // the permutation).
-    SmallVector<int64_t> shifts;
-    shifts.resize(ciphertextSize, 0);
-    for (int64_t index : group) {
-      shifts[index] = normalizeShift(index, permutation[index], ciphertextSize);
+  LLVM_DEBUG({
+    llvm::dbgs() << "Shifts for permutation: ";
+    for (int64_t shift : shifts) {
+      llvm::dbgs() << shift << " ";
     }
+    llvm::dbgs() << "\n";
+  });
 
+  // The identity permutation is a base case where no shifts are applied.
+  Permutation identityPerm = FrozenVector<int64_t>(identity(ciphertextSize));
+  for (int64_t rotationAmount = 1; rotationAmount < ciphertextSize;
+       rotationAmount <<= 1) {
+    ShiftRound round;
+    ArrayRef<int64_t> lastRoundPositions =
+        !rounds.empty() ? ArrayRef<int64_t>(rounds.back().positions)
+                        : identityPerm;
+    int inputIndex = 0;
+    for (int64_t shift : shifts) {
+      // The bit is set, implying we would rotate by 2**bit in this round
+      if (shift & rotationAmount) {
+        // subtract because we are left-shifting by a positive amount
+        int64_t dest = lastRoundPositions[inputIndex] - rotationAmount;
+        if (dest < 0) {
+          dest += ciphertextSize;  // wrap around the bottom of the vector
+        }
+        round.positions.push_back(dest);
+        round.rotatedIndices.push_back(inputIndex);
+      } else {
+        // Otherwise the value is unchanged from last round
+        round.positions.push_back(lastRoundPositions[inputIndex]);
+      }
+      ++inputIndex;
+    }
+    round.rotationAmount = rotationAmount;
+    rounds.push_back(round);
     LLVM_DEBUG({
-      llvm::dbgs() << "Shifts for permutation: ";
-      for (int64_t shift : shifts) {
-        llvm::dbgs() << shift << " ";
+      llvm::dbgs() << "Round " << rotationAmount << ": ";
+      int inputIndex = 0;
+      for (int64_t index : round.positions) {
+        llvm::dbgs() << inputIndex++ << ": " << index << ", ";
+      }
+      llvm::dbgs() << "\n";
+      llvm::dbgs() << "Indices affected: ";
+      for (int64_t index : round.rotatedIndices) {
+        llvm::dbgs() << index << " ";
       }
       llvm::dbgs() << "\n";
     });
-
-    // The identity permutation is a base case where no shifts are applied.
-    Permutation identityPerm = FrozenVector<int64_t>(identity(ciphertextSize));
-    for (int64_t rotationAmount = 1; rotationAmount < ciphertextSize;
-         rotationAmount <<= 1) {
-      ShiftRound round;
-      ArrayRef<int64_t> lastRoundPositions =
-          !rounds.empty() ? ArrayRef<int64_t>(rounds.back().positions)
-                          : identityPerm;
-      int inputIndex = 0;
-      for (int64_t shift : shifts) {
-        // The bit is set, implying we would rotate by 2**bit in this round
-        if (shift & rotationAmount) {
-          // subtract because we are left-shifting by a positive amount
-          int64_t dest = lastRoundPositions[inputIndex] - rotationAmount;
-          if (dest < 0) {
-            dest += ciphertextSize;  // wrap around the bottom of the vector
-          }
-          round.positions.push_back(dest);
-          round.rotatedIndices.push_back(inputIndex);
-        } else {
-          // Otherwise the value is unchanged from last round
-          round.positions.push_back(lastRoundPositions[inputIndex]);
-        }
-        ++inputIndex;
-      }
-      round.rotationAmount = rotationAmount;
-      rounds.push_back(round);
-      LLVM_DEBUG({
-        llvm::dbgs() << "Round " << rotationAmount << ": ";
-        int inputIndex = 0;
-        for (int64_t index : round.positions) {
-          llvm::dbgs() << inputIndex++ << ": " << index << ", ";
-        }
-        llvm::dbgs() << "\n";
-        llvm::dbgs() << "Indices affected: ";
-        for (int64_t index : round.rotatedIndices) {
-          llvm::dbgs() << index << " ";
-        }
-        llvm::dbgs() << "\n";
-      });
-    }
   }
+}
 
- private:
-  SmallVector<ShiftRound> rounds;
-};
-
-// Cf. https://www.jeremykun.com/2024/09/02/shift-networks/
-// and https://link.springer.com/chapter/10.1007/978-3-031-17140-6_20
-// for an explanation of the algorithm.
-class VosVosErkinShiftNetworks {
- public:
-  VosVosErkinShiftNetworks(int64_t ciphertextSize)
-      : ciphertextSize(ciphertextSize) {}
-
-  // Computes a partition of the slot indices of a ciphertext into
-  // RotationGroups that are compatible with respect to the target permutation.
-  // Each RotationGroup corresponds to a set of indices that should be rotated
-  // together via power-of-two rotations.
-  //
-  // The returned ArrayRef is owned by this VosVosErkinShiftNetworks instance.
-  // The resulting set of rotation groups are is cached, and the cache is used
-  // on further calls to avoid recomputing the shift network.
-  ArrayRef<RotationGroup> computeShiftNetwork(const Permutation &permutation) {
-    if (rotationGroups.count(permutation)) {
-      return rotationGroups[permutation];
-    }
-
-    ShiftStrategy strategy;
-    RotationGroup allIndices;
-    for (int64_t i = 0; i < ciphertextSize; i++) {
-      allIndices.insert(i);
-    }
-    strategy.evaluate(permutation, allIndices);
-
-    // Create a graph whose vertices are the input indices to permute, and
-    // whose edges are conflicts: an edge being present means the two indices
-    // cannot participate in the same rotation group.
-    graph::UndirectedGraph<int64_t> conflictGraph;
-    for (int64_t i = 0; i < ciphertextSize; i++) {
-      conflictGraph.addVertex(i);
-    }
-    for (const ShiftRound &round : strategy.getRounds()) {
-      for (int64_t i = 0; i < ciphertextSize; i++) {
-        for (int64_t j = i + 1; j < ciphertextSize; j++) {
-          if (round.positions[i] == round.positions[j]) {
-            conflictGraph.addEdge(i, j);
-          }
-        }
-      }
-    }
-
-    LLVM_DEBUG({
-      llvm::dbgs() << "Conflict graph:\n";
-      for (int64_t vertex : conflictGraph.getVertices()) {
-        llvm::dbgs() << "  " << vertex << ": ";
-        for (int64_t neighbor : conflictGraph.edgesIncidentTo(vertex)) {
-          llvm::dbgs() << neighbor << " ";
-        }
-        llvm::dbgs() << "\n";
-      }
-    });
-
-    graph::GreedyGraphColoring<int64_t> colorer;
-    std::unordered_map<int64_t, int> coloring = colorer.color(conflictGraph);
-
-    SmallVector<RotationGroup> resultRotationGroups;
-    resultRotationGroups.reserve(64);
-    for (const auto &entry : coloring) {
-      int64_t index = entry.first;
-      int64_t color = entry.second;
-      if (color >= resultRotationGroups.size()) {
-        resultRotationGroups.resize(color + 1);
-      }
-      resultRotationGroups[color].insert(index);
-    }
-
-    LLVM_DEBUG({
-      llvm::dbgs() << "Splitting permutation into permutation groups:\n";
-      for (int i = 0; i < resultRotationGroups.size(); i++) {
-        llvm::dbgs() << "Group " << i << ": ";
-        llvm::SmallVector<int64_t> group = llvm::SmallVector<int64_t>(
-            resultRotationGroups[i].begin(), resultRotationGroups[i].end());
-        llvm::sort(group);
-        for (int64_t index : group) {
-          llvm::dbgs() << index << " ";
-        }
-        llvm::dbgs() << "\n";
-      }
-    });
-
-    rotationGroups[permutation] = resultRotationGroups;
+ArrayRef<RotationGroup> VosVosErkinShiftNetworks::computeShiftNetwork(
+    const Permutation &permutation) {
+  if (rotationGroups.count(permutation)) {
     return rotationGroups[permutation];
   }
 
-  int64_t getCiphertextSize() const { return ciphertextSize; }
+  ShiftStrategy strategy;
+  RotationGroup allIndices;
+  for (int64_t i = 0; i < ciphertextSize; i++) {
+    allIndices.insert(i);
+  }
+  strategy.evaluate(permutation, allIndices);
 
- private:
-  int64_t ciphertextSize;
-  DenseMap<Permutation, llvm::SmallVector<RotationGroup>> rotationGroups;
-};
+  // Create a graph whose vertices are the input indices to permute, and
+  // whose edges are conflicts: an edge being present means the two indices
+  // cannot participate in the same rotation group.
+  graph::UndirectedGraph<int64_t> conflictGraph;
+  for (int64_t i = 0; i < ciphertextSize; i++) {
+    conflictGraph.addVertex(i);
+  }
+  for (const ShiftRound &round : strategy.getRounds()) {
+    for (int64_t i = 0; i < ciphertextSize; i++) {
+      for (int64_t j = i + 1; j < ciphertextSize; j++) {
+        if (round.positions[i] == round.positions[j]) {
+          conflictGraph.addEdge(i, j);
+        }
+      }
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Conflict graph:\n";
+    for (int64_t vertex : conflictGraph.getVertices()) {
+      llvm::dbgs() << "  " << vertex << ": ";
+      for (int64_t neighbor : conflictGraph.edgesIncidentTo(vertex)) {
+        llvm::dbgs() << neighbor << " ";
+      }
+      llvm::dbgs() << "\n";
+    }
+  });
+
+  graph::GreedyGraphColoring<int64_t> colorer;
+  std::unordered_map<int64_t, int> coloring = colorer.color(conflictGraph);
+
+  SmallVector<RotationGroup> resultRotationGroups;
+  resultRotationGroups.reserve(64);
+  for (const auto &entry : coloring) {
+    int64_t index = entry.first;
+    int64_t color = entry.second;
+    if (color >= resultRotationGroups.size()) {
+      resultRotationGroups.resize(color + 1);
+    }
+    resultRotationGroups[color].insert(index);
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Splitting permutation into permutation groups:\n";
+    for (int i = 0; i < resultRotationGroups.size(); i++) {
+      llvm::dbgs() << "Group " << i << ": ";
+      llvm::SmallVector<int64_t> group = llvm::SmallVector<int64_t>(
+          resultRotationGroups[i].begin(), resultRotationGroups[i].end());
+      llvm::sort(group);
+      for (int64_t index : group) {
+        llvm::dbgs() << index << " ";
+      }
+      llvm::dbgs() << "\n";
+    }
+  });
+
+  rotationGroups[permutation] = resultRotationGroups;
+  return rotationGroups[permutation];
+}
+
+int64_t VosVosErkinShiftNetworks::getCiphertextSize() const {
+  return ciphertextSize;
+}
 
 // Create a tensor with zeros everywhere except for the indices specified in
 // the input `indices` vector.

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h
@@ -1,7 +1,11 @@
 #ifndef LIB_DIALECT_TENSOREXT_TRANSFORMS_IMPLEMENTSHIFTNETWORK_H_
 #define LIB_DIALECT_TENSOREXT_TRANSFORMS_IMPLEMENTSHIFTNETWORK_H_
 
-#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+#include "lib/Utils/ADT/FrozenVector.h"
+#include "lib/Utils/AffineMapUtils.h"
+#include "lib/Utils/Graph/Graph.h"
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"      // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -9,6 +13,69 @@ namespace tensor_ext {
 
 #define GEN_PASS_DECL_IMPLEMENTSHIFTNETWORK
 #include "lib/Dialect/TensorExt/Transforms/Passes.h.inc"
+
+// A permutation of 0..n-1. This vector should always have size n and contain
+// each integer from 0 to n-1 exactly once.
+using Permutation = FrozenVector<int64_t>;
+
+// A group of indices to rotate together
+using RotationGroup = DenseSet<int64_t>;
+
+// The ShiftStrategy class applies power-of-two shifts to each set bit in
+// LSB-to-MSB order, 1, 2, 4, 8, .... Each shift amount is considered a "round"
+// in which a group of indices are attempted to be shifted together. This can be
+// used both to identify conflicts for the graph coloring technique of
+// Vos-Vos-Erkin, and also to construct the concrete shift network after a
+// partition has been decided by Vos-Vos-Erkin.
+struct ShiftRound {
+  // Maps the index of the original input to its current position in the
+  // tensor. This may contain multiple indices mapping to the same slot due to
+  // conflicts in the shifting strategy.
+  SmallVector<int64_t> positions;
+  // The set of indices that are rotated left in this round. This can be used
+  // to generate a mask to select the indices that need rotating.
+  SmallVector<int64_t> rotatedIndices;
+  // The amount rotated left;
+  int64_t rotationAmount;
+};
+
+class ShiftStrategy {
+ public:
+  ShiftStrategy() = default;
+
+  SmallVector<ShiftRound> getRounds() const;
+
+  // Run the shifting strategy and populate the `rounds` member variable.
+  void evaluate(const Permutation &permutation, const RotationGroup &group);
+
+ private:
+  SmallVector<ShiftRound> rounds;
+};
+
+// Cf. https://www.jeremykun.com/2024/09/02/shift-networks/
+// and https://link.springer.com/chapter/10.1007/978-3-031-17140-6_20
+// for an explanation of the algorithm.
+class VosVosErkinShiftNetworks {
+ public:
+  VosVosErkinShiftNetworks(int64_t ciphertextSize)
+      : ciphertextSize(ciphertextSize) {}
+
+  // Computes a partition of the slot indices of a ciphertext into
+  // RotationGroups that are compatible with respect to the target permutation.
+  // Each RotationGroup corresponds to a set of indices that should be rotated
+  // together via power-of-two rotations.
+  //
+  // The returned ArrayRef is owned by this VosVosErkinShiftNetworks instance.
+  // The resulting set of rotation groups are is cached, and the cache is used
+  // on further calls to avoid recomputing the shift network.
+  ArrayRef<RotationGroup> computeShiftNetwork(const Permutation &permutation);
+
+  int64_t getCiphertextSize() const;
+
+ private:
+  int64_t ciphertextSize;
+  DenseMap<Permutation, llvm::SmallVector<RotationGroup>> rotationGroups;
+};
 
 }  // namespace tensor_ext
 }  // namespace heir

--- a/lib/Transforms/ConvertToCiphertextSemantics/BUILD
+++ b/lib/Transforms/ConvertToCiphertextSemantics/BUILD
@@ -22,6 +22,7 @@ cc_library(
         "@heir//lib/Utils:ContextAwareDialectConversion",
         "@heir//lib/Utils:ContextAwareTypeConversion",
         "@heir//lib/Utils:MathUtils",
+        "@heir//lib/Utils:TransformUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -22,6 +22,7 @@
 #include "lib/Utils/ContextAwareDialectConversion.h"
 #include "lib/Utils/ContextAwareTypeConversion.h"
 #include "lib/Utils/MathUtils.h"
+#include "lib/Utils/TransformUtils.h"
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/ArrayRef.h"         // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"        // from @llvm-project
@@ -262,42 +263,6 @@ class ConvertAssignLayout
  private:
   int64_t ciphertextSize;
 };
-
-// Return the first output index not mapped to by the partial permutation.
-int64_t getMinUnusedTarget(llvm::ArrayRef<int64_t> perm) {
-  std::vector<int64_t> unmappedOutputsVector(perm.size());
-  std::iota(unmappedOutputsVector.begin(), unmappedOutputsVector.end(), 0);
-  std::set<int64_t> unmappedOutputs(unmappedOutputsVector.begin(),
-                                    unmappedOutputsVector.end());
-  for (int64_t target : perm) {
-    if (target != kUnset) {
-      unmappedOutputs.erase(target);
-    }
-  }
-
-  if (unmappedOutputs.empty()) {
-    return -1;
-  }
-
-  LLVM_DEBUG({
-    llvm::dbgs() << "Unmapped outputs: ";
-    for (int64_t i : unmappedOutputs) {
-      llvm::dbgs() << i << " ";
-    }
-    llvm::dbgs() << "\n";
-  });
-
-  return *unmappedOutputs.begin();
-}
-
-// Return the first unused input index not mapped from by the partial
-// permutation.
-int64_t getMinUnusedInput(llvm::ArrayRef<int64_t> perm) {
-  for (int64_t i = 0; i < perm.size(); ++i) {
-    if (perm[i] == kUnset) return i;
-  }
-  return -1;
-}
 
 class ConvertConvertLayout
     : public ContextAwareOpConversionPattern<tensor_ext::ConvertLayoutOp> {

--- a/lib/Transforms/LayoutOptimization/BUILD
+++ b/lib/Transforms/LayoutOptimization/BUILD
@@ -12,6 +12,7 @@ cc_library(
     deps = [
         ":Hoisting",
         ":InterfaceImpl",
+        ":LayoutConversionCost",
         ":Patterns",
         ":pass_inc_gen",
         "@heir//lib/Dialect:HEIRInterfaces",
@@ -73,6 +74,20 @@ cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "LayoutConversionCost",
+    srcs = ["LayoutConversionCost.cpp"],
+    hdrs = ["LayoutConversionCost.h"],
+    deps = [
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/Transforms:ImplementShiftNetwork",
+        "@heir//lib/Utils",
+        "@heir//lib/Utils:AttributeUtils",
+        "@heir//lib/Utils:TransformUtils",
+        "@llvm-project//llvm:Support",
     ],
 )
 

--- a/lib/Transforms/LayoutOptimization/LayoutConversionCost.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutConversionCost.cpp
@@ -1,0 +1,107 @@
+#include "LayoutConversionCost.h"
+
+#include <cstdint>
+
+#include "lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.h"
+#include "lib/Utils/AffineMapUtils.h"
+#include "lib/Utils/TransformUtils.h"
+#include "lib/Utils/Utils.h"
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+
+#define DEBUG_TYPE "layout-conversion-cost"
+
+namespace mlir {
+namespace heir {
+
+using Cost = int64_t;
+
+// An unset value of a permutation as it's being built up.
+static constexpr int kUnset = -1;
+
+SmallVector<int64_t> createPermutation(Value value, int64_t slots,
+                                       tensor_ext::LayoutAttr fromLayout,
+                                       tensor_ext::LayoutAttr toLayout) {
+  Type dataSemanticType = value.getType();
+  SmallVector<int64_t> permutation(slots, kUnset);
+
+  std::set<int64_t> uniqueRotations = {};
+
+  // see
+  // lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp::ConvertConvertLayout
+  // for a full explanation of the algorithm
+  int64_t minUnusedTarget = 0;
+  int64_t minUnusedInput = 0;
+  while (minUnusedInput != -1) {
+    IndexTupleConsumer evaluateNextIndex =
+        [&](const std::vector<int64_t> &indices) {
+          SmallVector<int64_t> fromResults;
+          SmallVector<int64_t> toResults;
+          evaluateStatic(fromLayout.getMap(), indices, fromResults);
+          evaluateStatic(toLayout.getMap(), indices, toResults);
+          int64_t input =
+              (minUnusedInput + fromResults[fromResults.size() - 1]) % slots;
+          int64_t output =
+              (minUnusedTarget + toResults[toResults.size() - 1]) % slots;
+          permutation[input] = output;
+        };
+
+    SmallVector<int64_t> dataSemanticShape;
+    if (auto tensorTy = dyn_cast<RankedTensorType>(dataSemanticType)) {
+      dataSemanticShape = SmallVector<int64_t>(tensorTy.getShape());
+    } else {
+      // assumed to be a scalar
+      dataSemanticShape = {1};
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "dataSemanticShape: \n"; {
+      for (int64_t val : dataSemanticShape) {
+        llvm::dbgs() << val << ' ';
+      };
+    } llvm::dbgs() << "\n";);
+
+    iterateIndices(dataSemanticShape, evaluateNextIndex);
+    minUnusedTarget = getMinUnusedTarget(permutation);
+    minUnusedInput = getMinUnusedInput(permutation);
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "my permutation: \n"; {
+    for (int64_t val : permutation) {
+      llvm::dbgs() << val << ' ';
+    };
+  } llvm::dbgs() << "\n";);
+  return permutation;
+}
+
+Cost computeCostOfLayoutConversion(Value value, int64_t slots,
+                                   tensor_ext::LayoutAttr fromLayout,
+                                   tensor_ext::LayoutAttr toLayout) {
+  if (fromLayout == toLayout) {
+    LLVM_DEBUG(llvm::dbgs() << "Layouts are the same, conversion cost is 0\n";);
+    return 0;
+  }
+  SmallVector<int64_t> permutation =
+      createPermutation(value, slots, fromLayout, toLayout);
+  FrozenVector<int64_t> permKey = FrozenVector<int64_t>(std::move(permutation));
+
+  tensor_ext::VosVosErkinShiftNetworks shiftNetwork{slots};
+  ArrayRef<tensor_ext::RotationGroup> vveRotationGroups =
+      shiftNetwork.computeShiftNetwork(permKey);
+
+  int64_t maxRotations = 0;
+  for (const tensor_ext::RotationGroup &group : vveRotationGroups) {
+    tensor_ext::ShiftStrategy rotationStrategy;
+    rotationStrategy.evaluate(permKey, group);
+    int64_t numRounds = rotationStrategy.getRounds().size();
+    LLVM_DEBUG(llvm::dbgs() << "Number of rounds in this group is " << numRounds
+                            << "\n";);
+    if (numRounds > maxRotations) {
+      maxRotations = numRounds;
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Estimated cost is " << maxRotations << "\n";);
+  return maxRotations;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/LayoutOptimization/LayoutConversionCost.h
+++ b/lib/Transforms/LayoutOptimization/LayoutConversionCost.h
@@ -1,0 +1,20 @@
+#ifndef LIB_TRANSFORM_LAYOUTCONVERSION_LAYOUTCONVERSION_H_
+#define LIB_TRANSFORM_LAYOUTCONVERSION_LAYOUTCONVERSION_H_
+
+#include <cstdint>
+
+#include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
+
+namespace mlir {
+namespace heir {
+
+using Cost = int64_t;
+using tensor_ext::LayoutAttr;
+
+Cost computeCostOfLayoutConversion(Value value, int64_t slots,
+                                   LayoutAttr fromLayout, LayoutAttr toLayout);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORM_LAYOUTCONVERSION_LAYOUTCONVERSION_H_

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.td
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.td
@@ -78,6 +78,16 @@ def LayoutOptimization : Pass<"layout-optimization"> {
   let dependentDialects = [
     "mlir::heir::tensor_ext::TensorExtDialect",
   ];
+
+  let options = [
+    Option<
+      "ciphertextSize",
+      "ciphertext-size",
+      "int",
+      /*default=*/"1024",
+      "Power of two length of the ciphertexts the data is packed in."
+    >
+  ];
 }
 
 #endif  // LIB_TRANSFORMS_LAYOUTOPTIMIZATION_LAYOUTOPTIMIZATION_TD_

--- a/lib/Utils/ADT/FrozenVector.h
+++ b/lib/Utils/ADT/FrozenVector.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 
 #include "llvm/include/llvm/ADT/DenseMapInfo.h"  // from @llvm-project
+#include "llvm/include/llvm/ADT/Hashing.h"       // from @llvm-project
 #include "llvm/include/llvm/ADT/SmallVector.h"   // from @llvm-project
 
 namespace mlir {

--- a/lib/Utils/TransformUtils.h
+++ b/lib/Utils/TransformUtils.h
@@ -26,6 +26,16 @@ Value convertIntegerValueToMemrefOfBits(Value integer, OpBuilder &b,
 Value convertMemrefOfBitsToInteger(Value memref, Type resultType, OpBuilder &b,
                                    Location loc);
 
+/// Returns first uninitialized index not yet mapped to an output in an
+/// in-process permutation perm on perm.size() where perm[i] = j maps index i in
+/// the original vector to index j in the permutation. An index is uninitialized
+/// if perm[i] == -1.
+int64_t getMinUnusedInput(llvm::ArrayRef<int64_t> perm);
+
+/// Similar to getMinUnusedInput except this function returns the first
+/// uninitialized index not yet mapped from the permutation
+int64_t getMinUnusedTarget(llvm::ArrayRef<int64_t> perm);
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/tests/Transforms/layout_optimization/multiple_uses.mlir
+++ b/tests/Transforms/layout_optimization/multiple_uses.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --layout-optimization --canonicalize %s | FileCheck %s
+// RUN: heir-opt --layout-optimization=ciphertext-size=64 --canonicalize %s | FileCheck %s
 
 // CHECK-DAG: [[map:#[^ ]*]] = #tensor_ext.layout<map = (d0) -> ((d0 + 1) mod 32)>
 // CHECK-DAG: [[map2:#[^ ]*]] = #tensor_ext.layout<map = (d0) -> ((d0 + 2) mod 32)>


### PR DESCRIPTION
Implemented a basic layout conversion cost analysis for the `layout-optimization` pass. It reuses the logic for creating a permutation/shift network from the `convert-to-ciphertext-semantics` and `implement-shift-network` passes, respectively.

To estimate the cost, I compare the number of rounds required in every rotation group and return the largest.

I moved two functions `getMinArgUnusedTarget()` and `getMinUnusedInput()` to `TransformUtils` and a lot of the code from `implement-shift-network` to the header file so I'm not duplicating too much.

This is from #1595 