### PR TITLE
Fix Roberts cross plaintext tests segfault

### DIFF
--- a/tests/Examples/plaintext/roberts_cross/roberts_cross_mod_test.c
+++ b/tests/Examples/plaintext/roberts_cross/roberts_cross_mod_test.c
@@ -18,8 +18,12 @@ struct Memref1D roberts_cross(
 
 void memrefCopy();
 
+// Needs to be allocated in .bss
+// Maybe for alignment?
+// Otherwise segfault inside memrefCopy
+_Alignas(uint64_t) int64_t input[4096];
+
 int main() {
-  int64_t input[4096];
   int64_t expected[4096];
 
   for (int i = 0; i < 4096; ++i) {

--- a/tests/Examples/plaintext/roberts_cross/roberts_cross_test.c
+++ b/tests/Examples/plaintext/roberts_cross/roberts_cross_test.c
@@ -18,8 +18,12 @@ struct Memref1D roberts_cross(
 
 void memrefCopy();
 
+// Needs to be allocated in .bss
+// Maybe for alignment?
+// Otherwise segfault inside memrefCopy
+_Alignas(uint64_t) int16_t input[4096];
+
 int main() {
-  int16_t input[4096];
   int16_t expected[4096];
 
   for (int i = 0; i < 4096; ++i) {


### PR DESCRIPTION
Fixes #1988

The segfault happens inside memrefCopy,
```
(gdb) bt
#0  __memmove_evex_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:339
#1  0x00007ffff7fb493b in memrefCopy (elemSize=4, srcArg=0x7fffffff9370, dstArg=0x7fffffff9380) at tests/Examples/plaintext/memrefCopy.cpp:84
#2  0x0000555555557ae8 in roberts_cross ()
#3  0x00007ffff7fb88c3 in main () at tests/Examples/plaintext/roberts_cross/roberts_cross_test.c:48
(gdb)
```

Moving `int16_t input[4096]` from stack to .bss seems to solve the problem in my Linux box (not segfault anymore when gdb it). Maybe it is because of alignment, or it is because of the difference between `allocated/aligned` field in the memref descriptor. I still do not have a good understanding of the memref descriptor.