### PR TITLE
Add bicyclic layout and matmul kernel

### DIFF
--- a/lib/Kernel/BUILD
+++ b/lib/Kernel/BUILD
@@ -73,6 +73,7 @@ cc_library(
         ":AbstractValue",
         ":ArithmeticDag",
         ":Kernel",
+        "@heir//lib/Utils:APIntUtils",
         "@heir//lib/Utils:MathUtils",
         "@llvm-project//mlir:Support",
     ],

--- a/lib/Utils/Layout/Evaluate.h
+++ b/lib/Utils/Layout/Evaluate.h
@@ -87,6 +87,27 @@ std::vector<std::vector<T>> evaluateLayoutOnMatrix(
   return evaluateLayout(relation, getValueFn);
 }
 
+template <typename T>
+std::vector<std::vector<T>> unpackLayoutToMatrix(
+    const presburger::IntegerRelation& relation,
+    const std::vector<std::vector<T>>& packed,
+    ArrayRef<int64_t> originalShape) {
+  std::vector<std::vector<T>> result(originalShape[0],
+                                     std::vector<T>(originalShape[1], 0));
+
+  // Get all points in the relation.
+  PointPairCollector collector(relation.getNumDomainVars(), /*rangeDims=*/2);
+  enumeratePoints(relation, collector);
+
+  for (const auto& pointPair : collector.points) {
+    std::vector<int64_t> domainPoint = pointPair.first;
+    std::vector<int64_t> rangePoint = pointPair.second;
+    result[domainPoint[0]][domainPoint[1]] =
+        packed[rangePoint[0]][rangePoint[1]];
+  }
+  return result;
+}
+
 }  // namespace heir
 }  // namespace mlir
 

--- a/lib/Utils/Layout/Utils.h
+++ b/lib/Utils/Layout/Utils.h
@@ -48,6 +48,11 @@ presburger::IntegerRelation getRowMajorLayoutRelation(
 presburger::IntegerRelation getDiagonalLayoutRelation(
     RankedTensorType matrixType, int64_t ciphertextSize);
 
+// Returns an IntegerRelation that represents a bicyclic layout for a matrix.
+// See https://eprint.iacr.org/2024/1762 for details.
+presburger::IntegerRelation getBicyclicLayoutRelation(
+    RankedTensorType matrixType, int64_t numSlots);
+
 // Returns an IntegerRelation that represents a per-row layout for a matrix
 // such that each row of the matrix is in a separate ciphertext.
 presburger::IntegerRelation getPerRowLayoutRelation(RankedTensorType matrixType,

--- a/lib/Utils/Layout/UtilsTest.cpp
+++ b/lib/Utils/Layout/UtilsTest.cpp
@@ -160,6 +160,45 @@ TEST(UtilsTest, SquatDiagonalLayout) {
   }
 }
 
+TEST(UtilsTest, BicyclicLayout3x5) {
+  MLIRContext context;
+  int64_t numSlots = 15;
+  RankedTensorType matrixType =
+      RankedTensorType::get({3, 5}, IndexType::get(&context));
+  IntegerRelation bicyclicRelation =
+      getBicyclicLayoutRelation(matrixType, numSlots);
+
+  std::vector<std::vector<int>> matrix = {
+      {1, 2, 3, 4, 5}, {6, 7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+  std::vector<std::vector<int>> packedMatrix =
+      evaluateLayoutOnMatrix(bicyclicRelation, matrix);
+
+  std::vector<std::vector<int>> expected = {
+      {1, 7, 13, 4, 10, 11, 2, 8, 14, 5, 6, 12, 3, 9, 15}};
+  EXPECT_EQ(packedMatrix, expected);
+}
+
+TEST(UtilsTest, BicyclicLayout3x5Repeated) {
+  MLIRContext context;
+
+  int64_t numSlots = 32;
+  RankedTensorType matrixType =
+      RankedTensorType::get({3, 5}, IndexType::get(&context));
+  IntegerRelation bicyclicRelation =
+      getBicyclicLayoutRelation(matrixType, numSlots);
+
+  std::vector<std::vector<int>> matrix = {
+      {1, 2, 3, 4, 5}, {6, 7, 8, 9, 10}, {11, 12, 13, 14, 15}};
+  std::vector<std::vector<int>> packedMatrix =
+      evaluateLayoutOnMatrix(bicyclicRelation, matrix);
+
+  std::vector<std::vector<int>> expected = {
+      {1, 7, 13, 4, 10, 11, 2, 8, 14, 5, 6, 12, 3, 9, 15,
+       // Cyclically repeated to fill 32 slots
+       1, 7, 13, 4, 10, 11, 2, 8, 14, 5, 6, 12, 3, 9, 15, 1, 7}};
+  EXPECT_EQ(packedMatrix, expected);
+}
+
 TEST(UtilsTest, TestGetRangePoints) {
   MLIRContext context;
   auto rel = getIntegerRelationFromIslStr(


### PR DESCRIPTION
This PR adds a new layout relation to represent the bicyclic matrix layout from https://eprint.iacr.org/2024/1762, along with the matmul kernel BMM-I from that paper, implemented in the ArithmeticDag framework.

This follows the python reference implementation at https://github.com/j2kun/fhe-packing/commit/87abe57193a6f2ee5d76bcd38888071d331dc814

However, it does not include the Baby-Step Giant-Step optimization as described in https://eprint.iacr.org/2025/1200. I wanted to get the initial kernel implemented correctly, then in a followup PR I can focus on the (independent) steps of:

- Integrating the layout/kernel into the pipeline
- Improving the kernel to use BSGS

Open question: the rotations used use this nontrivial structure

```
    auto rotA = NodeTy::leftRotate(packedADag, (-i * m));
    auto rotB = NodeTy::leftRotate(packedBDag, (i * (r * n - m)));
```

It was not clear to me if the existing `tensor_ext.rotate_and_reduce` would support this. Based on my understanding of section 6.2 of Lawrence's paper (https://eprint.iacr.org/2025/1200.pdf), BSGS only applies to the ciphertext-plaintext matmul kernel, so it's not immediately clear how to optimize the rotation schedule except in using the lower-level rotation hoisting.

Part of https://github.com/google/heir/issues/1376