### PR TITLE
Partition RNS limbs (not poly coefficients) in key_switch_inner lowering

### DIFF
--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/BUILD
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Parameters/CKKS:Params",
         "@heir//lib/Utils:APIntUtils",
         "@heir//lib/Utils:ConversionUtils",

--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.td
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.td
@@ -20,6 +20,12 @@ def PolynomialToModArith : Pass<"polynomial-to-mod-arith", "ModuleOp"> {
     "mlir::scf::SCFDialect",
     "mlir::tensor::TensorDialect",
   ];
+
+  // TODO(#2157): Remove option once key_switch_inner lowering is done
+  let options = [
+    Option<"buildMaterializations", "build-materializations", "bool", /*default=*/"true",
+           "Whether to build materializations">,
+  ];
 }
 
 #endif  // LIB_DIALECT_POLYNOMIAL_CONVERSIONS_POLYNOMIALTOMODARITH_POLYNOMIALTOMODARITH_TD_

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
@@ -302,12 +302,7 @@ LogicalResult EvalOp::verify() {
 }
 
 LogicalResult KeySwitchInnerOp::verify() {
-  auto keyPolyType = getKeySwitchingKey().getType().getElementType();
-  if (keyPolyType != getValue().getType()) {
-    return emitOpError() << "keySwitchingKey element type " << keyPolyType
-                         << " does not match input type "
-                         << getValue().getType();
-  }
+  // TODO(#2157): check the ksk's RNS chain extends the value's RNS chain.
   return success();
 }
 

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -91,7 +91,9 @@ cc_library(
         ":ops_inc_gen",
         ":types_inc_gen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
     ],
 )
 
@@ -107,6 +109,7 @@ td_library(
     includes = ["../../../.."],
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
     ],
 )

--- a/lib/Dialect/RNS/IR/RNSOps.cpp
+++ b/lib/Dialect/RNS/IR/RNSOps.cpp
@@ -1,1 +1,57 @@
 #include "lib/Dialect/RNS/IR/RNSOps.h"
+
+#include "lib/Dialect/RNS/IR/RNSTypes.h"
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/TypeUtilities.h"      // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rns {
+
+LogicalResult ExtractSliceOp::inferReturnTypes(
+    MLIRContext* context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
+  ExtractSliceOpAdaptor op(operands, attrs, properties, regions);
+  RNSType elementType =
+      cast<RNSType>(getElementTypeOrSelf(op.getInput().getType()));
+  int64_t start = op.getStart().getZExtValue();
+  int64_t size = op.getSize().getZExtValue();
+
+  rns::RNSType truncatedType = rns::RNSType::get(
+      context, elementType.getBasisTypes().drop_front(start).take_front(size));
+  Type resultType = truncatedType;
+  if (auto shapedType = dyn_cast<ShapedType>(op.getInput().getType())) {
+    resultType = shapedType.clone(truncatedType);
+  }
+
+  results.push_back(resultType);
+  return success();
+}
+
+LogicalResult ExtractSliceOp::verify() {
+  auto rnsType = cast<RNSType>(getElementTypeOrSelf(getInput().getType()));
+  int64_t numLimbs = rnsType.getBasisTypes().size();
+  int64_t start = getStart().getZExtValue();
+  int64_t size = getSize().getZExtValue();
+
+  if (start < 0) {
+    return emitOpError() << "start index " << start << " cannot be negative";
+  }
+
+  if (size < 0) {
+    return emitOpError() << "size " << size << " cannot be negative";
+  }
+
+  if (start + size > numLimbs) {
+    return emitOpError() << "slice of size " << size << " starting at " << start
+                         << " is out of bounds for RNS type with " << numLimbs
+                         << " limbs";
+  }
+
+  return success();
+}
+
+}  // namespace rns
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/IR/RNSOps.h
+++ b/lib/Dialect/RNS/IR/RNSOps.h
@@ -1,6 +1,11 @@
 #ifndef LIB_DIALECT_RNS_IR_RNSOPS_H_
 #define LIB_DIALECT_RNS_IR_RNSOPS_H_
 
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+
 #define GET_OP_CLASSES
 #include "lib/Dialect/RNS/IR/RNSOps.h.inc"
 

