### PR TITLE
Cleanup ::mlir::heir::polynomial

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
@@ -47,25 +47,25 @@ class CiphertextTypeConverter : public TypeConverter {
     addConversion([](Type type) { return type; });
     addConversion([ctx](lwe::NewLWECiphertextType type) -> Type {
       auto ring = type.getCiphertextSpace().getRing();
-      auto polyTy = ::mlir::heir::polynomial::PolynomialType::get(ctx, ring);
+      auto polyTy = polynomial::PolynomialType::get(ctx, ring);
 
       return RankedTensorType::get({type.getCiphertextSpace().getSize()},
                                    polyTy);
     });
     addConversion([ctx](lwe::NewLWEPlaintextType type) -> Type {
       auto ring = type.getPlaintextSpace().getRing();
-      auto polyTy = ::mlir::heir::polynomial::PolynomialType::get(ctx, ring);
+      auto polyTy = polynomial::PolynomialType::get(ctx, ring);
       return polyTy;
     });
     addConversion([ctx](lwe::NewLWESecretKeyType type) -> Type {
       auto ring = type.getRing();
-      auto polyTy = ::mlir::heir::polynomial::PolynomialType::get(ctx, ring);
+      auto polyTy = polynomial::PolynomialType::get(ctx, ring);
 
       return RankedTensorType::get({2}, polyTy);
     });
     addConversion([ctx](lwe::NewLWEPublicKeyType type) -> Type {
       auto ring = type.getRing();
-      auto polyTy = ::mlir::heir::polynomial::PolynomialType::get(ctx, ring);
+      auto polyTy = polynomial::PolynomialType::get(ctx, ring);
 
       return RankedTensorType::get({2}, polyTy);
     });
@@ -352,8 +352,8 @@ struct ConvertRAdd : public OpConversionPattern<RAddOp> {
   LogicalResult matchAndRewrite(
       RAddOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<::mlir::heir::polynomial::AddOp>(
-        op, adaptor.getOperands()[0], adaptor.getOperands()[1]);
+    rewriter.replaceOpWithNewOp<polynomial::AddOp>(op, adaptor.getOperands()[0],
+                                                   adaptor.getOperands()[1]);
     return success();
   }
 };
@@ -367,8 +367,8 @@ struct ConvertRAddPlain : public OpConversionPattern<RAddPlainOp> {
   LogicalResult matchAndRewrite(
       RAddPlainOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<::mlir::heir::polynomial::AddOp>(
-        op, adaptor.getOperands()[0], adaptor.getOperands()[1]);
+    rewriter.replaceOpWithNewOp<polynomial::AddOp>(op, adaptor.getOperands()[0],
+                                                   adaptor.getOperands()[1]);
     return success();
   }
 };
@@ -382,8 +382,8 @@ struct ConvertRSub : public OpConversionPattern<RSubOp> {
   LogicalResult matchAndRewrite(
       RSubOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<::mlir::heir::polynomial::SubOp>(
-        op, adaptor.getLhs(), adaptor.getRhs());
+    rewriter.replaceOpWithNewOp<polynomial::SubOp>(op, adaptor.getLhs(),
+                                                   adaptor.getRhs());
     return success();
   }
 };
@@ -397,8 +397,8 @@ struct ConvertRSubPlain : public OpConversionPattern<RSubPlainOp> {
   LogicalResult matchAndRewrite(
       RSubPlainOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<::mlir::heir::polynomial::SubOp>(
-        op, adaptor.getLhs(), adaptor.getRhs());
+    rewriter.replaceOpWithNewOp<polynomial::SubOp>(op, adaptor.getLhs(),
+                                                   adaptor.getRhs());
     return success();
   }
 };
@@ -437,9 +437,8 @@ struct ConvertRNegate : public OpConversionPattern<RNegateOp> {
       return failure();
     }
 
-    rewriter.replaceOp(op,
-                       rewriter.create<::mlir::heir::polynomial::MulScalarOp>(
-                           loc, arg.getType(), arg, neg.value()));
+    rewriter.replaceOp(op, rewriter.create<polynomial::MulScalarOp>(
+                               loc, arg.getType(), arg, neg.value()));
     return success();
   }
 };
