### PR TITLE
add `arith.negf` --> `ckks.negate` lowering

### DIFF
--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -370,6 +370,7 @@ struct SecretToCKKS : public impl::SecretToCKKSBase<SecretToCKKS> {
         SecretGenericOpCipherPlainConversion<arith::MulIOp, ckks::MulPlainOp>,
         SecretGenericOpCipherPlainConversion<arith::SubFOp, ckks::SubPlainOp>,
         SecretGenericOpCipherPlainConversion<arith::SubIOp, ckks::SubPlainOp>,
+        SecretGenericOpConversion<arith::NegFOp, ckks::NegateOp>,
         SecretGenericOpConversion<arith::AddFOp, ckks::AddOp>,
         SecretGenericOpConversion<arith::AddIOp, ckks::AddOp>,
         SecretGenericOpConversion<arith::ExtSIOp,

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/ops.mlir
@@ -36,17 +36,23 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [3602879
         %1 = arith.addf %ARG0, %ARG1 : tensor<1024xf32>
         secret.yield %1 : tensor<1024xf32>
     } -> (!efi1 {mgmt.mgmt = #mgmt})
+    // CHECK: ckks.negate
+    %1 = secret.generic(%0: !efi1) {
+      ^bb0(%ARG0 : tensor<1024xf32>):
+        %2 = arith.negf %ARG0 : tensor<1024xf32>
+        secret.yield %2 : tensor<1024xf32>
+    } -> ((!efi1 {mgmt.mgmt = #mgmt}) {mgmt.mgmt = #mgmt})
     // CHECK: ckks.mul
-    %1 = secret.generic(%0: !efi1, %arg2: !efi1) {
-      ^bb0(%ARG0 : tensor<1024xf32>, %ARG1 : tensor<1024xf32>):
-        %1 = arith.mulf %ARG0, %ARG1 : tensor<1024xf32>
-        secret.yield %1 : tensor<1024xf32>
+    %3 = secret.generic(%1: !efi1, %arg2: !efi1) {
+    ^bb0(%ARG0 : tensor<1024xf32>, %ARG1 : tensor<1024xf32>):
+      %4 = arith.mulf %ARG0, %ARG1 : tensor<1024xf32>
+      secret.yield %4 : tensor<1024xf32>
     } -> (!efi1 {mgmt.mgmt = #mgmt1})
     // CHECK: return
     // CHECK-SAME: message_type = tensor<1024xf32>
     // CHECK-SAME: polynomialModulus = <1 + x**1024>
     // CHECK-SAME: size = 3
-    return %1 : !efi1
+    return %3 : !efi1
   }
 
   // CHECK: func @test_extract


### PR DESCRIPTION
I realized that we had `ckks.negate` and even tests for `ckks.negate` --> openfhe, but no way to actually reach that op from higher-level code, so this extends `--mlir-to-ckks` with a lowering for `arith.negf`