### PR TITLE
Add bicyclic matmul to layout pipeline

### DIFF
--- a/lib/Kernel/Kernel.cpp
+++ b/lib/Kernel/Kernel.cpp
@@ -22,6 +22,7 @@ static std::unordered_map<KernelName, std::string> correspondingOp = {
     {KernelName::VecmatDiagonal, "linalg.vecmat"},
     {KernelName::MatmulDiagonal, "linalg.matmul"},
     {KernelName::MatmulDiagonal, "linalg.conv2d"},
+    {KernelName::MatmulBicyclic, "linalg.matmul"},
 };
 
 std::set<std::string> requiredNontrivial = {"linalg"};
@@ -66,25 +67,24 @@ std::string kernelNameAsStr(const KernelName& kernelName) {
       return "MatmulDiagonal";
     case KernelName::VecmatDiagonal:
       return "VecmatDiagonal";
+    case KernelName::MatmulBicyclic:
+      return "MatmulBicyclic";
     default:
       return "Unknown";
   }
 }
 
+std::ostream& operator<<(std::ostream& os, const KernelName& k) {
+  return os << "\"" << kernelNameAsStr(k) << "\"";
+}
+
+llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const KernelName& k) {
+  return os << "\"" << kernelNameAsStr(k) << "\"";
+}
+
+mlir::Diagnostic& operator<<(mlir::Diagnostic& diag, const KernelName& k) {
+  return diag << kernelNameAsStr(k);
+}
+
 }  // namespace heir
-
-std::ostream& operator<<(std::ostream& os, const heir::KernelName& k) {
-  return os << "\"" << heir::kernelNameAsStr(k) << "\"";
-}
-
-llvm::raw_ostream& operator<<(llvm::raw_ostream& os,
-                              const heir::KernelName& k) {
-  return os << "\"" << heir::kernelNameAsStr(k) << "\"";
-}
-
-mlir::Diagnostic& operator<<(mlir::Diagnostic& diag,
-                             const heir::KernelName& k) {
-  return diag << heir::kernelNameAsStr(k);
-}
-
 }  // namespace mlir

--- a/lib/Kernel/Kernel.h
+++ b/lib/Kernel/Kernel.h
@@ -28,6 +28,7 @@ struct FieldParser<heir::KernelName> {
     if (kernelName == "MatvecDiagonal") return heir::KernelName::MatvecDiagonal;
     if (kernelName == "VecmatDiagonal") return heir::KernelName::VecmatDiagonal;
     if (kernelName == "MatmulDiagonal") return heir::KernelName::MatmulDiagonal;
+    if (kernelName == "MatmulBicyclic") return heir::KernelName::MatmulBicyclic;
 
     return failure();
   }

--- a/lib/Kernel/KernelName.h
+++ b/lib/Kernel/KernelName.h
@@ -11,20 +11,30 @@ enum KernelName : int {
   // A trivial kernel is one for which there is only a single known option
   // (e.g., an elementwise addition).
   Trivial = 0,
+
+  // TODO(#1589): implement MatvecNaive kernel
   MatvecNaive,
+
+  // Plaintext-ciphertext matvec using the Halevi-Shoup diagonal method.
   MatvecDiagonal,
+
+  // Ciphertext-plaintext vecmat using the Halevi-Shoup diagonal method
+  // (transpose of MatvecDiagonal).
   VecmatDiagonal,
+
   // LHS matrix is secret, RHS is a plaintext matrix. This expands the matmul
   // into a single matvec using the diagonal matrix vector kernel.
   MatmulDiagonal,
+
+  // Ciphertext-ciphertext matmul using the bicyclic packing method.
+  MatmulBicyclic,
 };
 
+std::ostream& operator<<(std::ostream& os, const KernelName& k);
+llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const KernelName& k);
+mlir::Diagnostic& operator<<(mlir::Diagnostic& diag, const KernelName& k);
+
 }  // namespace heir
-
-std::ostream& operator<<(std::ostream& os, const heir::KernelName& k);
-llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const heir::KernelName& k);
-mlir::Diagnostic& operator<<(mlir::Diagnostic& diag, const heir::KernelName& k);
-
 }  // namespace mlir
 
 #endif  // LIB_KERNEL_KERNELNAME_H_

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -247,10 +247,10 @@ struct ConvertFunc : public ContextAwareFuncConversion {
   };
 };
 
