### PR TITLE
add extract_slice_of_splat pattern

### DIFF
--- a/lib/Transforms/FoldConstantTensors/FoldConstantTensors.td
+++ b/lib/Transforms/FoldConstantTensors/FoldConstantTensors.td
@@ -15,7 +15,8 @@ def FoldConstantTensors : Pass<"fold-constant-tensors"> {
 
     The following folders are supported:
     * `tensor.insert` of a constant tensor
-    * `tensor.collapse_shape` of a constant tensor
+    * `tensor.collapse_shape` of a constant or empty tensor
+    * `tensor.extract_slice` of a splat to a splat of the new shape
   }];
 }
 

--- a/tests/Transforms/fold_constant_tensors/extract_slice_of_splat.mlir
+++ b/tests/Transforms/fold_constant_tensors/extract_slice_of_splat.mlir
@@ -1,0 +1,11 @@
+// RUN: heir-opt --fold-constant-tensors %s | FileCheck %s
+
+// CHECK: func @extract_slice_of_splat
+func.func @extract_slice_of_splat(%arg0: i32) -> (tensor<1024xi32>) {
+  // Fold a collapse shape of a constant
+  // CHECK-NEXT: %[[splat:.+]] = tensor.splat
+  // CHECK-NEXT: return %[[splat]]
+  %0 = tensor.splat %arg0 : tensor<10x1024xi32>
+  %slice = tensor.extract_slice %0[1, 0] [1, 1024] [1, 1] : tensor<10x1024xi32> to tensor<1024xi32>
+  return %slice : tensor<1024xi32>
+}


### PR DESCRIPTION
This has shown up in some tests with the new layout system, for example:

```
  // Assign_layout for packing a cleartext scalar
  %splat = tensor.splat %arg0 : tensor<1x1024xi64>

  // Extract slice to get one ciphertext-semantic tensor out of the packed scalar
  %extracted_slice = tensor.extract_slice %splat[0, 0] [1, 1024] [1, 1] : tensor<1x1024xi64> to tensor<1024xi64>

  // encode the one ciphertext-semantic tensor
  %pt_2 = openfhe.make_packed_plaintext %cc, %extracted_slice : (!cc, tensor<1024xi64>) -> !pt1

  // use it for some operation
  %ct_3 = openfhe.mul_plain %cc, %ct_1, %pt_2 : (!cc, !ct_L1_1, !pt1) -> !ct_L1_1
}
```

This is an artifact of the OpenFHE API not supporting bulk encode operations that we can apply elementwise, as well as the actual operations (mul_plain) that need individual ciphertexts.

And anyway, this pattern is a very simple and obviously correct peephole rewrite. I put it in FoldConstantTensors pass because, even though it doesn't involve constant tensors, it has the same property that it accepts possibly materializing more tensor values (i.e., adding an extra splat) to avoid additional operations (the slice).