### PR TITLE
Add BSGS support for bicyclic matmul

### DIFF
--- a/lib/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/lib/Dialect/TensorExt/IR/TensorExtOps.td
@@ -150,30 +150,27 @@ def TensorExt_RotateAndReduceOp : TensorExt_Op<"rotate_and_reduce",[Pure, AllTyp
 
     In almost full generality, the reduction performed is
 
-    \[
-      \sum_{i \in [0, n]} p(P, T*i) \cdot rotate(v, T*i)
-    \]
+    $$ \sum_{i \in [0, n]} p(P, iT) \cdot rotate(v, iT) $$
 
-    where $f$ is a function, $p(P, T*i)$ is a function of a plaintext $P$ and
-    $rotate(v, T*i)$ is a rotation of the ciphertext $v$ with period $T$. The
+    where $f$ is a function, $p(P, iT)$ is a function of a plaintext $P$ and
+    $rotate(v, iT)$ is a rotation of the ciphertext $v$ with period $T$. The
     operation takes as input the ciphertext vector $v$, the period $T$, the
-    number of reductions $n$, and a tensor of plaintext values `[p(P, 0), p(P,
-    T), ..., p(P, T*(n-1))]`.
+    number of reductions $n$, and a tensor of plaintext values
+
+    `[p(P, 0), p(P, T), ..., p(P, (n-1)T)]`
 
     This can be used to implement a matrix vector product that uses a
     Halevi-Shoup diagonalization of the plaintext matrix. In this case, the
     reduction is
 
-    \[
-      \sum_{i \in [0, n]} P(i) \cdot rotate(v, i)
-    \]
+    $$ \sum_{i \in [0, n]} P(i) \cdot rotate(v, i) $$
 
     where $P(i)$ is the $i$th diagonal of the plaintext matrix and the period
     $T$ is $1$.
 
     An accumulation of the ciphertext slots is also handled via this operation
-    by omitting the plaintext $p(P, T*i)$ argument and using a period of 1 with
-    `n = |v|` so that the reduction is simply a sum of all rotation of the
+    by omitting the plaintext $p(P, Ti)$ argument and using a period of 1 with
+    `n = |v|` so that the reduction is simply a sum of all rotations of the
     ciphertext.
 
     If `reduceOp` is set to an MLIR operation name (e.g., `arith.mulf`), then

--- a/lib/Kernel/BUILD
+++ b/lib/Kernel/BUILD
@@ -111,6 +111,7 @@ cc_test(
         ":ArithmeticDag",
         ":Kernel",
         ":KernelImplementation",
+        ":RotationCountVisitor",
         ":TestingUtils",
         "@googletest//:gtest_main",
         "@heir//lib/Utils/Layout:Evaluate",

--- a/lib/Kernel/RotationCountVisitor.h
+++ b/lib/Kernel/RotationCountVisitor.h
@@ -21,7 +21,7 @@ class RotationCountVisitor {
  public:
   using NodeTy = ArithmeticDagNode<SymbolicValue>;
 
-  RotationCountVisitor() {}
+  RotationCountVisitor() = default;
 
   // Main entry point - counts rotations in the DAG
   int64_t process(const std::shared_ptr<NodeTy>& node);


### PR DESCRIPTION
This PR adds baby-step-giant-step support for the bicyclic matmul kernel, as per 6.2.2 of https://eprint.iacr.org/2025/1200 and https://github.com/google/heir/pull/2359#issuecomment-3474016620

It does so by extracting the subset of the "rotate and reduce" kernel that implements the BSGS routine into a separate helper, which is sufficiently generalized to express the bicyclic matmul variant of BSGS. This is two steps:

- Adding the ability to have just one "plaintext" operand (which is renamed to the "babySteppedOperand") instead of a tensor of plaintexts that is extracted from.
- Adding a callback that computes the actual rotation to use for the baby stepped operand, which is different in bicyclic matmul than in the simpler rotate-and-reduce case.

[EDIT]: the stuff below was the issue I was seeing before I found #2162 again which has suggestions for what to do to fix the issue.

I did notice that for the test I ran, for `n=124` the actual number of rotations is `158`, while the predicted formula of `n + 2sqrt(n) - 3` gives 143 rotations. 158 is closer to `n + 3 sqrt(n)` than the other formula. This led me to run the kernel for a range of dimension sizes (x, x+1, x+2) for x odd, and I got this chart

<img width="705" height="426" alt="image" src="https://github.com/user-attachments/assets/0112cce4-e667-4c4e-bcf4-11bd219aba54" />

Note troughs seem to line up with the claimed bound in the paper, but the peaks are decently close to `3n/2`, which seems like a bug in my code. A concrete example that exhibits this behavior is `n=133, m=134, p=135`

I don't have time to dig in before the weekend, so posting in case anyone has a chance to look over it before I return to work Monday.