### PR TITLE
try simplifying caching logic for CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,8 +14,6 @@ jobs:
   check-cache:
     runs-on:
       labels: ubuntu-22.04-8core
-    outputs:
-      runner: ${{ steps.runner.outputs.runner }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
@@ -26,50 +24,37 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
           lookup-only: true
-      - name: Select runner
-        id: runner
-        env:
-          CACHE_HIT: ${{ steps.cache.outputs.cache-hit  == 'true' }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${CACHE_HIT}" == "true" ]]; then
-            echo "runner=ubuntu-22.04-8core" >> "$GITHUB_OUTPUT"
-          else
-            echo "runner=ubuntu-22.04-32core" >> "$GITHUB_OUTPUT"
-          fi
 
   build-and-test:
     needs: check-cache
     runs-on:
-      labels: ${{ needs.check-cache.outputs.runner }}
+      labels: ubuntu-22.04-32core
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update
           sudo apt-get install -y libomp-dev
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
         with:
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
 
       - name: Cache bazel build artifacts
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
 
       - name: "Run `bazel build`"
         run: |
-          bazel build --incompatible_strict_action_env -c opt //...
+          bazel build -c opt //...
 
       - name: "Run `bazel test`"
         run: |
-          bazel test --incompatible_strict_action_env -c opt //...
+          bazel test -c opt //...

--- a/.github/workflows/build_and_test_macos.yml
+++ b/.github/workflows/build_and_test_macos.yml
@@ -14,8 +14,6 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.label.name == 'ci:macos'
     runs-on:
       labels: macos-15
-    outputs:
-      runner: ${{ steps.runner.outputs.runner }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
@@ -26,42 +24,30 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
           lookup-only: true
-      - name: Select runner
-        id: runner
-        env:
-          CACHE_HIT: ${{ steps.cache.outputs.cache-hit  == 'true' }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${CACHE_HIT}" == "true" ]]; then
-            echo "runner=macos-15" >> "$GITHUB_OUTPUT"
-          else
-            echo "runner=macos-15" >> "$GITHUB_OUTPUT"
-          fi
 
   build-and-test:
     if: github.event_name != 'pull_request' || github.event.label.name == 'ci:macos'
     needs: check-cache
     runs-on:
-      labels: ${{ needs.check-cache.outputs.runner }}
+      labels: macos-15
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
         with:
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
 
       - name: Cache bazel build artifacts
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
 
       - name: Install coreutils
         run: brew install coreutils

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,6 @@ jobs:
   check-cache:
     runs-on:
       labels: ubuntu-22.04-8core
-    outputs:
-      runner: ${{ steps.runner.outputs.runner }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
@@ -25,27 +23,15 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+            ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
           lookup-only: true
-      - name: Select runner
-        id: runner
-        env:
-          CACHE_HIT: ${{ steps.cache.outputs.cache-hit  == 'true' }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${CACHE_HIT}" == "true" ]]; then
-            echo "runner=ubuntu-22.04-8core" >> "$GITHUB_OUTPUT"
-          else
-            echo "runner=ubuntu-22.04-32core" >> "$GITHUB_OUTPUT"
-          fi
 
   build-and-deploy:
     needs: check-cache
     runs-on:
-      labels: ${{ needs.check-cache.outputs.runner }}
+      labels: ubuntu-22.04-32core
     permissions:
       contents: write
     steps:
@@ -58,9 +44,9 @@ jobs:
       with:
         path: |
           ~/.cache/bazel
-        key: ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
+        key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-${{ hashFiles('bazel/import_llvm.bzl') }}
         restore-keys: |
-          ${{ runner.os }}-${{ env.ImageVersion }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
+          ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE') }}-
 
     # This requires building mlir-tblgen, but may not require a full llvm build
     # as a result. It results in the files being added to their respective


### PR DESCRIPTION
The theory is that something changed between the 8core and 32core images, such that switching between them during cache miss/hit make bazel invalidate the cache. I.e., 8-core can't use a cache produced by a 32-core machine.