-struct ConvertGeneric : public ConvertAnyContextAware<secret::GenericOp> {
+struct ConvertSecretGeneric : public ConvertAnyContextAware<secret::GenericOp> {
  public:
-  ConvertGeneric(const ContextAwareTypeConverter& converter,
-                 MLIRContext* context)
+  ConvertSecretGeneric(const ContextAwareTypeConverter& converter,
+                       MLIRContext* context)
       : ConvertAnyContextAware(converter, context) {
     setDebugName("ConvertGeneric");
   }
@@ -1594,7 +1594,7 @@ class ConvertTensorExtractSlice
   }
 };
 
-class ConvertCollapseShape
+class ConvertTensorCollapseShape
     : public ContextAwareOpConversionPattern<tensor::CollapseShapeOp> {
  public:
   using ContextAwareOpConversionPattern<
@@ -1663,7 +1663,7 @@ class ConvertCollapseShape
   }
 };
 
-class ConvertExpandShape
+class ConvertTensorExpandShape
     : public ContextAwareOpConversionPattern<tensor::ExpandShapeOp> {
  public:
   using ContextAwareOpConversionPattern<
@@ -1784,6 +1784,86 @@ struct DropRotateAndReduceUnitDims
   }
 };
 
+struct ConvertLinalgMatmul
+    : public ContextAwareOpConversionPattern<linalg::MatmulOp> {
+ public:
+  using ContextAwareOpConversionPattern<
+      linalg::MatmulOp>::ContextAwareOpConversionPattern;
+
+  ConvertLinalgMatmul(
+      const ContextAwareTypeConverter& contextAwareTypeConverter,
+      MLIRContext* context)
+      : ContextAwareOpConversionPattern(contextAwareTypeConverter, context,
+                                        /*benefit=*/10) {}
+
+  LayoutAttr getLayoutAttr(Value value) const {
+    auto layoutLookup = getTypeConverter()->getContextualAttr(value);
+    if (failed(layoutLookup)) {
+      return nullptr;
+    }
+    return dyn_cast<LayoutAttr>(layoutLookup.value());
+  }
+
+  bool supportsBicyclic(linalg::MatmulOp op, OpAdaptor adaptor) const {
+    auto kernelAttr = op->getAttrOfType<secret::KernelAttr>(
+        secret::SecretDialect::kKernelAttrName);
+    return kernelAttr && kernelAttr.getName() == KernelName::MatmulBicyclic;
+  }
+
+  void bicyclicKernel(linalg::MatmulOp op, OpAdaptor adaptor,
+                      ContextAwareConversionPatternRewriter& rewriter) const {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Converting linalg.matmul op with bicyclic kernel: " << op
+               << "\n");
+
+    TypedValue<RankedTensorType> lhs =
+        cast<TypedValue<RankedTensorType>>(adaptor.getInputs()[0]);
+    SSAValue lhsLeaf(lhs);
+    TypedValue<RankedTensorType> rhs =
+        cast<TypedValue<RankedTensorType>>(adaptor.getInputs()[1]);
+    SSAValue rhsLeaf(rhs);
+
+    auto lhsType = cast<RankedTensorType>(op.getInputs()[0].getType());
+    auto rhsType = cast<RankedTensorType>(op.getInputs()[1].getType());
+
+    // TODO(#2368): zero-pad inputs to ensure coprime dimensions
+    std::shared_ptr<ArithmeticDagNode<SSAValue>> implementedKernel =
+        kernel::implementBicyclicMatmul(lhsLeaf, rhsLeaf, lhsType.getShape()[0],
+                                        lhsType.getShape()[1],
+                                        rhsType.getShape()[1]);
+
+    rewriter.setInsertionPointAfter(op);
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    IRMaterializingVisitor visitor(b, lhs.getType(), [&](Operation* createdOp) {
+      setMaterializedAttr(op);
+    });
+    Value finalOutput = implementedKernel->visit(visitor);
+
+    auto layoutAttr = cast<LayoutAttr>(op->getAttr(kLayoutAttrName));
+    auto* finalOutputOp = finalOutput.getDefiningOp();
+    finalOutputOp->setAttr(kLayoutAttrName, layoutAttr);
+    setMaterializedAttr(finalOutputOp);
+
+    // Add the initial accumulator value.
+    Value result = adaptor.getOutputs()[0];
+    Operation* addBias =
+        makeAppropriatelyTypedAddOp(b, op->getLoc(), finalOutput, result);
+    addBias->setAttr(kLayoutAttrName, layoutAttr);
+    setMaterializedAttr(addBias);
+    rewriter.replaceOp(op, addBias);
+  }
+
+  LogicalResult matchAndRewrite(
+      linalg::MatmulOp op, OpAdaptor adaptor,
+      ContextAwareConversionPatternRewriter& rewriter) const final {
+    if (supportsBicyclic(op, adaptor)) {
+      bicyclicKernel(op, adaptor, rewriter);
+      return success();
+    }
+    return failure();
+  }
+};
+
 struct ConvertToCiphertextSemantics
     : impl::ConvertToCiphertextSemanticsBase<ConvertToCiphertextSemantics> {
   using ConvertToCiphertextSemanticsBase::ConvertToCiphertextSemanticsBase;
@@ -1802,18 +1882,13 @@ struct ConvertToCiphertextSemantics
       return isa<ModuleOp>(op) || hasMaterializedAttr(op);
     });
 