--- a/lib/Dialect/RNS/IR/RNSOps.td
+++ b/lib/Dialect/RNS/IR/RNSOps.td
@@ -3,11 +3,31 @@
 
 include "lib/Dialect/RNS/IR/RNSDialect.td"
 include "lib/Dialect/RNS/IR/RNSTypes.td"
+include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class RNS_Op<string mnemonic, list<Trait> traits = []> :
         Op<RNS_Dialect, mnemonic, traits> {
   let cppNamespace = "::mlir::heir::rns";
 }
+
+def RNS_ExtractSliceOp : RNS_Op<"extract_slice", [Pure, ElementwiseMappable, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
+  let summary = "Extracts a slice of RNS limbs";
+  let description = [{
+    Given an RNS-typed value with $k$ basis types (limbs), extract the slice of
+    RNS components starting at `start` and having size `size`.
+
+    The result type is an RNS type containing the subset of basis types
+    corresponding to the extracted slice. This is useful for operations like
+    truncating or partitioning a modulus chain.
+  }];
+  let arguments = (ins RNSLike:$input, IndexAttr:$start, IndexAttr:$size);
+  let results = (outs RNSLike:$output);
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
+  let hasVerifier = 1;
+}
+
 
 #endif  // LIB_DIALECT_RNS_IR_RNSOPS_TD_

--- a/lib/Dialect/RNS/IR/RNSTypes.td
+++ b/lib/Dialect/RNS/IR/RNSTypes.td
@@ -38,4 +38,6 @@ def RNS : RNS_Type<"RNS", "rns", [OpAsmTypeInterface]> {
   }];
 }
 
+def RNSLike: TypeOrValueSemanticsContainer<RNS, "rns-like">;
+
 #endif  // LIB_DIALECT_RNS_IR_RNSTYPES_TD_

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/lower_keyswitch_inner.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/lower_keyswitch_inner.mlir
@@ -1,13 +1,10 @@
-// RUN: heir-opt --polynomial-to-mod-arith %s | FileCheck %s
+// RUN: heir-opt --polynomial-to-mod-arith="build-materializations=false" --split-input-file %s | FileCheck %s
 
 !Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
 !Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>
