### PR TITLE
fix lld/libomp misconfig in cibuildwheel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,9 +23,6 @@ build --action_env=CXX=clang++
 build --host_action_env=CC=clang
 build --host_action_env=CXX=clang++
 
-# linux-specific options
-build:linux --linkopt="-fuse-ld=lld"
-
 # macos specific options
 # openmp is not supported in apple clang
 build:macos --//:enable_openmp=0

--- a/.github/install_cibuildwheel_deps.sh
+++ b/.github/install_cibuildwheel_deps.sh
@@ -7,7 +7,7 @@ if ! bazel version; then
     arch="arm64"
   fi
   echo "Downloading $arch Bazel binary from GitHub releases."
-  curl -L -o $HOME/bin/bazel --create-dirs "https://github.com/bazelbuild/bazel/releases/download/8.1.0/bazel-8.1.0-linux-$arch"
+  curl -L -o $HOME/bin/bazel --create-dirs "https://github.com/bazelbuild/bazel/releases/download/8.4.0/bazel-8.4.0-linux-$arch"
   chmod +x $HOME/bin/bazel
 else
   # Bazel is installed for the correct architecture

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,6 +34,7 @@ bazel_dep(name = "googletest", version = "1.16.0")
 bazel_dep(name = "google_benchmark", version = "1.9.1")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 
 # Yosys dependencies that are already on the bazel central registry
 # abc can't be used in place because it changes the names of the targets from

--- a/bazel/openfhe/copts.bzl
+++ b/bazel/openfhe/copts.bzl
@@ -25,7 +25,6 @@ OPENFHE_COPTS = [
 
 _OPENFHE_LINKOPTS = [
     "-fopenmp",
-    "-lomp",
 ]
 
 _OPENMP_COPTS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ where = ["frontend"]
 [tool.cibuildwheel]
 build = "cp311-* cp312-* cp313-*"
 build-frontend = "build[uv]"
-skip = "*-musllinux_* pp-*"
+skip = "*-musllinux_*"
 # The test must be run in an isolated directory so that python uses the wheel
 # when running `import heir` instead of the local source files. cibuildwheel
 # creates an isolated directory for this purpose, and cd's to it before running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ zip-safe = false
 where = ["frontend"]
 
 [tool.cibuildwheel]
+# The default 2_28 wheel uses a C ABI that seems to be too old for openfhe?
+manylinux-x86_64-image = "manylinux_2_34"
+manylinux-aarch64-image = "manylinux_2_34"
+manylinux-i686-image = "manylinux_2_34"
 build = "cp311-* cp312-* cp313-*"
 build-frontend = "build[uv]"
 skip = "*-musllinux_*"

--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,8 @@ class BuildBazelExtension(build_ext.build_ext):
             "--action_env=CXX=g++",
             "--host_action_env=CC=gcc",
             "--host_action_env=CXX=g++",
+            # TODO(#2249): figure out how to enable OpenMP in manylinux wheels
+            "--//:enable_openmp=0",
         ]
         if is_cibuildwheel()
         else [


### PR DESCRIPTION
The forcing of the `lld` linker is breaking the cibuildwheel, and once I fixed that I found it was broken by a lack of openmp. I found a way to allow `libomp` and `libgomp` by using just the `-fopenmp` option, which allows the compiler to pick the exact linker flag based on what's available on the system. Also needed to install `libgomp` in the cibuildwheel container. 