### PR TITLE
Add insert/extract slice to noise analysis

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BFV/NoiseAnalysis.cpp
@@ -184,7 +184,12 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
             }
 
             if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
-                           arith::ExtFOp, mgmt::InitOp>(op)) {
+                           arith::ExtFOp, mgmt::InitOp,
+                           // extract_slice is used for selecting one ciphertext
+                           // from a tensor of ciphertexts when packing data
+                           // across multiple ciphertexts. It does not change
+                           // noise.
+                           tensor::ExtractSliceOp, tensor::InsertSliceOp>(op)) {
               op.emitError()
                   << "Unsupported operation for noise analysis encountered.";
             }

--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseAnalysis.cpp
@@ -202,7 +202,12 @@ LogicalResult NoiseAnalysis<NoiseModel>::visitOperation(
             }
 
             if (!mlir::isa<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
-                           arith::ExtFOp, mgmt::InitOp>(op)) {
+                           arith::ExtFOp, mgmt::InitOp,
+                           // extract_slice is used for selecting one ciphertext
+                           // from a tensor of ciphertexts when packing data
+                           // across multiple ciphertexts. It does not change
+                           // noise.
+                           tensor::ExtractSliceOp, tensor::InsertSliceOp>(op)) {
               op.emitError()
                   << "Unsupported operation for noise analysis encountered.";
             }


### PR DESCRIPTION
This is in support of the new layout system, which will use insert_slice and extract_slice for extracting a single row (one ciphertext) from a ciphertext-semantic tensor (multi-packed ciphertext).