-    patterns.add<ConvertFunc, ConvertGeneric,
-                 // tensor_ext ops
-                 ConvertConvertLayout,
-                 // linalg ops
-                 ConvertLinalgReduce, ConvertLinalgMatvecLayout,
-                 ConvertLinalgConv2D,
-                 // tensor ops
-                 ConvertTensorExtractLayout, ConvertTensorInsertLayout,
-                 ConvertCollapseShape, ConvertExpandShape,
-                 ConvertTensorInsertSlice, ConvertTensorExtractSlice,
-                 // default
-                 ConvertAnyAddingMaterializedAttr>(typeConverter, context);
+    patterns.add<ConvertAnyAddingMaterializedAttr, ConvertConvertLayout,
+                 ConvertFunc, ConvertLinalgConv2D, ConvertLinalgMatmul,
+                 ConvertLinalgMatvecLayout, ConvertLinalgReduce,
+                 ConvertSecretGeneric, ConvertTensorCollapseShape,
+                 ConvertTensorExpandShape, ConvertTensorExtractLayout,
+                 ConvertTensorExtractSlice, ConvertTensorInsertLayout,
+                 ConvertTensorInsertSlice>(typeConverter, context);
     patterns.add<ConvertAssignLayout>(typeConverter, context, ciphertextSize);
 
     ConversionConfig config;

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -476,6 +476,13 @@ bool isRelation2dConvFilterDiagonalized(RankedTensorType filterType,
   return relation.isEqual(diagonalizedRelation.value());
 }
 
