### PR TITLE
ISL-string based layout attribute

### DIFF
--- a/lib/Dialect/TensorExt/IR/BUILD
+++ b/lib/Dialect/TensorExt/IR/BUILD
@@ -48,6 +48,7 @@ cc_library(
     deps = [
         ":attributes_inc_gen",
         ":dialect_inc_gen",
+        "@heir//lib/Utils/Layout:IslConversion",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:Analysis",

--- a/lib/Dialect/TensorExt/IR/TensorExtAttributes.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtAttributes.cpp
@@ -1,15 +1,15 @@
 #include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
 
-#include <cstdint>
-#include <memory>
 #include <string>
-#include <utility>
 
+#include "include/isl/ctx.h"         // from @isl
+#include "include/isl/map.h"         // from @isl
+#include "include/isl/space_type.h"  // from @isl
+#include "lib/Utils/Layout/IslConversion.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"        // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
-#include "mlir/include/mlir/AsmParser/AsmParser.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/Analysis/AffineStructures.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/AffineMap.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributeInterfaces.h"  // from @llvm-project
@@ -122,116 +122,51 @@ LogicalResult LayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
-void NewLayoutAttr::print(AsmPrinter& p) const {
-  p << "<domainSize=" << getDomainSize();
-  if (getLocalSize() > 0) {
-    p << ", localSize=" << getLocalSize();
+namespace {
+
+FailureOr<IntegerRelation> getIntegerRelationFromIslStr(std::string islStr) {
+  isl_ctx* ctx = isl_ctx_alloc();
+  isl_basic_map* bmap = isl_basic_map_read_from_str(ctx, islStr.c_str());
+  if (!bmap) {
+    isl_ctx_free(ctx);
+    return failure();
   }
-  p << ", relation=\"";
-  getRelation().print(p.getStream());
-  p << "\">";
+  return convertBasicMapToRelation(bmap);
 }
 
-Attribute NewLayoutAttr::parse(AsmParser& parser, Type type) {
-  // <domainSize=
-  if (failed(parser.parseLess()) || failed(parser.parseKeyword("domainSize")) ||
-      parser.parseEqual())
-    return {};
-
-  APInt parsedDomainSize(64, 1);
-  if (failed(parser.parseInteger(parsedDomainSize))) {
-    parser.emitError(parser.getCurrentLocation())
-        << "required integer for domainSize";
-    return {};
-  }
-  unsigned domainSize = parsedDomainSize.getZExtValue();
-
-  // ,
-  if (failed(parser.parseComma())) return {};
-
-  // localSize=
-  unsigned localSize = 0;
-  if (succeeded(parser.parseOptionalKeyword("localSize"))) {
-    APInt parsedLocalSize(64, 1);
-    if (failed(parser.parseEqual()) ||
-        failed(parser.parseInteger(parsedLocalSize))) {
-      parser.emitError(parser.getCurrentLocation())
-          << "required integer for localSize";
-      return {};
-    }
-    localSize = parsedLocalSize.getZExtValue();
-
-    if (failed(parser.parseComma())) return {};
-  }
-
-  // relation=
-  if (failed(parser.parseKeyword("relation")) || parser.parseEqual()) return {};
-
-  std::string parsedRelationString;
-  if (failed(parser.parseString(&parsedRelationString))) {
-    parser.emitError(parser.getCurrentLocation())
-        << "expected integer relation for relation";
-    return {};
-  }
-
-  IntegerSet parsedSet =
-      parseIntegerSet(parsedRelationString, parser.getContext());
-
-  if (failed(parser.parseGreater())) return {};
-  return NewLayoutAttr::get(parser.getContext(), domainSize, parsedSet,
-                            localSize);
-}
+}  // namespace
 
 LogicalResult NewLayoutAttr::verify(
-    function_ref<InFlightDiagnostic()> emitError, unsigned domainSize,
-    IntegerSet relation, unsigned localSize) {
-  // The range size (all variables except domain variables) should be 2, i.e.,
-  // the ciphertext index and slot index.
-  unsigned numVars = relation.getNumInputs();
-  if (localSize > numVars) {
-    return emitError() << "localSize (" << localSize
-                       << ") must be less than or equal to the number of "
-                          "variables in the relation ("
-                       << numVars << ")";
+    function_ref<InFlightDiagnostic()> emitError, StringAttr layoutStr) {
+  auto result = getIntegerRelationFromIslStr(layoutStr.getValue().str());
+  if (failed(result)) {
+    return emitError() << "Failed to parse the layout string (ISL): "
+                       << layoutStr;
   }
-  if (domainSize > numVars) {
-    return emitError() << "domainSize (" << domainSize
-                       << ") must be less than or equal to the number of "
-                          "variables in the relation ("
-                       << numVars << ")";
-  }
-  if (domainSize + localSize > numVars) {
-    return emitError() << "total number of domain and local variables ("
-                       << domainSize + localSize
-                       << ") must be less than or equal to the number of "
-                          "variables in the relation ("
-                       << numVars << ")";
-  }
-  if (numVars - domainSize - localSize != 2) {
-    return emitError()
-           << "relation must have 2 range variables, but got total vars = "
-           << numVars << ", domainSize = " << domainSize
-           << ", localSize = " << localSize;
-  }
+  // Success if you can parse the ISL string and convert it.
   return success();
+}
+
+IntegerRelation NewLayoutAttr::getIntegerRelation() const {
+  auto result = getIntegerRelationFromIslStr(getLayoutStr());
+  assert(succeeded(result) && "Failed to parse the layout string");
+  return result.value();
 }
 
 NewLayoutAttr NewLayoutAttr::getFromIntegerRelation(
     ::mlir::MLIRContext* context, IntegerRelation relation) {
-  relation.removeTrivialRedundancy();
-  relation.removeDuplicateDivs();
-  relation.simplify();
+  isl_ctx* ctx = isl_ctx_alloc();
+  isl_basic_map* bmap = convertRelationToBasicMap(relation, ctx);
 
-  std::unique_ptr<IntegerRelation> copy = relation.clone();
-  copy->convertVarKind(VarKind::Domain, 0, copy->getNumDomainVars(),
-                       VarKind::SetDim, 0);
-  copy->convertVarKind(VarKind::Local, 0, copy->getNumLocalVars(),
-                       VarKind::SetDim);
-  affine::FlatAffineValueConstraints integerSet =
-      IntegerPolyhedron(std::move(*copy));
-  return NewLayoutAttr::get(context, relation.getNumDomainVars(),
-                            integerSet.getAsIntegerSet(context),
-                            relation.getNumLocalVars());
+  bmap = isl_basic_map_set_dim_name(bmap, isl_dim_out, 0, "ct");
+  bmap = isl_basic_map_set_dim_name(bmap, isl_dim_out, 1, "slot");
+
+  char* resultStr = isl_basic_map_to_str(bmap);
+  std::string layoutStr(resultStr);
+  free(resultStr);
+  isl_basic_map_free(bmap);
+  isl_ctx_free(ctx);
+  return NewLayoutAttr::get(context, layoutStr);
 }
 
 }  // namespace tensor_ext

--- a/lib/Dialect/TensorExt/IR/TensorExtAttributes.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtAttributes.td
@@ -205,38 +205,34 @@ def TensorExt_NewLayoutAttr : TensorExt_Attr<"NewLayout", "new_layout"> {
     at index $(2, 3)$ is placed in slot 0 of ciphertext 7. This could be
     defined as part of the relation by a constraint like `row + col + 2 - ct +
     slot = 0`.
-  }];
-  // Note that we use IntegerSet here because it's hashable upstream while
-  // IntegerRelation is not. So we have a helper function below to reconstruct
-  // the relation from the attribute.
-  let parameters = (ins "unsigned":$domainSize,
-                    "::mlir::IntegerSet":$relation,
-                    DefaultValuedParameter<"unsigned", "0">:$localSize
-  );
-  let assemblyFormat = ?;
-  let hasCustomAssemblyFormat = 1;
 
+    The attribute stores a string representation of the integer relation,
+    which follows the ISL syntax for `isl_basic_map`. For example:
+
+    ```mlir
+    #vec_layout = #tensor_ext.new_layout<"{ [i0] -> [ct, slot] : (i0 - slot) mod 1024 = 7 and i0 >= 0 and 0 >= i0 and slot >= 0 and 1023 >= slot and ct = 0 }">
+
+    #mat_layout = #tensor_ext.new_layout<"{ [row, col] -> [ct, slot] : (slot - row) mod 512 = 0 and (ct + slot - col) mod 512 = 0 and row >= 0 and col >= 0 and ct >= 0 and slot >= 0 and 1023 >= slot and 511 >= ct and 511 >= row and 511 >= col }">
+
+    // Example with local (existential) variables.
+    #layout = #tensor_ext.new_layout<"{[d0] -> [ct, slot] : exists d3, d4 : -ct + d3 = 0 and d0 - d4 * 1024 = 0 and -d0 + 31 >= 0 and d0 >= 0 and ct >= 0 and slot >= 0 and -slot + 1023 >= 0 and -d0 + d3 * 1024 + 1023 >= 0 and d0 - d3 * 1024 >= 0 and -d0 + d4 * 1024 + 1023 >= 0 and d0 - d4 * 1024 >= 0 }">
+    ```
+  }];
+  let parameters = (ins "mlir::StringAttr":$layout);
   let genVerifyDecl = 1;
+  let assemblyFormat = "`<` $layout `>`";
 
   let builders = [
-    AttrBuilder<(ins "unsigned":$domainSize,
-                    "::mlir::IntegerSet":$relation), [{
-      return get($_ctxt, domainSize, relation, /*localSize=*/0);
-    }]>
+    AttrBuilder<(ins "std::string":$layoutStr), [{
+      return $_get($_ctxt, StringAttr::get($_ctxt, layoutStr));
+    }]>,
   ];
 
-
   let extraClassDeclaration = commonClassDeclaration # [{
-    presburger::IntegerRelation getIntegerRelation() const {
-      presburger::IntegerRelation relation =
-          affine::FlatAffineValueConstraints(getRelation());
-      relation.convertVarKind(presburger::VarKind::SetDim, 0, getDomainSize(),
-                              presburger::VarKind::Domain);
-      // Keep 2 variables for range (SetDim) vars, the verifier asserts this.
-      relation.convertVarKind(presburger::VarKind::SetDim, 2,
-                              2 + getLocalSize(),
-                              presburger::VarKind::Local);
-      return relation;
+    presburger::IntegerRelation getIntegerRelation() const;
+
+    std::string getLayoutStr() const {
+      return getLayout().str();
     }
 
     static NewLayoutAttr getFromIntegerRelation(

--- a/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -88,12 +88,13 @@ LogicalResult verifyLayoutMatchesType(const Attribute& layoutAttr, Type type,
   }
 
   if (auto newLayout = dyn_cast<NewLayoutAttr>(layoutAttr)) {
-    if (shapedType && newLayout.getDomainSize() != shapedType.getRank()) {
+    presburger::IntegerRelation rel = newLayout.getIntegerRelation();
+    if (shapedType && rel.getNumDomainVars() != shapedType.getRank()) {
       return op->emitOpError()
              << "requires tensor rank to match the layout's domain size, "
                 "but found rank "
              << shapedType.getRank() << " and domain size "
-             << newLayout.getDomainSize();
+             << rel.getNumDomainVars();
     }
   }
 

--- a/lib/Transforms/LayoutPropagation/NewLayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/NewLayoutPropagation.cpp
@@ -378,7 +378,7 @@ LogicalResult NewLayoutPropagation::visitOperation(CollapseShapeOp op) {
 
   MLIRContext* ctx = &getContext();
   NewLayoutAttr resultLayoutAttr =
-      NewLayoutAttr::getFromIntegerRelation(ctx, std::move(*clonedRelation));
+      NewLayoutAttr::getFromIntegerRelation(ctx, *clonedRelation);
 
   assignedLayouts.insert({op.getResult(), resultLayoutAttr});
   setResultLayoutAttr(op);
@@ -433,7 +433,7 @@ LogicalResult NewLayoutPropagation::visitOperation(ExpandShapeOp op) {
 
   MLIRContext* ctx = &getContext();
   NewLayoutAttr resultLayoutAttr =
-      NewLayoutAttr::getFromIntegerRelation(ctx, std::move(*clonedRelation));
+      NewLayoutAttr::getFromIntegerRelation(ctx, *clonedRelation);
 
   assignedLayouts.insert({op.getResult(), resultLayoutAttr});
   setResultLayoutAttr(op);
@@ -769,7 +769,7 @@ FailureOr<NewLayoutAttr> NewLayoutPropagation::defaultLayoutForScalarType(
     Type scalarType) {
   // FIXME: Does a scalar have domainSize=0? And should the output type be
   // tensor<1 x ciphertextSize x type> or tensor<ciphertextSize x type>?
-  auto ctx = scalarType.getContext();
+  auto* ctx = scalarType.getContext();
   OpBuilder builder(ctx);
 
   // Only support Int/Index/Float scalars,
@@ -778,12 +778,9 @@ FailureOr<NewLayoutAttr> NewLayoutPropagation::defaultLayoutForScalarType(
     return failure();
   }
 
-  IntegerSet integerSet = mlir::parseIntegerSet(
-      llvm::formatv("(ct, slot) : (0 <= ct, 0 >= ct, slot >=0, {0} >= slot)",
-                    ciphertextSize - 1)
-          .str(),
-      ctx);
-  return NewLayoutAttr::get(ctx, /*domainSize=*/0, /*relation=*/integerSet);
+  std::string relationStr = llvm::formatv(
+      "{ [] -> [ct, slot] : ct = 0 and 0 <= slot <= {0} }", ciphertextSize - 1);
+  return NewLayoutAttr::get(ctx, relationStr);
 }
 
 FailureOr<NewLayoutAttr> NewLayoutPropagation::defaultLayoutForType(Type type) {

--- a/lib/Utils/Layout/IslConversionTest.cpp
+++ b/lib/Utils/Layout/IslConversionTest.cpp
@@ -114,6 +114,28 @@ TEST(IslConversionTest, RoundTripRegressionTest) {
   ASSERT_TRUE(relation.isEqual(actual));
 }
 
+TEST(IslConversionTest, ScalarLayout) {
+  MLIRContext context;
+  std::string relStr =
+      "(ct, slot) : (0 <= ct, 0 >= ct, slot >=0, 1023 >= slot)";
+  IntegerRelation relation =
+      affine::FlatAffineValueConstraints(parseIntegerSet(relStr, &context));
+  // No domain vars, set dims are range vars by default
+
+  std::string expected = "{ [] -> [o0, o1] : o0 = 0 and 0 <= o1 <= 1023 }";
+
+  isl_ctx* ctx = isl_ctx_alloc();
+  isl_basic_map* result = convertRelationToBasicMap(relation, ctx);
+
+  char* resultStr = isl_basic_map_to_str(result);
+  std::string actual(resultStr);
+  free(resultStr);
+  EXPECT_EQ(expected, actual);
+
+  isl_basic_map_free(result);
+  isl_ctx_free(ctx);
+}
+
 }  // namespace
 }  // namespace heir
 }  // namespace mlir

--- a/tests/Dialect/TensorExt/IR/new_layout.mlir
+++ b/tests/Dialect/TensorExt/IR/new_layout.mlir
@@ -2,10 +2,7 @@
 
 // 1024 x 1024 matrix -> 1024 cts with 1024 slots each
 // via halevi-shoup diagonal layout
-#layout = #tensor_ext.new_layout<
-  domainSize=2,
-  relation="(row, col, ct, slot) : ((slot mod 1024) - row == 0, (ct + slot) mod 1024 - col == 0, row >= 0, col >= 0, ct >= 0, slot >= 0)"
->
+#layout = #tensor_ext.new_layout<"{ [row, col] -> [ct, slot] : (slot mod 1024) - row = 0 and (ct + slot) mod 1024 - col = 0 and row >= 0 and col >= 0 and ct >= 0 and slot >= 0 }">
 func.func private @test_fn(tensor<16xi32> {foo.bar = #layout})
 
 // -----

--- a/tests/Transforms/add_client_interface/add_client_interface_new_layout.mlir
+++ b/tests/Transforms/add_client_interface/add_client_interface_new_layout.mlir
@@ -3,7 +3,7 @@
 // Data is 32x64, being packed into ciphertexts of size 1024 via Halevi-Shoup
 // diagonal layout.
 !ct_ty = !secret.secret<tensor<32x1024xi16>>
-#layout = #tensor_ext.new_layout<domainSize=2, relation="(row, col, ct, slot) : ((slot mod 32) - row == 0, (ct + slot) mod 64 - col == 0, row >= 0, col >= 0, ct >= 0, slot >= 0, 1023 - slot >= 0, 31 - ct >= 0, 31 - row >= 0, 64 - col >= 0)">
+#layout = #tensor_ext.new_layout<"{ [row, col] -> [ct, slot] : (slot mod 32) - row = 0 and (ct + slot) mod 64 - col = 0 and row >= 0 and col >= 0 and ct >= 0 and slot >= 0 and 1023 - slot >= 0 and 31 - ct >= 0 and 31 - row >= 0 and 64 - col >= 0 }">
 #original_type = #tensor_ext.original_type<originalType = tensor<32x64xi16>, layout = #layout>
 
 // The ISL generated loop nest is:

--- a/tests/Transforms/add_client_interface/elementwise_new_layout.mlir
+++ b/tests/Transforms/add_client_interface/elementwise_new_layout.mlir
@@ -1,7 +1,7 @@
 // RUN: heir-opt --add-client-interface="ciphertext-size=1024" --canonicalize --cse %s | FileCheck %s
 
 !ct_ty = !secret.secret<tensor<1x1024xi16>>
-#layout = #tensor_ext.new_layout<domainSize=1, localSize=5, relation="(d0, d1, d2, d3, d4, d5, d6, d7) : (-d1 + d3 == 0, d0 - d4 * 1024 - d5 == 0, d2 - d6 * 32 - d7 == 0, d5 - d7 == 0, -d0 + 31 >= 0, d0 >= 0, d1 >= 0, d2 >= 0, -d2 + 1023 >= 0, -d0 + d3 * 1024 + 1023 >= 0, d0 - d3 * 1024 >= 0, -d0 + d4 * 1024 + 1023 >= 0, d0 - d4 * 1024 >= 0, -d2 + d6 * 32 + 31 >= 0, d2 - d6 * 32 >= 0)">
+#layout = #tensor_ext.new_layout<"{[d0] -> [ct, slot] : exists d3, d4, d5, d6, d7 : -ct + d3 = 0 and d0 - d4 * 1024 - d5 = 0 and slot - d6 * 32 - d7 = 0 and d5 - d7 = 0 and -d0 + 31 >= 0 and d0 >= 0 and ct >= 0 and slot >= 0 and -slot + 1023 >= 0 and -d0 + d3 * 1024 + 1023 >= 0 and d0 - d3 * 1024 >= 0 and -d0 + d4 * 1024 + 1023 >= 0 and d0 - d4 * 1024 >= 0 and -slot + d6 * 32 + 31 >= 0 and slot - d6 * 32 >= 0 }">
 #original_type = #tensor_ext.original_type<originalType = tensor<32xi16>, layout = #layout>
 
 // The ISL AST for this layout is:

--- a/tests/Transforms/add_client_interface/new_layout_strided.mlir
+++ b/tests/Transforms/add_client_interface/new_layout_strided.mlir
@@ -2,7 +2,7 @@
 
 // Go from 16xi16 -> 1x32xi16 with a layout that strides the input by 2
 !ct_ty = !secret.secret<tensor<1x32xi16>>
-#layout = #tensor_ext.new_layout<domainSize=1, relation="(d0, d1, d2) : (d2 - 2 * d0 == 0, d0 >= 0, d2 >= 0, 15 >= d0, 31 >= d2, d1 == 0)">
+#layout = #tensor_ext.new_layout<"{ [d0] -> [ct, slot] : slot - 2 * d0 = 0 and d0 >= 0 and slot >= 0 and 15 >= d0 and 31 >= slot and ct = 0}">
 #original_type = #tensor_ext.original_type<originalType = tensor<16xi16>, layout = #layout>
 
 // The ISL AST for this layout is:

--- a/tests/Transforms/layout_optimization/hoist_matvec.mlir
+++ b/tests/Transforms/layout_optimization/hoist_matvec.mlir
@@ -1,10 +1,10 @@
 // RUN: heir-opt --layout-optimization %s | FileCheck %s
 
-#vec_layout = #tensor_ext.new_layout<domainSize=1, relation="(d, ct, slot) : ((d - slot) mod 1024 == 4, d >= 0, 0 >= d, slot >= 0, 1023 >= slot, ct == 0)">
-#vec_layout_2 = #tensor_ext.new_layout<domainSize=1, relation="(d, ct, slot) : ((d - slot) mod 1024 == 7, d >= 0, 0 >= d, slot >= 0, 1023 >= slot, ct == 0)">
-#mat_layout = #tensor_ext.new_layout<domainSize=2, relation="(row, col, ct, slot) : ((slot - row) mod 512 == 0, (ct + slot - col) mod 512 == 0, row >= 0, col >= 0, ct >= 0, slot >= 0, 1023 >= slot, 511 >= ct, 511 >= row, 511 >= col)">
+#vec_layout = #tensor_ext.new_layout<"{ [i0] -> [ct, slot] : (i0 - slot) mod 1024 = 4 and i0 >= 0 and 0 >= i0 and slot >= 0 and 1023 >= slot and ct = 0 }">
+#vec_layout_2 = #tensor_ext.new_layout<"{ [i0] -> [ct, slot] : (i0 - slot) mod 1024 = 7 and i0 >= 0 and 0 >= i0 and slot >= 0 and 1023 >= slot and ct = 0 }">
+#mat_layout = #tensor_ext.new_layout<"{ [row, col] -> [ct, slot] : (slot - row) mod 512 = 0 and (ct + slot - col) mod 512 = 0 and row >= 0 and col >= 0 and ct >= 0 and slot >= 0 and 1023 >= slot and 511 >= ct and 511 >= row and 511 >= col }">
 
-// CHECK: #tensor_ext.new_layout<domainSize=2, localSize=7,
+// CHECK: #tensor_ext.new_layout<"{ [i0, i1] -> [ct, slot]
 
 func.func @main(%arg0: tensor<512x512xf32>, %arg1: !secret.secret<tensor<512xf32>> {tensor_ext.layout = #vec_layout}) -> (!secret.secret<tensor<512xf32>> {tensor_ext.layout = #vec_layout_2}) {
   %cst = arith.constant dense<0.000000e+00> : tensor<512xf32>

--- a/tests/Transforms/new_layout_propagation/cleartext_args.mlir
+++ b/tests/Transforms/new_layout_propagation/cleartext_args.mlir
@@ -1,6 +1,6 @@
 // RUN: heir-opt --new-layout-propagation=ciphertext-size=1024 %s | FileCheck %s
 
-// CHECK-DAG: [[layout:#[^ ]*]] = #tensor_ext.new_layout<domainSize=0, relation="(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 1023 >= 0)">
+// CHECK-DAG: [[layout:#[^ ]*]] = #tensor_ext.new_layout<"{ [] -> [ct, slot] : ct = 0 and 0 <= slot <= 1023 }">
 
 // Layouts should not be assigned to the cleartext function args
 // CHECK: func @cmux

--- a/tests/Transforms/new_layout_propagation/extract.mlir
+++ b/tests/Transforms/new_layout_propagation/extract.mlir
@@ -2,8 +2,8 @@
 
 // Assigns a scalar layout to the results of extract
 
-// CHECK: [[scalar_layout:.*]] = #tensor_ext.new_layout<domainSize=0
-// CHECK: [[tensor_layout:.*]] = #tensor_ext.new_layout<domainSize=1
+// CHECK: [[scalar_layout:.*]] = #tensor_ext.new_layout<"{ [] ->
+// CHECK: [[tensor_layout:.*]] = #tensor_ext.new_layout<"{ [i0] ->
 
 // CHECK: @dot_product
 // CHECK-SAME: [[arg0:%[^:]*]]: !secret.secret<tensor<8xi16>> {tensor_ext.layout = [[tensor_layout]]}

--- a/tests/Transforms/new_layout_propagation/insert_conversion.mlir
+++ b/tests/Transforms/new_layout_propagation/insert_conversion.mlir
@@ -8,11 +8,11 @@
 // Test that when an operation changes the tensor layour in an incompatible way,
 // a layout conversion operation is inserted.
 
-// CHECK: [[rm_layout:[^ ]*]] = #tensor_ext.new_layout<domainSize=2
+// CHECK: [[rm_layout:[^ ]*]] = #tensor_ext.new_layout<"{ [i0, i1] -> [ct, slot] :
 
 // CHECK: insert_conversion
-// CHECK-SAME: %[[arg0:[^:]+]]: !secret.secret<tensor<32x32xi16>> {tensor_ext.layout = [[rm_layout]]}
-// CHECK-SAME: %[[arg1:[^:]+]]: !secret.secret<tensor<32x32xi16>> {tensor_ext.layout = [[rm_layout]]}
+// CHECK-SAME: %[[arg0:[^:]+]]: !secret.secret<tensor<32x32xi16>> {tensor_ext.layout = [[rm_layout]]
+// CHECK-SAME: %[[arg1:[^:]+]]: !secret.secret<tensor<32x32xi16>> {tensor_ext.layout = [[rm_layout]]
 func.func @insert_conversion(%arg0: !stensor, %arg1: !stensor) -> !stensor2 {
   // CHECK: [[cst:%.*]] = arith.constant dense<0>
   %out_1 = arith.constant dense<0> : !tensor2

--- a/tests/Transforms/new_layout_propagation/mnist.mlir
+++ b/tests/Transforms/new_layout_propagation/mnist.mlir
@@ -11,7 +11,7 @@ module attributes {backend.openfhe, scheme.bgv} {
     ^body(%input0: tensor<1x784xf32>):
       %transposed = linalg.transpose ins(%arg0 : tensor<512x784xf32>) outs(%0 : tensor<784x512xf32>) permutation = [1, 0]
       // CHECK: tensor.collapse_shape
-      // CHECK-SAME: {tensor_ext.layout = #tensor_ext.new_layout<domainSize=1
+      // CHECK-SAME: {tensor_ext.layout = #tensor_ext.new_layout<"{ [i0] ->
       %collapsed = tensor.collapse_shape %input0 [[0, 1]] : tensor<1x784xf32> into tensor<784xf32>
       %3 = linalg.vecmat ins(%collapsed, %transposed : tensor<784xf32>, tensor<784x512xf32>) outs(%cst : tensor<512xf32>) -> tensor<512xf32>
       %4 = arith.addf %arg1, %3 : tensor<512xf32>
@@ -20,7 +20,7 @@ module attributes {backend.openfhe, scheme.bgv} {
       %6 = linalg.vecmat ins(%5, %transposed_1 : tensor<512xf32>, tensor<512x10xf32>) outs(%cst_0 : tensor<10xf32>) -> tensor<10xf32>
       %7 = arith.addf %arg3, %6 : tensor<10xf32>
       // CHECK: tensor.expand_shape
-      // CHECK-SAME: {tensor_ext.layout = #tensor_ext.new_layout
+      // CHECK-SAME: {tensor_ext.layout = #tensor_ext.new_layout<"{ [i0, i1] ->
       %expanded = tensor.expand_shape %7 [[0, 1]] output_shape [1, 10] : tensor<10xf32> into tensor<1x10xf32>
       secret.yield %expanded : tensor<1x10xf32>
     } -> !secret.secret<tensor<1x10xf32>>

--- a/tests/Transforms/new_layout_propagation/scalar.mlir
+++ b/tests/Transforms/new_layout_propagation/scalar.mlir
@@ -2,7 +2,7 @@
 
 // Test that layout propagation can handle secret scalars
 
-// CHECK: #tensor_ext.new_layout<domainSize=0, relation="(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 1023 >= 0)">
+// CHECK: #tensor_ext.new_layout<"{ [] -> [ct, slot] : ct = 0 and 0 <= slot <= 1023 }">
 
 // CHECK: @scalar_mul
 func.func @scalar_mul(%arg0: !secret.secret<i16>) -> !secret.secret<i16> {


### PR DESCRIPTION
The layout attribute is too messy when printing it as a flat IntegerSet, so instead we convert to and from ISL to use its string representation, which represents the formulas more readably.

Rebased on https://github.com/google/heir/pull/2127

Fixes https://github.com/google/heir/issues/2125