@@ -484,11 +483,11 @@ struct ConvertRMul : public OpConversionPattern<RMulOp> {
     auto y1 =
         b.create<tensor::ExtractOp>(yT.getElementType(), y, ValueRange{i1});
 
-    auto z0 = b.create<::mlir::heir::polynomial::MulOp>(x0, y0);
-    auto x0y1 = b.create<::mlir::heir::polynomial::MulOp>(x0, y1);
-    auto x1y0 = b.create<::mlir::heir::polynomial::MulOp>(x1, y0);
-    auto z1 = b.create<::mlir::heir::polynomial::AddOp>(x0y1, x1y0);
-    auto z2 = b.create<::mlir::heir::polynomial::MulOp>(x1, y1);
+    auto z0 = b.create<polynomial::MulOp>(x0, y0);
+    auto x0y1 = b.create<polynomial::MulOp>(x0, y1);
+    auto x1y0 = b.create<polynomial::MulOp>(x1, y0);
+    auto z1 = b.create<polynomial::AddOp>(x0y1, x1y0);
+    auto z2 = b.create<polynomial::MulOp>(x1, y1);
 
     auto z = b.create<tensor::FromElementsOp>(ArrayRef<Value>({z0, z1, z2}));
 

--- a/lib/Dialect/LWE/IR/LWETraits.h
+++ b/lib/Dialect/LWE/IR/LWETraits.h
@@ -17,9 +17,9 @@ class SameOperandsAndResultRings
     : public OpTrait::TraitBase<ConcreteType, SameOperandsAndResultRings> {
  public:
   static LogicalResult verifyTrait(Operation *op) {
-    ::mlir::heir::polynomial::RingAttr rings = nullptr;
+    polynomial::RingAttr rings = nullptr;
     auto initOrCheckRings =
-        [&](::mlir::heir::polynomial::RingAttr ring) {
+        [&](polynomial::RingAttr ring) {
           if (rings == nullptr) {
             rings = ring;
             return success();

--- a/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.cpp
@@ -58,13 +58,12 @@ namespace {
 FailureOr<polynomial::RingAttr> getRlweRNSRing(
     MLIRContext *ctx, const std::vector<int64_t> &primes, int polyModDegree) {
   // monomial
-  std::vector<::mlir::heir::polynomial::IntMonomial> monomials;
+  std::vector<polynomial::IntMonomial> monomials;
   monomials.emplace_back(1, polyModDegree);
   monomials.emplace_back(1, 0);
-  auto result =
-      ::mlir::heir::polynomial::IntPolynomial::fromMonomials(monomials);
+  auto result = polynomial::IntPolynomial::fromMonomials(monomials);
   if (failed(result)) return failure();
-  ::mlir::heir::polynomial::IntPolynomial xnPlusOne = result.value();
+  polynomial::IntPolynomial xnPlusOne = result.value();
 
   // moduli chain
   SmallVector<Type, 4> modTypes;
@@ -76,7 +75,7 @@ FailureOr<polynomial::RingAttr> getRlweRNSRing(
 
   // types
   auto rnsType = rns::RNSType::get(ctx, modTypes);
-  return ::mlir::heir::polynomial::RingAttr::get(
+  return polynomial::RingAttr::get(
       rnsType, polynomial::IntPolynomialAttr::get(ctx, xnPlusOne));
 }
 
@@ -86,8 +85,7 @@ polynomial::RingAttr getRlweRNSRingWithLevel(polynomial::RingAttr ringAttr,
 
   auto newRnsType = rns::RNSType::get(
       rnsType.getContext(), rnsType.getBasisTypes().take_front(level + 1));
-  return ::mlir::heir::polynomial::RingAttr::get(
-      newRnsType, ringAttr.getPolynomialModulus());
+  return polynomial::RingAttr::get(newRnsType, ringAttr.getPolynomialModulus());
 }
 
 }  // namespace
@@ -95,8 +93,7 @@ polynomial::RingAttr getRlweRNSRingWithLevel(polynomial::RingAttr ringAttr,
 class SecretToBGVTypeConverter
     : public UniquelyNamedAttributeAwareTypeConverter {
  public:
-  SecretToBGVTypeConverter(MLIRContext *ctx,
-                           ::mlir::heir::polynomial::RingAttr rlweRing,
+  SecretToBGVTypeConverter(MLIRContext *ctx, polynomial::RingAttr rlweRing,
                            int64_t ptm, bool isBFV)
       : UniquelyNamedAttributeAwareTypeConverter(
             mgmt::MgmtDialect::kArgMgmtAttrName),
@@ -116,7 +113,7 @@ class SecretToBGVTypeConverter
     auto scale = mgmtAttr.getScale();
 
     auto *ctx = type.getContext();
-    auto plaintextRing = ::mlir::heir::polynomial::RingAttr::get(
+    auto plaintextRing = polynomial::RingAttr::get(
         type.getContext(),
         mod_arith::ModArithType::get(
             ctx, IntegerAttr::get(IntegerType::get(ctx, 64), plaintextModulus)),
@@ -146,7 +143,7 @@ class SecretToBGVTypeConverter
   }
 
  private:
-  ::mlir::heir::polynomial::RingAttr ring;
+  polynomial::RingAttr ring;
   int64_t plaintextModulus;
   bool isBFV;
 };

--- a/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.cpp
@@ -65,13 +65,12 @@ namespace {
 FailureOr<polynomial::RingAttr> getRlweRNSRing(
     MLIRContext *ctx, const std::vector<int64_t> &primes, int polyModDegree) {
   // monomial
-  std::vector<::mlir::heir::polynomial::IntMonomial> monomials;
+  std::vector<polynomial::IntMonomial> monomials;
   monomials.emplace_back(1, polyModDegree);
   monomials.emplace_back(1, 0);
-  auto result =
-      ::mlir::heir::polynomial::IntPolynomial::fromMonomials(monomials);
+  auto result = polynomial::IntPolynomial::fromMonomials(monomials);
   if (failed(result)) return failure();
-  ::mlir::heir::polynomial::IntPolynomial xnPlusOne = result.value();
+  polynomial::IntPolynomial xnPlusOne = result.value();
 
   // moduli chain
   SmallVector<Type, 4> modTypes;
@@ -83,7 +82,7 @@ FailureOr<polynomial::RingAttr> getRlweRNSRing(
 
   // types
   auto rnsType = rns::RNSType::get(ctx, modTypes);
-  return ::mlir::heir::polynomial::RingAttr::get(
+  return polynomial::RingAttr::get(
       rnsType, polynomial::IntPolynomialAttr::get(ctx, xnPlusOne));
 }
 
@@ -93,8 +92,7 @@ polynomial::RingAttr getRlweRNSRingWithLevel(polynomial::RingAttr ringAttr,
 
   auto newRnsType = rns::RNSType::get(
       rnsType.getContext(), rnsType.getBasisTypes().take_front(level + 1));
-  return ::mlir::heir::polynomial::RingAttr::get(
-      newRnsType, ringAttr.getPolynomialModulus());
+  return polynomial::RingAttr::get(newRnsType, ringAttr.getPolynomialModulus());
 }
 
 // Returns the unique non-unit dimension of a tensor and its rank.
@@ -118,8 +116,7 @@ FailureOr<std::pair<unsigned, int64_t>> getNonUnitDimension(
 class SecretToCKKSTypeConverter
     : public UniquelyNamedAttributeAwareTypeConverter {
  public:
-  SecretToCKKSTypeConverter(MLIRContext *ctx,
-                            ::mlir::heir::polynomial::RingAttr rlweRing,
+  SecretToCKKSTypeConverter(MLIRContext *ctx, polynomial::RingAttr rlweRing,
                             bool packTensorInSlots)
       : UniquelyNamedAttributeAwareTypeConverter(
             mgmt::MgmtDialect::kArgMgmtAttrName) {
@@ -144,7 +141,7 @@ class SecretToCKKSTypeConverter
     // Note that slot number for CKKS is always half of the ring dimension.
     // so ring_.getPolynomialModulus() is not useful here
     // TODO(#1191): use packing information to get the correct slot number
-    auto plaintextRing = ::mlir::heir::polynomial::RingAttr::get(
+    auto plaintextRing = polynomial::RingAttr::get(
         type.getContext(), Float64Type::get(ctx), ring_.getPolynomialModulus());
 
     SmallVector<IntegerAttr, 6> moduliChain;
@@ -189,7 +186,7 @@ class SecretToCKKSTypeConverter
   }
 
  private:
-  ::mlir::heir::polynomial::RingAttr ring_;
+  polynomial::RingAttr ring_;
   bool packTensorInSlots_;
 };
 

--- a/lib/Pipelines/PipelineRegistration.cpp
+++ b/lib/Pipelines/PipelineRegistration.cpp
@@ -94,7 +94,7 @@ void tosaPipelineBuilder(OpPassManager &manager, bool unroll) {
 void polynomialToLLVMPipelineBuilder(OpPassManager &manager) {
   // Poly
   manager.addPass(createElementwiseToAffine());
-  manager.addPass(::mlir::heir::polynomial::createPolynomialToModArith());
+  manager.addPass(polynomial::createPolynomialToModArith());
   manager.addPass(::mlir::heir::mod_arith::createModArithToArith());
   manager.addPass(createCanonicalizerPass());
 

--- a/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
+++ b/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
@@ -88,12 +88,12 @@ void registerToOpenFhePkeTranslation() {
                                      options->skipVectorResizing);
       },
       [](DialectRegistry &registry) {
-        registry.insert<arith::ArithDialect, func::FuncDialect,
-                        openfhe::OpenfheDialect, lwe::LWEDialect,
-                        tensor_ext::TensorExtDialect,
-                        ::mlir::heir::polynomial::PolynomialDialect,
-                        tensor::TensorDialect, mod_arith::ModArithDialect,
-                        rns::RNSDialect, affine::AffineDialect>();
+        registry
+            .insert<arith::ArithDialect, func::FuncDialect,
+                    openfhe::OpenfheDialect, lwe::LWEDialect,
+                    tensor_ext::TensorExtDialect, polynomial::PolynomialDialect,
+                    tensor::TensorDialect, mod_arith::ModArithDialect,
+                    rns::RNSDialect, affine::AffineDialect>();
         rns::registerExternalRNSTypeInterfaces(registry);
       });
 }
@@ -108,12 +108,11 @@ void registerToOpenFhePkeHeaderTranslation() {
                                            options->openfheImportType);
       },
       [](DialectRegistry &registry) {
-        registry.insert<arith::ArithDialect, affine::AffineDialect,
-                        func::FuncDialect, tensor::TensorDialect,
-                        tensor_ext::TensorExtDialect, openfhe::OpenfheDialect,
-                        lwe::LWEDialect, rns::RNSDialect,
-                        ::mlir::heir::polynomial::PolynomialDialect,
-                        mod_arith::ModArithDialect>();
+        registry.insert<
+            arith::ArithDialect, affine::AffineDialect, func::FuncDialect,
+            tensor::TensorDialect, tensor_ext::TensorExtDialect,
+            openfhe::OpenfheDialect, lwe::LWEDialect, rns::RNSDialect,
+            polynomial::PolynomialDialect, mod_arith::ModArithDialect>();
         rns::registerExternalRNSTypeInterfaces(registry);
       });
 }
@@ -133,7 +132,7 @@ void registerToOpenFhePkePybindTranslation() {
         registry.insert<arith::ArithDialect, func::FuncDialect,
                         tensor::TensorDialect, openfhe::OpenfheDialect,
                         lwe::LWEDialect, tensor_ext::TensorExtDialect,
-                        ::mlir::heir::polynomial::PolynomialDialect,
+                        polynomial::PolynomialDialect,
                         mod_arith::ModArithDialect, rns::RNSDialect>();
         rns::registerExternalRNSTypeInterfaces(registry);
       });

--- a/lib/Transforms/LowerPolynomialEval/Patterns.h
+++ b/lib/Transforms/LowerPolynomialEval/Patterns.h
@@ -11,11 +11,9 @@
 namespace mlir {
 namespace heir {
 
-struct LoweringBase
-    : public OpRewritePattern<::mlir::heir::polynomial::EvalOp> {
+struct LoweringBase : public OpRewritePattern<polynomial::EvalOp> {
   LoweringBase(mlir::MLIRContext *context, bool force = false)
-      : mlir::OpRewritePattern<::mlir::heir::polynomial::EvalOp>(context),
-        force(force) {}
+      : mlir::OpRewritePattern<polynomial::EvalOp>(context), force(force) {}
 
   bool shouldForce() const { return force; }
 
@@ -31,7 +29,7 @@ struct LoweringBase
 struct LowerViaHorner : public LoweringBase {
   using LoweringBase::LoweringBase;
 
-  LogicalResult matchAndRewrite(::mlir::heir::polynomial::EvalOp op,
+  LogicalResult matchAndRewrite(polynomial::EvalOp op,
                                 PatternRewriter &rewriter) const override;
 };
 

--- a/lib/Utils/Approximation/CaratheodoryFejer.cpp
+++ b/lib/Utils/Approximation/CaratheodoryFejer.cpp
@@ -22,7 +22,7 @@ using ::Eigen::SelfAdjointEigenSolver;
 using ::Eigen::VectorXd;
 using ::llvm::APFloat;
 using ::llvm::SmallVector;
-using ::mlir::heir::polynomial::FloatPolynomial;
+using polynomial::FloatPolynomial;
 
 FloatPolynomial caratheodoryFejerApproximationUnitInterval(
     const std::function<APFloat(APFloat)> &func, int32_t degree) {

--- a/lib/Utils/Approximation/CaratheodoryFejer.h
+++ b/lib/Utils/Approximation/CaratheodoryFejer.h
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <optional>
 
 #include "lib/Utils/Polynomial/Polynomial.h"
 #include "llvm/include/llvm/ADT/APFloat.h"  // from @llvm-project
@@ -27,7 +26,7 @@ namespace approximation {
 ///
 /// The arguments lower and upper provide the bounds of the interval of
 /// approximation. which defaults to [-1, 1].
-::mlir::heir::polynomial::FloatPolynomial caratheodoryFejerApproximation(
+polynomial::FloatPolynomial caratheodoryFejerApproximation(
     const std::function<::llvm::APFloat(::llvm::APFloat)> &func, int32_t degree,
     double lower = -1.0, double upper = 1.0);
 

--- a/lib/Utils/Approximation/CaratheodoryFejerTest.cpp
+++ b/lib/Utils/Approximation/CaratheodoryFejerTest.cpp
@@ -15,7 +15,7 @@ namespace approximation {
 namespace {
 
 using ::llvm::APFloat;
-using ::mlir::heir::polynomial::FloatPolynomial;
+using polynomial::FloatPolynomial;
 using ::testing::DoubleNear;
 
 TEST(CaratheodoryFejerTest, ApproximateExpDegree3) {

--- a/lib/Utils/Approximation/Chebyshev.cpp
+++ b/lib/Utils/Approximation/Chebyshev.cpp
@@ -19,7 +19,7 @@ namespace approximation {
 
 using ::llvm::APFloat;
 using ::llvm::SmallVector;
-using ::mlir::heir::polynomial::FloatPolynomial;
+using polynomial::FloatPolynomial;
 
 // When we move to C++20, we can use std::numbers::pi
 inline constexpr double kPi = 3.14159265358979323846;

--- a/lib/Utils/Approximation/Chebyshev.h
+++ b/lib/Utils/Approximation/Chebyshev.h
@@ -27,12 +27,12 @@ void getChebyshevPoints(int64_t numPoints,
 /// The first few polynomials are 1, x, 2x^2 - 1, 4x^3 - 3x, ...
 void getChebyshevPolynomials(
     int64_t numPolynomials,
-    ::llvm::SmallVector<::mlir::heir::polynomial::FloatPolynomial> &results);
+    ::llvm::SmallVector<polynomial::FloatPolynomial> &results);
 
 /// Convert a vector of Chebyshev coefficients to the monomial basis. If the
 /// Chebyshev polynomials are T_0, T_1, ..., then entry i of the input vector
 /// is the coefficient of T_i.
-::mlir::heir::polynomial::FloatPolynomial chebyshevToMonomial(
+polynomial::FloatPolynomial chebyshevToMonomial(
     const ::llvm::SmallVector<::llvm::APFloat> &coefficients);
 
 /// Interpolate Chebyshev coefficients for a given set of points. The values in

--- a/lib/Utils/Approximation/ChebyshevTest.cpp
+++ b/lib/Utils/Approximation/ChebyshevTest.cpp
@@ -15,7 +15,7 @@ namespace approximation {
 namespace {
 
 using ::llvm::APFloat;
-using ::mlir::heir::polynomial::FloatPolynomial;
+using polynomial::FloatPolynomial;
 using ::testing::DoubleEq;
 using ::testing::DoubleNear;
 using ::testing::ElementsAre;

--- a/tools/heir-lsp.cpp
+++ b/tools/heir-lsp.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
   registry.insert<func::FuncDialect>();
   registry.insert<math::MathDialect>();
   registry.insert<memref::MemRefDialect>();
-  registry.insert<::mlir::heir::polynomial::PolynomialDialect>();
+  registry.insert<polynomial::PolynomialDialect>();
   registry.insert<scf::SCFDialect>();
   registry.insert<tensor::TensorDialect>();
 

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -180,7 +180,7 @@ int main(int argc, char **argv) {
   registry.insert<func::FuncDialect>();
   registry.insert<math::MathDialect>();
   registry.insert<memref::MemRefDialect>();
-  registry.insert<::mlir::heir::polynomial::PolynomialDialect>();
+  registry.insert<polynomial::PolynomialDialect>();
   registry.insert<scf::SCFDialect>();
   registry.insert<tensor::TensorDialect>();
 
@@ -250,7 +250,7 @@ int main(int argc, char **argv) {
   lwe::registerLWEPasses();
   mgmt::registerMgmtPasses();
   openfhe::registerOpenfhePasses();
-  ::mlir::heir::polynomial::registerPolynomialPasses();
+  polynomial::registerPolynomialPasses();
   secret::registerSecretPasses();
   tensor_ext::registerTensorExtPasses();
   registerAddClientInterfacePass();
@@ -335,7 +335,7 @@ int main(int argc, char **argv) {
   lwe::registerLWEToLattigoPasses();
   lwe::registerLWEToOpenfhePasses();
   lwe::registerLWEToPolynomialPasses();
-  ::mlir::heir::polynomial::registerPolynomialToModArithPasses();
+  polynomial::registerPolynomialToModArithPasses();
   tensor_ext::registerTensorExtToTensorPasses();
   registerCGGIToJaxitePasses();
   registerCGGIToTfheRustPasses();
@@ -363,7 +363,7 @@ int main(int argc, char **argv) {
   PassPipelineRegistration<>(
       "heir-polynomial-to-llvm",
       "Run passes to lower the polynomial dialect to LLVM",
-      ::mlir::heir::polynomialToLLVMPipelineBuilder);
+      polynomialToLLVMPipelineBuilder);
 
   PassPipelineRegistration<>("heir-basic-mlir-to-llvm",
                              "Lower basic MLIR to LLVM",


### PR DESCRIPTION
This was needed before to avoid a namespace conflict with the upstream polynomial dialect, which I have since removed from upstream.