### PR TITLE
First step of lowering ckks.relinearize

### DIFF
--- a/lib/Dialect/CKKS/IR/CKKSOps.td
+++ b/lib/Dialect/CKKS/IR/CKKSOps.td
@@ -168,15 +168,33 @@ def CKKS_RelinearizeOp : CKKS_Op<"relinearize", [SameOperandsAndResultRings,
   let arguments = (ins
     LWECiphertext:$input,
     DenseI32ArrayAttr:$from_basis,
-    DenseI32ArrayAttr:$to_basis
+    DenseI32ArrayAttr:$to_basis,
+    Optional<RankedTensorOf<[LWECiphertext]>>:$keySwitchingKey
   );
 
   let results = (outs
     LWECiphertext:$output
   );
 
+  let builders = [
+    OpBuilder<(ins
+      "Value":$input,
+      CArg<"::mlir::DenseI32ArrayAttr">:$fromBasis,
+      CArg<"::mlir::DenseI32ArrayAttr">:$toBasis), [{
+      return build($_builder, $_state, input,
+                   fromBasis, toBasis, {});
+    }]>
+  ];
+
   let hasVerifier = 1;
-  let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
+  // This format is a bit weird because even if the key is omitted, you still
+  // have to declare the type with parentheses around the operands (e.g.,
+  // `(!ct1) -> !ct`). I can't get the declarative format to work with two
+  // different type signatures because... well mlir-tblgen just doesn't do
+  // optional stuff well.
+  let assemblyFormat = [{
+    $input (`,` $keySwitchingKey^)? attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def CKKS_RescaleOp : CKKS_Op<"rescale"> {

--- a/lib/Dialect/LWE/Conversions/LWEToPolynomial/BUILD
+++ b/lib/Dialect/LWE/Conversions/LWEToPolynomial/BUILD
@@ -13,6 +13,7 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
@@ -301,6 +301,16 @@ LogicalResult EvalOp::verify() {
   return success();
 }
 
+LogicalResult KeySwitchInnerOp::verify() {
+  auto keyPolyType = getKeySwitchingKey().getType().getElementType();
+  if (keyPolyType != getValue().getType()) {
+    return emitOpError() << "keySwitchingKey element type " << keyPolyType
+                         << " does not match input type "
+                         << getValue().getType();
+  }
+  return success();
+}
+
 ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
   auto loc = parser.getCurrentLocation();
 

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.td
@@ -396,5 +396,28 @@ def Polynomial_EvalOp : Polynomial_Op<"eval", [AllTypesMatch<["value", "output"]
   let hasVerifier = 1;
 }
 
+def Polynomial_KeySwitchInnerOp : Polynomial_Op<"key_switch_inner",
+    [AllTypesMatch<["value", "constantOutput", "linearOutput"]>]> {
+  let summary = "Key switch on an RNS polynomial component";
+  let description = [{
+    Generates a linear ciphertext that, when added to a ciphertext encrypted
+    under the input key, switches it to a ciphertext encrypted under the output
+    key.
+
+    This operation is intended to be an internal implementation detail of
+    higher-level ciphertext operations such as `ckks.relinearize`, isolated
+    here for reuse among multiple op lowerings.
+  }];
+  let arguments = (ins
+      Polynomial_PolynomialType:$value,
+      RankedTensorOf<[Polynomial_PolynomialType]>: $keySwitchingKey
+  );
+  let results = (outs
+    Polynomial_PolynomialType:$constantOutput,
+    Polynomial_PolynomialType:$linearOutput
+  );
+  let hasVerifier = 1;
+}
+
 
 #endif  // LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALOPS_TD_

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir
@@ -62,7 +62,7 @@ module {
     // CHECK: %[[v6:.*]] = openfhe.relin [[C]], %[[x6:.*]]: ([[S]], [[T]]) -> [[T2:.*]]
     %relin = ckks.relinearize %x  {
       from_basis = array<i32: 0, 1, 2, 3>, to_basis = array<i32: 0, 1>
-    }: !ct_D4 -> !ct
+    }: (!ct_D4) -> !ct
     return %relin : !ct
   }
 }

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/invalid.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/invalid.mlir
@@ -24,7 +24,7 @@
 func.func @test_relin_to_basis_error(%x: !ct1) -> !ct {
   // expected-error@+2 {{toBasis must be [0, 1], got [0, 2]}}
   // expected-error@+1 {{failed to legalize operation 'ckks.relinearize'}}
-  %relin_error = ckks.relinearize %x  { from_basis = array<i32: 0, 1, 2, 3>, to_basis = array<i32: 0, 2> }: !ct1 -> !ct
+  %relin_error = ckks.relinearize %x { from_basis = array<i32: 0, 1, 2, 3>, to_basis = array<i32: 0, 2> }: (!ct1) -> !ct
   return %relin_error : !ct
 }
 

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/linear_polynomial.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/linear_polynomial.mlir
@@ -27,13 +27,13 @@
 // CHECK-SAME: (%[[cc:.*]]: [[cc_ty:.*crypto_context]], %[[arg0:.*]]: [[T:.*lwe_ciphertext.*]], %[[arg1:.*]]: [[T]], %[[arg2:.*]]: [[T]], %[[arg3:.*]]: [[T]]) -> [[T]] {
 func.func @linear_polynomial(%arg0: !ct_ty, %arg1: !ct_ty, %arg2: !ct_ty, %arg3: !ct_ty) -> !ct_ty {
   // CHECK: %[[v0:.*]] = openfhe.mul_no_relin %[[cc]], %[[arg0]], %[[arg2]]
-  %0 = ckks.mul %arg0, %arg2  : (!ct_ty, !ct_ty) -> !ct_sq_ty
+  %0 = ckks.mul %arg0, %arg2 : (!ct_ty, !ct_ty) -> !ct_sq_ty
   // CHECK: %[[v1:.*]] = openfhe.relin %[[cc]], %[[v0]]
-  %1 = ckks.relinearize %0  {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !ct_sq_ty -> !ct_ty
+  %1 = ckks.relinearize %0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : (!ct_sq_ty) -> !ct_ty
   // CHECK: %[[v2:.*]] = openfhe.sub %[[cc]], %[[arg3]], %[[v1]]
-  %2 = ckks.sub %arg3, %1  : (!ct_ty, !ct_ty) -> !ct_ty
+  %2 = ckks.sub %arg3, %1 : (!ct_ty, !ct_ty) -> !ct_ty
   // CHECK: %[[v3:.*]] = openfhe.sub %[[cc]], %[[v2]], %[[arg1]]
-  %3 = ckks.sub %2, %arg1  : (!ct_ty, !ct_ty) -> !ct_ty
+  %3 = ckks.sub %2, %arg1 : (!ct_ty, !ct_ty) -> !ct_ty
   // CHECK: return %[[v3]]
   return %3 : !ct_ty
 }

--- a/tests/Dialect/CKKS/IR/ops.mlir
+++ b/tests/Dialect/CKKS/IR/ops.mlir
@@ -37,7 +37,7 @@
 // CHECK: module
 module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
   // CHECK: @test_multiply
-  func.func @test_multiply(%arg0 : !ct, %arg1: !ct) -> !ct {
+  func.func @test_multiply(%arg0 : !ct, %arg1: !ct, %ksk: tensor<10x!ct>) -> !ct {
     %add = ckks.add %arg0, %arg1 : (!ct, !ct) -> !ct
     %sub = ckks.sub %arg0, %arg1 : (!ct, !ct) -> !ct
     %neg = ckks.negate %arg0 : !ct
@@ -45,10 +45,16 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [3602879
     // CHECK: ring = <coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>, !mod_arith.int<1032955396097 : i64>>, polynomialModulus = <1 + x**1024>>
     // CHECK: size = 3
     %0 = ckks.mul %arg0, %arg1  : (!ct, !ct) -> !ct1
-    %1 = ckks.relinearize %0  {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : !ct1 -> !ct
+    %1 = ckks.relinearize %0, %ksk {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!ct1, tensor<10x!ct>) -> !ct
     %2 = ckks.rescale %1  {to_ring = #ring_rns_L0_1_x1024_} : !ct -> !ct2
     // CHECK: ring = <coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>>
     return %arg0 : !ct
+  }
+
+  // CHECK: @test_relin_no_key
+  func.func @test_relin_no_key(%arg0 : !ct1) -> !ct {
+    %1 = ckks.relinearize %arg0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!ct1) -> !ct
+    return %1 : !ct
   }
 
   // CHECK: @test_ciphertext_plaintext

--- a/tests/Dialect/CKKS/IR/verifier.mlir
+++ b/tests/Dialect/CKKS/IR/verifier.mlir
@@ -103,7 +103,7 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [3602879
   func.func @mul(%ct: !ct_L1_) -> !ct_L0_ {
     // expected-error@+1 {{'ckks.mul' op output plaintext space does not match}}
     %ct_0 = ckks.mul %ct, %ct : (!ct_L1_, !ct_L1_) -> !ct_L1_D3_
-    %ct_1 = ckks.relinearize %ct_0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !ct_L1_D3_ -> !ct_L1_
+    %ct_1 = ckks.relinearize %ct_0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : (!ct_L1_D3_) -> !ct_L1_
     %ct_2 = ckks.rescale %ct_1 {to_ring = #ring_rns_L0_1_x1024_} : !ct_L1_ -> !ct_L0_
     return %ct_2 : !ct_L0_
   }
@@ -137,7 +137,7 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [3602879
 module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797019389953, 35184372121601], P = [36028797019488257], logDefaultScale = 45>, scheme.ckks} {
   func.func @mul(%ct: !ct_L1_) -> !ct_L0_ {
     %ct_0 = ckks.mul %ct, %ct : (!ct_L1_, !ct_L1_) -> !ct_L1_D3_
-    %ct_1 = ckks.relinearize %ct_0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : !ct_L1_D3_ -> !ct_L1_1
+    %ct_1 = ckks.relinearize %ct_0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : (!ct_L1_D3_) -> !ct_L1_1
     // expected-error@+1 {{'ckks.rescale' op output plaintext space does not match}}
     %ct_2 = ckks.rescale %ct_1 {to_ring = #ring_rns_L0_1_x1024_} : !ct_L1_1 -> !ct_L0_
     return %ct_2 : !ct_L0_

--- a/tests/Dialect/LWE/Conversions/lwe_to_polynomial/relin.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_polynomial/relin.mlir
@@ -1,0 +1,38 @@
+// RUN: heir-opt --lwe-to-polynomial %s | FileCheck %s
+
+!Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64 = !mod_arith.int<65537 : i64>
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1 = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1 = !rns.rns<!Z1095233372161_i64, !Z1032955396097_i64>
+#ring_Z65537_i64_1_x1024 = #polynomial.ring<coefficientType = !Z65537_i64, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024 = #polynomial.ring<coefficientType = !rns_L1, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L1 = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024, encryption_type = lsb>
+#ciphertext_space_L1_D3 = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024, encryption_type = lsb, size = 3>
+!ct_L1 = !lwe.lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = <ring = #ring_Z65537_i64_1_x1024, encoding = #inverse_canonical_encoding>, ciphertext_space = #ciphertext_space_L1, key = #key, modulus_chain = #modulus_chain_L5_C1>
+!ct_L1_D3 = !lwe.lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = <ring = #ring_Z65537_i64_1_x1024, encoding = #inverse_canonical_encoding>, ciphertext_space = #ciphertext_space_L1_D3, key = #key, modulus_chain = #modulus_chain_L5_C1>
+
+module {
+  // CHECK: @test_relin(
+  // CHECK-SAME: [[X:%.+]]: [[ct_ty:.*tensor<3x.*]],
+  // CHECK-SAME: [[ksk:%.+]]: [[ksk_ty:tensor<10x.*]])
+  func.func @test_relin(%ct: !ct_L1_D3, %arg0: tensor<10x!ct_L1>) -> !ct_L1 {
+    // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+    // CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
+    // CHECK-DAG: [[C2:%.+]] = arith.constant 2 : index
+
+    // CHECK-DAG: [[extracted0:%.+]] = tensor.extract [[X]]{{\[}}[[C0]]]
+    // CHECK-DAG: [[extracted1:%.+]] = tensor.extract [[X]]{{\[}}[[C1]]]
+    // CHECK-DAG: [[extracted2:%.+]] = tensor.extract [[X]]{{\[}}[[C2]]]
+
+    // CHECK-NEXT: [[constOutput:%.+]], [[linearOutput:%.+]] = polynomial.key_switch_inner [[extracted2]], [[ksk]]
+    // CHECK-DAG: [[tensor0:%.+]] = polynomial.add [[extracted0]], [[constOutput]]
+    // CHECK-DAG: [[tensor1:%.+]] = polynomial.add [[extracted1]], [[linearOutput]]
+    // CHECK-NEXT: [[result:%.+]] = tensor.from_elements [[tensor0]], [[tensor1]]
+    // CHECK-NEXT: return [[result]]
+    %ct_0 = ckks.relinearize %ct, %arg0 {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>} : (!ct_L1_D3, tensor<10x!ct_L1>) -> !ct_L1
+    return %ct_0 : !ct_L1
+  }
+}

--- a/tests/Emitter/SimFHE/emit_simfhe.mlir
+++ b/tests/Emitter/SimFHE/emit_simfhe.mlir
@@ -42,7 +42,7 @@ module {
     // CHECK:  [[CT5:ct[0-9]+]] = [[CT]]
     %relin = ckks.relinearize %mul  {
       from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1>
-    }: !ct_D3 -> !ct
+    }: (!ct_D3) -> !ct
     // CHECK: stats += evaluator.key_switch([[CT5]], scheme_params.fresh_ctxt, scheme_params.arch_param)
     // CHECK:  [[CT6:ct[0-9]+]] = [[CT5]]
     %mul_again = ckks.mul %relin, %x  : (!ct, !ct) -> !ct_D3


### PR DESCRIPTION
This PR does the first step in lowering ckks.relinearize (implementing the crypto in the compiler). To do this, it requires:

A new `polynomial.key_switch_inner` op, since key switch operates on the actual polynomial components of a ciphertext it cannot easily be represented at a higher level of abstraction. If we _had_ to, we could add higher-level `lwe` ops that extract different components of a ciphertext, but we felt this was easier until we had a strong reason to do that.

An optional key-switching-key operand to `ckks.relinearize`, which is represented as a tensor of ciphertexts. I think we may ultimately need to add a higher-level relin key or key switching key type, since we may need to identify which function argument is the key switching key for the purpose of setting up the client interfaces, and right now if it's just a tensor of ciphertext it may be hard to identify it (you'd have to find a relin op and trace it back up to the function argument, but the relin op itself may have been lowered by then?). Punting on this for now though because it's not clear we definitely need it.

This PR depends on #2036 which adds RNS support to `lwe-to-polynomial`.