### PR TITLE
frontend: Emit ordered comparison predicates for floats

### DIFF
--- a/frontend/heir/mlir_emitter.py
+++ b/frontend/heir/mlir_emitter.py
@@ -629,13 +629,17 @@ class TextualMlirEmitter:
 
     match binop.fn:
       case operator.lt:
-        return f"arith.cmp{suffix} slt, {lhs_ssa}, {rhs_ssa}", ext, ty
+        pred = "olt" if suffix == "f" else "slt"
+        return f"arith.cmp{suffix} {pred}, {lhs_ssa}, {rhs_ssa}", ext, ty
       case operator.ge:
-        return f"arith.cmp{suffix} sge, {lhs_ssa}, {rhs_ssa}", ext, ty
+        pred = "oge" if suffix == "f" else "sge"
+        return f"arith.cmp{suffix} {pred}, {lhs_ssa}, {rhs_ssa}", ext, ty
       case operator.eq:
-        return f"arith.cmp{suffix} eq, {lhs_ssa}, {rhs_ssa}", ext, ty
+        pred = "oeq" if suffix == "f" else "eq"
+        return f"arith.cmp{suffix} {pred}, {lhs_ssa}, {rhs_ssa}", ext, ty
       case operator.ne:
-        return f"arith.cmp{suffix} ne, {lhs_ssa}, {rhs_ssa}", ext, ty
+        pred = "one" if suffix == "f" else "ne"
+        return f"arith.cmp{suffix} {pred}, {lhs_ssa}, {rhs_ssa}", ext, ty
       case operator.add:
         return f"arith.add{suffix} {lhs_ssa}, {rhs_ssa}", ext, ty
       case operator.mul:


### PR DESCRIPTION
Floating point comparison predicates in the arith dialect differ from integer ones. This inserts the ordered variants fixing erroneous outputs such as `arith.cmpf slt` -> `arith.cmpf olt`.

This is another issue I had while experimenting with the Python frontend and here I'm a bit more confident that this is indeed a bug.