### PR TITLE
Add a basic layout codegen (without IR materialization)

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -131,3 +131,12 @@ git_repository(
     commit = "bb5bdb776c64819f66cb2205f78bef1581448628",
     remote = "https://gitlab.mpcdf.mpg.de/mtr/pocketfft.git",
 )
+
+# j2kun's bazel-friendly fork of ISL (Integer Set Library). Needed for
+# polyhedral analysis and codegen until the MLIR upstream FPL support is good
+# enough.
+git_repository(
+    name = "isl",
+    commit = "58eaa613ffcd2b11c36a773c19531f75fbcfc66c",
+    remote = "https://github.com/j2kun/isl.git",
+)

--- a/lib/Utils/Layout/BUILD
+++ b/lib/Utils/Layout/BUILD
@@ -1,0 +1,42 @@
+# Utilities for layout manipulation
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Codegen",
+    srcs = ["Codegen.cpp"],
+    hdrs = ["Codegen.h"],
+    deps = [
+        "@isl",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineAnalysis",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "Parser",
+    srcs = ["Parser.cpp"],
+    hdrs = ["Parser.h"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineAnalysis",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "CodegenTest",
+    srcs = ["CodegenTest.cpp"],
+    deps = [
+        ":Codegen",
+        ":Parser",
+        "@googletest//:gtest_main",
+        "@isl",
+    ],
+)

--- a/lib/Utils/Layout/Codegen.cpp
+++ b/lib/Utils/Layout/Codegen.cpp
@@ -1,0 +1,161 @@
+#include "lib/Utils/Layout/Codegen.h"
+
+#include "isl/ast_build.h"                                          // from @isl
+#include "isl/ast_type.h"                                           // from @isl
+#include "isl/constraint.h"                                         // from @isl
+#include "isl/ctx.h"                                                // from @isl
+#include "isl/map.h"                                                // from @isl
+#include "isl/set.h"                                                // from @isl
+#include "isl/space.h"                                              // from @isl
+#include "isl/union_map.h"                                          // from @isl
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+using presburger::IntegerRelation;
+using presburger::VarKind;
+
+static __isl_give isl_union_map* convertRelationToUnionMap(
+    const IntegerRelation& rel, isl_ctx* ctx) {
+  // ISL has these variables types, which map to MLIR FPL variable types:
+  // isl_dim_param -> VarKind::Symbol
+  // isl_dim_in -> VarKind::Domain
+  // isl_dim_out -> VarKind::Range
+  // isl_dim_div -> VarKind::Local
+  //
+  // ISL puts parameters first, but since we have zero symbols, we can ignore
+  // the implied change to the offsets.
+  unsigned numDomain = rel.getNumVarKind(VarKind::Domain);
+  unsigned numRange = rel.getNumVarKind(VarKind::Range);
+  unsigned numLocal = rel.getNumVarKind(VarKind::Local);
+
+  // This represents the mapping from all four variables to just iterate over
+  // the range variables. This is specific to FHE because we know the packing
+  // must be a partial function from range to domain.
+  //
+  // E.g., this is specifying the `S[row,col,ct,slot] -> [ct,slot]` part of a
+  // union map like
+  //
+  //   {
+  //      S[row,col,ct,slot] -> [ct,slot] :
+  //      0 <= row,ct < 4
+  //      and 0 <= col < 8
+  //      and 0 <= slot < 32
+  //      and ((-row + slot) % 4) = 0 and (-col + ct + slot) % 8 = 0
+  //   }
+  //
+  unsigned numIn = numDomain + numRange;
+  unsigned numOut = numRange;
+  isl_space* space = isl_space_alloc(ctx, /*n_params=*/0, numIn, numOut);
+
+  // "S" is a hardcoded name for the inner-most statement that will be executed
+  // to assign the data entry to the ciphertext slot. Users will be forced to
+  // match on this name in the generated AST.
+  //
+  // E.g., S might be defined in plain C, using the layout example above, as
+  //
+  //   void S(int a, int b, int c, int d, int data[4][8], int slot[4][32]) {
+  //     slot[c][d] = data[a][b];
+  //   }
+  //
+  space = isl_space_set_tuple_name(space, isl_dim_in, "S");
+
+  // Nb., consider someday using isl_space_set_dim_name to link these variables
+  // to relevant constructs (like MLIR SSA variables, somehow?)
+
+  isl_basic_map* bmap = isl_basic_map_universe(isl_space_copy(space));
+  isl_local_space* ls = isl_local_space_from_space(space);
+  if (numLocal > 0) {
+    ls = isl_local_space_add_dims(ls, isl_dim_div, numLocal);
+  }
+
+  // Identical variables in the range and domain must be linked
+  //
+  // E.g., in S[row,col,ct,slot] -> [ct,slot], the ct and slot variables are
+  // different and must be marked as the same.
+  for (int i = 0; i < numRange; i++) {
+    isl_constraint* c = isl_constraint_alloc_equality(isl_local_space_copy(ls));
+    c = isl_constraint_set_coefficient_si(c, isl_dim_in, numDomain + i, 1);
+    c = isl_constraint_set_coefficient_si(c, isl_dim_out, i, -1);
+    bmap = isl_basic_map_add_constraint(bmap, c);
+  }
+
+  // Now copy the coefficients of the constraints from the flattened IntegerSet
+  // to ISL.
+  auto copyConstraintsFromUnionMap = [&](bool isEquality) {
+    unsigned numConstraints =
+        isEquality ? rel.getNumEqualities() : rel.getNumInequalities();
+
+    for (unsigned idx = 0; idx < numConstraints; ++idx) {
+      SmallVector<int64_t> coeffs =
+          isEquality ? rel.getEquality64(idx) : rel.getInequality64(idx);
+
+      auto* spaceCopy = isl_local_space_copy(ls);
+      isl_constraint* c = isEquality
+                              ? isl_constraint_alloc_equality(spaceCopy)
+                              : isl_constraint_alloc_inequality(spaceCopy);
+
+      c = isl_constraint_set_constant_si(c, coeffs.back());
+
+      for (int i = 0; i < numDomain; i++) {
+        unsigned offset = i + rel.getVarKindOffset(VarKind::Domain);
+        c = isl_constraint_set_coefficient_si(c, isl_dim_in, i, coeffs[offset]);
+      }
+
+      for (int i = 0; i < numRange; i++) {
+        unsigned offset = i + rel.getVarKindOffset(VarKind::Range);
+        c = isl_constraint_set_coefficient_si(c, isl_dim_in, numDomain + i,
+                                              coeffs[offset]);
+      }
+
+      for (int i = 0; i < numLocal; i++) {
+        unsigned offset = i + rel.getVarKindOffset(VarKind::Local);
+        c = isl_constraint_set_coefficient_si(c, isl_dim_div, i,
+                                              coeffs[offset]);
+      }
+
+      bmap = isl_basic_map_add_constraint(bmap, c);
+    }
+  };
+
+  copyConstraintsFromUnionMap(/*isEquality=*/true);
+  copyConstraintsFromUnionMap(/*isEquality=*/false);
+
+  return isl_union_map_from_basic_map(bmap);
+}
+
+__isl_give isl_ast_node* constructAst(const presburger::IntegerRelation& rel,
+                                      isl_ctx* ctx) {
+  // The easiest way to convert an integer relation to an ISL schedule is
+  // actually to write the ISL union-set as a string. This is because ISL's API
+  // otherwise manually requires you to flatten constraints and remove
+  // divs/mods.
+  isl_union_map* schedule = convertRelationToUnionMap(rel, ctx);
+
+  // Context and options are intentionally empty. We don't need any of these
+  // features, though I admit I have not looked into what they can provide.
+  isl_set* context = isl_set_universe(isl_space_params_alloc(ctx, 0));
+  isl_union_map* options = isl_union_map_empty(isl_space_params_alloc(ctx, 0));
+
+  // Build the AST
+  isl_ast_build* build = isl_ast_build_from_context(context);
+  build = isl_ast_build_set_options(build, options);
+  isl_ast_node* tree = isl_ast_build_node_from_schedule_map(build, schedule);
+  isl_ast_build_free(build);
+
+  return tree;
+}
+
+FailureOr<isl_ast_node*> generateLoopNest(
+    const presburger::IntegerRelation& rel, isl_ctx* ctx) {
+  isl_ast_node* tree = constructAst(rel, ctx);
+  if (!tree) {
+    return failure();
+  }
+  return tree;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/Codegen.h
+++ b/lib/Utils/Layout/Codegen.h
@@ -1,0 +1,19 @@
+#include "isl/ast_type.h"                                           // from @isl
+#include "isl/ctx.h"                                                // from @isl
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// Generate an ISL AST representing a loop nest from an IntegerRelation.
+//
+// This is intended to support the case where the IntegerRelation defines a
+// single polyhedron representing a ciphertext layout, and the code generated
+// for the packing can be expressed as a single perfect loop nest with a single
+// assignment operator in the innermost loop body.
+FailureOr<isl_ast_node*> generateLoopNest(
+    const presburger::IntegerRelation& rel, isl_ctx* ctx);
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/CodegenTest.cpp
+++ b/lib/Utils/Layout/CodegenTest.cpp
@@ -1,0 +1,84 @@
+#include "gmock/gmock.h"  // from @googletest
+#include "gtest/gtest.h"  // from @googletest
+#include "isl/ast.h"      // from @isl
+#include "lib/Utils/Layout/Codegen.h"
+#include "lib/Utils/Layout/Parser.h"
+#include "mlir/include/mlir/IR/MLIRContext.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using presburger::IntegerRelation;
+using ::testing::Eq;
+
+FailureOr<std::string> runAndGetCStr(const IntegerRelation &relation) {
+  isl_ctx *ctx = isl_ctx_alloc();
+  auto result = generateLoopNest(relation, ctx);
+  if (failed(result)) {
+    isl_ctx_free(ctx);
+    return failure();
+  }
+  isl_ast_node *tree = result.value();
+  std::string actual = std::string(isl_ast_node_to_C_str(tree));
+  isl_ast_node_free(tree);
+  isl_ctx_free(ctx);
+  // Add a leading newline for ease of comparison with multiline strings.
+  return "\n" + actual;
+}
+
+TEST(CodegenTest, PureAffineEquality) {
+  MLIRContext context;
+  IntegerRelation relation = relationFromString(
+      "(d0, d1) : (d0 - d1 == 0, d0 >= 0, d1 >= 0, 10 >= d0, 10 >= d1)", 1,
+      &context);
+  auto result = runAndGetCStr(relation);
+  ASSERT_TRUE(succeeded(result));
+  std::string actual = result.value();
+  std::string expected = R"(
+for (int c0 = 0; c0 <= 10; c0 += 1)
+  S(c0, c0);
+)";
+  ASSERT_THAT(actual, Eq(expected));
+}
+
+TEST(CodegenTest, EqualityWithMod) {
+  MLIRContext context;
+  IntegerRelation relation = relationFromString(
+      "(d0, d1) : ((d0 - d1) mod 2 == 0, d0 >= 0, d1 >= 0, 10 >= d0, 30 >= d1)",
+      1, &context);
+
+  auto result = runAndGetCStr(relation);
+  ASSERT_TRUE(succeeded(result));
+  std::string actual = result.value();
+  std::string expected = R"(
+for (int c0 = 0; c0 <= 30; c0 += 1)
+  for (int c1 = -((c0 + 1) % 2) + 1; c1 <= 10; c1 += 2)
+    S(c1, c0);
+)";
+  ASSERT_THAT(actual, Eq(expected));
+}
+
+TEST(CodegenTest, HaleviShoup) {
+  MLIRContext context;
+  // Data is 32x64, being packed into ciphertexts of size 1024 via Halevi-Shoup
+  // diagonal layout.
+  IntegerRelation relation = relationFromString(
+      "(row, col, ct, slot) : ((slot - row) mod 32 == 0, (ct + slot - col) mod "
+      "64 == 0, row >= 0, col >= 0, ct >= 0, slot >= 0, 1023 >= slot, 31 >= "
+      "ct, 31 >= row, 63 >= col)",
+      2, &context);
+  auto result = runAndGetCStr(relation);
+  ASSERT_TRUE(succeeded(result));
+  std::string actual = result.value();
+  std::string expected = R"(
+for (int c0 = 0; c0 <= 31; c0 += 1)
+  for (int c1 = 0; c1 <= 1023; c1 += 1)
+    S(c1 % 32, -((-c0 - c1 + 1087) % 64) + 63, c0, c1);
+)";
+  ASSERT_THAT(actual, Eq(expected));
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/Parser.cpp
+++ b/lib/Utils/Layout/Parser.cpp
@@ -1,0 +1,28 @@
+#include "lib/Utils/Layout/Parser.h"
+
+#include "llvm/include/llvm/ADT/StringRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/AsmParser/AsmParser.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/Analysis/AffineAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/IntegerSet.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"    // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+using presburger::IntegerRelation;
+using presburger::VarKind;
+
+presburger::IntegerRelation relationFromString(StringRef integerSetStr,
+                                               int numDomainVars,
+                                               MLIRContext *context) {
+  IntegerRelation relation = affine::FlatAffineValueConstraints(
+      parseIntegerSet(integerSetStr, context));
+  relation.convertVarKind(VarKind::SetDim, 0, numDomainVars, VarKind::Domain);
+  return relation;
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/Parser.h
+++ b/lib/Utils/Layout/Parser.h
@@ -1,0 +1,22 @@
+// Helper functions to parse an integer relation from a string
+
+#include "llvm/include/llvm/ADT/StringRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+/// Parse an integer relation from a string representation. A thin wrapper
+/// around MLIR's upstream parser for IntegerSet, but in IntegerSet there is no
+/// distinction between domain and range dimensions. In IntegerSet, all
+/// dimensions are "set" dimensions, and a "set" dimension is interpreted as a
+/// "range" dimension in IntegerRelation. In IntegerRelation, all domain
+/// dimensions precede all range dimensions, so we need to specify how many of
+/// the leading dimensions are domain dimensions.
+presburger::IntegerRelation relationFromString(llvm::StringRef integerSetStr,
+                                               int numDomainVars,
+                                               MLIRContext *context);
+
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
This PR creates a helper library for doing code generation for a layout expressed as an integer relation. This does not include the materialization of the generated AST as MLIR, but Asra has an in-progress PR that does this step and just needs to be updated to use the ISL API.