### PR TITLE
Fix issues with Docker setup

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -1,0 +1,53 @@
+name: Test Dockerfile
+permissions: read-all
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  pull_request:
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-dev.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-dev-docker-image:
+    runs-on:
+      labels: ubuntu-24.04-16core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+
+      - name: Build dev image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            --file docker/Dockerfile \
+            --tag heir:dev-ci \
+            .
+
+      - name: Smoke test clang availability
+        run: |
+          docker run \
+            --rm \
+            --platform linux/amd64 \
+            --user heiruser \
+            heir:dev-ci \
+            bash -lc 'clang --version'
+
+      - name: Build and test with Bazel inside container
+        run: |
+          docker run \
+            --rm \
+            --platform linux/amd64 \
+            --user heiruser \
+            -v "${PWD}:/home/heiruser/heir" \
+            -w /home/heiruser/heir \
+            heir:dev-ci \
+            bash -lc "set -euo pipefail; bazelisk --version; bazelisk build -c opt //...; bazelisk test -c opt //..."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,9 @@ FROM ubuntu:24.04
 # Set non-interactive mode for apt
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Default LLVM toolchain version; can be overridden at build time
+ARG CLANG_VERSION=19
+
 # Install essential build tools and Python
 RUN apt-get update && \
     apt-get install -y \
@@ -13,7 +16,6 @@ RUN apt-get update && \
     git \
     zip \
     unzip \
-    clang-19 \
     python3-dev \
     python3-pip \
     python3-venv \
@@ -34,28 +36,45 @@ RUN apt-get update && \
     cmake \
     bats \
     ninja-build \
-    libomp-dev \
-    lld \
-    python3-pip python3-numpy python3-wheel python3-setuptools python3-requests \
+    python3-numpy \
+    python3-wheel \
+    python3-setuptools \
+    python3-requests \
     libstdc++-14-dev \
-    && apt-get clean
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    && CODENAME=$(lsb_release -cs) && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CLANG_VERSION} main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y \
+    clang-${CLANG_VERSION} \
+    lld-${CLANG_VERSION} \
+    libomp-${CLANG_VERSION}-dev \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 1 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 1
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 200 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 200 && \
+    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${CLANG_VERSION} 200
 
 
 # Install Bazelisk on Linux AMD64
-WORKDIR /workspace
-RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-amd64.deb
-RUN apt install ./bazelisk-amd64.deb
+WORKDIR /tmp
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-amd64.deb && \
+    apt install -y ./bazelisk-amd64.deb && \
+    rm bazelisk-amd64.deb
 
-WORKDIR /workspace
-RUN git clone https://github.com/google/heir.git
+# Create non-root user and prepare home for bind mounts
+RUN useradd --create-home --shell /bin/bash heiruser && \
+    mkdir -p /home/heiruser/heir && \
+    chown -R heiruser:heiruser /home/heiruser
 
-# Create user
-RUN adduser heiruser
+# Default working directory points at the mounted repo path
+WORKDIR /home/heiruser/heir
 
 # Entry point to get into the container
 CMD ["/bin/bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,12 +7,12 @@ environment and trigger the build which follows below.
 ## Building Docker Image
 
 You can build the docker image using command for your platform. Replace
-meta-syntactic variables.
+meta-syntactic variables (e.g. replace `heir:@imagename@` with `heir:dev`).
 
 ### Linux
 
 ```
-$ docker buildx build -t heir:@imagename@ .
+$ docker buildx build --platform linux/amd64 -f docker/Dockerfile -t heir:@imagename@ .
 ```
 
 ## Run Docker Image
@@ -23,8 +23,13 @@ Typically we like to map the local HEIR source folder into the container at
 To run the docker image follow the commands:
 
 ```
-$ docker run --user heiruser -v `pwd`/heir:/home/heiruser/heir/  -it heir:@imagename@
+$ docker run --user heiruser --platform linux/amd64 -v "$(pwd)":/home/heiruser/heir -it heir:@imagename@
 ```
+
+Alternatively, from the repository root you can run `./docker/run.sh`. The
+script builds the image with `docker/Dockerfile` and binds your working tree at
+`$(pwd)` directly to `/home/heiruser/heir` so edits inside the container are
+mirrored on the host.
 
 # Compiling HEIR
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-heir:dev}"
+
+# Build the development image using the Dockerfile in docker/
+docker buildx build --platform linux/amd64 -t "${IMAGE_TAG}" -f "${SCRIPT_DIR}/Dockerfile" "${PROJECT_ROOT}"
+
+# Run the container with the repo root bind mounted into the container workspace
+docker run --user heiruser --platform linux/amd64 -v "${PROJECT_ROOT}:/home/heiruser/heir" -it "${IMAGE_TAG}"


### PR DESCRIPTION
Disclaimer: Mostly AI generated code

Main goal is to fix `libomp-dev` and `clang` related issues on ubuntu-amd64 hosts ( https://github.com/google/heir/issues/2234) . The fixes are taken from https://github.com/google/heir/pull/2179. )
Few other improvements to make dev experience better:
1. The instructions in docker/Readme is converted to a script. We also specifically mention `linux/amd64` as a platform since on macos by default `linux/arm64` will be chosen - which resulted in errors for me. 
3. Since it's expected that user has already cloned the repo, we simply mount the project dir inside container instead of downloading it again. this also means the setup can be used as a persisted dev environment.

I expect to remove the extras if they are considered not useful or should be reviewed separately.
Also how do we test in a clean environment?