### PR TITLE
Lower the partition step of key_switch_inner

### DIFF
--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/BUILD
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/BUILD
@@ -16,6 +16,7 @@ cc_library(
         ":pass_inc_gen",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@heir//lib/Parameters/CKKS:Params",
         "@heir//lib/Utils:APIntUtils",
         "@heir//lib/Utils:ConversionUtils",
         "@heir//lib/Utils/Polynomial",

--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
@@ -10,12 +10,14 @@
 #include <utility>
 #include <vector>
 
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
 #include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTypes.h"
+#include "lib/Parameters/CKKS/Params.h"
 #include "lib/Utils/APIntUtils.h"
 #include "lib/Utils/ConversionUtils.h"
 #include "lib/Utils/Polynomial/Polynomial.h"
@@ -1246,6 +1248,90 @@ struct ConvertINTT : public OpConversionPattern<INTTOp> {
   }
 };
 
+struct ConvertKeySwitchInner
+    : public OpConversionPattern<polynomial::KeySwitchInnerOp> {
+  ConvertKeySwitchInner(mlir::MLIRContext* context)
+      : OpConversionPattern<polynomial::KeySwitchInnerOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      polynomial::KeySwitchInnerOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto b = ImplicitLocOpBuilder(op.getLoc(), rewriter);
+
+    RankedTensorType coefficientTensorType =
+        cast<RankedTensorType>(adaptor.getValue().getType());
+
+    if (coefficientTensorType.getRank() != 1) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "Can only lower key_switch_inner when input is a single polynomial");
+    }
+
+    // TODO(#2157): enable this for more than just CKKS
+    ckks::SchemeParamAttr schemeParamAttr =
+        op->getParentOfType<ModuleOp>()->getAttrOfType<ckks::SchemeParamAttr>(
+            ckks::CKKSDialect::kSchemeParamAttrName);
+    if (!schemeParamAttr) {
+      return rewriter.notifyMatchFailure(
+          op, "Cannot find scheme param attribute on parent module");
+    }
+
+    auto schemeParam =
+        ckks::SchemeParam::getSchemeParamFromAttr(schemeParamAttr);
+
+    int64_t partSize = schemeParam.getPi().size();
+
+    if (partSize <= 0) {
+      return rewriter.notifyMatchFailure(
+          op, "Cannot lower key_switch_inner with empty modulus chain");
+    }
+
+    int64_t numFullPartitions = coefficientTensorType.getShape()[0] / partSize;
+    int64_t sliceSize = partSize * numFullPartitions;
+    int64_t extraPartSize = coefficientTensorType.getShape()[0] - sliceSize;
+
+    // Step 1: partition the coefficients of the polynomial into pieces. Note
+    // the partition may not be even, so there may be one leftover part of an
+    // uneven size that must be tracked manually through the rest of the
+    // lowering.
+
+    // First extract the parts that are divisible and reshape it i.e., a
+    // tensor<17xi32> with partitionSize 5 would first slice-extract to
+    // tensor<15xi32> then reshape to tensor<3x5xi32>.
+    SmallVector<OpFoldResult> offsets(1, b.getIndexAttr(0));
+    SmallVector<OpFoldResult> sizes(1, b.getIndexAttr(sliceSize));
+    SmallVector<OpFoldResult> strides(1, b.getIndexAttr(1));
+    Value extracted = tensor::ExtractSliceOp::create(b, adaptor.getValue(),
+                                                     offsets, sizes, strides);
+
+    SmallVector<int64_t> partitionShape = {numFullPartitions, partSize};
+    RankedTensorType partitionType = RankedTensorType::get(
+        partitionShape, coefficientTensorType.getElementType());
+    // Create a dense constant for targetShape
+    auto shapeOp = mlir::arith::ConstantOp::create(
+        rewriter, op.getLoc(),
+        RankedTensorType::get(partitionType.getRank(), rewriter.getIndexType()),
+        rewriter.getIndexTensorAttr(partitionType.getShape()));
+
+    Value reshaped =
+        tensor::ReshapeOp::create(b, partitionType, extracted, shapeOp);
+
+    // Then extract the trailing piece that doesn't have the same tensor size.
+    SmallVector<OpFoldResult> extraPartOffsets(1, b.getIndexAttr(sliceSize));
+    SmallVector<OpFoldResult> extraPartSizes(1, b.getIndexAttr(extraPartSize));
+    SmallVector<OpFoldResult> extraPartStrides(1, b.getIndexAttr(1));
+    Value extraPart =
+        tensor::ExtractSliceOp::create(b, adaptor.getValue(), extraPartOffsets,
+                                       extraPartSizes, extraPartStrides);
+
+    // TODO(#2157): implement the rest
+
+    return success();
+  }
+};
+
 void PolynomialToModArith::runOnOperation() {
   MLIRContext* context = &getContext();
 
@@ -1293,8 +1379,8 @@ void PolynomialToModArith::runOnOperation() {
                ConvertPolyBinop<AddOp, arith::AddIOp, mod_arith::AddOp>,
                ConvertPolyBinop<SubOp, arith::SubIOp, mod_arith::SubOp>,
                ConvertLeadingTerm, ConvertMonomial, ConvertMonicMonomialMul,
-               ConvertConstant, ConvertMulScalar, ConvertNTT, ConvertINTT>(
-      typeConverter, context);
+               ConvertConstant, ConvertMulScalar, ConvertNTT, ConvertINTT,
+               ConvertKeySwitchInner>(typeConverter, context);
   patterns.add<ConvertMul>(typeConverter, patterns.getContext(), getDivmodOp);
   addStructuralConversionPatterns(typeConverter, patterns, target);
   addTensorOfTensorConversionPatterns(typeConverter, patterns, target);

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/BUILD
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/BUILD
@@ -6,5 +6,7 @@ glob_lit_tests(
     name = "all_tests",
     data = ["@heir//tests:test_utilities"],
     driver = "@heir//tests:run_lit.sh",
+    # TODO(#2157): re-enable when the rest of key_switch_inner is lowered
+    exclude = ["lower_keyswitch_inner.mlir"],
     test_file_exts = ["mlir"],
 )

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/lower_keyswitch_inner.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/lower_keyswitch_inner.mlir
@@ -1,0 +1,26 @@
+// RUN: heir-opt --polynomial-to-mod-arith %s | FileCheck %s
+
+!Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>
+!rns_L1 = !rns.rns<!Z1095233372161_i64, !Z1032955396097_i64>
+!rns_new = !rns.rns<!Z1095233372161_i64>
+#ring_rns_L1_1_x1024 = #polynomial.ring<coefficientType = !rns_L1, polynomialModulus = <1 + x**1024>>
+#ring_new = #polynomial.ring<coefficientType = !rns_new, polynomialModulus = <1 + x**1024>>
+!poly = !polynomial.polynomial<ring = #ring_rns_L1_1_x1024>
+!poly_new = !polynomial.polynomial<ring = #ring_new>
+
+module attributes {
+    ckks.schemeParam = #ckks.scheme_param<
+      logN = 14,
+      Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113],
+      P = [36028797019488257, 36028797020209153],
+      logDefaultScale = 45
+    >
+} {
+  // CHECK: @test_keyswitch_inner_lowering
+  func.func @test_keyswitch_inner_lowering(%p: !poly, %ksk: tensor<10x2x!poly>) -> (!poly, !poly) {
+    // CHECK-NOT: polynomial.key_switch_inner
+    %c, %l = polynomial.key_switch_inner %p, %ksk : (!poly, tensor<10x2x!poly>) -> (!poly, !poly)
+    return %c, %l : !poly, !poly
+  }
+}


### PR DESCRIPTION
One of the ops for lowering `key_switch_inner` is to partition the coefficients of a polynomial. This op will eventually lower to a combination of

```
tensor.extract_slice (extract the divisible part)
tensor.reshape (reshape the divisible part)
tensor.extract_slice (extract the extra piece)
```

This actually kind of makes me think we don't need a dedicated op at all. We can just lower directly to the three ops this will lower to. Is there an advantage to having this intermediate op? I suppose that would depend on how other methods of implementing keyswitch might differ with this one.

Part of #2157

CC @crockea @AlexanderViand 