### PR TITLE
BGV: NoiseAnalysis KPZ21: more conservative on ct-pt mul

### DIFF
--- a/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.cpp
+++ b/lib/Analysis/NoiseAnalysis/BGV/NoiseByBoundCoeffModel.cpp
@@ -156,16 +156,15 @@ typename NoiseByBoundCoeffModel::StateType NoiseByBoundCoeffModel::evalMul(
   auto ringDim = resultParam.getSchemeParam()->getRingDim();
 
   // (m_0 + tv_0) * (m_1 + tv_1) <=
-  //   [m_0 * m_1]_t + t(v_0 * m_1 + v_1 * m_0 + v_0 * v_1 + r_m)
+  //   [m_0 * m_1]_t + t(v_0 * m_1 + v_1 * m_0 + t * v_0 * v_1 + r_m)
   // where m_0 * m_1 = [m_0 * m_1]_t + tr_m
-  // ||r_m|| <= delta * t / 2, delta is the expansion factor
-  // v_mul = v_0 * m_1 + v_1 * m_0 + v_0 * v_1 + r_m
-  // for m_0 * m_1 we have to use the N expansion factor
+  // ||r_m|| <= N * t / 2, delta is the expansion factor
+  // v_mul = v_0 * m_1 + v_1 * m_0 + t * v_0 * v_1 + r_m
+  // for m_0 * m_1 and v * m we have to use the N expansion factor
   // ||v_mul|| <=
-  //   (delta * t / 2) * (2 * ||v_0|| * ||v_1|| + ||v_0|| + ||v_1||)
-  //   + N * (t / 2)
-  return (lhs * rhs * 2 + lhs + rhs) * (expansionFactor * t / 2) +
-         ringDim * t / 2;
+  //   (delta * t) * ||v_0|| * ||v_1|| + (||v_0|| + ||v_1|| + 1) * (N * t / 2)
+  return (lhs * rhs) * expansionFactor * t +
+         (lhs + rhs + 1) * (ringDim * t / 2);
 }
 
 typename NoiseByBoundCoeffModel::StateType

--- a/tests/Transforms/validate_noise/validate_noise_pass.mlir
+++ b/tests/Transforms/validate_noise/validate_noise_pass.mlir
@@ -1,6 +1,6 @@
 // RUN: heir-opt --validate-noise=model=bgv-noise-by-bound-coeff-average-case %s | FileCheck %s
 
-module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [134250497, 33832961, 140737488486401], P = [140737488928769, 140737489256449], plaintextModulus = 65537>, scheme.bgv} {
+module attributes {bgv.schemeParam = #bgv.scheme_param<logN = 13, Q = [134250497, 2147565569, 140737488486401], P = [140737488928769, 140737489256449], plaintextModulus = 65537>, scheme.bgv} {
   // CHECK: @dot_product
   func.func @dot_product(%arg0: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}, %arg1: !secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 2>}) -> (!secret.secret<tensor<1024xi16>> {mgmt.mgmt = #mgmt.mgmt<level = 0>}) {
     %c7 = arith.constant 7 : index


### PR DESCRIPTION
See https://github.com/google/heir/pull/2319#issuecomment-3413879680 for backgrounds.

A 2sqrt(N) expansion factor for ct-pt mul is not enough as we do not know the distribution of pt. In previous testing for BGV, we only emphasized ct-ct cases where the v1 * v2 dominates but put less consideration for ct-pt case where v1 * v2 = 0.

This PR uses the expansion factor of N for ct-pt mul. I've experimentally observed an at-most 2 bit overflow so it suggests we could not adjust to some other Csqrt(N) (in this case this would mean 8sqrt(N)).

In BGV, ct-ct mul and ct-pt mul shares the same noise estimation function/formula and can be adjusted as in this PR. I would remark that ct-pt case is also relevant for BFV, but BFV ct-ct v.s. ct-pt use different multiplication structure (former uses multiplication technique, while later is much simpler), and the ct-ct formula is much more conservative when applied to ct-pt case so it should not cause overflow for BFV ct-pt mul. In other words, a new formula for ct-pt mul for BFV is an optimization but the current formula is good enough. 

@j2kun Could you please test 2319 again with this patch?

Cc @yspolyakov for what it's worth.