-!rns_L1 = !rns.rns<!Z1095233372161_i64, !Z1032955396097_i64>
-!rns_new = !rns.rns<!Z1095233372161_i64>
-#ring_rns_L1_1_x1024 = #polynomial.ring<coefficientType = !rns_L1, polynomialModulus = <1 + x**1024>>
-#ring_new = #polynomial.ring<coefficientType = !rns_new, polynomialModulus = <1 + x**1024>>
-!poly = !polynomial.polynomial<ring = #ring_rns_L1_1_x1024>
-!poly_new = !polynomial.polynomial<ring = #ring_new>
+!rns_2 = !rns.rns<!Z1095233372161_i64, !Z1032955396097_i64>
+#ring_rns_2 = #polynomial.ring<coefficientType = !rns_2, polynomialModulus = <1 + x**1024>>
+!poly = !polynomial.polynomial<ring = #ring_rns_2>
 
 module attributes {
     ckks.schemeParam = #ckks.scheme_param<
@@ -17,9 +14,52 @@ module attributes {
       logDefaultScale = 45
     >
 } {
-  // CHECK: @test_keyswitch_inner_lowering
-  func.func @test_keyswitch_inner_lowering(%p: !poly, %ksk: tensor<10x2x!poly>) -> (!poly, !poly) {
-    // CHECK-NOT: polynomial.key_switch_inner
+  // the partition step has a single part that evenly divides the whole: 2 rns limbs and partSize=2
+  // CHECK: @test_single_part
+  // CHECK-SAME: (%[[poly:[^:]*]]: tensor<1024x!rns.rns
+  // CHECK-SAME: , %[[ksk:[^:]*]]:
+  func.func @test_single_part(%p: !poly, %ksk: tensor<10x2x!poly>) -> (!poly, !poly) {
+    // CHECK: rns.extract_slice %[[poly]] {size = 2 : i32, start = 0 : i32}
+    %c, %l = polynomial.key_switch_inner %p, %ksk : (!poly, tensor<10x2x!poly>) -> (!poly, !poly)
+    return %c, %l : !poly, !poly
+  }
+}
+
+// -----
+
+// 11 primes, part size 3
+!Z0 = !mod_arith.int<900015181768817533 : i64>
+!Z1 = !mod_arith.int<143516525413762673 : i64>
+!Z2 = !mod_arith.int<261405424692085787 : i64>
+!Z3 = !mod_arith.int<820721655958272181 : i64>
+!Z4 = !mod_arith.int<474168048327747811 : i64>
+!Z5 = !mod_arith.int<997578949738158913 : i64>
+!Z6 = !mod_arith.int<734673533440457291 : i64>
+!Z7 = !mod_arith.int<783799894861165661 : i64>
+!Z8 = !mod_arith.int<237657300033566549 : i64>
+!Z9 = !mod_arith.int<480184796436462017 : i64>
+!Z10 =!mod_arith.int<591169749652992061 : i64>
+
+!rns_full = !rns.rns<!Z0, !Z1, !Z2, !Z3, !Z4, !Z5, !Z6, !Z7, !Z8, !Z9, !Z10>
+#ring_full = #polynomial.ring<coefficientType = !rns_full, polynomialModulus = <1 + x**1024>>
+!poly = !polynomial.polynomial<ring = #ring_full>
+
+module attributes {
+    ckks.schemeParam = #ckks.scheme_param<
+      logN = 14,
+      Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113],
+      P = [36028797019488257, 383061492451512379, 479480638416718187],
+      logDefaultScale = 45
+    >
+} {
+  // CHECK: @test_indivisible_parts
+  // CHECK-SAME: (%[[poly:[^:]*]]: tensor<1024x!rns.rns
+  // CHECK-SAME: , %[[ksk:[^:]*]]:
+  func.func @test_indivisible_parts(%p: !poly, %ksk: tensor<10x2x!poly>) -> (!poly, !poly) {
+    // CHECK: rns.extract_slice %[[poly]] {size = 3 : i32, start = 0 : i32}
+    // CHECK: rns.extract_slice %[[poly]] {size = 3 : i32, start = 3 : i32}
+    // CHECK: rns.extract_slice %[[poly]] {size = 3 : i32, start = 6 : i32}
+    // CHECK: rns.extract_slice %[[poly]] {size = 2 : i32, start = 9 : i32}
     %c, %l = polynomial.key_switch_inner %p, %ksk : (!poly, tensor<10x2x!poly>) -> (!poly, !poly)
     return %c, %l : !poly, !poly
   }

--- a/tests/Dialect/RNS/IR/syntax.mlir
+++ b/tests/Dialect/RNS/IR/syntax.mlir
@@ -5,9 +5,16 @@
 !Zp3 = !mod_arith.int<3180146689 : i64>
 
 !ty_modarith = !rns.rns<!Zp1, !Zp2, !Zp3>
+!ty_truncated = !rns.rns<!Zp1, !Zp2>
 
 func.func @test_syntax_modarith(%arg0: !ty_modarith) -> !ty_modarith {
+  %0 = rns.extract_slice %arg0 {start = 0 : index, size = 2 : index} : !ty_modarith -> !ty_truncated
   return %arg0 : !ty_modarith
+}
+
+func.func @elementwise_extract_slice(%arg0: tensor<10x!ty_modarith>) -> tensor<10x!ty_truncated> {
+  %0 = rns.extract_slice %arg0 {start = 0 : index, size = 2 : index} : tensor<10x!ty_modarith> -> tensor<10x!ty_truncated>
+  return %0 : tensor<10x!ty_truncated>
 }
 
 // expected-error@+1 {{RNS type has incompatible basis types}}
@@ -32,3 +39,73 @@ func.func @test_syntax_modarith(%arg0: !ty_modarith) -> !ty_modarith {
 
 // expected-error@+1 {{does not have RNSBasisTypeInterface}}
 !ty_int_bad = !rns.rns<i32, i64>
+
+// -----
+
+!Zp1_verify = !mod_arith.int<3721063133 : i64>
+!Zp2_verify = !mod_arith.int<2737228591 : i64>
+!Zp3_verify = !mod_arith.int<3180146689 : i64>
+!ty_modarith_verify = !rns.rns<!Zp1_verify, !Zp2_verify, !Zp3_verify>
+!ty_truncated_verify = !rns.rns<!Zp1_verify, !Zp2_verify>
+
+func.func @test_extract_slice_verifier_negative_start(%arg0: !ty_modarith_verify) {
+  // expected-error@+1 {{start index -1 cannot be negative}}
+  %0 = rns.extract_slice %arg0 {start = -1 : index, size = 2 : index} : !ty_modarith_verify -> !ty_truncated_verify
+  return
+}
+
+// -----
+
+!Zp1_verify = !mod_arith.int<3721063133 : i64>
+!Zp2_verify = !mod_arith.int<2737228591 : i64>
+!Zp3_verify = !mod_arith.int<3180146689 : i64>
+!ty_modarith_verify = !rns.rns<!Zp1_verify, !Zp2_verify, !Zp3_verify>
+!ty_truncated_verify = !rns.rns<!Zp1_verify, !Zp2_verify>
+
+func.func @test_extract_slice_verifier_negative_size(%arg0: !ty_modarith_verify) {
+  // expected-error@+1 {{size -1 cannot be negative}}
+  %0 = rns.extract_slice %arg0 {start = 0 : index, size = -1 : index} : !ty_modarith_verify -> !ty_truncated_verify
+  return
+}
+
+// -----
+
+!Zp1_verify = !mod_arith.int<3721063133 : i64>
+!Zp2_verify = !mod_arith.int<2737228591 : i64>
+!Zp3_verify = !mod_arith.int<3180146689 : i64>
+!ty_modarith_verify = !rns.rns<!Zp1_verify, !Zp2_verify, !Zp3_verify>
+!ty_truncated_verify = !rns.rns<!Zp1_verify, !Zp2_verify>
+
+func.func @test_extract_slice_verifier_oob_start_plus_size(%arg0: !ty_modarith_verify) {
+  // expected-error@+1 {{slice of size 3 starting at 1 is out of bounds for RNS type with 3 limbs}}
+  %0 = rns.extract_slice %arg0 {start = 1 : index, size = 3 : index} : !ty_modarith_verify -> !ty_truncated_verify
+  return
+}
+
+// -----
+
+!Zp1_verify = !mod_arith.int<3721063133 : i64>
+!Zp2_verify = !mod_arith.int<2737228591 : i64>
+!Zp3_verify = !mod_arith.int<3180146689 : i64>
+!ty_modarith_verify = !rns.rns<!Zp1_verify, !Zp2_verify, !Zp3_verify>
+!ty_truncated_verify = !rns.rns<!Zp1_verify, !Zp2_verify>
+
+func.func @test_extract_slice_verifier_oob_size(%arg0: !ty_modarith_verify) {
+  // expected-error@+1 {{slice of size 4 starting at 0 is out of bounds for RNS type with 3 limbs}}
+  %0 = rns.extract_slice %arg0 {start = 0 : index, size = 4 : index} : !ty_modarith_verify -> !ty_truncated_verify
+  return
+}
+
+// -----
+
+!Zp1_verify = !mod_arith.int<3721063133 : i64>
+!Zp2_verify = !mod_arith.int<2737228591 : i64>
+!Zp3_verify = !mod_arith.int<3180146689 : i64>
+!ty_modarith_verify = !rns.rns<!Zp1_verify, !Zp2_verify, !Zp3_verify>
+!ty_truncated_verify = !rns.rns<!Zp1_verify, !Zp2_verify>
+
+func.func @test_extract_slice_verifier_oob_start(%arg0: !ty_modarith_verify) {
+  // expected-error@+1 {{slice of size 1 starting at 3 is out of bounds for RNS type with 3 limbs}}
+  %0 = rns.extract_slice %arg0 {start = 3 : index, size = 1 : index} : !ty_modarith_verify -> !ty_truncated_verify
+  return
+}


### PR DESCRIPTION
- Add `rns.extract_slice` op as a helper to partition RNS limbs, including a type inference hook
- Fixes the lowering to partition RNS limbs instead of polynomial coefficients (a showcase of my ignorance!)
- Adds tests with the dialect conversion config option to allow us to test the partial lowering