### PR TITLE
Another segfault workaround

### DIFF
--- a/tests/Examples/plaintext/dot_product_f_debug/dot_product_8f_debug_test.c
+++ b/tests/Examples/plaintext/dot_product_f_debug/dot_product_8f_debug_test.c
@@ -43,6 +43,12 @@ float dot_product__decrypt__result0(float *allocated, float *aligned,
                                     int64_t offset, int64_t size,
                                     int64_t stride);
 
+// Needs to be allocated in .bss
+// Maybe for alignment?
+// Otherwise segfault inside memrefCopy
+_Alignas(uint64_t) float arg0[8];
+_Alignas(uint64_t) float arg1[8];
+
 // debug handler
 void __heir_debug_tensor_8xf32_(
     /* arg 0*/


### PR DESCRIPTION
@MeronZerihun ran into an issue that seemed like it might be similar to #1988 so I just did the same as #2043 in the hope that it'll fix the issue...

```
Meron-HEIR@Merons-MacBook heir % bazel build --//:enable_openmp=0 //...
INFO: Analyzed 2068 targets (32 packages loaded, 474 targets configured).
ERROR: /Users/Meron-HEIR/Documents/heir/tests/Examples/plaintext/dot_product_f_debug/BUILD:10:15: BinaryRule tests/Examples/plaintext/dot_product_f_debug/dot_product_8f_debug.log failed: (Segmentation fault): dot_product_8f_debug_cc_binary failed: error executing BinaryRule command (from target //tests/Examples/plaintext/dot_product_f_debug:dot_product_8f_debug_binary_rule) bazel-out/darwin_arm64-dbg/bin/tests/Examples/plaintext/dot_product_f_debug/dot_product_8f_debug_cc_binary ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
INFO: Elapsed time: 11.828s, Critical Path: 5.85s
INFO: 35 processes: 1 action cache hit, 9 internal, 26 darwin-sandbox.
ERROR: Build did NOT complete successfully
```


~~(ignore the unrelated change further down the file, accidentally accepted some AI autocomplete garbage, will push a clean version later)~~