### PR TITLE
Add deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![GitHub Discussions](https://img.shields.io/github/discussions/google/heir)
 ![GitHub License](https://img.shields.io/github/license/google/heir)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/google/heir/badge)](https://securityscorecards.dev/viewer/?uri=github.com/google/heir)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/google/heir)
 
 An MLIR-based toolchain for
 [homomorphic encryption](https://en.wikipedia.org/wiki/Homomorphic_encryption)


### PR DESCRIPTION
Deepwiki analyzses public GH repos and creates summaries of them which are human readable but primairly designed to be used with RAG or agentic AI coding assistants

See https://deepwiki.com/google/heir for the information it has compiled on HEIR, which (at first glance) seems pretty nice.
In fact, it seems to have some info we should have in our human-written docs, too, such as info on the Context Aware dialect conversion (unless we do have that somewhere and I just couldn't find it?)

By default, it does not seem to refresh the information very often (e.g., it was currently from April), and while one can manually get it to refresh (I just requested a refresh), if you add the deepwiki badge to a repo's README, it will auto-refresh on a weekly basis.

Whether or not WE end up using deepwiki, it's very likely it'll end up "consumed" by various AI things people are using, so it's probably a good idea to have it be more up to date.

PS: let me try to request an AI review on this AI-focused PR, for maximum AI-ness xD
EDIT: formatting fails because of unrelated failure on main
EDIT2: Ironically, after re-generation, the info is arguably _worse_ even if it is more up-to-date (for example, it decided aginst generating a page on context aware dialect conversion this time?!)