### PR TITLE
Migrate op builders to Op::create() for better IDE awareness

### DIFF
--- a/lib/Dialect/Arith/Conversions/ArithToCGGI/ArithToCGGI.cpp
+++ b/lib/Dialect/Arith/Conversions/ArithToCGGI/ArithToCGGI.cpp
@@ -129,7 +129,7 @@ static Value materializeTarget(OpBuilder &builder, Type type, ValueRange inputs,
   if (auto inValue = inputs.front().getDefiningOp<mlir::arith::ConstantOp>()) {
     auto intAttr = cast<IntegerAttr>(inValue.getValueAttr());
 
-    return builder.create<cggi::CreateTrivialOp>(loc, type, intAttr);
+    return cggi::CreateTrivialOp::create(builder, loc, type, intAttr);
   }
   // Comes from function/loop argument: Trivial encrypt through LWE
   auto ciphertextType = cast<lwe::NewLWECiphertextType>(type);
@@ -146,11 +146,10 @@ static Value materializeTarget(OpBuilder &builder, Type type, ValueRange inputs,
   auto ptxtTy = lwe::NewLWEPlaintextType::get(
       builder.getContext(), ciphertextType.getApplicationData(),
       ciphertextType.getPlaintextSpace());
-  return builder.create<lwe::TrivialEncryptOp>(
-      loc, type,
-      builder.create<lwe::EncodeOp>(loc, ptxtTy, inputs[0],
-                                    builder.getIndexAttr(plaintextBits),
-                                    overflowAttr),
+  return lwe::TrivialEncryptOp::create(
+      builder, loc, type,
+      lwe::EncodeOp::create(builder, loc, ptxtTy, inputs[0],
+                            builder.getIndexAttr(plaintextBits), overflowAttr),
       builder.getIndexAttr(ciphertextBits));
 }
 
@@ -187,7 +186,8 @@ struct ConvertTruncIOp : public OpConversionPattern<mlir::arith::TruncIOp> {
 
     auto outType = convertArithToCGGIType(
         cast<IntegerType>(op.getResult().getType()), op->getContext());
-    auto castOp = b.create<cggi::CastOp>(op.getLoc(), outType, adaptor.getIn());
+    auto castOp =
+        cggi::CastOp::create(b, op.getLoc(), outType, adaptor.getIn());
 
     rewriter.replaceOp(op, castOp);
     return success();
@@ -207,7 +207,8 @@ struct ConvertExtUIOp : public OpConversionPattern<mlir::arith::ExtUIOp> {
 
     auto outType = convertArithToCGGIType(
         cast<IntegerType>(op.getResult().getType()), op->getContext());
-    auto castOp = b.create<cggi::CastOp>(op.getLoc(), outType, adaptor.getIn());
+    auto castOp =
+        cggi::CastOp::create(b, op.getLoc(), outType, adaptor.getIn());
 
     rewriter.replaceOp(op, castOp);
     return success();
@@ -227,7 +228,8 @@ struct ConvertExtSIOp : public OpConversionPattern<mlir::arith::ExtSIOp> {
 
     auto outType = convertArithToCGGIType(
         cast<IntegerType>(op.getResult().getType()), op->getContext());
-    auto castOp = b.create<cggi::CastOp>(op.getLoc(), outType, adaptor.getIn());
+    auto castOp =
+        cggi::CastOp::create(b, op.getLoc(), outType, adaptor.getIn());
 
     rewriter.replaceOp(op, castOp);
     return success();
@@ -250,8 +252,8 @@ struct ConvertCmpOp : public OpConversionPattern<mlir::arith::CmpIOp> {
 
     if (auto lhsDefOp = op.getLhs().getDefiningOp()) {
       if (!hasLWEAnnotation(lhsDefOp) && allowedRemainArith(lhsDefOp)) {
-        auto result = b.create<cggi::CmpOp>(lweBooleanType, op.getPredicate(),
-                                            adaptor.getRhs(), op.getLhs());
+        auto result = cggi::CmpOp::create(b, lweBooleanType, op.getPredicate(),
+                                          adaptor.getRhs(), op.getLhs());
         rewriter.replaceOp(op, result);
         return success();
       }
@@ -259,15 +261,15 @@ struct ConvertCmpOp : public OpConversionPattern<mlir::arith::CmpIOp> {
 
     if (auto rhsDefOp = op.getRhs().getDefiningOp()) {
       if (!hasLWEAnnotation(rhsDefOp) && allowedRemainArith(rhsDefOp)) {
-        auto result = b.create<cggi::CmpOp>(lweBooleanType, op.getPredicate(),
-                                            adaptor.getLhs(), op.getRhs());
+        auto result = cggi::CmpOp::create(b, lweBooleanType, op.getPredicate(),
+                                          adaptor.getLhs(), op.getRhs());
         rewriter.replaceOp(op, result);
         return success();
       }
     }
 
-    auto cmpOp = b.create<cggi::CmpOp>(lweBooleanType, op.getPredicate(),
-                                       adaptor.getLhs(), adaptor.getRhs());
+    auto cmpOp = cggi::CmpOp::create(b, lweBooleanType, op.getPredicate(),
+                                     adaptor.getLhs(), adaptor.getRhs());
 
     rewriter.replaceOp(op, cmpOp);
     return success();
@@ -287,15 +289,15 @@ struct ConvertSubOp : public OpConversionPattern<mlir::arith::SubIOp> {
 
     if (auto rhsDefOp = op.getRhs().getDefiningOp()) {
       if (!hasLWEAnnotation(rhsDefOp) && allowedRemainArith(rhsDefOp)) {
-        auto result = b.create<cggi::SubOp>(adaptor.getLhs().getType(),
-                                            adaptor.getLhs(), op.getRhs());
+        auto result = cggi::SubOp::create(b, adaptor.getLhs().getType(),
+                                          adaptor.getLhs(), op.getRhs());
         rewriter.replaceOp(op, result);
         return success();
       }
     }
 
-    auto subOp = b.create<cggi::SubOp>(adaptor.getLhs().getType(),
-                                       adaptor.getLhs(), adaptor.getRhs());
+    auto subOp = cggi::SubOp::create(b, adaptor.getLhs().getType(),
+                                     adaptor.getLhs(), adaptor.getRhs());
     rewriter.replaceOp(op, subOp);
     return success();
   }
@@ -312,8 +314,8 @@ struct ConvertSelectOp : public OpConversionPattern<mlir::arith::SelectOp> {
       ConversionPatternRewriter &rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto cmuxOp = b.create<cggi::SelectOp>(
-        adaptor.getTrueValue().getType(), adaptor.getCondition(),
+    auto cmuxOp = cggi::SelectOp::create(
+        b, adaptor.getTrueValue().getType(), adaptor.getCondition(),
         adaptor.getTrueValue(), adaptor.getFalseValue());
 
     rewriter.replaceOp(op, cmuxOp);
@@ -347,7 +349,7 @@ struct ConvertShOp : public OpConversionPattern<SourceArithShOp> {
           mlir::IntegerAttr::get(rewriter.getIndexType(), (int8_t)shiftAmount);
 
       auto shiftOp =
-          b.create<TargetCGGIShOp>(outputType, adaptor.getLhs(), inputValue);
+          TargetCGGIShOp::create(b, outputType, adaptor.getLhs(), inputValue);
       rewriter.replaceOp(op, shiftOp);
 
       return success();
@@ -365,7 +367,7 @@ struct ConvertShOp : public OpConversionPattern<SourceArithShOp> {
         mlir::IntegerAttr::get(rewriter.getIndexType(), shiftAmount);
 
     auto shiftOp =
-        b.create<TargetCGGIShOp>(outputType, adaptor.getLhs(), inputValue);
+        TargetCGGIShOp::create(b, outputType, adaptor.getLhs(), inputValue);
     rewriter.replaceOp(op, shiftOp);
 
     return success();
@@ -386,8 +388,8 @@ struct ConvertArithBinOp : public OpConversionPattern<SourceArithOp> {
 
     if (auto lhsDefOp = op.getLhs().getDefiningOp()) {
       if (!hasLWEAnnotation(lhsDefOp) && allowedRemainArith(lhsDefOp)) {
-        auto result = b.create<TargetCGGIOp>(adaptor.getRhs().getType(),
-                                             adaptor.getRhs(), op.getLhs());
+        auto result = TargetCGGIOp::create(b, adaptor.getRhs().getType(),
+                                           adaptor.getRhs(), op.getLhs());
         rewriter.replaceOp(op, result);
         return success();
       }
@@ -395,15 +397,15 @@ struct ConvertArithBinOp : public OpConversionPattern<SourceArithOp> {
 
     if (auto rhsDefOp = op.getRhs().getDefiningOp()) {
       if (!hasLWEAnnotation(rhsDefOp) && allowedRemainArith(rhsDefOp)) {
-        auto result = b.create<TargetCGGIOp>(adaptor.getLhs().getType(),
-                                             adaptor.getLhs(), op.getRhs());
+        auto result = TargetCGGIOp::create(b, adaptor.getLhs().getType(),
+                                           adaptor.getLhs(), op.getRhs());
         rewriter.replaceOp(op, result);
         return success();
       }
     }
 
-    auto result = b.create<TargetCGGIOp>(adaptor.getLhs().getType(),
-                                         adaptor.getLhs(), adaptor.getRhs());
+    auto result = TargetCGGIOp::create(b, adaptor.getLhs().getType(),
+                                       adaptor.getLhs(), adaptor.getRhs());
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -427,7 +429,7 @@ struct ConvertAllocOp : public OpConversionPattern<mlir::memref::AllocOp> {
 
     auto lweType = getTypeConverter()->convertType(op.getType());
     auto allocOp =
-        b.create<memref::AllocOp>(op.getLoc(), lweType, op.getOperands());
+        memref::AllocOp::create(b, op.getLoc(), lweType, op.getOperands());
     rewriter.replaceOp(op, allocOp);
     return success();
   }

--- a/lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.cpp
+++ b/lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.cpp
@@ -109,8 +109,9 @@ struct ConvertCGGITRBBinOp : public OpConversionPattern<BinOp> {
 
     Value serverKey = result.value();
 
-    rewriter.replaceOp(op, b.create<TfheRustBoolBinOp>(
-                               serverKey, adaptor.getLhs(), adaptor.getRhs()));
+    rewriter.replaceOp(op,
+                       TfheRustBoolBinOp::create(b, serverKey, adaptor.getLhs(),
+                                                 adaptor.getRhs()));
     return success();
   }
 };
@@ -131,7 +132,7 @@ struct ConvertBoolNotOp : public OpConversionPattern<cggi::NotOp> {
     Value serverKey = result.value();
 
     rewriter.replaceOp(
-        op, b.create<tfhe_rust_bool::NotOp>(serverKey, adaptor.getInput()));
+        op, tfhe_rust_bool::NotOp::create(b, serverKey, adaptor.getInput()));
     return success();
   }
 };
@@ -169,9 +170,9 @@ struct ConvertPackedOp : public OpConversionPattern<cggi::PackedOp> {
 
     auto outputType = adaptor.getLhs().getType();
 
-    rewriter.replaceOp(op, b.create<tfhe_rust_bool::PackedOp>(
-                               outputType, serverKey, oplist, adaptor.getLhs(),
-                               adaptor.getRhs()));
+    rewriter.replaceOp(op, tfhe_rust_bool::PackedOp::create(
+                               b, outputType, serverKey, oplist,
+                               adaptor.getLhs(), adaptor.getRhs()));
     return success();
   }
 };
@@ -198,8 +199,8 @@ struct ConvertBoolTrivialEncryptOp
     }
     auto outputType = tfhe_rust_bool::EncryptedBoolType::get(getContext());
 
-    auto createTrivialOp = rewriter.create<tfhe_rust_bool::CreateTrivialOp>(
-        op.getLoc(), outputType, serverKey, encodeOp.getInput());
+    auto createTrivialOp = tfhe_rust_bool::CreateTrivialOp::create(
+        rewriter, op.getLoc(), outputType, serverKey, encodeOp.getInput());
     rewriter.replaceOp(op, createTrivialOp);
     return success();
   }

--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -146,10 +146,10 @@ struct ConvertEncryptOp : public OpConversionPattern<lwe::RLWEEncryptOp> {
     if (failed(result)) return result;
 
     Value cryptoContext = result.value();
-    rewriter.replaceOp(op,
-                       rewriter.create<openfhe::EncryptOp>(
-                           op.getLoc(), op.getOutput().getType(), cryptoContext,
-                           adaptor.getInput(), adaptor.getKey()));
+    rewriter.replaceOp(
+        op, openfhe::EncryptOp::create(rewriter, op.getLoc(),
+                                       op.getOutput().getType(), cryptoContext,
+                                       adaptor.getInput(), adaptor.getKey()));
     return success();
   }
 };
@@ -167,10 +167,10 @@ struct ConvertDecryptOp : public OpConversionPattern<lwe::RLWEDecryptOp> {
     if (failed(result)) return result;
 
     Value cryptoContext = result.value();
-    rewriter.replaceOp(op,
-                       rewriter.create<openfhe::DecryptOp>(
-                           op.getLoc(), op.getOutput().getType(), cryptoContext,
-                           adaptor.getInput(), adaptor.getSecretKey()));
+    rewriter.replaceOp(
+        op, openfhe::DecryptOp::create(
+                rewriter, op.getLoc(), op.getOutput().getType(), cryptoContext,
+                adaptor.getInput(), adaptor.getSecretKey()));
     return success();
   }
 };
@@ -211,10 +211,10 @@ struct ConvertEncodeOp : public OpConversionPattern<lwe::RLWEEncodeOp> {
           // Sign extending an i1 results in a -1 i64, so ensure that booleans
           // are unsigned.
           input =
-              rewriter.create<arith::ExtUIOp>(op.getLoc(), newTensorTy, input);
+              arith::ExtUIOp::create(rewriter, op.getLoc(), newTensorTy, input);
         } else {
           input =
-              rewriter.create<arith::ExtSIOp>(op.getLoc(), newTensorTy, input);
+              arith::ExtSIOp::create(rewriter, op.getLoc(), newTensorTy, input);
         }
       }
     } else {
@@ -228,7 +228,8 @@ struct ConvertEncodeOp : public OpConversionPattern<lwe::RLWEEncodeOp> {
         // are std::vector<double>, so we need to cast the input to that type.
         auto f64Ty = rewriter.getF64Type();
         auto newTensorTy = RankedTensorType::get(tensorTy.getShape(), f64Ty);
-        input = rewriter.create<arith::ExtFOp>(op.getLoc(), newTensorTy, input);
+        input =
+            arith::ExtFOp::create(rewriter, op.getLoc(), newTensorTy, input);
       }
     }
 

--- a/lib/Dialect/LWE/Transforms/AddDebugPort.cpp
+++ b/lib/Dialect/LWE/Transforms/AddDebugPort.cpp
@@ -58,7 +58,7 @@ func::FuncOp getOrCreateExternalDebugFunc(
 
   ImplicitLocOpBuilder b =
       ImplicitLocOpBuilder::atBlockBegin(module.getLoc(), module.getBody());
-  auto funcOp = b.create<func::FuncOp>(funcName, debugFuncType);
+  auto funcOp = func::FuncOp::create(b, funcName, debugFuncType);
   // required for external func call
   funcOp.setPrivate();
   return funcOp;
@@ -116,10 +116,11 @@ LogicalResult insertExternalCall(func::FuncOp op, Type lwePrivateKeyType) {
       attrs.push_back(b.getNamedAttr(
           "message.size", b.getStringAttr(std::to_string(messageSize))));
 
-      b.create<func::CallOp>(
-           getOrCreateExternalDebugFunc(module, lwePrivateKeyType,
-                                        lweCiphertextType, typeToInt),
-           ArrayRef<Value>{privateKey, value})
+      func::CallOp::create(
+          b,
+          getOrCreateExternalDebugFunc(module, lwePrivateKeyType,
+                                       lweCiphertextType, typeToInt),
+          ArrayRef<Value>{privateKey, value})
           ->setDialectAttrs(attrs);
     }
   };

--- a/lib/Dialect/Lattigo/Transforms/AllocToInplace.cpp
+++ b/lib/Dialect/Lattigo/Transforms/AllocToInplace.cpp
@@ -143,8 +143,8 @@ struct ConvertBinOp : public OpRewritePattern<BinOp> {
     // InplaceOp has the form: output = InplaceOp(evaluator, lhs, rhs,
     // inplace) where inplace is the actual output but for SSA form we need to
     // return a new value
-    auto inplaceOp = rewriter.create<InplaceOp>(
-        op.getLoc(), op.getOperand(1).getType(), op.getOperand(0),
+    auto inplaceOp = InplaceOp::create(
+        rewriter, op.getLoc(), op.getOperand(1).getType(), op.getOperand(0),
         op.getOperand(1), op.getOperand(2), storage);
 
     // Update storage info, which must happen before the op is removed
@@ -181,8 +181,8 @@ struct ConvertUnaryOp : public OpRewritePattern<UnaryOp> {
     // where inplace is the actual output but for SSA form we need to return a
     // new value
     auto inplaceOp =
-        rewriter.create<InplaceOp>(op.getLoc(), op.getOperand(1).getType(),
-                                   op.getOperand(0), op.getOperand(1), storage);
+        InplaceOp::create(rewriter, op.getLoc(), op.getOperand(1).getType(),
+                          op.getOperand(0), op.getOperand(1), storage);
 
     storageInfo.replaceAllocWithInplace(op, inplaceOp, storage);
     rewriter.replaceOp(op, inplaceOp);
@@ -215,8 +215,8 @@ struct ConvertRotateOp : public OpRewritePattern<RotateOp> {
     // InplaceOp has the form: output = InplaceOp(evaluator, lhs, inplace)
     // {offset} where inplace is the actual output but for SSA form we need to
     // return a new value
-    auto inplaceOp = rewriter.create<InplaceOp>(
-        op.getLoc(), op.getOperand(1).getType(), op.getOperand(0),
+    auto inplaceOp = InplaceOp::create(
+        rewriter, op.getLoc(), op.getOperand(1).getType(), op.getOperand(0),
         op.getOperand(1), storage, op.getOffset());
 
     // update storage info
@@ -251,8 +251,8 @@ struct ConvertDropLevelOp : public OpRewritePattern<DropLevelOp> {
     // InplaceOp has the form: output = InplaceOp(evaluator, lhs, inplace)
     // {levelToDrop} where inplace is the actual output but for SSA form we need
     // to return a new value
-    auto inplaceOp = rewriter.create<InplaceOp>(
-        op.getLoc(), op.getOperand(1).getType(), op.getOperand(0),
+    auto inplaceOp = InplaceOp::create(
+        rewriter, op.getLoc(), op.getOperand(1).getType(), op.getOperand(0),
         op.getOperand(1), storage, op.getLevelToDrop());
 
     // update storage info

--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -412,7 +412,7 @@ Operation *ModArithDialect::materializeConstant(OpBuilder &builder,
   if (!intAttr) return nullptr;
   auto modType = dyn_cast_if_present<ModArithType>(type);
   if (!modType) return nullptr;
-  auto op = builder.create<mod_arith::ConstantOp>(loc, modType, intAttr);
+  auto op = mod_arith::ConstantOp::create(builder, loc, modType, intAttr);
   return op.getOperation();
 }
 

--- a/lib/Dialect/ModArith/Transforms/ConvertToMac.cpp
+++ b/lib/Dialect/ModArith/Transforms/ConvertToMac.cpp
@@ -38,7 +38,8 @@ struct FindMac : public OpRewritePattern<mod_arith::AddOp> {
       addOperand = op.getLhs();
     }
 
-    auto result = b.create<MacOp>(parent.getLhs(), parent.getRhs(), addOperand);
+    auto result =
+        MacOp::create(b, parent.getLhs(), parent.getRhs(), addOperand);
 
     rewriter.replaceOp(op, result);
 

--- a/lib/Dialect/Secret/Conversions/Patterns.cpp
+++ b/lib/Dialect/Secret/Conversions/Patterns.cpp
@@ -81,12 +81,12 @@ LogicalResult ConvertClientConceal::matchAndRewrite(
   auto plaintextTy = lwe::NewLWEPlaintextType::get(
       op.getContext(), resultCtTy.getApplicationData(),
       resultCtTy.getPlaintextSpace());
-  auto encoded = rewriter.create<lwe::RLWEEncodeOp>(
-      op.getLoc(), plaintextTy, adaptor.getCleartext(),
+  auto encoded = lwe::RLWEEncodeOp::create(
+      rewriter, op.getLoc(), plaintextTy, adaptor.getCleartext(),
       resultCtTy.getPlaintextSpace().getEncoding(),
       resultCtTy.getPlaintextSpace().getRing());
-  auto encryptOp = rewriter.create<lwe::RLWEEncryptOp>(
-      op.getLoc(), resultCtTy, encoded.getResult(), keyBlockArg);
+  auto encryptOp = lwe::RLWEEncryptOp::create(rewriter, op.getLoc(), resultCtTy,
+                                              encoded.getResult(), keyBlockArg);
 
   // Copy attributes from the original op to preserve any mgmt attrs needed by
   // dialect conversion from secret to scheme.
@@ -133,8 +133,8 @@ LogicalResult ConvertClientReveal::matchAndRewrite(
   auto plaintextTy = lwe::NewLWEPlaintextType::get(op.getContext(),
                                                    argCtTy.getApplicationData(),
                                                    argCtTy.getPlaintextSpace());
-  auto decrypted = rewriter.create<lwe::RLWEDecryptOp>(
-      op.getLoc(), plaintextTy, adaptor.getInput(), keyBlockArg);
+  auto decrypted = lwe::RLWEDecryptOp::create(
+      rewriter, op.getLoc(), plaintextTy, adaptor.getInput(), keyBlockArg);
 
   // Note: we use the secret.reveal op's original result type as the result
   // type for the new rlwe_decode op, rather than the type from the parent
@@ -160,8 +160,8 @@ LogicalResult ConvertClientReveal::matchAndRewrite(
   // this pattern lowers the reveal op to have an output tensor type (rather
   // than i16). The rest of the IR manages unpacking, and the rlwe_decode op
   // will only manage the cryptosystem-relevant decoding step (such as iNTT).
-  auto decoded = rewriter.create<lwe::RLWEDecodeOp>(
-      op.getLoc(), op.getResult().getType(), decrypted.getResult(),
+  auto decoded = lwe::RLWEDecodeOp::create(
+      rewriter, op.getLoc(), op.getResult().getType(), decrypted.getResult(),
       argCtTy.getPlaintextSpace().getEncoding(),
       argCtTy.getPlaintextSpace().getRing());
 

--- a/lib/Dialect/Secret/Conversions/SecretToCGGI/SecretToCGGI.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCGGI/SecretToCGGI.cpp
@@ -81,8 +81,8 @@ Value buildSelectTruthTable(Location loc, OpBuilder &b, Value t, Value f,
       buildSelectTruthTable(loc, b, t, f, firstHalf, lutInputs.drop_back());
   Value selectFalse =
       buildSelectTruthTable(loc, b, t, f, lastHalf, lutInputs.drop_back());
-  return b.create<arith::SelectOp>(loc, lutInputs.back(), selectTrue,
-                                   selectFalse);
+  return arith::SelectOp::create(b, loc, lutInputs.back(), selectTrue,
+                                 selectFalse);
 }
 
 Operation *convertWriteOpInterface(
@@ -113,38 +113,38 @@ Operation *convertWriteOpInterface(
                                       .getIntOrFloatBitWidth());
 
         if (valType.getWidth() == 1) {
-          auto ctValue = b.create<lwe::TrivialEncryptOp>(
-              ctTy,
-              b.create<lwe::EncodeOp>(ptxtTy, valueToStore, plaintextBits,
-                                      ctTy.getApplicationData().getOverflow()),
+          auto ctValue = lwe::TrivialEncryptOp::create(
+              b, ctTy,
+              lwe::EncodeOp::create(b, ptxtTy, valueToStore, plaintextBits,
+                                    ctTy.getApplicationData().getOverflow()),
               ciphertextBits);
-          return b.create<memref::StoreOp>(ctValue, toMemRef, indices);
+          return memref::StoreOp::create(b, ctValue, toMemRef, indices);
         }
 
         // Get i-th bit of input and insert the bit into the memref of
         // ciphertexts.
-        auto loop = b.create<mlir::affine::AffineForOp>(0, valType.getWidth());
+        auto loop = mlir::affine::AffineForOp::create(b, 0, valType.getWidth());
         b.setInsertionPointToStart(loop.getBody());
         auto idx = loop.getInductionVar();
 
-        auto one = b.create<arith::ConstantOp>(
-            valType, rewriter.getIntegerAttr(valType, 1));
-        auto shiftAmount = b.create<arith::IndexCastOp>(valType, idx);
-        auto bitMask = b.create<arith::ShLIOp>(valType, one, shiftAmount);
-        auto andOp = b.create<arith::AndIOp>(valueToStore, bitMask);
-        auto shifted = b.create<arith::ShRSIOp>(andOp, shiftAmount);
-        auto bitValue = b.create<arith::TruncIOp>(b.getI1Type(), shifted);
-        auto ctValue = b.create<lwe::TrivialEncryptOp>(
-            ctTy,
-            b.create<lwe::EncodeOp>(ptxtTy, bitValue, plaintextBits,
-                                    ctTy.getApplicationData().getOverflow()),
+        auto one = arith::ConstantOp::create(
+            b, valType, rewriter.getIntegerAttr(valType, 1));
+        auto shiftAmount = arith::IndexCastOp::create(b, valType, idx);
+        auto bitMask = arith::ShLIOp::create(b, valType, one, shiftAmount);
+        auto andOp = arith::AndIOp::create(b, valueToStore, bitMask);
+        auto shifted = arith::ShRSIOp::create(b, andOp, shiftAmount);
+        auto bitValue = arith::TruncIOp::create(b, b.getI1Type(), shifted);
+        auto ctValue = lwe::TrivialEncryptOp::create(
+            b, ctTy,
+            lwe::EncodeOp::create(b, ptxtTy, bitValue, plaintextBits,
+                                  ctTy.getApplicationData().getOverflow()),
             ciphertextBits);
 
         indices.push_back(idx);
-        return b.create<memref::StoreOp>(ctValue, toMemRef, indices);
+        return memref::StoreOp::create(b, ctValue, toMemRef, indices);
       })
       .Case<lwe::NewLWECiphertextType>([&](auto valType) {
-        return b.create<memref::StoreOp>(valueToStore, toMemRef, indices);
+        return memref::StoreOp::create(b, valueToStore, toMemRef, indices);
       })
       .Case<MemRefType>([&](MemRefType valType) {
         int rank = toMemRefTy.getRank();
@@ -170,9 +170,9 @@ Operation *convertWriteOpInterface(
         mlir::Type memRefType =
             mlir::memref::SubViewOp::inferRankReducedResultType(
                 valType.getShape(), toMemRefTy, offsets, sizes, strides);
-        auto subview = b.create<memref::SubViewOp>(
-            cast<MemRefType>(memRefType), toMemRef, offsets, sizes, strides);
-        return b.create<memref::CopyOp>(valueToStore, subview);
+        auto subview = memref::SubViewOp::create(
+            b, cast<MemRefType>(memRefType), toMemRef, offsets, sizes, strides);
+        return memref::CopyOp::create(b, valueToStore, subview);
       });
   llvm_unreachable("expected integer or memref to store in ciphertext memref");
 }
@@ -209,11 +209,11 @@ Operation *convertReadOpInterface(
   // If the offsets are dynamic and the resulting type does not match the
   // converted output type, we must allocate and copy into one with a static 0
   // offset. Otherwise we can return the subview.
-  auto subViewOp = b.create<memref::SubViewOp>(
-      cast<MemRefType>(memRefType), fromMemRef, offsets, sizes, strides);
+  auto subViewOp = memref::SubViewOp::create(
+      b, cast<MemRefType>(memRefType), fromMemRef, offsets, sizes, strides);
   if (memRefType != outputMemRefType) {
-    auto allocOp = b.create<memref::AllocOp>(outputMemRefType);
-    b.create<memref::CopyOp>(subViewOp, allocOp);
+    auto allocOp = memref::AllocOp::create(b, outputMemRefType);
+    memref::CopyOp::create(b, subViewOp, allocOp);
     return allocOp;
   }
   return subViewOp;
@@ -250,8 +250,8 @@ SmallVector<Value> encodeInputs(
       return rewriter
           .create<lwe::TrivialEncryptOp>(
               op->getLoc(), ctxtTy,
-              rewriter.create<lwe::EncodeOp>(op->getLoc(), ptxtTy, input,
-                                             plaintextBits, overflow),
+              lwe::EncodeOp::create(rewriter, op->getLoc(), ptxtTy, input,
+                                    plaintextBits, overflow),
               ciphertextBits)
           .getResult();
     }
@@ -544,10 +544,12 @@ struct ConvertTruthTableOp
     assert(op->getParentOfType<secret::GenericOp>() == nullptr);
 
     // Create a truth table op out of arithmetic statements.
-    Value t = rewriter.create<arith::ConstantOp>(
-        op.getLoc(), rewriter.getIntegerAttr(rewriter.getI1Type(), 1));
-    Value f = rewriter.create<arith::ConstantOp>(
-        op.getLoc(), rewriter.getIntegerAttr(rewriter.getI1Type(), 0));
+    Value t = arith::ConstantOp::create(
+        rewriter, op.getLoc(),
+        rewriter.getIntegerAttr(rewriter.getI1Type(), 1));
+    Value f = arith::ConstantOp::create(
+        rewriter, op.getLoc(),
+        rewriter.getIntegerAttr(rewriter.getI1Type(), 0));
     rewriter.replaceOp(op, buildSelectTruthTable(op.getLoc(), rewriter, t, f,
                                                  op.getLookupTable().getValue(),
                                                  adaptor.getInputs()));
@@ -639,8 +641,8 @@ struct ConvertSecretCastOp
         if (failed(rhsMemRefTy.getStridesAndOffset(strides, offset)))
           return rewriter.notifyMatchFailure(
               op, "failed to get stride and offset exprs");
-        auto castOp = rewriter.create<memref::ReinterpretCastOp>(
-            op.getLoc(), rhsMemRefTy, adaptor.getInput(), offset,
+        auto castOp = memref::ReinterpretCastOp::create(
+            rewriter, op.getLoc(), rhsMemRefTy, adaptor.getInput(), offset,
             rhsMemRefTy.getShape(), strides);
         rewriter.replaceOp(op, castOp);
         return success();
@@ -687,39 +689,39 @@ struct ConvertSecretConcealOp
       auto point = b.saveInsertionPoint();
       auto valueType = element.getType();
       if (valueType.getWidth() == 1) {
-        auto ctValue = b.create<lwe::TrivialEncryptOp>(
-            ctTy,
-            b.create<lwe::EncodeOp>(ptxtTy, element, plaintextBits,
-                                    ctTy.getApplicationData().getOverflow()),
+        auto ctValue = lwe::TrivialEncryptOp::create(
+            b, ctTy,
+            lwe::EncodeOp::create(b, ptxtTy, element, plaintextBits,
+                                  ctTy.getApplicationData().getOverflow()),
             ciphertextBits);
-        b.create<memref::StoreOp>(ctValue, memref, indices);
+        memref::StoreOp::create(b, ctValue, memref, indices);
         return;
       }
-      auto loop = b.create<mlir::affine::AffineForOp>(0, valueType.getWidth());
+      auto loop = mlir::affine::AffineForOp::create(b, 0, valueType.getWidth());
       b.setInsertionPointToStart(loop.getBody());
       auto idx = loop.getInductionVar();
 
-      auto one = b.create<arith::ConstantOp>(
-          valueType, rewriter.getIntegerAttr(valueType, 1));
-      auto shiftAmount = b.create<arith::IndexCastOp>(valueType, idx);
-      auto bitMask = b.create<arith::ShLIOp>(valueType, one, shiftAmount);
-      auto andOp = b.create<arith::AndIOp>(element, bitMask);
-      auto shifted = b.create<arith::ShRSIOp>(andOp, shiftAmount);
-      auto bitValue = b.create<arith::TruncIOp>(b.getI1Type(), shifted);
-      auto ctValue = b.create<lwe::TrivialEncryptOp>(
-          ctTy,
-          b.create<lwe::EncodeOp>(ptxtTy, bitValue, plaintextBits,
-                                  ctTy.getApplicationData().getOverflow()),
+      auto one = arith::ConstantOp::create(
+          b, valueType, rewriter.getIntegerAttr(valueType, 1));
+      auto shiftAmount = arith::IndexCastOp::create(b, valueType, idx);
+      auto bitMask = arith::ShLIOp::create(b, valueType, one, shiftAmount);
+      auto andOp = arith::AndIOp::create(b, element, bitMask);
+      auto shifted = arith::ShRSIOp::create(b, andOp, shiftAmount);
+      auto bitValue = arith::TruncIOp::create(b, b.getI1Type(), shifted);
+      auto ctValue = lwe::TrivialEncryptOp::create(
+          b, ctTy,
+          lwe::EncodeOp::create(b, ptxtTy, bitValue, plaintextBits,
+                                ctTy.getApplicationData().getOverflow()),
           ciphertextBits);
       indices.append({idx});
-      b.create<memref::StoreOp>(ctValue, memref, indices);
+      memref::StoreOp::create(b, ctValue, memref, indices);
       b.restoreInsertionPoint(point);
     };
 
     Value newValue;
     Value valueToStore = adaptor.getCleartext();
     if (auto memrefTy = dyn_cast<MemRefType>(convertedTy)) {
-      auto allocOp = b.create<memref::AllocOp>(memrefTy);
+      auto allocOp = memref::AllocOp::create(b, memrefTy);
       newValue = allocOp.getResult();
       if (auto inputMemrefTy =
               dyn_cast<MemRefType>(adaptor.getCleartext().getType())) {
@@ -728,7 +730,7 @@ struct ConvertSecretConcealOp
         SmallVector<Value> constIndices;
         const auto *maxDimension = llvm::max_element(inputMemrefTy.getShape());
         for (auto i = 0; i < *maxDimension; ++i) {
-          constIndices.push_back(b.create<arith::ConstantIndexOp>(i));
+          constIndices.push_back(arith::ConstantIndexOp::create(b, i));
         }
         for (auto i = 0; i < inputMemrefTy.getNumElements(); ++i) {
           // Extract the value from the original memref.
@@ -737,7 +739,7 @@ struct ConvertSecretConcealOp
               rawIndices,
               [&](int64_t index) -> Value { return constIndices[index]; });
           auto extractedValue =
-              b.create<memref::LoadOp>(valueToStore, indices).getResult();
+              memref::LoadOp::create(b, valueToStore, indices).getResult();
           storeElement(cast<TypedValue<IntegerType>>(extractedValue), indices,
                        newValue);
         }
@@ -749,10 +751,10 @@ struct ConvertSecretConcealOp
     } else {
       // The input was an i1 and the output was a scalar ct.
       assert(cast<IntegerType>(valueToStore.getType()).getWidth() == 1);
-      newValue = b.create<lwe::TrivialEncryptOp>(
-          ctTy,
-          b.create<lwe::EncodeOp>(ptxtTy, valueToStore, plaintextBits,
-                                  ctTy.getApplicationData().getOverflow()),
+      newValue = lwe::TrivialEncryptOp::create(
+          b, ctTy,
+          lwe::EncodeOp::create(b, ptxtTy, valueToStore, plaintextBits,
+                                ctTy.getApplicationData().getOverflow()),
           ciphertextBits);
     }
 

--- a/lib/Dialect/Secret/Conversions/SecretToModArith/SecretToModArith.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToModArith/SecretToModArith.cpp
@@ -215,9 +215,9 @@ Value encodeCleartext(Value cleartext, Type resultType,
     extendedType = shapedType.cloneWith(shapedType.getShape(), modulusType);
   }
 
-  auto extOp = b.create<arith::ExtSIOp>(extendedType, cleartext);
+  auto extOp = arith::ExtSIOp::create(b, extendedType, cleartext);
   auto encapsulateOp =
-      b.create<mod_arith::EncapsulateOp>(resultType, extOp.getResult());
+      mod_arith::EncapsulateOp::create(b, resultType, extOp.getResult());
   return encapsulateOp.getResult();
 }
 
@@ -275,14 +275,14 @@ struct ConvertReveal : public OpConversionPattern<secret::RevealOp> {
     }
 
     auto extractOp =
-        b.create<mod_arith::ExtractOp>(beforeTrunc, adaptor.getInput());
+        mod_arith::ExtractOp::create(b, beforeTrunc, adaptor.getInput());
     Value result = extractOp.getResult();
 
     Type truncatedType = op.getResult().getType();
     if (getElementTypeOrSelf(truncatedType).getIntOrFloatBitWidth() <
         getElementTypeOrSelf(extractOp.getResult().getType())
             .getIntOrFloatBitWidth()) {
-      auto truncOp = b.create<arith::TruncIOp>(truncatedType, result);
+      auto truncOp = arith::TruncIOp::create(b, truncatedType, result);
       result = truncOp.getResult();
     }
 
@@ -354,7 +354,7 @@ struct ConvertDebugCall : public SecretGenericOpConversion<func::CallOp> {
     // because we want to do a reveal and let the reveal pattern handle the
     // type conversion.
     auto revealOp =
-        rewriter.create<secret::RevealOp>(op.getLoc(), op.getOperands()[0]);
+        secret::RevealOp::create(rewriter, op.getLoc(), op.getOperands()[0]);
     auto newCallOp = rewriter.replaceOpWithNewOp<func::CallOp>(
         op, innerOp.getResultTypes(), innerOp.getCallee(),
         revealOp.getResult());

--- a/lib/Dialect/Secret/Transforms/AddDebugPort.cpp
+++ b/lib/Dialect/Secret/Transforms/AddDebugPort.cpp
@@ -40,7 +40,7 @@ func::FuncOp getOrCreateExternalDebugFunc(ModuleOp module, Type valueType) {
 
   ImplicitLocOpBuilder b =
       ImplicitLocOpBuilder::atBlockBegin(module.getLoc(), module.getBody());
-  auto funcOp = b.create<func::FuncOp>(funcName, debugFuncType);
+  auto funcOp = func::FuncOp::create(b, funcName, debugFuncType);
   // required for external func call
   funcOp.setPrivate();
   return funcOp;
@@ -55,8 +55,8 @@ LogicalResult insertExternalCall(secret::GenericOp op, DataFlowSolver &solver) {
   auto insertCall = [&](Value value) {
     Type valueType = value.getType();
 
-    b.create<func::CallOp>(getOrCreateExternalDebugFunc(module, valueType),
-                           ArrayRef<Value>{value});
+    func::CallOp::create(b, getOrCreateExternalDebugFunc(module, valueType),
+                         ArrayRef<Value>{value});
   };
 
   // insert for each argument

--- a/lib/Dialect/Secret/Transforms/DistributeGeneric.cpp
+++ b/lib/Dialect/Secret/Transforms/DistributeGeneric.cpp
@@ -259,8 +259,8 @@ struct SplitGeneric : public OpRewritePattern<GenericOp> {
           // be promoted to a secret and added to the new generic's operands if
           // the loop was yielding a secret value.
           rewriter.setInsertionPoint(clonedLoop);
-          auto newInit = rewriter.create<secret::ConcealOp>(genericOp.getLoc(),
-                                                            operand.get());
+          auto newInit = secret::ConcealOp::create(rewriter, genericOp.getLoc(),
+                                                   operand.get());
           clonedLoop->setOperand(operand.getOperandNumber(), newInit);
           blockArg.setType(operand.get().getType());
           newInitsToOperands.insert({blockArg, operand.get()});
@@ -318,9 +318,9 @@ struct SplitGeneric : public OpRewritePattern<GenericOp> {
       }
 
       SmallVector<Operation *> opsToErase;
-      GenericOp newGenericOp = rewriter.create<GenericOp>(
-          clonedLoopBody.getOperations().front().getLoc(), newGenericOperands,
-          loopResultTypes,
+      GenericOp newGenericOp = GenericOp::create(
+          rewriter, clonedLoopBody.getOperations().front().getLoc(),
+          newGenericOperands, loopResultTypes,
           [&](OpBuilder &b, Location loc, ValueRange blockArguments) {
             IRMapping mp;
             for (BlockArgument blockArg : genericOp.getBody()->getArguments()) {
@@ -350,7 +350,7 @@ struct SplitGeneric : public OpRewritePattern<GenericOp> {
                  clonedLoopBody.getTerminator()->getOperands()) {
               newYieldedValues.push_back(mp.lookup(oldYieldedValue));
             }
-            b.create<YieldOp>(loc, newYieldedValues);
+            YieldOp::create(b, loc, newYieldedValues);
           });
 
       LLVM_DEBUG(genericOp->getParentOp()->emitRemark()

--- a/lib/Dialect/Secret/Transforms/ForgetSecrets.cpp
+++ b/lib/Dialect/Secret/Transforms/ForgetSecrets.cpp
@@ -43,7 +43,7 @@ static Value materializeSource(OpBuilder &builder, Type type, ValueRange inputs,
     llvm_unreachable(
         "Secret types should never be the input to a materializeSource.");
 
-  return builder.create<ConcealOp>(loc, inputs[0]);
+  return ConcealOp::create(builder, loc, inputs[0]);
 }
 
 static Value materializeTarget(OpBuilder &builder, Type type, ValueRange inputs,
@@ -54,7 +54,7 @@ static Value materializeTarget(OpBuilder &builder, Type type, ValueRange inputs,
     llvm_unreachable(
         "Non-secret types should never be the input to a materializeTarget.");
 
-  return builder.create<RevealOp>(loc, inputs[0]);
+  return RevealOp::create(builder, loc, inputs[0]);
 }
 
 class ForgetSecretsTypeConverter : public TypeConverter {

--- a/lib/Dialect/TOSA/Conversions/TosaToSecretArith/TosaToSecretArith.cpp
+++ b/lib/Dialect/TOSA/Conversions/TosaToSecretArith/TosaToSecretArith.cpp
@@ -47,7 +47,7 @@ Value createConstantFloat(ImplicitLocOpBuilder &b, double floatValue,
   }
 
   auto constantValuesAttr = SplatElementsAttr::get(type, value);
-  return b.create<arith::ConstantOp>(constantValuesAttr);
+  return arith::ConstantOp::create(b, constantValuesAttr);
 }
 
 struct ConvertTosaSigmoid : public OpRewritePattern<mlir::tosa::SigmoidOp> {
@@ -91,18 +91,18 @@ struct ConvertTosaSigmoid : public OpRewritePattern<mlir::tosa::SigmoidOp> {
         createConstantFloat(b, -0.004, rankedTensorType);
 
     auto coefficientMultiplyDegreeOne =
-        b.create<arith::MulFOp>(coefficientDegreeOne, op.getOperand());
+        arith::MulFOp::create(b, coefficientDegreeOne, op.getOperand());
     auto calculateDegreeTwo =
-        b.create<arith::MulFOp>(op.getOperand(), op.getOperand());
+        arith::MulFOp::create(b, op.getOperand(), op.getOperand());
     auto calculateDegreeThree =
-        b.create<arith::MulFOp>(calculateDegreeTwo, op.getOperand());
+        arith::MulFOp::create(b, calculateDegreeTwo, op.getOperand());
     auto coefficientMultiplyDegreeThree =
-        b.create<arith::MulFOp>(calculateDegreeThree, coefficientDegreeThree);
+        arith::MulFOp::create(b, calculateDegreeThree, coefficientDegreeThree);
 
-    auto sumDegreeZeroAndOne = b.create<arith::AddFOp>(
-        coefficientDegreeZero, coefficientMultiplyDegreeOne);
-    auto totalSum = b.create<arith::AddFOp>(sumDegreeZeroAndOne,
-                                            coefficientMultiplyDegreeThree);
+    auto sumDegreeZeroAndOne = arith::AddFOp::create(
+        b, coefficientDegreeZero, coefficientMultiplyDegreeOne);
+    auto totalSum = arith::AddFOp::create(b, sumDegreeZeroAndOne,
+                                          coefficientMultiplyDegreeThree);
     rewriter.replaceOp(op, totalSum);
     return success();
   }

--- a/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.cpp
+++ b/lib/Dialect/TensorExt/Conversions/TensorExtToTensor/TensorExtToTensor.cpp
@@ -60,32 +60,32 @@ struct ConvertRotateOp : public OpRewritePattern<RotateOp> {
     auto rightTensorType =
         RankedTensorType::get({tensorSize - shiftValue}, tensorElementType);
 
-    auto left = rewriter.create<tensor::ExtractSliceOp>(
-        op.getLoc(), leftTensorType, op.getTensor(), ArrayRef<Value>{},
-        ArrayRef<Value>{}, ArrayRef<Value>{},
+    auto left = tensor::ExtractSliceOp::create(
+        rewriter, op.getLoc(), leftTensorType, op.getTensor(),
+        ArrayRef<Value>{}, ArrayRef<Value>{}, ArrayRef<Value>{},
         /*offsets=*/ArrayRef<int64_t>{0},
         /*sizes=*/ArrayRef{shiftValue}, /*strides=*/ArrayRef<int64_t>{1});
-    auto right = rewriter.create<tensor::ExtractSliceOp>(
-        op.getLoc(), rightTensorType, op.getTensor(), ArrayRef<Value>{},
-        ArrayRef<Value>{}, ArrayRef<Value>{},
+    auto right = tensor::ExtractSliceOp::create(
+        rewriter, op.getLoc(), rightTensorType, op.getTensor(),
+        ArrayRef<Value>{}, ArrayRef<Value>{}, ArrayRef<Value>{},
         /*offsets=*/ArrayRef{shiftValue},
         /*sizes=*/ArrayRef{tensorSize - shiftValue},
         /*strides=*/ArrayRef<int64_t>{1});
     // for tensor.concat to lower we need to use
     // transform.apply_patterns.tensor.decompose_concat which is quite painful
-    // auto concat = rewriter.create<tensor::ConcatOp>(
+    // auto concat = tensor::ConcatOp::create(rewriter,
     //    op.getLoc(), /*dim=*/0,
     //    ValueRange{right.getResult(), left.getResult()});
-    auto empty = rewriter.create<tensor::EmptyOp>(op.getLoc(), tensorShape,
-                                                  tensorElementType);
-    auto insertLeftToRight = rewriter.create<tensor::InsertSliceOp>(
-        op.getLoc(), left.getResult(), empty, ArrayRef<Value>{},
+    auto empty = tensor::EmptyOp::create(rewriter, op.getLoc(), tensorShape,
+                                         tensorElementType);
+    auto insertLeftToRight = tensor::InsertSliceOp::create(
+        rewriter, op.getLoc(), left.getResult(), empty, ArrayRef<Value>{},
         ArrayRef<Value>{}, ArrayRef<Value>{},
         /*offsets=*/ArrayRef<int64_t>{tensorSize - shiftValue},
         /*sizes=*/ArrayRef{shiftValue}, /*strides=*/ArrayRef<int64_t>{1});
-    auto insertRightToLeft = rewriter.create<tensor::InsertSliceOp>(
-        op.getLoc(), right.getResult(), insertLeftToRight, ArrayRef<Value>{},
-        ArrayRef<Value>{}, ArrayRef<Value>{},
+    auto insertRightToLeft = tensor::InsertSliceOp::create(
+        rewriter, op.getLoc(), right.getResult(), insertLeftToRight,
+        ArrayRef<Value>{}, ArrayRef<Value>{}, ArrayRef<Value>{},
         /*offsets=*/ArrayRef<int64_t>{0},
         /*sizes=*/ArrayRef{tensorSize - shiftValue},
         /*strides=*/ArrayRef<int64_t>{1});

--- a/lib/Dialect/TensorExt/Transforms/CollapseInsertionChains.cpp
+++ b/lib/Dialect/TensorExt/Transforms/CollapseInsertionChains.cpp
@@ -166,7 +166,7 @@ struct ConvertAlignedExtractInsertToRotate
     // user
     rewriter.replaceOpWithNewOp<tensor_ext::RotateOp>(
         current, extractionSource,
-        rewriter.create<arith::ConstantIndexOp>(current.getLoc(), shift));
+        arith::ConstantIndexOp::create(rewriter, current.getLoc(), shift));
 
     // The rest of the chain of insertions and extractions itself will be
     // DCE'd by canonicalization if possible.

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
@@ -256,7 +256,7 @@ Value createMask(TypedValue<RankedTensorType> tensor,
 
   auto denseAttr = DenseElementsAttr::get(tensor.getType(), maskAttrs);
   auto constant =
-      rewriter.create<arith::ConstantOp>(tensor.getLoc(), denseAttr);
+      arith::ConstantOp::create(rewriter, tensor.getLoc(), denseAttr);
   return constant.getResult();
 }
 
@@ -281,15 +281,15 @@ Value rotateGroup(TypedValue<RankedTensorType> tensor,
 
     Value mask = createMask(tensor, round.rotatedIndices, rewriter);
     arith::MulIOp maskOp =
-        rewriter.create<arith::MulIOp>(tensor.getLoc(), tensor, mask);
-    Value rotated = rewriter.create<tensor_ext::RotateOp>(
-        tensor.getLoc(), maskOp.getResult(),
-        rewriter.create<arith::ConstantIntOp>(
-            tensor.getLoc(), rewriter.getI32Type(), rotationAmount));
+        arith::MulIOp::create(rewriter, tensor.getLoc(), tensor, mask);
+    Value rotated = tensor_ext::RotateOp::create(
+        rewriter, tensor.getLoc(), maskOp.getResult(),
+        arith::ConstantIntOp::create(rewriter, tensor.getLoc(),
+                                     rewriter.getI32Type(), rotationAmount));
 
     if (result.has_value()) {
-      result = rewriter.create<arith::AddIOp>(tensor.getLoc(), result.value(),
-                                              rotated);
+      result = arith::AddIOp::create(rewriter, tensor.getLoc(), result.value(),
+                                     rotated);
     } else {
       result = rotated;
     }
@@ -365,7 +365,7 @@ LogicalResult convertPermuteOp(PermuteOp op,
         rotateGroup(op.getInput(), group, ciphertextSize, permKey, rewriter);
     if (result.has_value())
       result =
-          rewriter.create<arith::AddIOp>(op.getLoc(), *result, perGroupResult);
+          arith::AddIOp::create(rewriter, op.getLoc(), *result, perGroupResult);
     else
       result = perGroupResult;
   }

--- a/lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.cpp
+++ b/lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.cpp
@@ -84,8 +84,8 @@ struct IfToSelectConversion : OpRewritePattern<scf::IfOp> {
            llvm::enumerate(llvm::zip(thenYieldArgs, elseYieldArgs))) {
         Value trueVal = std::get<0>(it.value());
         Value falseVal = std::get<1>(it.value());
-        newResults[it.index()] = rewriter.create<arith::SelectOp>(
-            ifOp.getLoc(), cond, trueVal, falseVal);
+        newResults[it.index()] = arith::SelectOp::create(
+            rewriter, ifOp.getLoc(), cond, trueVal, falseVal);
       }
 
       rewriter.replaceOp(ifOp, newResults);

--- a/lib/Transforms/DropUnitDims/DropUnitDims.cpp
+++ b/lib/Transforms/DropUnitDims/DropUnitDims.cpp
@@ -78,8 +78,8 @@ static Value collapseValue(RewriterBase &rewriter, Location loc, Value operand,
   auto tensorType = cast<RankedTensorType>(operand.getType());
   auto targetType =
       RankedTensorType::get(targetShape, tensorType.getElementType());
-  return rewriter.create<tensor::CollapseShapeOp>(loc, targetType, operand,
-                                                  reassociation);
+  return tensor::CollapseShapeOp::create(rewriter, loc, targetType, operand,
+                                         reassociation);
 }
 
 /// Returns a collapsed `val` where the collapsing occurs at dims in positions.
@@ -118,8 +118,8 @@ struct ReduceLinalgMap : OpRewritePattern<linalg::MapOp> {
   Value expandResult(PatternRewriter &rewriter, Value result,
                      RankedTensorType expandedType,
                      SmallVector<int64_t> dims) const {
-    return rewriter.create<tensor::ExpandShapeOp>(
-        result.getLoc(), expandedType, result,
+    return tensor::ExpandShapeOp::create(
+        rewriter, result.getLoc(), expandedType, result,
         getReassociationForReshapeAtDim(expandedType.getRank(), dims));
   }
 
@@ -176,8 +176,8 @@ struct ReduceLinalgMap : OpRewritePattern<linalg::MapOp> {
                                           collapsedOperands.end() - 1};
     SmallVector<Type, 1> collapsedResultTy;
     collapsedResultTy.push_back(collapsedInit.getType());
-    linalg::MapOp collapsedOp = rewriter.create<linalg::MapOp>(
-        loc, collapsedInputs, collapsedInit,
+    linalg::MapOp collapsedOp = linalg::MapOp::create(
+        rewriter, loc, collapsedInputs, collapsedInit,
         [&](OpBuilder &b, Location loc, ValueRange blockArguments) {
           IRMapping mp;
           for (BlockArgument blockArg : mapper->getArguments()) {

--- a/lib/Transforms/FoldConstantTensors/FoldConstantTensors.cpp
+++ b/lib/Transforms/FoldConstantTensors/FoldConstantTensors.cpp
@@ -150,8 +150,8 @@ class InsertIntoFromElements final : public OpRewritePattern<tensor::InsertOp> {
       if (flatIndexToElement.contains(i)) {
         values.push_back(flatIndexToElement[i]);
       } else {
-        values.push_back(rewriter.create<arith::ConstantOp>(
-            insertOp.getLoc(), constantValue.getElementType(),
+        values.push_back(arith::ConstantOp::create(
+            rewriter, insertOp.getLoc(), constantValue.getElementType(),
             cast<TypedAttr>(constantValue.getValues<Attribute>()[i])));
       }
     }

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
@@ -234,9 +234,9 @@ LayoutOptimization::OpHoistResult LayoutOptimization::hoistOp(
                             << originalLayout.value() << " to layout "
                             << minHoistResult.newInputLayouts[i] << "\n");
     LayoutAttr newInputLayout = minHoistResult.newInputLayouts[i];
-    auto newInput = builder.create<ConvertLayoutOp>(
-        op->getLoc(), operand, cast<LayoutAttr>(originalLayout.value()),
-        newInputLayout);
+    auto newInput = ConvertLayoutOp::create(
+        builder, op->getLoc(), operand,
+        cast<LayoutAttr>(originalLayout.value()), newInputLayout);
     newInput->setAttr(kLayoutAttrName, newInputLayout);
     builder.replaceUsesWithIf(operand, newInput, [&](OpOperand &operand) {
       return operand.getOwner() == op;

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
@@ -145,7 +145,7 @@ FailureOr<AssignLayoutOp> LayoutPropagation::assignDefaultLayoutForOpOperand(
   }
   LayoutAttr layoutAttr = layout.value();
   AssignLayoutOp assignLayoutOp =
-      builder.create<AssignLayoutOp>(op->getLoc(), operand, layoutAttr);
+      AssignLayoutOp::create(builder, op->getLoc(), operand, layoutAttr);
   setAttributeAssociatedWith(assignLayoutOp.getResult(),
                              tensor_ext::TensorExtDialect::kLayoutAttrName,
                              layoutAttr);
@@ -597,8 +597,8 @@ LogicalResult LayoutPropagation::visitOperation(MatvecOp op) {
     LayoutAttr squatDiagonalLayoutAttr = LayoutAttr::get(
         getDiagonalLayoutMap(matrixType, ciphertextSemanticShape), alignment);
 
-    ConvertLayoutOp convertLayoutOp = builder.create<ConvertLayoutOp>(
-        op->getLoc(), matrix, matrixLayout, squatDiagonalLayoutAttr);
+    ConvertLayoutOp convertLayoutOp = ConvertLayoutOp::create(
+        builder, op->getLoc(), matrix, matrixLayout, squatDiagonalLayoutAttr);
     convertLayoutOp->setAttr(tensor_ext::TensorExtDialect::kLayoutAttrName,
                              squatDiagonalLayoutAttr);
     Value toReplace = convertLayoutOp.getResult();
@@ -825,8 +825,9 @@ void LayoutPropagation::rectifyIncompatibleOperandLayouts(Operation *op) {
 
           if (sourceLayout != targetLayout) {
             builder.setInsertionPoint(op);
-            ConvertLayoutOp convertOp = builder.create<ConvertLayoutOp>(
-                op->getLoc(), opOperand.get(), sourceLayout, targetLayout);
+            ConvertLayoutOp convertOp =
+                ConvertLayoutOp::create(builder, op->getLoc(), opOperand.get(),
+                                        sourceLayout, targetLayout);
 
             // Layout of the result is the same as the target layout of the
             // conversion. Mostly this is done for consistency: all ops have an
@@ -851,8 +852,8 @@ void LayoutPropagation::rectifyIncompatibleOperandLayouts(ReduceOp op) {
         convertLayoutForReduce(inputLayout, op.getDimensions());
 
     if (reducedInputLayout != initLayout) {
-      ConvertLayoutOp convertOp = builder.create<ConvertLayoutOp>(
-          op->getLoc(), init, initLayout, reducedInputLayout);
+      ConvertLayoutOp convertOp = ConvertLayoutOp::create(
+          builder, op->getLoc(), init, initLayout, reducedInputLayout);
       Value toReplace = convertOp.getResult();
       builder.replaceUsesWithIf(init, toReplace, [&](OpOperand &operand) {
         return operand.getOwner() == op;

--- a/lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.cpp
+++ b/lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.cpp
@@ -105,8 +105,8 @@ struct FoldConstantLinalgTranspose
                   denseAttr, outputShape, permutation);
         }
       }
-      auto transposedConstantOp = rewriter.create<arith::ConstantOp>(
-          transposeOp.getLoc(), transposedDenseElementsAttr);
+      auto transposedConstantOp = arith::ConstantOp::create(
+          rewriter, transposeOp.getLoc(), transposedDenseElementsAttr);
       rewriter.replaceOp(transposeOp, transposedConstantOp.getResult());
       return success();
     }

--- a/lib/Transforms/MemrefToArith/ExpandCopy.cpp
+++ b/lib/Transforms/MemrefToArith/ExpandCopy.cpp
@@ -39,21 +39,21 @@ SmallVector<affine::AffineForOp> expandWithAffineLoops(OpBuilder& builder,
   SmallVector<mlir::Value, 4> indices;
   SmallVector<affine::AffineForOp> loops;
 
-  auto zero = b.create<arith::ConstantIndexOp>(0);
+  auto zero = arith::ConstantIndexOp::create(b, 0);
   for (auto dim : memRefType.getShape()) {
     if (dim == 1) {
       // No need to create a loop for a one-dimensional index.
       indices.push_back(zero);
       continue;
     }
-    auto loop = b.create<mlir::affine::AffineForOp>(0, dim);
+    auto loop = mlir::affine::AffineForOp::create(b, 0, dim);
     b.setInsertionPointToStart(loop.getBody());
     indices.push_back(loop.getInductionVar());
     loops.push_back(loop);
   }
 
-  auto load = b.create<mlir::affine::AffineLoadOp>(copy.getSource(), indices);
-  b.create<mlir::affine::AffineStoreOp>(load, copy.getTarget(), indices);
+  auto load = mlir::affine::AffineLoadOp::create(b, copy.getSource(), indices);
+  mlir::affine::AffineStoreOp::create(b, load, copy.getTarget(), indices);
   return loops;
 }
 

--- a/lib/Transforms/MemrefToArith/ExtractLoopBody.cpp
+++ b/lib/Transforms/MemrefToArith/ExtractLoopBody.cpp
@@ -156,7 +156,7 @@ void extractLoopBody(AffineForOp loop, unsigned int minimumLoopSize,
   OpBuilder builder(loop->getParentOfType<func::FuncOp>());
   auto type = builder.getFunctionType(inputTypes, result.getType());
   std::string funcName = llvm::formatv("for_{0}", mlir::hash_value(result));
-  auto funcOp = builder.create<func::FuncOp>(moduleLoc, funcName, type);
+  auto funcOp = func::FuncOp::create(builder, moduleLoc, funcName, type);
 
   // Populate function body by cloning the ops in the inner body and mapping
   // the func args and func outputs.
@@ -179,11 +179,11 @@ void extractLoopBody(AffineForOp loop, unsigned int minimumLoopSize,
   }
 
   // Add a return statement for the final cloned operation's result.
-  builder.create<func::ReturnOp>(funcOp.getLoc(), clonedOp->getResult(0));
+  func::ReturnOp::create(builder, funcOp.getLoc(), clonedOp->getResult(0));
 
   // Call the function.
   builder.setInsertionPointAfter(result.getDefiningOp());
-  auto callOp = builder.create<func::CallOp>(result.getLoc(), funcOp, inputs);
+  auto callOp = func::CallOp::create(builder, result.getLoc(), funcOp, inputs);
   result.getDefiningOp()->replaceAllUsesWith(callOp);
 
   // Erase previous ops, except for the load statements and its dependents.

--- a/lib/Transforms/MemrefToArith/MemrefGlobalReplace.cpp
+++ b/lib/Transforms/MemrefToArith/MemrefGlobalReplace.cpp
@@ -128,8 +128,8 @@ class MemrefGlobalLoweringPattern final : public mlir::ConversionPattern {
         // forward the load to this value.
         OpBuilder builder(user);
         auto val = *(constantAttrIt + flattenedIndex.value());
-        auto cst = builder.create<mlir::arith::ConstantOp>(
-            user->getLoc(), resultElementType,
+        auto cst = mlir::arith::ConstantOp::create(
+            builder, user->getLoc(), resultElementType,
             mlir::cast<mlir::TypedAttr>(val));
         rewriter.replaceOp(user, cst);
       }

--- a/lib/Transforms/MemrefToArith/UnrollAndForward.cpp
+++ b/lib/Transforms/MemrefToArith/UnrollAndForward.cpp
@@ -292,11 +292,11 @@ static LogicalResult forwardFullyUnrolledStoreToLoad(
     llvm::SmallVector<Value> indexValues;
     for (auto ndx :
          unflattenIndex(loadAccessIndex, endingStrides, endingOffset)) {
-      Value ndxValue = b.create<ConstantOp>(b.getIndexAttr(ndx));
+      Value ndxValue = ConstantOp::create(b, b.getIndexAttr(ndx));
       indexValues.push_back(ndxValue);
     }
 
-    auto newLoadOp = b.create<AffineLoadOp>(loadSourceMemref, indexValues);
+    auto newLoadOp = AffineLoadOp::create(b, loadSourceMemref, indexValues);
     loadOp.getValue().replaceAllUsesWith(newLoadOp.getValue());
     opsToErase.push_back(loadOp);
     return success();

--- a/lib/Transforms/OperationBalancer/OperationBalancer.cpp
+++ b/lib/Transforms/OperationBalancer/OperationBalancer.cpp
@@ -32,8 +32,8 @@ OpType recursiveProduceBalancedTree(OpBuilder &builder, Location &loc,
   // Else, split the operands in half and recursively call this function on each
   // half, creating an appropriate operation for each half.
   if (flattenedOperands.size() == 2) {
-    return builder.create<OpType>(loc, flattenedOperands[0],
-                                  flattenedOperands[1]);
+    return OpType::create(builder, loc, flattenedOperands[0],
+                          flattenedOperands[1]);
   } else if (flattenedOperands.size() == 3) {
     std::vector<Value> leftOperands;
     leftOperands.reserve(2);
@@ -42,7 +42,7 @@ OpType recursiveProduceBalancedTree(OpBuilder &builder, Location &loc,
 
     auto leftTree =
         recursiveProduceBalancedTree<OpType>(builder, loc, leftOperands);
-    return builder.create<OpType>(loc, leftTree, flattenedOperands.back());
+    return OpType::create(builder, loc, leftTree, flattenedOperands.back());
   } else {
     // split the operands in half
     int leftSize = flattenedOperands.size() / 2;
@@ -66,7 +66,7 @@ OpType recursiveProduceBalancedTree(OpBuilder &builder, Location &loc,
         recursiveProduceBalancedTree<OpType>(builder, loc, rightOperands);
 
     // create an appropriate operation for the two halves
-    return builder.create<OpType>(loc, leftTree, rightTree);
+    return OpType::create(builder, loc, leftTree, rightTree);
   }
 }
 

--- a/lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.cpp
+++ b/lib/Transforms/OptimizeRelinearization/OptimizeRelinearization.cpp
@@ -59,7 +59,7 @@ struct OptimizeRelinearization
 
       b.setInsertionPointAfter(op);
       for (Value result : op->getResults()) {
-        auto reduceOp = b.create<mgmt::RelinearizeOp>(op->getLoc(), result);
+        auto reduceOp = mgmt::RelinearizeOp::create(b, op->getLoc(), result);
         result.replaceAllUsesExcept(reduceOp.getResult(), {reduceOp});
       }
     });

--- a/lib/Transforms/SelectRewrite/SelectRewrite.cpp
+++ b/lib/Transforms/SelectRewrite/SelectRewrite.cpp
@@ -28,7 +28,7 @@ Value matchShapedType(OpBuilder builder, Value op, Value target) {
   if (targetShapedType && !opShapedType) {
     auto newShapedType =
         targetShapedType.cloneWith(targetShapedType.getShape(), op.getType());
-    return builder.create<tensor::SplatOp>(op.getLoc(), op, newShapedType);
+    return tensor::SplatOp::create(builder, op.getLoc(), op, newShapedType);
   }
   return op;
 }

--- a/lib/Transforms/StraightLineVectorizer/StraightLineVectorizer.cpp
+++ b/lib/Transforms/StraightLineVectorizer/StraightLineVectorizer.cpp
@@ -126,8 +126,8 @@ bool tryVectorizeBlock(Block *block, Dialect *dialect) {
         for (auto *op : bucket) {
           operands.push_back(op->getOperand(operandIndex));
         }
-        auto fromElementsOp = builder.create<tensor::FromElementsOp>(
-            key->getLoc(), tensorType, operands);
+        auto fromElementsOp = tensor::FromElementsOp::create(
+            builder, key->getLoc(), tensorType, operands);
         vectorizedOperands.push_back(fromElementsOp.getResult());
       }
 
@@ -137,10 +137,10 @@ bool tryVectorizeBlock(Block *block, Dialect *dialect) {
 
       int bucketIndex = 0;
       for (auto *op : bucket) {
-        auto extractionIndex = builder.create<arith::ConstantOp>(
-            op->getLoc(), builder.getIndexAttr(bucketIndex));
-        auto extractOp = builder.create<tensor::ExtractOp>(
-            op->getLoc(), elementType, vectorizedOp->getResult(0),
+        auto extractionIndex = arith::ConstantOp::create(
+            builder, op->getLoc(), builder.getIndexAttr(bucketIndex));
+        auto extractOp = tensor::ExtractOp::create(
+            builder, op->getLoc(), elementType, vectorizedOp->getResult(0),
             extractionIndex.getResult());
         op->replaceAllUsesWith(ValueRange{extractOp.getResult()});
         bucketIndex++;

--- a/lib/Transforms/TensorToScalars/TensorToScalars.cpp
+++ b/lib/Transforms/TensorToScalars/TensorToScalars.cpp
@@ -62,7 +62,7 @@ SmallVector<SmallVector<int64_t>> getAllIndices(TensorType tensorType) {
 static Value buildFromElementsOp(OpBuilder &builder,
                                  RankedTensorType resultType, ValueRange inputs,
                                  Location loc) {
-  return builder.create<tensor::FromElementsOp>(loc, resultType, inputs);
+  return tensor::FromElementsOp::create(builder, loc, resultType, inputs);
 }
 
 static SmallVector<Value> buildExtractOps(OpBuilder &builder,
@@ -80,13 +80,13 @@ static SmallVector<Value> buildExtractOps(OpBuilder &builder,
   const auto *maxDimension = llvm::max_element(inputType.getShape());
   SmallVector<Value> constVals;
   for (auto i = 0; i < *maxDimension; ++i) {
-    constVals.push_back(b.create<arith::ConstantIndexOp>(i));
+    constVals.push_back(arith::ConstantIndexOp::create(b, i));
   }
   auto rawIndices = getAllIndices(inputType);
   for (SmallVector<int64_t> indices : rawIndices) {
     SmallVector<Value> idxRange = llvm::to_vector(
         llvm::map_range(indices, [&](int64_t idx) { return constVals[idx]; }));
-    Value element = builder.create<tensor::ExtractOp>(loc, input, idxRange);
+    Value element = tensor::ExtractOp::create(builder, loc, input, idxRange);
     values.push_back(element);
   }
   return values;
@@ -207,8 +207,8 @@ class ConvertConstantOp : public OpConversionPattern<arith::ConstantOp> {
     // Replace the current op with flattened constants.
     SmallVector<Value> constants;
     for (auto valueAttr : elementsAttr.getValues<Attribute>()) {
-      constants.push_back(rewriter.create<arith::ConstantOp>(
-          op.getLoc(), elementsAttr.getElementType(),
+      constants.push_back(arith::ConstantOp::create(
+          rewriter, op.getLoc(), elementsAttr.getElementType(),
           cast<TypedAttr>(valueAttr)));
     }
 

--- a/lib/Transforms/YosysOptimizer/BooleanGateImporter.cpp
+++ b/lib/Transforms/YosysOptimizer/BooleanGateImporter.cpp
@@ -23,13 +23,13 @@ mlir::Operation *BooleanGateImporter::createOp(Yosys::RTLIL::Cell *cell,
   // standard cell names look like $_CELL_
   auto op = llvm::StringSwitch<mlir::Operation *>(
                 cell->type.substr(2, cell->type.size() - 3))
-                .Case("NOT", b.create<comb::InvOp>(inputs[0], false))
-                .Case("XNOR", b.create<comb::XNorOp>(inputs, false))
-                .Case("AND", b.create<comb::AndOp>(inputs, false))
-                .Case("XOR", b.create<comb::XorOp>(inputs, false))
-                .Case("NAND", b.create<comb::NandOp>(inputs, false))
-                .Case("NOR", b.create<comb::NorOp>(inputs, false))
-                .Case("OR", b.create<comb::OrOp>(inputs, false))
+                .Case("NOT", comb::InvOp::create(b, inputs[0], false))
+                .Case("XNOR", comb::XNorOp::create(b, inputs, false))
+                .Case("AND", comb::AndOp::create(b, inputs, false))
+                .Case("XOR", comb::XorOp::create(b, inputs, false))
+                .Case("NAND", comb::NandOp::create(b, inputs, false))
+                .Case("NOR", comb::NorOp::create(b, inputs, false))
+                .Case("OR", comb::OrOp::create(b, inputs, false))
                 .Default(nullptr);
   if (op == nullptr) {
     llvm_unreachable("unexpected cell type");

--- a/lib/Transforms/YosysOptimizer/LUTImporter.cpp
+++ b/lib/Transforms/YosysOptimizer/LUTImporter.cpp
@@ -37,7 +37,7 @@ mlir::Operation *LUTImporter::createOp(Yosys::RTLIL::Cell *cell,
 
   auto lookupTable =
       b.getIntegerAttr(b.getIntegerType(lutSize, /*isSigned=*/false), lutValue);
-  return b.create<comb::TruthTableOp>(inputs, lookupTable);
+  return comb::TruthTableOp::create(b, inputs, lookupTable);
 }
 
 SmallVector<Yosys::RTLIL::SigSpec> LUTImporter::getInputs(

--- a/lib/Transforms/YosysOptimizer/YosysOptimizer.cpp
+++ b/lib/Transforms/YosysOptimizer/YosysOptimizer.cpp
@@ -200,8 +200,8 @@ LogicalResult convertOpOperands(secret::GenericOp op, func::FuncOp func,
                          << convertedType;
           return failure();
         }
-        input = builder.create<arith::IndexCastOp>(
-            op.getLoc(),
+        input = arith::IndexCastOp::create(
+            builder, op.getLoc(),
             builder.getIntegerType(functionMemrefTy.getNumElements()), input);
       }
       auto convertedValue =
@@ -222,8 +222,9 @@ LogicalResult convertOpOperands(secret::GenericOp op, func::FuncOp func,
 
     // Insert a conversion from the original type to the converted type
     OpBuilder builder(op);
-    typeConvertedArgs.push_back(builder.create<secret::CastOp>(
-        op.getLoc(), secret::SecretType::get(convertedType), opOperand.get()));
+    typeConvertedArgs.push_back(secret::CastOp::create(
+        builder, op.getLoc(), secret::SecretType::get(convertedType),
+        opOperand.get()));
   }
 
   return success();
@@ -265,8 +266,9 @@ LogicalResult convertOpResults(secret::GenericOp op,
     // memref version.
     OpBuilder builder(op);
     builder.setInsertionPointAfter(op);
-    auto castOp = builder.create<secret::CastOp>(
-        op.getLoc(), originalResultTy[opResult.getResultNumber()], opResult);
+    auto castOp = secret::CastOp::create(
+        builder, op.getLoc(), originalResultTy[opResult.getResultNumber()],
+        opResult);
     castOps.insert(castOp);
     typeConvertedResults.push_back(castOp.getOutput());
   }
@@ -502,8 +504,8 @@ LogicalResult YosysOptimizer::runOnGenericOp(secret::GenericOp op) {
   Block &block = op.getRegion().getBlocks().front();
   func::ReturnOp returnOp = cast<func::ReturnOp>(block.getTerminator());
   OpBuilder bodyBuilder(&block, block.end());
-  bodyBuilder.create<secret::YieldOp>(returnOp.getLoc(),
-                                      returnOp.getOperands());
+  secret::YieldOp::create(bodyBuilder, returnOp.getLoc(),
+                          returnOp.getOperands());
   returnOp.erase();
   func.erase();
 

--- a/lib/Utils/ContextAwareConversionUtils.cpp
+++ b/lib/Utils/ContextAwareConversionUtils.cpp
@@ -141,8 +141,8 @@ FailureOr<Operation *> SecretGenericFuncCallConversion::matchAndRewriteInner(
   newFuncOp.setFunctionType(newFunctionType);
   newFuncOp.setSymName(llvm::formatv("{0}_secret", callee.getSymName()).str());
 
-  auto newCallOp = rewriter.create<func::CallOp>(op.getLoc(), outputTypes,
-                                                 newFuncOp.getName(), inputs);
+  auto newCallOp = func::CallOp::create(rewriter, op.getLoc(), outputTypes,
+                                        newFuncOp.getName(), inputs);
   rewriter.replaceOp(op, newCallOp);
   rewriter.eraseOp(callee);
   return newCallOp.getOperation();

--- a/lib/Utils/ContextAwareDialectConversion.cpp
+++ b/lib/Utils/ContextAwareDialectConversion.cpp
@@ -1479,7 +1479,7 @@ ContextAwareConversionPatternRewriterImpl::buildUnresolvedMaterialization(
   OpBuilder builder(outputTypes.front().getContext());
   builder.setInsertionPoint(ip.getBlock(), ip.getPoint());
   auto convertOp =
-      builder.create<UnrealizedConversionCastOp>(loc, outputTypes, inputs);
+      UnrealizedConversionCastOp::create(builder, loc, outputTypes, inputs);
   if (!valuesToMap.empty()) mapping.map(valuesToMap, convertOp.getResults());
   if (castOp) *castOp = convertOp;
   appendRewrite<UnresolvedMaterializationRewrite>(

--- a/lib/Utils/ConversionUtils.cpp
+++ b/lib/Utils/ConversionUtils.cpp
@@ -195,13 +195,13 @@ struct ConvertFromElements
         newShape.append(shape.begin(), shape.end());
 
         // Create a dense constant for targetShape
-        auto shapeOp = rewriter.create<mlir::arith::ConstantOp>(
-            op.getLoc(),
+        auto shapeOp = mlir::arith::ConstantOp::create(
+            rewriter, op.getLoc(),
             RankedTensorType::get(newShape.size(), rewriter.getIndexType()),
             rewriter.getIndexTensorAttr(newShape));
 
-        auto reshapeOp = rewriter.create<tensor::ReshapeOp>(
-            op.getLoc(),
+        auto reshapeOp = tensor::ReshapeOp::create(
+            rewriter, op.getLoc(),
             RankedTensorType::get(newShape, tensorType.getElementType()), o,
             shapeOp);
         newOperands.push_back(reshapeOp);

--- a/lib/Utils/TransformUtils.cpp
+++ b/lib/Utils/TransformUtils.cpp
@@ -60,19 +60,19 @@ Value convertIntegerValueToMemrefOfBits(Value integer, OpBuilder &b,
   }
 
   auto allocOp =
-      b.create<memref::AllocOp>(loc, MemRefType::get({width}, b.getI1Type()));
+      memref::AllocOp::create(b, loc, MemRefType::get({width}, b.getI1Type()));
   for (int i = 0; i < width; i++) {
     // These arith ops correspond to extracting the i-th bit
     // from the input
-    auto shiftAmount =
-        b.create<arith::ConstantOp>(loc, argType, b.getIntegerAttr(argType, i));
-    auto bitMask = b.create<arith::ConstantOp>(
-        loc, argType, b.getIntegerAttr(argType, 1 << i));
-    auto andOp = b.create<arith::AndIOp>(loc, integer, bitMask);
-    auto shifted = b.create<arith::ShRSIOp>(loc, andOp, shiftAmount);
-    b.create<memref::StoreOp>(
-        loc, b.create<arith::TruncIOp>(loc, b.getI1Type(), shifted), allocOp,
-        ValueRange{b.create<arith::ConstantIndexOp>(loc, i)});
+    auto shiftAmount = arith::ConstantOp::create(b, loc, argType,
+                                                 b.getIntegerAttr(argType, i));
+    auto bitMask = arith::ConstantOp::create(b, loc, argType,
+                                             b.getIntegerAttr(argType, 1 << i));
+    auto andOp = arith::AndIOp::create(b, loc, integer, bitMask);
+    auto shifted = arith::ShRSIOp::create(b, loc, andOp, shiftAmount);
+    memref::StoreOp::create(
+        b, loc, arith::TruncIOp::create(b, loc, b.getI1Type(), shifted),
+        allocOp, ValueRange{arith::ConstantIndexOp::create(b, loc, i)});
   }
 
   return allocOp.getResult();
@@ -85,15 +85,16 @@ Value convertMemrefOfBitsToInteger(Value memref, Type resultType, OpBuilder &b,
   assert(memrefType.getRank() == 1 && "Expected memref of bits to be 1D");
 
   Value result =
-      b.create<arith::ConstantIntOp>(loc, integerType, 0).getResult();
+      arith::ConstantIntOp::create(b, loc, integerType, 0).getResult();
   for (int i = 0; i < memrefType.getNumElements(); i++) {
     // The i-th bit of the memref is stored at bit position i
-    auto loadOp = b.create<memref::LoadOp>(
-        loc, memref, ValueRange{b.create<arith::ConstantIndexOp>(loc, i)});
-    auto extOp = b.create<arith::ExtSIOp>(loc, integerType, loadOp.getResult());
-    auto shiftAmount = b.create<arith::ConstantIntOp>(loc, integerType, i);
-    auto shifted = b.create<arith::ShLIOp>(loc, extOp, shiftAmount);
-    auto orOp = b.create<arith::OrIOp>(loc, integerType, result, shifted);
+    auto loadOp = memref::LoadOp::create(
+        b, loc, memref, ValueRange{arith::ConstantIndexOp::create(b, loc, i)});
+    auto extOp =
+        arith::ExtSIOp::create(b, loc, integerType, loadOp.getResult());
+    auto shiftAmount = arith::ConstantIntOp::create(b, loc, integerType, i);
+    auto shifted = arith::ShLIOp::create(b, loc, extOp, shiftAmount);
+    auto orOp = arith::OrIOp::create(b, loc, integerType, result, shifted);
     result = orOp.getResult();
   }
 


### PR DESCRIPTION
Cf. https://discourse.llvm.org/t/psa-opty-create-now-with-100-more-tab-complete/87339/1 and https://github.com/llvm/llvm-project/pull/147168

This is going to be broken since the LLVM integration is a week or so behind. Leaving this PR in draft form until then.

This PR was implemented by running (GNU) sed

```bash
sed -E -i 's/(\w+)\.create<(.*?)>\(/\2::create(\1,/g' **/*.cpp
```

then applying the formatter.