+bool isRelationBicyclic(RankedTensorType matrixType, int64_t numSlots,
+                        const presburger::IntegerRelation& relation) {
+  IntegerRelation bicyclicRelation =
+      getBicyclicLayoutRelation(matrixType, numSlots);
+  return relation.isEqual(bicyclicRelation);
+}
+
 presburger::IntegerRelation collapseDimensions(
     const presburger::IntegerRelation& relation, RankedTensorType sourceType,
     ArrayRef<ReassociationIndices> reassociation) {

--- a/lib/Utils/Layout/Utils.h
+++ b/lib/Utils/Layout/Utils.h
@@ -102,6 +102,11 @@ bool isRelation2dConvFilterDiagonalized(RankedTensorType filterType,
                                         int64_t padding, int64_t ciphertextSize,
                                         presburger::IntegerRelation relation);
 
+// Returns true if the given relation is a bicyclic layout for the given
+// matrix type and ciphertext semantic shape.
+bool isRelationBicyclic(RankedTensorType matrixType, int64_t numSlots,
+                        const presburger::IntegerRelation& relation);
+
 // Returns a new IntegerRelation that is the same as the given relation, but
 // with the given dimensions collapsed. This expects that the reassociation
 // indices result in a rank-reduction of the source type (i.e. the collapsed

--- a/tests/Transforms/convert_to_ciphertext_semantics/matmul.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/matmul.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt --convert-to-ciphertext-semantics %s | FileCheck %s
+
+#kernel = #secret.kernel<name = "MatmulBicyclic", force = false>
+#layout = #tensor_ext.layout<"{ [i0, i1] -> [ct, slot] : ct = 0 and (2i0 + 3i1 + slot) mod 6 = 0 and 0 <= i0 <= 2 and 0 <= i1 <= 1 and 0 <= slot <= 7 }">
+#layout1 = #tensor_ext.layout<"{ [i0, i1] -> [ct, slot] : (5i0 - 6i1 - 7ct + slot) mod 15 = 0 and 0 <= i0 <= 2 and 0 <= i1 <= 4 and 0 <= ct <= 1 and 0 <= slot <= 7 }">
+#layout2 = #tensor_ext.layout<"{ [i0, i1] -> [ct, slot] : (4i0 + 5i1 - 2ct + slot) mod 10 = 0 and 0 <= i0 <= 4 and 0 <= i1 <= 1 and 0 <= ct <= 1 and 0 <= slot <= 7 }">
+#layout3 = #tensor_ext.layout<"{ [i0, i1] -> [ct, slot] : (3i0 - i1 + slot + 8*floor((-3i0 + i1)/8)) mod 16 = 0 and 0 <= i0 <= 2 and 0 <= i1 <= 4 and 0 <= ct <= 1 and -7 + 5i0 + i1 <= 8ct <= 5i0 + i1 and 0 <= slot <= 7 }">
+
+// CHECK: @matmul_secret_secret
+// CHECK-NOT: linalg.matmul
+func.func @matmul_secret_secret(%arg0: !secret.secret<tensor<3x5xf32>> {tensor_ext.layout = #layout1}, %arg1: !secret.secret<tensor<5x2xf32>> {tensor_ext.layout = #layout2}) -> (!secret.secret<tensor<3x2xf32>> {tensor_ext.layout = #layout}) {
+  %cst = arith.constant dense<0.000000e+00> : tensor<3x2xf32>
+  %0 = secret.generic(%arg0: !secret.secret<tensor<3x5xf32>> {tensor_ext.layout = #layout1}, %arg1: !secret.secret<tensor<5x2xf32>> {tensor_ext.layout = #layout2}) {
+  ^body(%input0: tensor<3x5xf32>, %input1: tensor<5x2xf32>):
+    %1 = tensor_ext.assign_layout %cst {layout = #layout3, tensor_ext.layout = #layout3} : tensor<3x2xf32>
+    %2 = linalg.matmul {secret.kernel = #kernel, tensor_ext.layout = #layout} ins(%input0, %input1 : tensor<3x5xf32>, tensor<5x2xf32>) outs(%1 : tensor<3x2xf32>) -> tensor<3x2xf32>
+    secret.yield %2 : tensor<3x2xf32>
+  } -> (!secret.secret<tensor<3x2xf32>> {tensor_ext.layout = #layout})
+  return %0 : !secret.secret<tensor<3x2xf32>>
+}

--- a/tests/Transforms/layout_propagation/matmul.mlir
+++ b/tests/Transforms/layout_propagation/matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --layout-propagation=ciphertext-size=8 --fold-convert-layout-into-assign-layout %s | FileCheck %s
+// RUN: heir-opt --layout-propagation=ciphertext-size=8 --mlir-print-local-scope --fold-convert-layout-into-assign-layout %s | FileCheck %s
 
 module {
   // CHECK: func @matmul
@@ -6,9 +6,24 @@ module {
     %cst = arith.constant dense<0.000000e+00> : tensor<3x3xf32>
     %0 = secret.generic(%arg0: !secret.secret<tensor<3x2xf32>>) {
     ^body(%input0: tensor<3x2xf32>):
+      // CHECK: linalg.matmul
+      // CHECK-SAME: #secret.kernel<name = "MatmulDiagonal"
       %1 = linalg.matmul ins(%input0, %arg1 : tensor<3x2xf32>, tensor<2x3xf32>) outs(%cst : tensor<3x3xf32>) -> tensor<3x3xf32>
       secret.yield %1 : tensor<3x3xf32>
     } -> !secret.secret<tensor<3x3xf32>>
     return %0 : !secret.secret<tensor<3x3xf32>>
+  }
+
+  // CHECK: func @matmul_secret_secret
+  func.func @matmul_secret_secret(%arg0: !secret.secret<tensor<3x5xf32>>, %arg1: !secret.secret<tensor<5x2xf32>>) -> !secret.secret<tensor<3x2xf32>> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<3x2xf32>
+    %0 = secret.generic(%arg0: !secret.secret<tensor<3x5xf32>>, %arg1: !secret.secret<tensor<5x2xf32>>) {
+    ^body(%input0: tensor<3x5xf32>, %input1: tensor<5x2xf32>):
+      // CHECK: linalg.matmul
+      // CHECK-SAME: #secret.kernel<name = "MatmulBicyclic"
+      %1 = linalg.matmul ins(%input0, %input1 : tensor<3x5xf32>, tensor<5x2xf32>) outs(%cst : tensor<3x2xf32>) -> tensor<3x2xf32>
+      secret.yield %1 : tensor<3x2xf32>
+    } -> !secret.secret<tensor<3x2xf32>>
+    return %0 : !secret.secret<tensor<3x2xf32>>
   }
 }


### PR DESCRIPTION
This PR adds bicyclic matmul to layout pipeline

Minor fixes:
- ensure secretness lattice is updated if convert-layout is inserted
  mid-pass
- cleanup of Codegen.cpp and support for floordiv op

Left for next PR: adding e2e test of the full matmul op

Open question: is there a meaningful convert-layout hoister for bicyclic matmul? Otherwise I feel that layout conversions will never be naturally hoisted through it by the heuristic.

Rebased over https://github.com/google/heir/pull/2359
Part of https://github.com/google/heir/issues/1376