### PR TITLE
Disable mdformat for good

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -93,3 +93,5 @@ https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 Note: A version of this file is also available in the
 [New Project repo](https://github.com/google/new-project/blob/master/docs/code-of-conduct.md).
+
+<!-- mdformat global-off -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,4 +77,14 @@ repos:
     - id: pyink
       language_version: python3.11
 
+- repo: local
+  hooks:
+    - id: disable-mdformat
+      name: Ensure google-internal mdformat is disabled on md files
+      entry: python scripts/disable_mdformat.py
+      language: system
+      types: [markdown]
+      pass_filenames: false # Run on all relevant files
+      always_run: true # Run the hook even if no files changed
+
 exclude: patches/.*\.patch$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,5 @@ information on using pull requests.
 
 Before contributing, please read
 [Contributing to HEIR](https://heir.dev/docs/contributing/).
+
+<!-- mdformat global-off -->

--- a/README.md
+++ b/README.md
@@ -118,3 +118,5 @@ The HEIR project can be cited in in academic work through following entry:
 ## Support disclaimer
 
 This is not an officially supported Google product.
+
+<!-- mdformat global-off -->

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,3 +50,5 @@ $ pushd ~heir
 $ bazelisk run //tools:heir-opt -- --help
 $ popd
 ```
+
+<!-- mdformat global-off -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,3 +82,5 @@ current versions to use:
    ```bash
    ./hugo/hugo server --minify
    ```
+
+<!-- mdformat global-off -->

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -93,3 +93,5 @@ The HEIR codebase and documentation are maintained by Google.
 
 Logo design by [Edward Chen](https://edwjchen.com/) and
 [Erin Park](https://www.yerinstudio.com/).
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/_index.md
+++ b/docs/content/en/blog/_index.md
@@ -4,3 +4,5 @@ weight: 100
 linkTitle: Blog
 menu: {main: {weight: 30}}
 ---
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/fheorg_talk_2025_03.md
+++ b/docs/content/en/blog/fheorg_talk_2025_03.md
@@ -11,3 +11,5 @@ Jeremy Kun gave a talk at the FHE.org 2025 conference in Sofia last month. The
 [video](https://www.youtube.com/watch?v=6JPwpTOcydM&list=PLnbmMskCVh1cCnWbmgxI0BM0UD2JHH9fz&index=5)
 has been posted on YouTube, and the slides can be found
 [here](https://docs.google.com/presentation/d/1nKj0i0tyBSGUAI-tYMUDeji-EgqCj4PBrgw_NgMb3fM/edit?usp=sharing).
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-06-27.md
+++ b/docs/content/en/blog/heir_meeting_2023-06-27.md
@@ -19,3 +19,5 @@ design rolling.
 - [High-Level FHE Dialect](https://github.com/google/heir/discussions/53)
 - [Scheme Dialects](https://github.com/google/heir/discussions/54)
 - [Poly/Math Dialects](https://github.com/google/heir/discussions/55)
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-07-18.md
+++ b/docs/content/en/blog/heir_meeting_2023-07-18.md
@@ -14,3 +14,5 @@ We decided to schedule future meetings every two weeks, with alternating focus
 on MLIR and Hardware. See the [meeting calendar](https://heir.dev/community/) to
 join.
 ([direct link to the calendar](https://calendar.google.com/calendar/u/0/embed?src=c85ecb3cda4bfb7daa3da95d5aeb19672930501b49d17896e65fa3f963f17a80@group.calendar.google.com&ctz=America/Los_Angeles))
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-08-01.md
+++ b/docs/content/en/blog/heir_meeting_2023-08-01.md
@@ -16,3 +16,5 @@ We're also starting on the Poly and Secret dialects in
 [#74 (poly)](https://github.com/google/heir/pull/74) and
 [#78 (secret)](https://github.com/google/heir/pull/78), so please join in the
 fun!
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-08-15.md
+++ b/docs/content/en/blog/heir_meeting_2023-08-15.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1DDNepYCSqgi-JlBLBzHrsL5CjjiwqcA_/view?usp=sharing)
 from the HEIR meeting on 2023-08-15.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-08-29.md
+++ b/docs/content/en/blog/heir_meeting_2023-08-29.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1Lax8Inby5Mg8BZLkcV_5hUiWH-roL22rtszfc0PBGmE/edit?usp=sharing)
 from the HEIR meeting on 2023-08-29. There was an issue with the recording, so
 there is no video recording this week.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-09-12.md
+++ b/docs/content/en/blog/heir_meeting_2023-09-12.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1zFtpBcCCq5d6UD8Nm8r3rfg3sgy-guz7/view?usp=sharing)
 from the HEIR meeting on 2023-09-12.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-09-26.md
+++ b/docs/content/en/blog/heir_meeting_2023-09-26.md
@@ -16,3 +16,5 @@ from the HEIR meeting on 2023-09-26.
 Next meeting (Oct 10) is canceled for the MLIR workshop, and I'll post an update
 from that workshop on this blog, hopefully also with a video of the talk that
 Alex Viand and I will be giving at the LLVM developers meeting.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-10-24.md
+++ b/docs/content/en/blog/heir_meeting_2023-10-24.md
@@ -17,3 +17,5 @@ Also of note: our talk at FHE.org was last Thursday
 ([recording](https://www.youtube.com/watch?v=kqDFdKUTNA4)), and the similar talk
 at the LLVM developers meeting talk was the previous Wednesday, though the video
 has not yet been posted for that.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-11-07.md
+++ b/docs/content/en/blog/heir_meeting_2023-11-07.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1I7aIipm54CCcDcLyRYXI_gARfT1z93cN/view?usp=sharing)
 from the HEIR meeting on 2023-11-07.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-11-28.md
+++ b/docs/content/en/blog/heir_meeting_2023-11-28.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1ykxaqlfVExqGC6saiSnfM2A7_TpWqKiE/view)
 from the HEIR meeting on 2023-11-28.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2023-12-12.md
+++ b/docs/content/en/blog/heir_meeting_2023-12-12.md
@@ -16,3 +16,5 @@ from the HEIR meeting on 2023-12-12.
 This is the last meeting for 2023. Please respond to
 [this poll](https://app.rallly.co/invite/fHNdzrbisHVA) for 2024 scheduling
 preferences.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-01-11.md
+++ b/docs/content/en/blog/heir_meeting_2024-01-11.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1gLwcshtNda6M6YMWSsyGrNDvlQ8QiL0O/view?usp=sharing)
 from the HEIR meeting on 2024-01-11.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-01-25.md
+++ b/docs/content/en/blog/heir_meeting_2024-01-25.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/11JTfRy_3LvHjJQe0nJuqe8WGa8F9oHu1/view?usp=sharing)
 from the HEIR meeting on 2024-01-25.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-02-08.md
+++ b/docs/content/en/blog/heir_meeting_2024-02-08.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1rTsc-sWdRCqJWONrgGo5FV7CQd1S_OV-/view?usp=sharing)
 from the HEIR meeting on 2024-02-08.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-02-22.md
+++ b/docs/content/en/blog/heir_meeting_2024-02-22.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1RDONadr54-7uX5ko5dmUX3s1l7QHeHbM/view?usp=sharing)
 from the HEIR meeting on 2024-02-22.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-03-07.md
+++ b/docs/content/en/blog/heir_meeting_2024-03-07.md
@@ -15,3 +15,5 @@ from the HEIR meeting on 2024-03-07.
 
 Note: there will be no HEIR meeting on 2024-03-21 due to the FHE.org, HACS, and
 RWC conferences. Hope to see you all there!
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-04-04.md
+++ b/docs/content/en/blog/heir_meeting_2024-04-04.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1_Ksjx8s8nD4cLsuZp5_KitYI2mPN72Je/view?usp=sharing)
 from the HEIR meeting on 2024-04-04.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-04-18.md
+++ b/docs/content/en/blog/heir_meeting_2024-04-18.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1WSsUp9CmjDmEVtGMYk2QXIpZCEetf_Ot/view?usp=sharing)
 from the HEIR meeting on 2024-04-18.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-05-02.md
+++ b/docs/content/en/blog/heir_meeting_2024-05-02.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1u1q74rUKdXFi08tAKFRKjI-bojuorQK8/view?usp=drivesdk)
 from the HEIR meeting on 2024-05-02.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-05-16.md
+++ b/docs/content/en/blog/heir_meeting_2024-05-16.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1gOf_Tb8k9UNx7i0OvjjikkYUG3HrPjoS/view?usp=sharing)
 from the HEIR meeting on 2024-05-16.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-05-30.md
+++ b/docs/content/en/blog/heir_meeting_2024-05-30.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1CTIyd7HRiNV857VO2EonquWZZlBhysLM/view?usp=sharing)
 from the HEIR meeting on 2024-05-30.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-06-13.md
+++ b/docs/content/en/blog/heir_meeting_2024-06-13.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/19oQOYlvfeHoSwWqOC4hXZTBuaPIf1zQl/view?usp=sharing)
 from the HEIR meeting on 2024-06-13.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-06-27.md
+++ b/docs/content/en/blog/heir_meeting_2024-06-27.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1-wMytGj3AHi55sA2jb81AsHOU8EcIq6d/view?usp=sharing)
 from the HEIR meeting on 2024-06-27.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-07-11.md
+++ b/docs/content/en/blog/heir_meeting_2024-07-11.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1-f5ZJ5h28FIgk_-LisNsYa77iuWPIAjU/view?usp=sharing)
 from the HEIR meeting on 2024-07-11.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-07-18.md
+++ b/docs/content/en/blog/heir_meeting_2024-07-18.md
@@ -13,3 +13,5 @@ and
 [video recording](https://drive.google.com/file/d/1bCMuuKnBVf6HP7R2SiZgo1C1vsG6FzF2/view?usp=sharing)
 from the HEIR meeting on 2024-07-18. This special discussion was focused on the
 modular arithmetic dialect.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-07-25.md
+++ b/docs/content/en/blog/heir_meeting_2024-07-25.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1_1CbRJeNr5NqcwEMXnfkxOqy9u5wJPyq/view?usp=sharing)
 from the HEIR meeting on 2024-07-25.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-08-08.md
+++ b/docs/content/en/blog/heir_meeting_2024-08-08.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1sHoRvNlS14RB-r3Rk0y2RyWOERVGNc-t/view?usp=sharing)
 from the HEIR meeting on 2024-08-08.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-08-22.md
+++ b/docs/content/en/blog/heir_meeting_2024-08-22.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1wFrGF7lMiYZmqbr5WQO17HomfoFoOeaj/view?usp=sharing)
 from the HEIR meeting on 2024-08-22.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-09-05.md
+++ b/docs/content/en/blog/heir_meeting_2024-09-05.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1XGheLF7kvJfwAMJJQ-XbDpa4Ld15kj4t/view?usp=sharing)
 from the HEIR meeting on 2024-09-05.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-09-19.md
+++ b/docs/content/en/blog/heir_meeting_2024-09-19.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1i-HqUi8pb2ywUJ-OT4fWExYCmeRLu2Cn/view?usp=sharing)
 from the HEIR meeting on 2024-09-19.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-10-03.md
+++ b/docs/content/en/blog/heir_meeting_2024-10-03.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1OFfrwWesFpxVHw2DFuNAxSB8seLG_tr1/view?usp=sharing)
 from the HEIR meeting on 2024-10-04.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-10-31.md
+++ b/docs/content/en/blog/heir_meeting_2024-10-31.md
@@ -12,3 +12,5 @@ Here are the
 and
 [video recording](https://drive.google.com/file/d/1Q9a7O7HwxKMDqI23l3154KIOw1ofANkX/view?usp=sharing)
 from the HEIR meeting on 2024-10-31.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-11-26.md
+++ b/docs/content/en/blog/heir_meeting_2024-11-26.md
@@ -13,3 +13,5 @@ Here are the
 and
 [a transcription of the recording](https://docs.google.com/document/d/1s5iXtOSpIDJX3JOEB5gQqUPm5lo1gLpRUM10pBfAdoo/edit?usp=sharing)
 from the HEIR meeting on 2024-11-26.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2024-12-05.md
+++ b/docs/content/en/blog/heir_meeting_2024-12-05.md
@@ -14,3 +14,5 @@ be needed, and discussing how the HEIR team could help with research projects.
 The [video recording of this talk](https://youtu.be/t_XHw7LVy8s) is on YouTube,
 and this is the first video posted on the
 [new HEIR YouTube channel](https://www.youtube.com/@HEIRCompiler).
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-01-23.md
+++ b/docs/content/en/blog/heir_meeting_2025-01-23.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1x8tFUC4vGeO0t-CvFQe4o-H8xgl4zEvBZaye_JlIEVo/edit?usp=sharing)
 and [video recording](https://youtu.be/HMgHNpJeINs) from the HEIR meeting on
 2025-01-23.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-02-20.md
+++ b/docs/content/en/blog/heir_meeting_2025-02-20.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1Aza4s6Z0NCON9rQR70DOUkKSwBV6bHAmuYV8sIb8n7o/edit?usp=sharing)
 and [video recording](https://youtu.be/Y82A6BLAVtc) from the HEIR meeting on
 2025-02-20.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-03-20.md
+++ b/docs/content/en/blog/heir_meeting_2025-03-20.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1TMXQBVumA4YmOTH5QgKR27_Sb-60PI7bKyltJ-D3jbE/edit?usp=sharing)
 and [video recording](https://youtu.be/ULRFEmhwzZE) from the HEIR meeting on
 2025-03-20.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-04-17.md
+++ b/docs/content/en/blog/heir_meeting_2025-04-17.md
@@ -16,3 +16,5 @@ Hongren Zheng gave an overview of the `mgmt` dialect which handles ciphertext
 management in the compiler. This talk
 [starts at 27:11](https://youtu.be/HHU6rCMxZRc?si=U_ePY5emqs6e4NoV&t=1631).
 [The slides can be found here](/slides/mgmt-2025-04-17.pdf).
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-06-12.md
+++ b/docs/content/en/blog/heir_meeting_2025-06-12.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/17HaAzW2KZMlwgQwVttDblWY3Ta7ey5LvJ0XOKvnnLZE/edit?usp=sharing)
 and [video recording](https://youtu.be/dCBWr05kOks) from the HEIR meeting on
 2025-06-12.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-08-07.md
+++ b/docs/content/en/blog/heir_meeting_2025-08-07.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1v3P8LhabG75UCM3xhNcp9yTes3P7DpOqsVDFKVCSdwg/edit?usp=sharing)
 and [video recording](https://youtu.be/t7T9dWtjM8Q) from the HEIR meeting on
 2025-08-07.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-09-04.md
+++ b/docs/content/en/blog/heir_meeting_2025-09-04.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1_Eoip7Gxr89V06SOI2rNH-a8SipGzQUsy5XC3mSmxyc/edit?usp=sharing)
 and [video recording](https://youtu.be/HfCUuwt0E0A) from the HEIR meeting on
 2025-09-04.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/heir_meeting_2025-10-02.md
+++ b/docs/content/en/blog/heir_meeting_2025-10-02.md
@@ -11,3 +11,5 @@ Here are the
 [notes](https://docs.google.com/document/d/1N0hlnCM8tQ9uwiTKVhbDoGdkZ0191sSIfhu7PWotBZc/edit?usp=sharing)
 and [video recording](https://youtu.be/uinxBjENAEE) from the HEIR meeting on
 2025-10-02.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/blog/hello_world.md
+++ b/docs/content/en/blog/hello_world.md
@@ -13,3 +13,5 @@ IRs.
 Our initial meeting was 2023-05-30
 ([read-only copy of the minutes](https://docs.google.com/document/d/1iyiHfseoVkA1qaP3Ig47kqVC-J1_AIidPaj61jvj2KM/edit?usp=sharing)).
 Stay tuned for future updates while we work out a meeting schedule.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/community/_index.md
+++ b/docs/content/en/community/_index.md
@@ -25,3 +25,4 @@ recordings are posted on the
 {{% /blocks/section %}}
 
 <iframe src="https://calendar.google.com/calendar/embed?src=c85ecb3cda4bfb7daa3da95d5aeb19672930501b49d17896e65fa3f963f17a80%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0; display:block; margin: 0 auto" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/_index.md
+++ b/docs/content/en/docs/Design/_index.md
@@ -16,3 +16,5 @@ is generally from the top of the diagram downward.
 <img style="display:block; margin-left:75px; width:500px;" src="/images/dialect-diagram.png" />
 
 The pages in this section describe the design of various subcomponents of HEIR.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/do_transformation.md
+++ b/docs/content/en/docs/Design/do_transformation.md
@@ -233,3 +233,5 @@ transformations goes as follows:
   data-dependent tensor read-write operations over the same tensor, we can
   benefit from upstream affine transformations over the resulting multiple
   affine loops produced by the Access-Transformation to fuse these loops.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/layout.md
+++ b/docs/content/en/docs/Design/layout.md
@@ -1,4 +1,4 @@
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 title: Ciphertext Packing System
 
@@ -6,15 +6,15 @@ title: Ciphertext Packing System
 
 This document describes HEIR's ciphertext packing system, including:
 
--   A notation and internal representation of a ciphertext packing, which we
-    call a *layout*.
--   An abstraction layer to associate SSA values with layouts and manipulate and
-    analyze them before a program is converted to concrete FHE operations.
--   A variety of layouts and kernels from the FHE literature.
--   A layout and kernel optimizer based on the
-    [Fhelipe compiler](https://github.com/fhelipe-compiler/fhelipe).
--   A layout conversion implementation of the
-    [Vos-Vos-Erkin graph coloring algorithm](https://link.springer.com/chapter/10.1007/978-3-031-17140-6_20).
+- A notation and internal representation of a ciphertext packing, which we call
+  a *layout*.
+- An abstraction layer to associate SSA values with layouts and manipulate and
+  analyze them before a program is converted to concrete FHE operations.
+- A variety of layouts and kernels from the FHE literature.
+- A layout and kernel optimizer based on the
+  [Fhelipe compiler](https://github.com/fhelipe-compiler/fhelipe).
+- A layout conversion implementation of the
+  [Vos-Vos-Erkin graph coloring algorithm](https://link.springer.com/chapter/10.1007/978-3-031-17140-6_20).
 
 For background on what ciphertext packing is and its role in homomorphic
 encryption, see
@@ -59,9 +59,9 @@ slot can store at most one cleartext value.
 
 HEIR restricts the above definition of a layout as follows:
 
--   The partial function must be expressible as a *Presburger relation*, which
-    will be defined in detail below.
--   Unmapped ciphertext slots always contain zero.\[^zero\]
+- The partial function must be expressible as a *Presburger relation*, which
+  will be defined in detail below.
+- Unmapped ciphertext slots always contain zero.\[^zero\]
 
 We claim that this subset of possible layouts is a superset of all layouts that
 have been used in the FHE literature to date. For example, both the layout
@@ -75,12 +75,12 @@ Next we define a Presburger relation, then move on to examples.
 **Definition:** A *quasi-affine* formula is a multivariate formula built from
 the following operations:
 
--   Integer literals
--   Integer-valued variables
--   addition and subtraction
--   multiplication by an integer constant
--   floor- and ceiling-rounded division by a nonzero integer constant
--   modulus by a nonzero integer constant
+- Integer literals
+- Integer-valued variables
+- addition and subtraction
+- multiplication by an integer constant
+- floor- and ceiling-rounded division by a nonzero integer constant
+- modulus by a nonzero integer constant
 
 Using the BNF grammar from the
 [MLIR website](https://mlir.llvm.org/docs/Dialects/Affine/#affine-expressions),
@@ -163,10 +163,10 @@ Generally, layout attributes are associated with an SSA value by being attached
 to the op that owns the SSA value. In MLIR, which op owns the value has two
 cases:
 
--   For an op result, the layout attribute is stored on the op.
--   For a block argument, the layout attribute is stored on the op owning the
-    block, using the `OperandAndResultAttrInterface` to give a consistent API
-    for accessing the attribute.
+- For an op result, the layout attribute is stored on the op.
+- For a block argument, the layout attribute is stored on the op owning the
+  block, using the `OperandAndResultAttrInterface` to give a consistent API for
+  accessing the attribute.
 
 These two differences are handled properly by a helper library,
 `lib/Utils/AttributeUtils.h`, which exposes setters and getters for layout
@@ -184,10 +184,10 @@ For example, `#layout_attr` is associated with the SSA value `%1`:
 In HEIR, before lowering to scheme ops, we distinguish between types in two
 regimes:
 
--   *Data-semantic tensors*, which are scalars and tensors that represent
-    cleartext data values, largely unchanged from the original input program.
--   *Ciphertext-semantic tensors*, which are rank-2 tensors that represent
-    packed cleartext values in ciphertexts.
+- *Data-semantic tensors*, which are scalars and tensors that represent
+  cleartext data values, largely unchanged from the original input program.
+- *Ciphertext-semantic tensors*, which are rank-2 tensors that represent packed
+  cleartext values in ciphertexts.
 
 The task of analyzing an IR to determine which layouts and kernels to use
 happens in the data-semantic regime. In these passes, chosen layouts are
@@ -198,16 +198,16 @@ In this regime, there are three special `tensor_ext` ops that are no-ops on
 data-semantic type, but are designed to manipulate the layout attributes. These
 ops are:
 
--   `tensor_ext.assign_layout`, which takes a data-semantic value and a layout
-    attribute, and produces the same data-semantic type. This is an "entry
-    point" into the layout system and lowers to a loop that packs the data
-    according to the layout.
--   `tensor_ext.convert_layout`, which makes an explicit conversion between a
-    data-semantic value's current layout and a new layout. Typically this lowers
-    to a shift network.
--   `tensor_ext.unpack`, which clears the layout attribute on a data-semantic
-    value, and serves as an exit point from the layout system. This lowers to a
-    loop which extracts the packed cleartext data back into user data.
+- `tensor_ext.assign_layout`, which takes a data-semantic value and a layout
+  attribute, and produces the same data-semantic type. This is an "entry point"
+  into the layout system and lowers to a loop that packs the data according to
+  the layout.
+- `tensor_ext.convert_layout`, which makes an explicit conversion between a
+  data-semantic value's current layout and a new layout. Typically this lowers
+  to a shift network.
+- `tensor_ext.unpack`, which clears the layout attribute on a data-semantic
+  value, and serves as an exit point from the layout system. This lowers to a
+  loop which extracts the packed cleartext data back into user data.
 
 A layout optimizer is expected to insert `assign_layout` ops for any server-side
 cleartexts that need to be packed at runtime.
@@ -246,11 +246,11 @@ form as part of a layout conversion step.
 The `mlir-to-<scheme>` pipeline involves the following passes that manipulate
 layouts:
 
--   `layout-propagation`
--   `layout-optimization`
--   `convert-to-ciphertext-semantics`
--   `implement-rotate-and-reduce`
--   `add-client-interface`
+- `layout-propagation`
+- `layout-optimization`
+- `convert-to-ciphertext-semantics`
+- `implement-rotate-and-reduce`
+- `add-client-interface`
 
 The two passes that are closest to Fhelipe's design are `layout-propagation` and
 `layout-optimization`. The former sets up initial default layouts for all values
@@ -301,14 +301,14 @@ hoist the `convert_layout` through the op to its arguments.
 
 In doing this, it must consider:
 
--   Changing the kernel of the op, and the cost of implementing the kernel.
-    E.g., a new kernel may be better for the new layout of the operands.
--   Whether the new layout of op results still need to be converted, and the new
-    cost of these conversions. E.g., if the op result has multiple uses, or the
-    op result had multiple layout conversions, only one of which is hoisted.
--   The new cost of operand layout conversions. E.g., if a layout conversion is
-    hoisted to one operand, it may require other operands to be converted to
-    remain compatible.
+- Changing the kernel of the op, and the cost of implementing the kernel. E.g.,
+  a new kernel may be better for the new layout of the operands.
+- Whether the new layout of op results still need to be converted, and the new
+  cost of these conversions. E.g., if the op result has multiple uses, or the op
+  result had multiple layout conversions, only one of which is hoisted.
+- The new cost of operand layout conversions. E.g., if a layout conversion is
+  hoisted to one operand, it may require other operands to be converted to
+  remain compatible.
 
 In all of the above, the "cost" includes an estimate of the latency of a kernel,
 an estimate of the latency of a layout conversion, as well as the knowledge that
@@ -338,9 +338,9 @@ The
 [`convert-to-ciphertext-semantics`](/docs/passes/#-convert-to-ciphertext-semantics)
 pass has two responsibilities that must happen at the same time:
 
--   Converting all data-semantic values to ciphertext-semantic values with
-    corresponding types.
--   Implementing FHE kernels for all ops as chosen by earlier passes.
+- Converting all data-semantic values to ciphertext-semantic values with
+  corresponding types.
+- Implementing FHE kernels for all ops as chosen by earlier passes.
 
 After this pass is complete, the IR must be in the ciphertext-semantic regime
 and all operations on secret-typed values must be constrained by the SIMD FHE
@@ -431,12 +431,12 @@ touching MLIR.
 The directory `lib/Utils/Layout` contains a variety of helper code for
 manipulating layout relations, including:
 
--   Constructing or testing for common kinds of layouts, such as row-major,
-    diagonal, and layouts related to particular machine learning ops like
-    convolution.
--   Generating explicit loops that iterate over the space of points in a layout,
-    which is used to generate packing and unpacking code.
--   Helpers for hoisting layout conversions through ops.
+- Constructing or testing for common kinds of layouts, such as row-major,
+  diagonal, and layouts related to particular machine learning ops like
+  convolution.
+- Generating explicit loops that iterate over the space of points in a layout,
+  which is used to generate packing and unpacking code.
+- Helpers for hoisting layout conversions through ops.
 
 These are implemented using two APIs: one is the Fast Presburger Library (FPL),
 which is part of MLIR and includes useful operations like composing relations
@@ -604,3 +604,5 @@ out if you'd like to be involved in the design.
 
 \[^zero\]: This may be relaxed in the future with additional static analyses
 that can determine that some slots are never read.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/management.md
+++ b/docs/content/en/docs/Design/management.md
@@ -185,3 +185,5 @@ difference is that, for "Before multiplication (including the first
 multiplication)" modulus switching policy, the user input should be encoded at
 $\\Delta^2$ or higher, as otherwise the first modulus switching (or rescaling in
 CKKS term) will rescale $\\Delta$ to $1$, rendering full precision loss.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/noise.md
+++ b/docs/content/en/docs/Design/noise.md
@@ -69,3 +69,5 @@ solver.initializeAndRun(op)
 
 See the [Passes](/docs/passes) page for details. Example passes include
 `generate-param-bgv` and `validate-noise`.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/relinearization_ilp.md
+++ b/docs/content/en/docs/Design/relinearization_ilp.md
@@ -228,3 +228,5 @@ equality $\\textup{KB}\_{\\textup{result}(o)} = 1$.
   initialization and constraints effectively force the key basis variables to be
   integer. As a result, the solve time of the above ILP should scale with the
   number of ciphertext-handling ops in the program.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/secret.md
+++ b/docs/content/en/docs/Design/secret.md
@@ -343,3 +343,5 @@ they can be lowered further. However, we want to keep the lowered ops grouped
 together for circuit optimization (e.g., fusing transposes and constant weights
 into the optimized layer), but because of this limitation, we can't simply wrap
 the `tosa` ops in a `secret.generic` (bufferization would fail).
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Design/simd.md
+++ b/docs/content/en/docs/Design/simd.md
@@ -307,3 +307,5 @@ Note that the index computations in the patterns above (e.g., `k+l`,
 `k mod t.size` are realized via emitting `arith` operations. However, for
 constant/compile-time-known indices, these will be subsequently constant-folded
 away by the canonicalization pass.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Development/_index.md
+++ b/docs/content/en/docs/Development/_index.md
@@ -262,3 +262,5 @@ make || abort "Build of openfhe-development failed."
 
 Compilation will be significantly slower but should then take less than 8GB of
 memory.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Development/bazel.md
+++ b/docs/content/en/docs/Development/bazel.md
@@ -111,3 +111,5 @@ And the output will be something like
 
 You can find more examples and alternative queries at the
 [Bazel query docs](https://bazel.build/query/language#rdeps).
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Development/boilerplate.md
+++ b/docs/content/en/docs/Development/boilerplate.md
@@ -75,3 +75,5 @@ python scripts/templates/templates.py new_dialect \
 Note that all `--enable` flags are `True` by default, so if you know your
 dialect will not have attributes or types, you have to explicitly disable those
 options.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Development/ide.md
+++ b/docs/content/en/docs/Development/ide.md
@@ -335,3 +335,5 @@ vim.keymap.set('n', '<leader>fi', function()
   vim.api.nvim_buf_set_lines(buf, -2, -1, false, { endif })
 end, { noremap = true })
 ```
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/Dialects/_index.md
+++ b/docs/content/en/docs/Dialects/_index.md
@@ -5,3 +5,5 @@ weight: 70
 
 This section contains the reference documentation for all of the dialects
 defined in HEIR.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -7,3 +7,5 @@ weight: 20
 ---
 
 This section is where the HEIR documentation lives.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/getting_started.md
+++ b/docs/content/en/docs/getting_started.md
@@ -463,3 +463,5 @@ would vectorize the dot-product program (`tensor<8xi16>`) then use
 rotate-and-reduce technique to compute the sum.
 
 {{% figure src="/images/dot_product_8.svg" link="/images/dot_product_8.svg" %}}
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/passes.md
+++ b/docs/content/en/docs/passes.md
@@ -2,3 +2,5 @@
 title: Passes
 weight: 70
 ---
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/pipelines.md
+++ b/docs/content/en/docs/pipelines.md
@@ -222,3 +222,5 @@ Example output:
   ]
 }
 ```
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/research_with_heir.md
+++ b/docs/content/en/docs/research_with_heir.md
@@ -60,3 +60,5 @@ the private repo.
 
 Once you're ready to publish your development work, you can push your commits to
 a branch in the public repository and create a pull request.
+
+<!-- mdformat global-off -->

--- a/docs/content/en/docs/tutorials.md
+++ b/docs/content/en/docs/tutorials.md
@@ -31,3 +31,5 @@ submit a pull request
 - [Negacyclic Polynomial Multiplication by Jeremy Kun](https://jeremykun.com/2022/12/09/negacyclic-polynomial-multiplication/)
 - [Sample Extraction from RLWE to LWE by Jeremy Kun](https://jeremykun.com/2023/02/27/sample-extraction-from-rlwe-to-lwe/)
 - [The Gadget Decomposition in FHE by Jeremy Kun](https://jeremykun.com/2021/12/11/the-gadget-decomposition-in-fhe/)
+
+<!-- mdformat global-off -->

--- a/docs/content/en/search.md
+++ b/docs/content/en/search.md
@@ -2,3 +2,5 @@
 title: Search Results
 layout: search
 ---
+
+<!-- mdformat global-off -->

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -87,3 +87,5 @@ internal style guide.
 The `pyink` repo has instructions for setting up `pyink` with VSCode. The
 pre-commit configuration for this repo will automatically run `pyink`, and to
 run a one-time format of the entire project, use `pre-commit run --all-files`.
+
+<!-- mdformat global-off -->

--- a/lib/Analysis/NoiseAnalysis/README.md
+++ b/lib/Analysis/NoiseAnalysis/README.md
@@ -8,3 +8,5 @@ HEIR mainly use the following papers for noise analysis
 - MMLGA22: Finding and Evaluating Parameters for BGV
 - BMCM23: Improving and Automating BFV Parameters Selection: An Average-Case
   Approacha
+
+<!-- mdformat global-off -->

--- a/scripts/disable_mdformat.py
+++ b/scripts/disable_mdformat.py
@@ -1,0 +1,127 @@
+"""A script to ensure markdown files ignored by Google's markdown formatter.
+
+Google's internal formatter doesn't support yaml frontmatter, and has different
+conventions than the OSS formatter.
+
+Puts the command at the end of each file.
+"""
+
+import sys
+import subprocess
+from pathlib import Path
+
+# --- Configuration ---
+LINE_TO_ADD = "<!-- mdformat global-off -->"
+FILE_GLOB_PATTERN = "*.md"
+# ---------------------
+
+
+def find_git_root():
+  """
+  Finds the root directory of the current git repository.
+  Exits if 'git' is not found or this is not a git repo.
+  """
+  try:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding="utf-8",
+    )
+    return result.stdout.strip()
+  except FileNotFoundError:
+    print("Error: 'git' command not found.", file=sys.stderr)
+    sys.exit(1)
+  except subprocess.CalledProcessError:
+    print("Error: Could not find git repository root.", file=sys.stderr)
+    print("Are you sure you are inside a git repository?", file=sys.stderr)
+    sys.exit(1)
+
+
+def get_non_ignored_files(root_dir, glob_pattern):
+  """
+  Uses 'git ls-files' to get a list of all files in the repo
+  that match the glob, while respecting .gitignore.
+  """
+  cmd = [
+      "git",
+      "ls-files",
+      "--cached",
+      "--others",
+      "--exclude-standard",
+      "--",
+      glob_pattern,
+  ]
+
+  print(f"Finding non-ignored '{glob_pattern}' files...")
+
+  try:
+    result = subprocess.run(
+        cmd,
+        cwd=root_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+        encoding="utf-8",
+    )
+    file_list = [line for line in result.stdout.splitlines() if line]
+    return file_list
+  except subprocess.CalledProcessError as e:
+    print("Error: 'git ls-files' failed.", file=sys.stderr)
+    print(f"Details: {e.stderr}", file=sys.stderr)
+    sys.exit(1)
+
+
+def add_footer_to_files(root_dir, relative_file_list):
+  """
+  Iterates over the list of relative file paths, checks if the
+  comment exists anywhere, and appends it if not.
+  """
+  count = 0
+  root_path = Path(root_dir)
+
+  print(f"Scanning {len(relative_file_list)} files...")
+
+  for rel_path in relative_file_list:
+    file_path = root_path / rel_path
+
+    if not file_path.is_file():
+      print(f"Skipping (not a file): {rel_path}")
+      continue
+
+    try:
+      # Check if the line exists anywhere in the file
+      content = file_path.read_text(encoding="utf-8")
+      if LINE_TO_ADD in content:
+        # print(f"Skipping (already present): {rel_path}")
+        continue
+
+      # If we're here, the line was not found.
+      # Open in 'a' (append) mode to add to the end.
+      print(f"Adding footer to: {rel_path}")
+      with file_path.open("a", encoding="utf-8") as f:
+        if content and not content.endswith("\n"):
+          f.write("\n")
+        f.write(f"{LINE_TO_ADD}\n")
+
+      count += 1
+
+    except UnicodeDecodeError:
+      print(f"Skipping (not utf-8): {rel_path}")
+    except Exception as e:
+      print(f"Error processing {rel_path}: {e}", file=sys.stderr)
+
+  print(f"\nDone. Footer added to {count} files.")
+  if count > 0:
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  git_root = find_git_root()
+  file_list = get_non_ignored_files(git_root, FILE_GLOB_PATTERN)
+
+  if file_list:
+    add_footer_to_files(git_root, file_list)
+  else:
+    print(f"No non-ignored '{FILE_GLOB_PATTERN}' files found.")

--- a/scripts/jupyter/README.md
+++ b/scripts/jupyter/README.md
@@ -68,3 +68,5 @@ ABC:
 ```
 ERROR: ABC: execution of command ""external/edu_berkeley_abc/abc" -s -f /tmp/yosys-abc-iEdp1F/abc.script 2>&1" failed: return code 127.
 ```
+
+<!-- mdformat global-off -->

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/README.md
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/README.md
@@ -64,3 +64,5 @@ directory with:
 rm lower_mul_*.mlir
 bazel run generate_test_cases -- --tests_toml_path $PWD/lower_mul_tests.toml --output_test_stem=$PWD/lower_mul_ --output_build_file $PWD/BUILD
 ```
+
+<!-- mdformat global-off -->

--- a/tests/Examples/lattigo/README.md
+++ b/tests/Examples/lattigo/README.md
@@ -6,3 +6,5 @@ compiling the generated golang source and running the resulting binary.
 
 Lattigo is added as a bazel project-level dependency (unlike the `tfhe-rs`
 end-to-end tests) and built from source.
+
+<!-- mdformat global-off -->

--- a/tests/Examples/openfhe/README.md
+++ b/tests/Examples/openfhe/README.md
@@ -5,3 +5,5 @@ These tests exercise OpenFHE codegen for the
 including compiling the generated C++ source and running the resulting binary.
 
 OpenFHE is added as a project-level dependency and built from source.
+
+<!-- mdformat global-off -->

--- a/tests/Examples/tfhe_rust/README.md
+++ b/tests/Examples/tfhe_rust/README.md
@@ -8,3 +8,5 @@ The tests are generated using a custom Bazel macro found in
 [test.bzl](tests/Examples/tfhe_rust/test.bzl). `tfhe-rs` is added a
 project-level dependency, and it's version is pinned in
 [MODULE.bazel](MODULE.bazel).
+
+<!-- mdformat global-off -->

--- a/tests/Examples/tfhe_rust_bool/cpu/README.md
+++ b/tests/Examples/tfhe_rust_bool/cpu/README.md
@@ -9,3 +9,5 @@ The tests are generated using a custom Bazel macro found in
 [test.bzl](tests/Examples/tfhe_rust/test.bzl). `tfhe-rs` is added a
 project-level dependency, and it's version is pinned in
 [MODULE.bazel](MODULE.bazel).
+
+<!-- mdformat global-off -->

--- a/tests/Examples/tfhe_rust_bool/fpga/README.md
+++ b/tests/Examples/tfhe_rust_bool/fpga/README.md
@@ -51,3 +51,5 @@ If you don't do this correctly, you will see an error like this:
 # |   Read-only file system (os error 30)
 # `-----------------------------
 ```
+
+<!-- mdformat global-off -->

--- a/tests/Examples/tfhe_rust_hl/cpu/README.md
+++ b/tests/Examples/tfhe_rust_hl/cpu/README.md
@@ -9,3 +9,5 @@ The tests are generated using a custom Bazel macro found in
 [test.bzl](tests/Examples/tfhe_rust/test.bzl). `tfhe-rs` is added a
 project-level dependency, and it's version is pinned in
 [MODULE.bazel](MODULE.bazel).
+
+<!-- mdformat global-off -->

--- a/tests/Examples/tfhe_rust_hl/fpga/README.md
+++ b/tests/Examples/tfhe_rust_hl/fpga/README.md
@@ -50,3 +50,5 @@ the following command:
 ```bash
 cargo run --release -- {$INPUT_1}
 ```
+
+<!-- mdformat global-off -->


### PR DESCRIPTION
Sigh. Why can't google's internal markdown formatter work.

Edit: this PR includes a fix to a broken yaml frontmatter, and also adds a script that ensures google's internal fork of mdformat is disabled for all markdown files. This script is added as a pre-commit hook.