### PR TITLE
ValidateNoise: make error message less verbose

### DIFF
--- a/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBFV.cpp
@@ -204,7 +204,7 @@ struct GenerateParamBFV : impl::GenerateParamBFVBase<GenerateParamBFV> {
       bfv::NoiseCanEmbModel model;
       run<bfv::NoiseCanEmbModel>(model);
     } else {
-      getOperation()->emitWarning() << "Unknown noise model.\n";
+      emitWarning(getOperation()->getLoc()) << "Unknown noise model.\n";
       generateFallbackParam();
     }
 

--- a/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamBGV.cpp
@@ -224,7 +224,7 @@ struct GenerateParamBGV : impl::GenerateParamBGVBase<GenerateParamBGV> {
       bgv::NoiseCanEmbModel model;
       run<bgv::NoiseCanEmbModel>(model);
     } else {
-      getOperation()->emitWarning() << "Unknown noise model.\n";
+      emitWarning(getOperation()->getLoc()) << "Unknown noise model.\n";
       generateFallbackParam();
     }
   }

--- a/lib/Transforms/ValidateNoise/ValidateNoise.cpp
+++ b/lib/Transforms/ValidateNoise/ValidateNoise.cpp
@@ -139,7 +139,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
     auto schemeParamAttr = getOperation()->getAttrOfType<bgv::SchemeParamAttr>(
         bgv::BGVDialect::kSchemeParamAttrName);
     if (!schemeParamAttr) {
-      getOperation()->emitOpError() << "No scheme param found.\n";
+      emitError(getOperation()->getLoc()) << "No scheme param found.\n";
       signalPassFailure();
       return;
     }
@@ -172,7 +172,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
 
     if (failed(
             validate<NoiseAnalysis<NoiseModel>>(&solver, schemeParam, model))) {
-      getOperation()->emitOpError() << "Noise validation failed.\n";
+      emitError(getOperation()->getLoc()) << "Noise validation failed.\n";
       signalPassFailure();
     }
   }
@@ -207,7 +207,7 @@ struct ValidateNoise : impl::ValidateNoiseBase<ValidateNoise> {
       bfv::NoiseCanEmbModel model;
       run<bfv::NoiseCanEmbModel>(model);
     } else {
-      getOperation()->emitOpError() << "Unknown noise model.\n";
+      emitError(getOperation()->getLoc()) << "Unknown noise model.\n";
       signalPassFailure();
       return;
     }

--- a/tests/Transforms/validate_noise/validate_noise_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_fail.mlir
@@ -15,7 +15,7 @@
 #alignment = #tensor_ext.alignment<in = [], out = [1024], insertedDims = [0]>
 #layout = #tensor_ext.layout<map = (d0) -> (d0 mod 1024), alignment = #alignment>
 #original_type = #tensor_ext.original_type<originalType = i16, layout = #layout>
-// expected-error@below {{'builtin.module' op Noise validation failed.}}
+// expected-error@below {{Noise validation failed.}}
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 14, Q = [35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113, 35184376184833], P = [35184376545281, 35184376578049], plaintextModulus = 4295294977>, scheme.bgv} {
   func.func @dot_product(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 5>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %0 = secret.generic(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 5>}) {

--- a/tests/Transforms/validate_noise/validate_noise_preserve_user_param_fail.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_preserve_user_param_fail.mlir
@@ -16,7 +16,7 @@ module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 11, Q = [17], P = 
 
 // -----
 
-// expected-error@below {{'builtin.module' op Noise validation failed.}}
+// expected-error@below {{Noise validation failed.}}
 module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 11, Q = [17, 23], P = [1093633], plaintextModulus = 65537>} {
   func.func @main(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %0 = secret.generic(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {


### PR DESCRIPTION
`getOperation()->emitOpError()` would dump the whole IR, making it quite verbose. Using `emitError(loc)` would make it less verbose.