### PR TITLE
Add a tensor.insert kernel for new layouts

### DIFF
--- a/lib/Transforms/ConvertToCiphertextSemantics/BUILD
+++ b/lib/Transforms/ConvertToCiphertextSemantics/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "@heir//lib/Utils:ContextAwareTypeConversion",
         "@heir//lib/Utils:MathUtils",
         "@heir//lib/Utils:TransformUtils",
+        "@heir//lib/Utils/Layout:Codegen",
         "@heir//lib/Utils/Layout:Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",

--- a/lib/Utils/Layout/BUILD
+++ b/lib/Utils/Layout/BUILD
@@ -60,7 +60,9 @@ cc_library(
     srcs = ["Utils.cpp"],
     hdrs = ["Utils.h"],
     deps = [
+        ":IslConversion",
         "@heir//lib/Utils:MathUtils",
+        "@isl",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:IR",

--- a/lib/Utils/Layout/Codegen.cpp
+++ b/lib/Utils/Layout/Codegen.cpp
@@ -226,6 +226,7 @@ FailureOr<scf::ForOp> MLIRLoopNestGenerator::generateForLoop(
     const presburger::IntegerRelation& rel, ValueRange initArgs,
     function_ref<scf::ValueVector(OpBuilder&, Location, ValueRange, ValueRange)>
         bodyBuilder) {
+  OpBuilder::InsertionGuard guard(builder_);
   isl_ast_node* tree = constructAst(rel, ctx_);
   if (!tree) {
     return failure();

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -6,12 +6,22 @@
 #include <memory>
 #include <utility>
 
+#include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/MathUtils.h"
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/Utils/Utils.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"            // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"               // from @llvm-project
+
+// ISL
+#include "include/isl/ctx.h"       // from @isl
+#include "include/isl/map.h"       // from @isl
+#include "include/isl/map_type.h"  // from @isl
+#include "include/isl/point.h"     // from @isl
+#include "include/isl/set.h"       // from @isl
+#include "include/isl/space.h"     // from @isl
+#include "include/isl/val.h"       // from @isl
 
 namespace mlir {
 namespace heir {
@@ -23,7 +33,7 @@ using presburger::VarKind;
 
 // Adds a modulo constraint to the result relation. Returns the index of the new
 // local variable that represents the modulo operation result.
-unsigned int addModConstraint(IntegerRelation& result, ArrayRef<int64_t> exprs,
+unsigned int addModConstraint(IntegerRelation &result, ArrayRef<int64_t> exprs,
                               int64_t modulus) {
   assert(modulus > 0 && "addModConstraint modulus argument must be positive");
 
@@ -174,24 +184,24 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
 
 bool isRelationSquatDiagonal(RankedTensorType matrixType,
                              int64_t ciphertextSize,
-                             presburger::IntegerRelation relation) {
+                             const presburger::IntegerRelation &relation) {
   IntegerRelation diagonalRelation =
       getDiagonalLayoutRelation(matrixType, ciphertextSize);
   return relation.isEqual(diagonalRelation);
 }
 
 bool isRelationRowMajor(RankedTensorType vectorType, int64_t numSlots,
-                        presburger::IntegerRelation relation) {
+                        const presburger::IntegerRelation &relation) {
   IntegerRelation rowMajorRelation =
       getRowMajorLayoutRelation(vectorType, numSlots);
   return relation.isEqual(rowMajorRelation);
 }
 
 presburger::IntegerRelation collapseDimensions(
-    presburger::IntegerRelation relation, RankedTensorType sourceType,
-    SmallVector<ReassociationIndices> reassociation) {
+    const presburger::IntegerRelation &relation, RankedTensorType sourceType,
+    ArrayRef<ReassociationIndices> reassociation) {
   std::unique_ptr<IntegerRelation> clonedRelation = relation.clone();
-  for (const ReassociationIndices& associationGroup : reassociation) {
+  for (const ReassociationIndices &associationGroup : reassociation) {
     // a single-entry association group is a no-op
     if (associationGroup.size() == 1) {
       continue;
@@ -207,8 +217,8 @@ presburger::IntegerRelation collapseDimensions(
 }
 
 presburger::IntegerRelation expandDimensions(
-    presburger::IntegerRelation relation, RankedTensorType resultType,
-    SmallVector<ReassociationIndices> reassociation) {
+    const presburger::IntegerRelation &relation, RankedTensorType resultType,
+    ArrayRef<ReassociationIndices> reassociation) {
   // tensor indices correspond to layout dimensions, and adding a dimension of
   // size 1 has no effect on the affine map expressions, so all we're doing is
   // adding new dimensions for each reassociation group index corresponding to
@@ -218,7 +228,7 @@ presburger::IntegerRelation expandDimensions(
   std::unique_ptr<IntegerRelation> clonedRelation = relation.clone();
   int oldDim = 0;
   DenseMap<AffineExpr, AffineExpr> oldDimsToNewDims;
-  for (const ReassociationIndices& associationGroup : reassociation) {
+  for (const ReassociationIndices &associationGroup : reassociation) {
     // a single-entry association group is a no-op
     if (associationGroup.size() == 1) {
       ++oldDim;
@@ -239,6 +249,56 @@ presburger::IntegerRelation expandDimensions(
     }
   }
   return std::move(*clonedRelation);
+}
+
+presburger::IntegerRelation fixDataIndices(
+    const presburger::IntegerRelation &relation,
+    ArrayRef<int64_t> fixedIndices) {
+  std::unique_ptr<IntegerRelation> rel = relation.clone();
+
+  // One constraint for each fixed index.
+  for (auto [dim, value] : llvm::enumerate(fixedIndices)) {
+    assert(value >= 0 && "invalid negative fixed index value");
+    SmallVector<int64_t> constraint(relation.getNumCols(), 0);
+    constraint[dim] = 1;
+    constraint.back() = -value;
+    rel->addEquality(constraint);
+  }
+
+  rel->simplify();
+  rel->removeRedundantConstraints();
+  return std::move(*rel);
+}
+
+isl_stat pointCallback(__isl_take isl_point *pnt, void *user) {
+  PointCollector *collector = static_cast<PointCollector *>(user);
+
+  // Use isl_space_dim instead of accessing struct members directly
+  isl_space *space = isl_point_get_space(pnt);
+  int dim = isl_space_dim(space, isl_dim_set);
+  isl_space_free(space);
+
+  std::vector<int> point(dim);
+
+  for (int i = 0; i < dim; i++) {
+    isl_val *coord = isl_point_get_coordinate_val(pnt, isl_dim_set, i);
+    if (isl_val_is_int(coord)) {
+      point[i] = isl_val_get_num_si(coord);
+    }
+    isl_val_free(coord);
+  }
+
+  collector->points.push_back(point);
+  isl_point_free(pnt);
+  return isl_stat_ok;
+}
+
+void getRangePoints(const presburger::IntegerRelation &relation,
+                    PointCollector &collector) {
+  auto *bmap = convertRelationToBasicMap(relation, collector.ctx);
+  isl_set *set = isl_set_from_basic_set(isl_basic_map_range(bmap));
+  isl_set_foreach_point(set, &pointCallback, &collector);
+  isl_set_free(set);
 }
 
 }  // namespace heir

--- a/lib/Utils/Layout/UtilsTest.cpp
+++ b/lib/Utils/Layout/UtilsTest.cpp
@@ -44,7 +44,7 @@ void runTest(RankedTensorType tensorType, int64_t numSlots) {
   }
 }
 
-TEST(ModConstraintTest, TestAddModConstraint) {
+TEST(UtilsTest, TestAddModConstraint) {
   MLIRContext context;
 
   IntegerRelation rel =
@@ -150,6 +150,16 @@ TEST(UtilsTest, SquatDiagonalLayout) {
       }
     }
   }
+}
+
+TEST(UtilsTest, TestGetPointsInRelation) {
+  MLIRContext context;
+  IntegerRelation rel =
+      relationFromString("(x) : (x >= 0, 7 >= x, x mod 3 == 0)", 0, &context);
+  std::vector<std::vector<int>> expected = {{0}, {3}, {6}};
+  PointCollector collector;
+  getRangePoints(rel, collector);
+  EXPECT_EQ(collector.points, expected);
 }
 
 }  // namespace

--- a/tests/Transforms/convert_to_ciphertext_semantics/BUILD
+++ b/tests/Transforms/convert_to_ciphertext_semantics/BUILD
@@ -10,7 +10,6 @@ glob_lit_tests(
         # TODO(#2047): Remove these tests after migrating to new layout
         "matvec.mlir",
         "tensor_extract.mlir",
-        "tensor_insert.mlir",
         "linalg_matvec_1024.mlir",
         "linalg_matvec_ckks.mlir",
     ],


### PR DESCRIPTION
tensor.insert kernel is broken into four cases:

  - insertion indices are static/dynamic
  - scalar `v` to insert is secret/cleartext

In all cases, this PR has the kernel generate a mask for the ciphertext-semantic scalar and dest tensors. The mask for the scalar has 1's or `v`'s for the secret/cleartext cases, and the mask for the dest has 1's everywhere except 0's in the target of the insertion.

If the indices are static, then the insertions can be done directly: take the layout, add constraints for the static indices on the domain, then simplify and (using ISL) enumerate the points of the range. Each point becomes one insertion. A new utility `getRangePoints` was added to support this, which can be generalized as needed.

If the indices are dynamic, then we have to use the codegen, where the body of the loop does the relevant mask construction.

This improves over the previous insert kernel in that:

- Rotations are no longer required
- It supports dynamic insertion indices (previous one required static)
- It supports arbitrary layouts for the scalar (including multi-packed ciphertexts, fixing the tensor.insert parts of #1542 and #1662)

This one feels like another win for the new layout system, since it is so straightforward to express the assembly of a special plaintext mask.