### PR TITLE
[NFC]: Rename `tensor_ext.permute` to `tensor_ext.remap`

### DIFF
--- a/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -171,7 +171,7 @@ LogicalResult UnpackOp::verify() {
   return verifyLayoutMatchesType(getLayout(), getResult().getType(), *this);
 }
 
-LogicalResult PermuteOp::verify() {
+LogicalResult RemapOp::verify() {
   auto tensorTy = getInput().getType();
   if (tensorTy.getRank() != 2) {
     return emitOpError() << "requires input tensor to be rank 2 "

--- a/lib/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.td
@@ -50,24 +50,39 @@ def TensorExt_RotateOp : TensorExt_Op<"rotate", [Pure, AllTypesMatch<["tensor", 
   let hasVerifier = 1;
 }
 
-def PermutationLike : AnyAttrOf<[
-  // A permutation defined explicitly by mapping (ct, slot) -> (ct, slot)
+def MappingLike : AnyAttrOf<[
+  // A list of tuples [a, b, c, d] representing an explicit map (ct, slot) ->
+  // (ct, slot) defined by f(a, b) = (c, d). This mapping is primarily used
+  // for testing implement-shift-network, as not all mappings can be achieved
+  // as a consequence of higher-level layout conversions.
   AnyI64ElementsAttr,
-  // A layout relation, representing a mapping (ct, slot) -> (ct, slot)
+  // A layout relation with domain and range space equal to (ct, slot).
   TensorExt_LayoutAttr,
 ]>;
 
-// TODO(#2047): rename PermuteOp to make it clear it supports more general mappings
-def TensorExt_PermuteOp : TensorExt_Op<"permute", [Pure, AllTypesMatch<["input", "output"]>]> {
-  let summary = "Permute a tensor by a static permutation.";
+def TensorExt_RemapOp : TensorExt_Op<"remap", [Pure, AllTypesMatch<["input", "output"]>]> {
+  let summary = "Reorganize the entries of a tensor by a static mapping.";
   let description = [{
-    This op represents a permutation of a tensor.
+    This op represents a remapping of entries of a tensor.
 
-    This is lowered from a `convert_layout` op, and is implemented in terms of
-    `rotate` operations.
+    This op is primarily inserted as a lowered form of `convert_layout` op, to
+    represent a ciphertext slot-repacking operation. However, it can more
+    generally express any partial mapping from source tensor indices to target
+    indices within a tensor. Unmapped entries from the input tensor are
+    unmodified.
+
+    This operation differs from a `tensor.gather/scatter` operation in that it
+    can replicate values from the source tensor or omit values in the
+    destination tensor. It differs from a "lane shuffle" in that the mapping
+    need not be a permutation. It differs from a "swizzle" in that it cannot
+    change the dimension of the result tensor.
+
+    In the slot form of a ciphertext, this op is lowered to a "shift network"
+    of ciphertext-plaintext mask, rotate, and sum operations by the
+    `implement-shift-network` pass.
   }];
 
-  let arguments = (ins AnyRankedTensor:$input, PermutationLike:$permutation);
+  let arguments = (ins AnyRankedTensor:$input, MappingLike:$permutation);
   let results = (outs AnyRankedTensor:$output);
   let assemblyFormat = "operands attr-dict `:` type($input)";
   let hasVerifier = 1;

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
@@ -52,7 +52,7 @@ ShiftScheme VosVosErkinShiftNetworks::findShiftScheme(
 
   ShiftStrategy strategy = evaluateShiftStrategy(mapping, shiftOrder);
 
-  // Create a graph whose vertices are the input indices to permute, and
+  // Create a graph whose vertices are the input indices to remap, and
   // whose edges are conflicts: an edge being present means the two indices
   // cannot participate in the same rotation group.
   graph::UndirectedGraph<CtSlot> conflictGraph;
@@ -208,8 +208,8 @@ void populateMappingFromDenseElementsAttr(
   }
 }
 
-LogicalResult convertPermuteOp(PermuteOp op,
-                               VosVosErkinShiftNetworks& shiftNetworks) {
+LogicalResult convertRemapOp(RemapOp op,
+                             VosVosErkinShiftNetworks& shiftNetworks) {
   LLVM_DEBUG(llvm::dbgs() << "Converting layout op: " << op << "\n");
   ImplicitLocOpBuilder b(op.getLoc(), op.getContext());
   RankedTensorType tensorTy = op.getInput().getType();
@@ -294,8 +294,8 @@ struct ImplementShiftNetwork
 
   void runOnOperation() override {
     VosVosErkinShiftNetworks shiftNetworks;
-    getOperation()->walk([&](PermuteOp op) {
-      if (failed(convertPermuteOp(op, shiftNetworks))) {
+    getOperation()->walk([&](RemapOp op) {
+      if (failed(convertRemapOp(op, shiftNetworks))) {
         signalPassFailure();
       }
     });

--- a/lib/Dialect/TensorExt/Transforms/Passes.td
+++ b/lib/Dialect/TensorExt/Transforms/Passes.td
@@ -106,7 +106,7 @@ def ImplementShiftNetwork : Pass<"implement-shift-network"> {
   let summary = "Implement tensor_ext.convert_layout ops as shift newtorks";
 
   let description = [{
-  This pass converts `tensor_ext.permute` ops into a network of
+  This pass converts `tensor_ext.remap` ops into a network of
   `tensor_ext.rotate` ops, aiming to minimize the overall latency of the
   permutation. The input IR must have tensors that correspond to plaintexts or
   ciphertexts, and be in "ciphertext semantics," i.e., after an IR has been

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -312,12 +312,12 @@ class ConvertConvertLayout
         fromLayout.getIntegerRelation().clone();
     composedLayout->inverse();
     composedLayout->compose(toLayout.getIntegerRelation());
-    auto permuteOp = tensor_ext::PermuteOp::create(
+    auto remapOp = tensor_ext::RemapOp::create(
         rewriter, op.getLoc(), adaptor.getValue(),
         LayoutAttr::getFromIntegerRelation(getContext(), *composedLayout));
-    permuteOp->setAttr(kLayoutAttrName, op->getAttr(kLayoutAttrName));
-    setMaterializedAttr(permuteOp);
-    rewriter.replaceOp(op, permuteOp);
+    remapOp->setAttr(kLayoutAttrName, op->getAttr(kLayoutAttrName));
+    setMaterializedAttr(remapOp);
+    rewriter.replaceOp(op, remapOp);
     return success();
   };
 };
@@ -347,12 +347,12 @@ class ConvertConvertLayoutLayout
     LayoutAttr combinedLayout =
         LayoutAttr::getFromIntegerRelation(getContext(), *toLayoutClone);
 
-    auto permuteOp = tensor_ext::PermuteOp::create(
+    auto remapOp = tensor_ext::RemapOp::create(
         rewriter, op.getLoc(), adaptor.getValue(), combinedLayout);
 
-    setMaterializedAttr(permuteOp);
-    setAttributeAssociatedWith(permuteOp, kLayoutAttrName, toLayout);
-    rewriter.replaceOp(op, permuteOp);
+    setMaterializedAttr(remapOp);
+    setAttributeAssociatedWith(remapOp, kLayoutAttrName, toLayout);
+    rewriter.replaceOp(op, remapOp);
     return success();
   };
 };

--- a/tests/Dialect/TensorExt/Transforms/implement_shift_network.mlir
+++ b/tests/Dialect/TensorExt/Transforms/implement_shift_network.mlir
@@ -12,7 +12,7 @@
 // CHECK: %[[INSERT:.*]] = tensor.insert_slice %[[ROT]] into %[[EMPTY]][0, 0] [1, 64] [1, 1] : tensor<64xi32> into tensor<1x64xi32>
 // CHECK: return %[[INSERT]] : tensor<1x64xi32>
 func.func @test_no_conflicts(%0: tensor<1x64xi32>) -> tensor<1x64xi32> {
-  %1 = tensor_ext.permute %0 {permutation = #map1} : tensor<1x64xi32>
+  %1 = tensor_ext.remap %0 {permutation = #map1} : tensor<1x64xi32>
   return %1 : tensor<1x64xi32>
 }
 
@@ -44,7 +44,7 @@ func.func @test_no_conflicts(%0: tensor<1x64xi32>) -> tensor<1x64xi32> {
 // CHECK: return %[[INSERT]] : tensor<1x64xi32>
 #map2 = #tensor_ext.layout<"{ [ct1, slot1] -> [ct2, slot2] : ct1 = 0 and ct2 = 0 and ((slot1 + 1) - slot2) mod 64 = 0 and slot1 >= 0 and 63 >= slot1 and slot2 >= 0 and 63 >= slot2 }">
 func.func @test_no_conflicts2(%0: tensor<1x64xi32>) -> tensor<1x64xi32> {
-  %1 = tensor_ext.permute %0 {permutation = #map2} : tensor<1x64xi32>
+  %1 = tensor_ext.remap %0 {permutation = #map2} : tensor<1x64xi32>
   return %1 : tensor<1x64xi32>
 }
 
@@ -57,7 +57,7 @@ func.func @test_no_conflicts2(%0: tensor<1x64xi32>) -> tensor<1x64xi32> {
 // CHECK: return %[[INSERT]] : tensor<1x64xi32>
 #map3 = #tensor_ext.layout<"{ [ct1, slot1] -> [ct2, slot2] : ct1 = 0 and ct2 = 0 and slot1 = slot2 and slot1 >= 0 and 63 >= slot1 and slot2 >= 0 and 63 >= slot2 }">
 func.func @identity(%0: tensor<1x64xi32>) -> tensor<1x64xi32> {
-  %1 = tensor_ext.permute %0 {permutation = #map3} : tensor<1x64xi32>
+  %1 = tensor_ext.remap %0 {permutation = #map3} : tensor<1x64xi32>
   return %1 : tensor<1x64xi32>
 }
 
@@ -75,7 +75,7 @@ func.func @identity(%0: tensor<1x64xi32>) -> tensor<1x64xi32> {
 // CHECK-NEXT: return %[[INSERT3]]
 #map4 = #tensor_ext.layout<"{ [ct1, slot1] -> [ct2, slot2] : (ct1 - ct2) mod 4 = 3 and (slot1 - slot2) mod 64 = 0 and 0 <= ct1 <= 3 and 0 <= ct2 <= 3 and 0 <= slot1 <= 63 and 0 <= slot2 <= 63 }">
 func.func @multi_ciphertext_swap_cts(%0: tensor<4x64xi32>) -> tensor<4x64xi32> {
-  %1 = tensor_ext.permute %0 {permutation = #map4} : tensor<4x64xi32>
+  %1 = tensor_ext.remap %0 {permutation = #map4} : tensor<4x64xi32>
   return %1 : tensor<4x64xi32>
 }
 
@@ -87,6 +87,6 @@ func.func @multi_ciphertext_swap_cts(%0: tensor<4x64xi32>) -> tensor<4x64xi32> {
 // CHECK-COUNT-16: tensor_ext.rotate
 #map5 = #tensor_ext.layout<"{ [ct1, slot1] -> [ct2, slot2] : (ct1 - ct2) mod 4 = 3 and (slot1 - slot2) mod 64 = 5 and 0 <= ct1 <= 3 and 0 <= ct2 <= 3 and 0 <= slot1 <= 63 and 0 <= slot2 <= 63 }">
 func.func @multi_ciphertext_complex(%0: tensor<4x64xi32>) -> tensor<4x64xi32> {
-  %1 = tensor_ext.permute %0 {permutation = #map5} : tensor<4x64xi32>
+  %1 = tensor_ext.remap %0 {permutation = #map5} : tensor<4x64xi32>
   return %1 : tensor<4x64xi32>
 }

--- a/tests/Dialect/TensorExt/Transforms/implement_shift_network_example.mlir
+++ b/tests/Dialect/TensorExt/Transforms/implement_shift_network_example.mlir
@@ -18,7 +18,7 @@
   [0, 14, 0, 9],
   [0, 15, 0, 1]]> : tensor<16x4xi64>
 func.func @figure3(%0: tensor<1x16xi32>) -> tensor<1x16xi32> {
-  %1 = tensor_ext.permute %0 {permutation = #map} : tensor<1x16xi32>
+  %1 = tensor_ext.remap %0 {permutation = #map} : tensor<1x16xi32>
   return %1 : tensor<1x16xi32>
 }
 

--- a/tests/Transforms/add_client_interface/scalar_unpack.mlir
+++ b/tests/Transforms/add_client_interface/scalar_unpack.mlir
@@ -54,7 +54,7 @@ module attributes {backend.lattigo} {
       %22 = arith.addi %20, %21 : tensor<1024xi16>
       %23 = arith.muli %collapsed, %22 : tensor<1024xi16>
       %expanded = tensor.expand_shape %23 [[0, 1]] output_shape [1, 1024] : tensor<1024xi16> into tensor<1x1024xi16>
-      %24 = tensor_ext.permute %expanded {permutation = #layout1} : tensor<1x1024xi16>
+      %24 = tensor_ext.remap %expanded {permutation = #layout1} : tensor<1x1024xi16>
       secret.yield %24 : tensor<1x1024xi16>
     } -> !secret.secret<tensor<1x1024xi16>>
     return %0 : !secret.secret<tensor<1x1024xi16>>

--- a/tests/Transforms/convert_to_ciphertext_semantics/linalg_reduce.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/linalg_reduce.mlir
@@ -45,13 +45,13 @@ func.func @convert_linalg_reduce(
     %1 = tensor_ext.assign_layout %cst {layout = #row_major_vec, tensor_ext.layout = #row_major_vec} : tensor<4xi16>
 
     // First reduction
-    // CHECK:  [[rotate1:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]>
+    // CHECK:  [[rotate1:%[^ ]*]] = tensor_ext.remap [[pt_arg0]] {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]>
     // CHECK:  [[sum1:%[^ ]*]] = arith.addi [[pt_cst1]], [[rotate1]]
-    // CHECK:  [[rotate2:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]>
+    // CHECK:  [[rotate2:%[^ ]*]] = tensor_ext.remap [[pt_arg0]] {permutation = dense<[12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]>
     // CHECK:  [[sum2:%[^ ]*]] = arith.addi [[sum1]], [[rotate2]] : tensor<16xi16>
-    // CHECK:  [[rotate3:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]>
+    // CHECK:  [[rotate3:%[^ ]*]] = tensor_ext.remap [[pt_arg0]] {permutation = dense<[8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]>
     // CHECK:  [[sum3:%[^ ]*]] = arith.addi [[sum2]], [[rotate3]] : tensor<16xi16>
-    // CHECK:  [[rotate4:%[^ ]*]] = tensor_ext.permute [[pt_arg0]] {permutation = dense<[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3]>
+    // CHECK:  [[rotate4:%[^ ]*]] = tensor_ext.remap [[pt_arg0]] {permutation = dense<[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3]>
     // CHECK:  [[sum4:%[^ ]*]] = arith.addi [[sum3]], [[rotate4]] : tensor<16xi16>
     %reduced = linalg.reduce { arith.addi {overflowFlags = #arith.overflow<none>} }
       ins(%input0 : tensor<4x4xi16>)
@@ -68,24 +68,24 @@ func.func @convert_linalg_reduce(
     // CHECK-NEXT: [[pt_cst2:[^ ]*]] = tensor.insert_slice [[cst]] into
     // CHECK-SAME: [12] [4] [1]
     %2 = tensor_ext.assign_layout %cst {layout = #row_major_vec, tensor_ext.layout = #row_major_vec} : tensor<4xi16>
-    // CHECK:  [[converted1:%[^ ]*]] = tensor_ext.permute [[pt_cst2]] {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]>
+    // CHECK:  [[converted1:%[^ ]*]] = tensor_ext.remap [[pt_cst2]] {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]>
     %3 = tensor_ext.convert_layout %2 {from_layout = #row_major_vec, tensor_ext.layout = #col_major_vec, to_layout = #col_major_vec} : tensor<4xi16>
 
     // second reduction
-    // CHECK:  [[rotate1_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]>
+    // CHECK:  [[rotate1_2:%[^ ]*]] = tensor_ext.remap [[pt_arg1]] {permutation = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]>
     // CHECK:  [[sum1_2:%[^ ]*]] = arith.addi [[converted1]], [[rotate1_2]]
-    // CHECK:  [[rotate2_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]>
+    // CHECK:  [[rotate2_2:%[^ ]*]] = tensor_ext.remap [[pt_arg1]] {permutation = dense<[15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]>
     // CHECK:  [[sum2_2:%[^ ]*]] = arith.addi [[sum1_2]], [[rotate2_2]] : tensor<16xi16>
-    // CHECK:  [[rotate3_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]>
+    // CHECK:  [[rotate3_2:%[^ ]*]] = tensor_ext.remap [[pt_arg1]] {permutation = dense<[14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]>
     // CHECK:  [[sum3_2:%[^ ]*]] = arith.addi [[sum2_2]], [[rotate3_2]] : tensor<16xi16>
-    // CHECK:  [[rotate4_2:%[^ ]*]] = tensor_ext.permute [[pt_arg1]] {permutation = dense<[13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]>
+    // CHECK:  [[rotate4_2:%[^ ]*]] = tensor_ext.remap [[pt_arg1]] {permutation = dense<[13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]>
     // CHECK:  [[sum4_2:%[^ ]*]] = arith.addi [[sum3_2]], [[rotate4_2]] : tensor<16xi16>
     %reduced_1 = linalg.reduce { arith.addi {overflowFlags = #arith.overflow<none>} }
       ins(%input1 : tensor<4x4xi16>)
       outs(%3 : tensor<4xi16>)
       dimensions = [1]  {tensor_ext.layout = #col_major_vec}
 
-    // CHECK: [[converted2:%[^ ]*]] = tensor_ext.permute [[sum4_2]] {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]>
+    // CHECK: [[converted2:%[^ ]*]] = tensor_ext.remap [[sum4_2]] {permutation = dense<[0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15]>
     %4 = tensor_ext.convert_layout %reduced_1 {from_layout = #col_major_vec, tensor_ext.layout = #row_major_vec, to_layout = #row_major_vec} : tensor<4xi16>
     // CHECK: arith.addi [[sum4]], [[converted2]]
     %5 = arith.addi %reduced, %4 {tensor_ext.layout = #row_major_vec} : tensor<4xi16>

--- a/tests/Transforms/convert_to_ciphertext_semantics/tensor_extract.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/tensor_extract.mlir
@@ -14,7 +14,7 @@
 // CHECK: ^body([[ARG0_INNER:%.+]]: tensor<1x16xi16>):
 // CHECK: [[INSERTED:%.+]] = tensor.insert [[C1]] into [[CST]]{{\[}}[[C0]], [[C3]]] : tensor<1x16xi16>
 // CHECK: [[MUL:%.+]] = arith.muli [[INSERTED]], [[ARG0_INNER]] : tensor<1x16xi16>
-// CHECK: [[PERMUTED:%.+]] = tensor_ext.permute [[MUL]] {permutation = {{.*}}} : tensor<1x16xi16>
+// CHECK: [[PERMUTED:%.+]] = tensor_ext.remap [[MUL]] {permutation = {{.*}}} : tensor<1x16xi16>
 // CHECK: secret.yield [[PERMUTED]] : tensor<1x16xi16>
 // CHECK: return [[RESULT]] : !secret.secret<tensor<1x16xi16>>
 


### PR DESCRIPTION
This PR rename `tensor_ext.permute` to `tensor_ext.remap` to better reflect its generality in the new implement-shift-network implementation