### PR TITLE
Isolate and improve ISL conversion step

### DIFF
--- a/lib/Utils/Layout/BUILD
+++ b/lib/Utils/Layout/BUILD
@@ -12,6 +12,7 @@ cc_library(
     srcs = ["Codegen.cpp"],
     hdrs = ["Codegen.h"],
     deps = [
+        ":IslConversion",
         "@isl",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:Support",
@@ -71,4 +72,43 @@ cc_test(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],
+)
+
+cc_library(
+    name = "IslConversion",
+    srcs = ["IslConversion.cpp"],
+    hdrs = ["IslConversion.h"],
+    deps = [
+        ":Utils",
+        "@isl",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "IslConversionTest",
+    srcs = ["IslConversionTest.cpp"],
+    deps = [
+        ":IslConversion",
+        ":Parser",
+        ":Utils",
+        "@googletest//:gtest_main",
+        "@isl",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_binary(
+    name = "debug_packing_1d",
+    srcs = ["debug_packing_1d.c"],
+)
+
+cc_binary(
+    name = "debug_packing_2d",
+    srcs = ["debug_packing_2d.c"],
 )

--- a/lib/Utils/Layout/Codegen.cpp
+++ b/lib/Utils/Layout/Codegen.cpp
@@ -1,19 +1,18 @@
 #include "lib/Utils/Layout/Codegen.h"
 
-#include <cstdint>
-
-#include "include/isl/ast_build.h"                                  // from @isl
-#include "include/isl/ast_type.h"                                   // from @isl
-#include "include/isl/constraint.h"                                 // from @isl
-#include "include/isl/ctx.h"                                        // from @isl
-#include "include/isl/local_space.h"                                // from @isl
-#include "include/isl/map.h"                                        // from @isl
-#include "include/isl/map_type.h"                                   // from @isl
-#include "include/isl/set.h"                                        // from @isl
-#include "include/isl/space.h"                                      // from @isl
-#include "include/isl/space_type.h"                                 // from @isl
-#include "include/isl/union_map.h"                                  // from @isl
-#include "include/isl/union_map_type.h"                             // from @isl
+#include "include/isl/ast_build.h"       // from @isl
+#include "include/isl/ast_type.h"        // from @isl
+#include "include/isl/constraint.h"      // from @isl
+#include "include/isl/ctx.h"             // from @isl
+#include "include/isl/local_space.h"     // from @isl
+#include "include/isl/map.h"             // from @isl
+#include "include/isl/map_type.h"        // from @isl
+#include "include/isl/set.h"             // from @isl
+#include "include/isl/space.h"           // from @isl
+#include "include/isl/space_type.h"      // from @isl
+#include "include/isl/union_map.h"       // from @isl
+#include "include/isl/union_map_type.h"  // from @isl
+#include "lib/Utils/Layout/IslConversion.h"
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
@@ -24,124 +23,58 @@ namespace heir {
 using presburger::IntegerRelation;
 using presburger::VarKind;
 
-static __isl_give isl_union_map* convertRelationToUnionMap(
-    const IntegerRelation& rel, isl_ctx* ctx) {
-  // ISL has these variables types, which map to MLIR FPL variable types:
-  // isl_dim_param -> VarKind::Symbol
-  // isl_dim_in -> VarKind::Domain
-  // isl_dim_out -> VarKind::Range
-  // isl_dim_div -> VarKind::Local
-  //
-  // ISL puts parameters first, but since we have zero symbols, we can ignore
-  // the implied change to the offsets.
-  unsigned numDomain = rel.getNumVarKind(VarKind::Domain);
-  unsigned numRange = rel.getNumVarKind(VarKind::Range);
-  unsigned numLocal = rel.getNumVarKind(VarKind::Local);
+// Converts a basic map (representing proper domain/range vars as in/out vars)
+// to a schedule that maps all domain+range vars to range vars.
+//
+// In particular, this tells the ISL codegen that we want to iterate over just
+// the range variables. This is specific to FHE because we know the packing must
+// be a partial function from range (ct, slot) to domain (data indices).
+//
+// E.g., for an input basic map like
+//
+//   {
+//      [row,col] -> [ct,slot] :
+//      0 <= row,ct < 4
+//      and 0 <= col < 8
+//      and 0 <= slot < 32
+//      and ((-row + slot) % 4) = 0 and (-col + ct + slot) % 8 = 0
+//   }
+//
+// The output schedule would have the same constraints, but the map would start
+// with
+//
+//   S[row,col,ct,slot] -> [ct,slot]
+//
+static __isl_give isl_union_map* createSchedule(__isl_keep isl_basic_map* bmap,
+                                                isl_ctx* ctx) {
+  isl_basic_map* schedule_bmap = isl_basic_map_copy(bmap);
+  unsigned numIn = isl_basic_map_dim(schedule_bmap, isl_dim_in);
+  unsigned numOut = isl_basic_map_dim(schedule_bmap, isl_dim_out);
 
-  // This represents the mapping from all four variables to just iterate over
-  // the range variables. This is specific to FHE because we know the packing
-  // must be a partial function from range to domain.
-  //
-  // E.g., this is specifying the `S[row,col,ct,slot] -> [ct,slot]` part of a
-  // union map like
-  //
-  //   {
-  //      S[row,col,ct,slot] -> [ct,slot] :
-  //      0 <= row,ct < 4
-  //      and 0 <= col < 8
-  //      and 0 <= slot < 32
-  //      and ((-row + slot) % 4) = 0 and (-col + ct + slot) % 8 = 0
-  //   }
-  //
-  unsigned numIn = numDomain + numRange;
-  unsigned numOut = numRange;
-  isl_space* space = isl_space_alloc(ctx, /*n_params=*/0, numIn, numOut);
+  // Insert two new dimensions for the original range variables into the domain.
+  schedule_bmap =
+      isl_basic_map_insert_dims(schedule_bmap, isl_dim_in, numIn, numOut);
 
-  // "S" is a hardcoded name for the inner-most statement that will be executed
-  // to assign the data entry to the ciphertext slot. Users will be forced to
-  // match on this name in the generated AST.
-  //
-  // E.g., S might be defined in plain C, using the layout example above, as
-  //
-  //   void S(int a, int b, int c, int d, int data[4][8], int slot[4][32]) {
-  //     slot[c][d] = data[a][b];
-  //   }
-  //
-  space = isl_space_set_tuple_name(space, isl_dim_in, "S");
-
-  // Nb., consider someday using isl_space_set_dim_name to link these variables
-  // to relevant constructs (like MLIR SSA variables, somehow?)
-
-  isl_basic_map* bmap = isl_basic_map_universe(isl_space_copy(space));
-  isl_local_space* ls = isl_local_space_from_space(space);
-  if (numLocal > 0) {
-    ls = isl_local_space_add_dims(ls, isl_dim_div, numLocal);
-  }
-
-  // Identical variables in the range and domain must be linked
-  //
-  // E.g., in S[row,col,ct,slot] -> [ct,slot], the ct and slot variables are
-  // different and must be marked as the same.
-  for (int i = 0; i < numRange; i++) {
-    isl_constraint* c = isl_constraint_alloc_equality(isl_local_space_copy(ls));
-    c = isl_constraint_set_coefficient_si(c, isl_dim_in, numDomain + i, 1);
+  // Add constraints to equate the new domain dimensions with the original range
+  // dimensions.
+  for (unsigned i = 0; i < numOut; ++i) {
+    isl_constraint* c = isl_constraint_alloc_equality(
+        isl_basic_map_get_local_space(schedule_bmap));
+    c = isl_constraint_set_coefficient_si(c, isl_dim_in, numIn + i, 1);
     c = isl_constraint_set_coefficient_si(c, isl_dim_out, i, -1);
-    bmap = isl_basic_map_add_constraint(bmap, c);
+    schedule_bmap = isl_basic_map_add_constraint(schedule_bmap, c);
   }
 
-  // Now copy the coefficients of the constraints from the flattened IntegerSet
-  // to ISL.
-  auto copyConstraintsFromUnionMap = [&](bool isEquality) {
-    unsigned numConstraints =
-        isEquality ? rel.getNumEqualities() : rel.getNumInequalities();
-
-    for (unsigned idx = 0; idx < numConstraints; ++idx) {
-      SmallVector<int64_t> coeffs =
-          isEquality ? rel.getEquality64(idx) : rel.getInequality64(idx);
-
-      auto* spaceCopy = isl_local_space_copy(ls);
-      isl_constraint* c = isEquality
-                              ? isl_constraint_alloc_equality(spaceCopy)
-                              : isl_constraint_alloc_inequality(spaceCopy);
-
-      c = isl_constraint_set_constant_si(c, coeffs.back());
-
-      for (int i = 0; i < numDomain; i++) {
-        unsigned offset = i + rel.getVarKindOffset(VarKind::Domain);
-        c = isl_constraint_set_coefficient_si(c, isl_dim_in, i, coeffs[offset]);
-      }
-
-      for (int i = 0; i < numRange; i++) {
-        unsigned offset = i + rel.getVarKindOffset(VarKind::Range);
-        c = isl_constraint_set_coefficient_si(c, isl_dim_in, numDomain + i,
-                                              coeffs[offset]);
-      }
-
-      for (int i = 0; i < numLocal; i++) {
-        unsigned offset = i + rel.getVarKindOffset(VarKind::Local);
-        c = isl_constraint_set_coefficient_si(c, isl_dim_div, i,
-                                              coeffs[offset]);
-      }
-
-      bmap = isl_basic_map_add_constraint(bmap, c);
-    }
-  };
-
-  copyConstraintsFromUnionMap(/*isEquality=*/true);
-  copyConstraintsFromUnionMap(/*isEquality=*/false);
-
-  isl_local_space_free(ls);
-
-  return isl_union_map_from_basic_map(bmap);
+  // Set the domain tuple name to "S". This will be used in codegen for the
+  // statement to be executed, e.g., S(a, b, c, d)
+  schedule_bmap = isl_basic_map_set_tuple_name(schedule_bmap, isl_dim_in, "S");
+  return isl_union_map_from_basic_map(schedule_bmap);
 }
 
 __isl_give isl_ast_node* constructAst(const presburger::IntegerRelation& rel,
                                       isl_ctx* ctx) {
-  // The easiest way to convert an integer relation to an ISL schedule is
-  // actually to write the ISL union-set as a string. This is because ISL's API
-  // otherwise manually requires you to flatten constraints and remove
-  // divs/mods.
-  isl_union_map* schedule = convertRelationToUnionMap(rel, ctx);
+  isl_basic_map* bmap = convertRelationToBasicMap(rel, ctx);
+  isl_union_map* schedule = createSchedule(bmap, ctx);
 
   // Context and options are intentionally empty. We don't need any of these
   // features, though I admit I have not looked into what they can provide.
@@ -164,6 +97,24 @@ FailureOr<isl_ast_node*> generateLoopNest(
     return failure();
   }
   return tree;
+}
+
+FailureOr<std::string> generateLoopNestAsCStr(
+    const presburger::IntegerRelation& rel) {
+  isl_ctx* ctx = isl_ctx_alloc();
+  auto result = generateLoopNest(rel, ctx);
+  if (failed(result)) {
+    isl_ctx_free(ctx);
+    return failure();
+  }
+  isl_ast_node* tree = result.value();
+  char* cStr = isl_ast_node_to_C_str(tree);
+  std::string actual = std::string(cStr);
+  free(cStr);
+  isl_ast_node_free(tree);
+  isl_ctx_free(ctx);
+  // Add a leading newline for ease of comparison with multiline strings.
+  return actual.insert(0, "\n");
 }
 
 }  // namespace heir

--- a/lib/Utils/Layout/Codegen.h
+++ b/lib/Utils/Layout/Codegen.h
@@ -15,5 +15,9 @@ namespace heir {
 FailureOr<isl_ast_node*> generateLoopNest(
     const presburger::IntegerRelation& rel, isl_ctx* ctx);
 
+// A debugging helper to generate a C string representation of the loop nest.
+FailureOr<std::string> generateLoopNestAsCStr(
+    const presburger::IntegerRelation& rel);
+
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Utils/Layout/IslConversion.cpp
+++ b/lib/Utils/Layout/IslConversion.cpp
@@ -1,0 +1,89 @@
+#include <iostream>
+
+#include "include/isl/ast_build.h"            // from @isl
+#include "include/isl/ast_type.h"             // from @isl
+#include "include/isl/constraint.h"           // from @isl
+#include "include/isl/ctx.h"                  // from @isl
+#include "include/isl/local_space.h"          // from @isl
+#include "include/isl/map.h"                  // from @isl
+#include "include/isl/map_type.h"             // from @isl
+#include "include/isl/mat.h"                  // from @isl
+#include "include/isl/set.h"                  // from @isl
+#include "include/isl/space.h"                // from @isl
+#include "include/isl/space_type.h"           // from @isl
+#include "include/isl/union_map.h"            // from @isl
+#include "include/isl/union_map_type.h"       // from @isl
+#include "include/isl/val.h"                  // from @isl
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+#define DEBUG_TYPE "isl-conversion"
+
+namespace mlir {
+namespace heir {
+
+using presburger::IntegerRelation;
+using presburger::VarKind;
+
+// Borrowed from
+// https://github.com/EnzymeAD/Enzyme-JAX/blob/ec61fe8bee1abb50ca3883cdded669e978624ad9/src/enzyme_ad/jax/Passes/SimplifyAffineExprs.cpp#L47
+__isl_give isl_mat* createConstraintRows(__isl_keep isl_ctx* ctx,
+                                         const IntegerRelation& rel,
+                                         bool isEq) {
+  unsigned numRows = isEq ? rel.getNumEqualities() : rel.getNumInequalities();
+  unsigned numDimVars = rel.getNumDimVars();
+  unsigned numLocalVars = rel.getNumLocalVars();
+  unsigned numSymbolVars = rel.getNumSymbolVars();
+
+  unsigned numCols = rel.getNumCols();
+  isl_mat* mat = isl_mat_alloc(ctx, numRows, numCols);
+
+  for (unsigned i = 0; i < numRows; i++) {
+    // Get the row based on isEq.
+    auto row = isEq ? rel.getEquality(i) : rel.getInequality(i);
+
+    assert(row.size() == numCols);
+
+    // Dims stay at the same positions.
+    for (unsigned j = 0; j < numDimVars; j++)
+      mat = isl_mat_set_element_si(mat, i, j, (int64_t)row[j]);
+    // Output local ids before symbols.
+    for (unsigned j = 0; j < numLocalVars; j++)
+      mat = isl_mat_set_element_si(
+          mat, i, j + numDimVars, (int64_t)row[j + numDimVars + numSymbolVars]);
+    // Output symbols in the end.
+    for (unsigned j = 0; j < numSymbolVars; j++)
+      mat = isl_mat_set_element_si(mat, i, j + numDimVars + numLocalVars,
+                                   (int64_t)row[j + numDimVars]);
+    // Finally outputs the constant.
+    mat =
+        isl_mat_set_element_si(mat, i, numCols - 1, (int64_t)row[numCols - 1]);
+  }
+  return mat;
+}
+
+__isl_give isl_basic_map* convertRelationToBasicMap(const IntegerRelation& rel,
+                                                    __isl_keep isl_ctx* ctx) {
+  isl_mat* eqMat = createConstraintRows(ctx, rel, /*isEq=*/true);
+  isl_mat* ineqMat = createConstraintRows(ctx, rel, /*isEq=*/false);
+  LLVM_DEBUG({
+    llvm::dbgs() << "Adding domain relation\n";
+    llvm::dbgs() << " ISL eq mat:\n";
+    isl_mat_dump(eqMat);
+    llvm::dbgs() << " ISL ineq mat:\n";
+    isl_mat_dump(ineqMat);
+    llvm::dbgs() << "\n";
+  });
+
+  isl_space* space =
+      isl_space_alloc(ctx, rel.getNumSymbolVars(), rel.getNumDomainVars(),
+                      rel.getNumRangeVars());
+  return isl_basic_map_from_constraint_matrices(
+      space, eqMat, ineqMat, isl_dim_in, isl_dim_out, isl_dim_div,
+      isl_dim_param, isl_dim_cst);
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/IslConversion.h
+++ b/lib/Utils/Layout/IslConversion.h
@@ -1,0 +1,23 @@
+#include "include/isl/ast_build.h"                                  // from @isl
+#include "include/isl/ast_type.h"                                   // from @isl
+#include "include/isl/constraint.h"                                 // from @isl
+#include "include/isl/ctx.h"                                        // from @isl
+#include "include/isl/local_space.h"                                // from @isl
+#include "include/isl/map.h"                                        // from @isl
+#include "include/isl/map_type.h"                                   // from @isl
+#include "include/isl/set.h"                                        // from @isl
+#include "include/isl/space.h"                                      // from @isl
+#include "include/isl/space_type.h"                                 // from @isl
+#include "include/isl/union_map.h"                                  // from @isl
+#include "include/isl/union_map_type.h"                             // from @isl
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+__isl_give isl_basic_map* convertRelationToBasicMap(
+    const presburger::IntegerRelation& rel, isl_ctx* ctx);
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/IslConversionTest.cpp
+++ b/lib/Utils/Layout/IslConversionTest.cpp
@@ -1,0 +1,79 @@
+#include <cstdlib>
+#include <string>
+
+#include "gmock/gmock.h"  // from @googletest
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Utils/Layout/IslConversion.h"
+#include "lib/Utils/Layout/Parser.h"
+#include "llvm/include/llvm/ADT/StringRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/AsmParser/AsmParser.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/Analysis/AffineAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/IntegerSet.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"    // from @llvm-project
+
+// ISL
+#include "include/isl/ast.h"       // from @isl
+#include "include/isl/ast_type.h"  // from @isl
+#include "include/isl/ctx.h"       // from @isl
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using presburger::IntegerRelation;
+using presburger::VarKind;
+using ::testing::Eq;
+
+TEST(IslConversionTest, SimpleTest) {
+  MLIRContext context;
+  std::string relStr =
+      "(d0, d1) : ((d0 - d1) mod 7 == 0, d0 >= 0, 20 >= d0, d1 >= 0, 20 >= d1)";
+  IntegerRelation relation =
+      affine::FlatAffineValueConstraints(parseIntegerSet(relStr, &context));
+  relation.convertVarKind(VarKind::SetDim, 0, 1, VarKind::Domain);
+
+  std::string expected =
+      "{ [i0] -> [o0] : (-i0 + o0) mod 7 = 0 and 0 <= i0 <= 20 and 0 <= o0 <= "
+      "20 }";
+
+  isl_ctx* ctx = isl_ctx_alloc();
+  isl_basic_map* result = convertRelationToBasicMap(relation, ctx);
+
+  char* resultStr = isl_basic_map_to_str(result);
+  std::string actual(resultStr);
+  free(resultStr);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(IslConversionTest, RegressionTest) {
+  MLIRContext context;
+  std::string relStr =
+      "(d0, d1, d2, d3, d4, d5, d6, d7) : (-d1 + d3 == 0, d0 - d4 * 1024 - d5 "
+      "== 0, d2 - d6 * 32 - d7 == 0, d5 - d7 == 0, -d0 + 31 >= 0, d0 >= 0, d1 "
+      "== 0, d2 >= 0, -d2 + 1023 >= 0, -d0 + d3 * 1024 + 1023 >= 0, d0 - d3 * "
+      "1024 >= 0, -d0 + d4 * 1024 + 1023 >= 0, d0 - d4 * 1024 >= 0, -d2 + d6 * "
+      "32 + 31 >= 0, d2 - d6 * 32 >= 0)";
+  IntegerRelation relation =
+      affine::FlatAffineValueConstraints(parseIntegerSet(relStr, &context));
+  relation.convertVarKind(VarKind::SetDim, 3, 8, VarKind::Local);
+  relation.convertVarKind(VarKind::SetDim, 0, 1, VarKind::Domain);
+
+  std::string expected =
+      "{ [i0] -> [o0, o1] : o0 = 0 and (-i0 + o1) mod 32 = 0 and 0 <= i0 <= 31 "
+      "and 0 <= o1 <= 1023 }";
+
+  isl_ctx* ctx = isl_ctx_alloc();
+  isl_basic_map* result = convertRelationToBasicMap(relation, ctx);
+
+  char* resultStr = isl_basic_map_to_str(result);
+  std::string actual(resultStr);
+  free(resultStr);
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/debug_packing_1d.c
+++ b/lib/Utils/Layout/debug_packing_1d.c
@@ -1,0 +1,64 @@
+/*
+ * This file is a debug helper for IntegerRelations that represent ciphertext
+ * packings. Given an IntegerRelation, you can call
+ * Codegen.h::generateLoopNestAsCStr in this directory to generate a C string
+ * that can be copied here and run to simulate the generated packing.
+ *
+ * Note that if the dimensions of the test relation differ, this file will need
+ * to be modified to match.
+ *
+ * This is the 1D version with a 1D data array.
+ */
+#include <stdio.h>
+
+#define SIZE 8
+#define CTS 1
+#define SLOTS 16
+
+int data[SIZE];
+int ciphertexts[CTS][SLOTS];
+
+void S(int d0, int d1, int d2) { ciphertexts[d1][d2] = data[d0]; }
+
+void print1D(int* array, int size) {
+  for (int i = 0; i < size; i++) {
+    printf("%4d ", array[i]);
+  }
+  printf("\n");
+}
+
+void print2D(int* matrix, int rows, int cols) {
+  for (int i = 0; i < rows; i++) {
+    for (int j = 0; j < cols; j++) {
+      printf("%4d ", matrix[i * cols + j]);
+    }
+    printf("\n");
+  }
+  printf("\n");
+}
+
+int main() {
+  // Data array is 0, 1, 2, ...
+  for (int i = 0; i < SIZE; i++) {
+    data[i] = i;
+  }
+  printf("Data array:\n");
+  print1D(data, SIZE);
+
+  for (int i = 0; i < CTS; i++) {
+    for (int j = 0; j < SLOTS; j++) {
+      ciphertexts[i][j] = 0;
+    }
+  }
+
+  // Insert the codegenned loop here from debug output.
+  // clang-format off
+  for (int c1 = 0; c1 <= 15; c1 += 1)
+    S((c1 + 3) % 8, 0, c1);
+  // clang-format ont
+
+  printf("Packed ciphertexts:\n");
+  print2D((int*)ciphertexts, CTS, SLOTS);
+
+  return 0;
+}

--- a/lib/Utils/Layout/debug_packing_2d.c
+++ b/lib/Utils/Layout/debug_packing_2d.c
@@ -1,0 +1,63 @@
+/*
+ * This file is a debug helper for IntegerRelations that represent ciphertext
+ * packings. Given an IntegerRelation, you can call
+ * Codegen.h::generateLoopNestAsCStr in this directory to generate a C string
+ * that can be copied here and run to simulate the generated packing.
+ *
+ * Note that if the dimensions of the test relation differ, this file will need
+ * to be modified to match.
+ */
+#include <stdio.h>
+
+#define ROWS 8
+#define COLS 8
+#define CTS 8
+#define SLOTS 16
+
+int data[ROWS][COLS];
+int ciphertexts[CTS][SLOTS];
+
+void S(int d0, int d1, int d2, int d3) {
+  printf("(%4d, %4d) -> (%4d, %4d)\n", d0, d1, d2, d3);
+  ciphertexts[d2][d3] = data[d0][d1];
+}
+
+void print2D(int* matrix, int rows, int cols) {
+  for (int i = 0; i < rows; i++) {
+    for (int j = 0; j < cols; j++) {
+      printf("%4d ", matrix[i * cols + j]);
+    }
+    printf("\n");
+  }
+  printf("\n");
+}
+
+int main() {
+  // Data matrix is 0, 1, 2, ...
+  for (int i = 0; i < ROWS; i++) {
+    for (int j = 0; j < COLS; j++) {
+      data[i][j] = i * COLS + j;
+    }
+  }
+
+  for (int i = 0; i < CTS; i++) {
+    for (int j = 0; j < SLOTS; j++) {
+      ciphertexts[i][j] = 0;
+    }
+  }
+
+  // Insert the codegenned loop here from debug output.
+  // clang-format off
+  for (int c0 = 0; c0 <= 7; c0 += 1)
+    for (int c1 = 0; c1 <= 15; c1 += 1)
+      S((c1 + 3) % 8, (c0 + c1 + 3) % 8, c0, c1);
+  // clang-format on
+
+  printf("Data matrix:\n");
+  print2D((int*)data, ROWS, COLS);
+
+  printf("Packed ciphertexts:\n");
+  print2D((int*)ciphertexts, CTS, SLOTS);
+
+  return 0;
+}


### PR DESCRIPTION
The previous way we were converting IntegerRelation to isl basic/union map was buggy because ISL was overthinking and creating duplicate local variables that were not being properly constrained (in `isl_basic_map_add_constraint`). A more direct way to do this (h/t Enzyme) is to use `isl_basic_map_from_constraint_matrices` and directly construct the constraint matrices from FPL.

I also took the opportunity to separate the FPL -> ISL conversion step from the schedule generation needed for codegen, as the schedule involves adding new variables to the domain (essentially duplicating range variables). That part is unrelated to the actual conversion, and was confounding me during bug hunting.

Next, it would be nice to have a backwards conversion from ISL -> FPL, so we could use ISL for simplification while FPL's simplification routines are incomplete.