### PR TITLE
Address performance of secret-insert-mgmt passes

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -29,7 +29,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/MODULE.bazel": "655c922ab1209978a94ef6ca7d9d43e940cd97d9c172fb55f94d91ac53f8610b",
     "https://bcr.bazel.build/modules/apple_support/1.22.1/MODULE.bazel": "90bd1a660590f3ceffbdf524e37483094b29352d85317060b2327fff8f3f4458",
-    "https://bcr.bazel.build/modules/apple_support/1.22.1/source.json": "2bc34da8d0ebc4c4132c8b26db766ca1b86bbcf26dea94b94aa1cd73e2623aeb",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
@@ -659,37 +660,6 @@
           }
         },
         "recordedRepoMappingEntries": []
-      }
-    },
-    "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "mmhYNTDXSgOxxt10eW/y1OjZejj+dhGDm+f1IMfBlzE=",
-        "usagesDigest": "jV6RHO9M/PRW7uPa+YycFZ6S8jForGaJ28iIsh76EDU=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_apple_cc_toolchains": {
-            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf_toolchains",
-            "attributes": {}
-          },
-          "local_config_apple_cc": {
-            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "apple_support+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "bazel_tools",
-            "rules_cc",
-            "rules_cc+"
-          ]
-        ]
       }
     },
     "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -35,6 +35,9 @@ class LevelState {
     assert(isInitialized());
     return level.value();
   }
+  void setLevel(LevelType value) {
+    level = std::make_optional<LevelType>(value);
+  }
   LevelType get() const { return getLevel(); }
 
   bool operator==(const LevelState& rhs) const { return level == rhs.level; }
@@ -117,6 +120,9 @@ class LevelAnalysis
     propagateIfChanged(state, changed);
   }
 };
+
+FailureOr<int64_t> deriveResultLevel(Operation* op,
+                                     ArrayRef<const LevelLattice*> operands);
 
 /// Backward Analyse the level of plaintext Value
 ///

--- a/lib/Analysis/MulDepthAnalysis/MulDepthAnalysis.h
+++ b/lib/Analysis/MulDepthAnalysis/MulDepthAnalysis.h
@@ -37,6 +37,10 @@ class MulDepthState {
     return mulDepth.value();
   }
 
+  void setMulDepth(int64_t depth) {
+    mulDepth = std::make_optional<int64_t>(depth);
+  }
+
   bool operator==(const MulDepthState& rhs) const {
     return mulDepth == rhs.mulDepth;
   }
@@ -101,6 +105,9 @@ class MulDepthAnalysis
     propagateIfChanged(state, changed);
   }
 };
+
+FailureOr<int64_t> deriveResultMulDepth(
+    Operation* op, ArrayRef<const MulDepthLattice*> operands);
 
 int64_t getMaxMulDepth(Operation* op, DataFlowSolver& solver);
 

--- a/lib/Transforms/SecretInsertMgmt/BUILD
+++ b/lib/Transforms/SecretInsertMgmt/BUILD
@@ -17,8 +17,42 @@ cc_library(
         "Passes.h",
     ],
     deps = [
+        ":Pipeline",
         ":SecretInsertMgmtPatterns",
         ":pass_inc_gen",
+        "@heir//lib/Analysis/LevelAnalysis",
+        "@heir//lib/Analysis/MulDepthAnalysis",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Mgmt/Transforms",
+        "@heir//lib/Dialect/Mgmt/Transforms:AnnotateMgmt",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "Pipeline",
+    srcs = [
+        "Pipeline.cpp",
+        "Pipeline.h",
+    ],
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":SecretInsertMgmtPatterns",
         "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/MulDepthAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",

--- a/lib/Transforms/SecretInsertMgmt/Pipeline.cpp
+++ b/lib/Transforms/SecretInsertMgmt/Pipeline.cpp
@@ -1,0 +1,178 @@
+#include "lib/Transforms/SecretInsertMgmt/Pipeline.h"
+
+#include <utility>
+
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Analysis/MulDepthAnalysis/MulDepthAnalysis.h"
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h"
+#include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"             // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+#define DEBUG_TYPE "secret-insert-mgmt"
+
+namespace mlir {
+namespace heir {
+
+LogicalResult runInsertMgmtPipeline(Operation* top,
+                                    const InsertMgmtPipelineOptions& options) {
+  DataFlowSolver solver;
+  dataflow::loadBaselineAnalyses(solver);
+  solver.load<SecretnessAnalysis>();
+  solver.load<LevelAnalysis>();
+  solver.load<MulDepthAnalysis>();
+
+  if (failed(solver.initializeAndRun(top))) {
+    top->emitOpError() << "Failed to run the analysis.\n";
+    return failure();
+  }
+
+  insertMgmtInitForPlaintexts(top, solver, options.includeFloats);
+  insertModReduceBeforeOrAfterMult(top, solver, options.modReduceAfterMul,
+                                   options.modReduceBeforeMulIncludeFirstMul,
+                                   options.includeFloats);
+  rerunDataflow(solver, top);
+
+  // this must be run after ModReduceAfterMult
+  insertRelinearizeAfterMult(top, solver, options.includeFloats);
+  rerunDataflow(solver, top);
+
+  // insert BootstrapOp after mgmt::ModReduceOp
+  // This must be run before level mismatch
+  // NOTE: actually bootstrap before mod reduce is better
+  // as after modreduce to level `0` there still might be add/sub
+  // and these op done there could be minimal cost.
+  // However, this greedy strategy is temporary so not too much
+  // optimization now
+  if (options.bootstrapWaterline.has_value()) {
+    insertBootstrapWaterLine(top, solver, options.bootstrapWaterline.value());
+    rerunDataflow(solver, top);
+  }
+
+  int idCounter = 0;  // for making adjust_scale op different to avoid cse
+  handleCrossLevelOps(top, solver, &idCounter, options.includeFloats);
+  rerunDataflow(solver, top);
+  handleCrossMulDepthOps(top, solver, &idCounter, options.includeFloats);
+  return success();
+}
+
+void rerunDataflow(DataFlowSolver& solver, Operation* top) {
+  LLVM_DEBUG(llvm::dbgs() << "Re-running dataflow\n");
+  solver.eraseAllStates();
+  (void)solver.initializeAndRun(top);
+}
+
+void insertMgmtInitForPlaintexts(Operation* top, DataFlowSolver& solver,
+                                 bool includeFloats) {
+  MLIRContext* ctx = top->getContext();
+  LLVM_DEBUG(llvm::dbgs() << "Insert Mgmt Init for Plaintext Operands\n");
+
+  RewritePatternSet patterns(ctx);
+  patterns.add<UseInitOpForPlaintextOperand<arith::AddIOp>,
+               UseInitOpForPlaintextOperand<arith::SubIOp>,
+               UseInitOpForPlaintextOperand<arith::MulIOp>,
+               UseInitOpForPlaintextOperand<tensor::ExtractSliceOp>,
+               UseInitOpForPlaintextOperand<tensor::InsertSliceOp>>(ctx, top,
+                                                                    &solver);
+
+  if (includeFloats) {
+    patterns.add<UseInitOpForPlaintextOperand<arith::AddFOp>,
+                 UseInitOpForPlaintextOperand<arith::SubFOp>,
+                 UseInitOpForPlaintextOperand<arith::MulFOp>>(ctx, top,
+                                                              &solver);
+  }
+
+  (void)walkAndApplyPatterns(top, std::move(patterns));
+}
+
+void insertModReduceBeforeOrAfterMult(Operation* top, DataFlowSolver& solver,
+                                      bool afterMul,
+                                      bool beforeMulIncludeFirstMul,
+                                      bool includeFloats) {
+  MLIRContext* ctx = top->getContext();
+  LLVM_DEBUG(llvm::dbgs() << "Insert ModReduce Before/After Mult\n");
+
+  RewritePatternSet patterns(ctx);
+  if (afterMul) {
+    patterns.add<ModReduceAfterMult<arith::MulIOp>>(ctx, top, &solver);
+    if (includeFloats)
+      patterns.add<ModReduceAfterMult<arith::MulFOp>>(ctx, top, &solver);
+  } else {
+    patterns.add<ModReduceBefore<arith::MulIOp>>(ctx, beforeMulIncludeFirstMul,
+                                                 top, &solver);
+    if (includeFloats)
+      patterns.add<ModReduceBefore<arith::MulFOp>>(
+          ctx, beforeMulIncludeFirstMul, top, &solver);
+    // includeFirstMul = false here
+    // as before yield we only want mulResult to be mod reduced
+    patterns.add<ModReduceBefore<secret::YieldOp>>(
+        ctx, /*includeFirstMul*/ false, top, &solver);
+  }
+  (void)walkAndApplyPatterns(top, std::move(patterns));
+}
+
+void insertRelinearizeAfterMult(Operation* top, DataFlowSolver& solver,
+                                bool includeFloats) {
+  MLIRContext* ctx = top->getContext();
+  LLVM_DEBUG(llvm::dbgs() << "Insert Relinearize After Mult\n");
+  RewritePatternSet patterns(ctx);
+  patterns.add<MultRelinearize<arith::MulIOp>>(ctx, top, &solver);
+  if (includeFloats)
+    patterns.add<MultRelinearize<arith::MulFOp>>(ctx, top, &solver);
+  (void)walkAndApplyPatterns(top, std::move(patterns));
+}
+
+void handleCrossLevelOps(Operation* top, DataFlowSolver& solver, int* idCounter,
+                         bool includeFloats) {
+  MLIRContext* ctx = top->getContext();
+  LLVM_DEBUG(llvm::dbgs() << "Handle Cross Level Ops\n");
+  RewritePatternSet patterns(ctx);
+  patterns.add<MatchCrossLevel<arith::AddIOp>, MatchCrossLevel<arith::SubIOp>,
+               MatchCrossLevel<arith::MulIOp>>(ctx, idCounter, top, &solver);
+  if (includeFloats)
+    patterns.add<MatchCrossLevel<arith::AddFOp>, MatchCrossLevel<arith::SubFOp>,
+                 MatchCrossLevel<arith::MulFOp>>(ctx, idCounter, top, &solver);
+  (void)walkAndApplyPatterns(top, std::move(patterns));
+}
+
+// this only happen for before-mul but not include-first-mul case
+// at the first level, a Value can be both mulResult or not mulResult
+// we should match their scale by adding one adjust scale op
+void handleCrossMulDepthOps(Operation* top, DataFlowSolver& solver,
+                            int* idCounter, bool includeFloats) {
+  MLIRContext* ctx = top->getContext();
+  LLVM_DEBUG(llvm::dbgs() << "Handle Cross MulDepth Ops\n");
+  RewritePatternSet patterns(ctx);
+  patterns
+      .add<MatchCrossMulDepth<arith::AddIOp>, MatchCrossMulDepth<arith::SubIOp>,
+           MatchCrossMulDepth<arith::MulIOp>>(ctx, idCounter, top, &solver);
+  if (includeFloats)
+    patterns.add<MatchCrossMulDepth<arith::AddFOp>,
+                 MatchCrossMulDepth<arith::SubFOp>,
+                 MatchCrossMulDepth<arith::MulFOp>>(ctx, idCounter, top,
+                                                    &solver);
+  (void)walkAndApplyPatterns(top, std::move(patterns));
+}
+
+void insertBootstrapWaterLine(Operation* top, DataFlowSolver& solver,
+                              int bootstrapWaterline) {
+  MLIRContext* ctx = top->getContext();
+  LLVM_DEBUG(llvm::dbgs() << "Insert Bootstrap at Water Line\n");
+
+  RewritePatternSet patterns(ctx);
+  patterns.add<BootstrapWaterLine<mgmt::ModReduceOp>>(ctx, top, &solver,
+                                                      bootstrapWaterline);
+  (void)walkAndApplyPatterns(top, std::move(patterns));
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/SecretInsertMgmt/Pipeline.h
+++ b/lib/Transforms/SecretInsertMgmt/Pipeline.h
@@ -1,0 +1,53 @@
+#ifndef LIB_TRANSFORMS_SECRETINSERTMGMT_PIPELINE_H_
+#define LIB_TRANSFORMS_SECRETINSERTMGMT_PIPELINE_H_
+
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+struct InsertMgmtPipelineOptions {
+  bool includeFloats;
+  bool modReduceAfterMul;
+  bool modReduceBeforeMulIncludeFirstMul;
+  std::optional<int64_t> bootstrapWaterline;
+};
+
+// Run the secret-insert-mgmt pipeline.
+//
+// If includeFloats is true, then patterns will be included for arith.*f ops
+// instead of just arith.*i ops.
+//
+// If bootstrapWaterline is present, a step of the pipeline will include a
+// waterline bootstrap insertion routine.
+LogicalResult runInsertMgmtPipeline(Operation* top,
+                                    const InsertMgmtPipelineOptions& options);
+
+void rerunDataflow(DataFlowSolver& solver, Operation* top);
+
+void insertMgmtInitForPlaintexts(Operation* top, DataFlowSolver& solver,
+                                 bool includeFloats);
+
+void insertModReduceBeforeOrAfterMult(Operation* top, DataFlowSolver& solver,
+                                      bool afterMul,
+                                      bool beforeMulIncludeFirstMul,
+                                      bool includeFloats);
+
+void insertRelinearizeAfterMult(Operation* top, DataFlowSolver& solver,
+                                bool includeFloats);
+
+void handleCrossLevelOps(Operation* top, DataFlowSolver& solver, int* idCounter,
+                         bool includeFloats);
+
+void handleCrossMulDepthOps(Operation* top, DataFlowSolver& solver,
+                            int* idCounter, bool includeFloats);
+
+void insertBootstrapWaterLine(Operation* top, DataFlowSolver& solver,
+                              int bootstrapWaterline);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_SECRETINSERTMGMT_PIPELINE_H_

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
@@ -1,33 +1,15 @@
-#include <cstdint>
-#include <iterator>
-#include <utility>
-
-#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
-#include "lib/Analysis/MulDepthAnalysis/MulDepthAnalysis.h"
-#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
-#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
 #include "lib/Dialect/Mgmt/Transforms/Passes.h"
 #include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
-#include "lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h"
-#include "llvm/include/llvm/ADT/STLExtras.h"   // from @llvm-project
-#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
-#include "mlir/include/mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"  // from @llvm-project
-#include "mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h"  // from @llvm-project
-#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
-#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"        // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"             // from @llvm-project
-#include "mlir/include/mlir/IR/Diagnostics.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"             // from @llvm-project
-#include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
-#include "mlir/include/mlir/Transforms/Passes.h"           // from @llvm-project
-#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+#include "lib/Transforms/SecretInsertMgmt/Pipeline.h"
+#include "llvm/include/llvm/Support/Debug.h"      // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"       // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+#define DEBUG_TYPE "secret-insert-mgmt-ckks"
 
 namespace mlir {
 namespace heir {
@@ -53,99 +35,19 @@ struct SecretInsertMgmtCKKS
     // Helper for future lowerings that want to know what scheme was used
     moduleSetCKKS(getOperation());
 
-    DataFlowSolver solver;
-    solver.load<dataflow::DeadCodeAnalysis>();
-    solver.load<dataflow::SparseConstantPropagation>();
-    solver.load<SecretnessAnalysis>();
-    solver.load<LevelAnalysis>();
-    solver.load<MulDepthAnalysis>();
+    InsertMgmtPipelineOptions options;
+    options.includeFloats = true;
+    options.modReduceAfterMul = afterMul;
+    options.modReduceBeforeMulIncludeFirstMul = beforeMulIncludeFirstMul;
+    options.bootstrapWaterline = bootstrapWaterline;
+    LogicalResult result = runInsertMgmtPipeline(getOperation(), options);
 
-    if (failed(solver.initializeAndRun(getOperation()))) {
-      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+    if (failed(result)) {
       signalPassFailure();
       return;
     }
 
-    // handle plaintext operands
-    RewritePatternSet patternsPlaintext(&getContext());
-    patternsPlaintext.add<UseInitOpForPlaintextOperand<arith::AddIOp>,
-                          UseInitOpForPlaintextOperand<arith::SubIOp>,
-                          UseInitOpForPlaintextOperand<arith::MulIOp>,
-                          UseInitOpForPlaintextOperand<arith::AddFOp>,
-                          UseInitOpForPlaintextOperand<arith::SubFOp>,
-                          UseInitOpForPlaintextOperand<arith::MulFOp>,
-                          UseInitOpForPlaintextOperand<tensor::ExtractSliceOp>,
-                          UseInitOpForPlaintextOperand<tensor::InsertSliceOp>>(
-        &getContext(), getOperation(), &solver);
-    (void)walkAndApplyPatterns(getOperation(), std::move(patternsPlaintext));
-
-    if (afterMul) {
-      RewritePatternSet patternsMultModReduce(&getContext());
-      patternsMultModReduce.add<ModReduceAfterMult<arith::MulIOp>,
-                                ModReduceAfterMult<arith::MulFOp>>(
-          &getContext(), getOperation(), &solver);
-      (void)walkAndApplyPatterns(getOperation(),
-                                 std::move(patternsMultModReduce));
-    } else {
-      RewritePatternSet patternsMultModReduce(&getContext());
-      patternsMultModReduce
-          .add<ModReduceBefore<arith::MulIOp>, ModReduceBefore<arith::MulFOp>>(
-              &getContext(), beforeMulIncludeFirstMul, getOperation(), &solver);
-      // includeFirstMul = false here
-      // as before yield we only want mulResult to be mod reduced
-      patternsMultModReduce.add<ModReduceBefore<secret::YieldOp>>(
-          &getContext(), /*includeFirstMul*/ false, getOperation(), &solver);
-      (void)walkAndApplyPatterns(getOperation(),
-                                 std::move(patternsMultModReduce));
-    }
-
-    // this must be run after ModReduceAfterMult
-    RewritePatternSet patternsRelinearize(&getContext());
-    patternsRelinearize
-        .add<MultRelinearize<arith::MulIOp>, MultRelinearize<arith::MulFOp>>(
-            &getContext(), getOperation(), &solver);
-    (void)walkAndApplyPatterns(getOperation(), std::move(patternsRelinearize));
-
-    // insert BootstrapOp after mgmt::ModReduceOp
-    // This must be run before level mismatch
-    // NOTE: actually bootstrap before mod reduce is better
-    // as after modreduce to level `0` there still might be add/sub
-    // and these op done there could be minimal cost.
-    // However, this greedy strategy is temporary so not too much
-    // optimization now
-    RewritePatternSet patternsBootstrapWaterLine(&getContext());
-    patternsBootstrapWaterLine.add<BootstrapWaterLine<mgmt::ModReduceOp>>(
-        &getContext(), getOperation(), &solver, bootstrapWaterline);
-    (void)walkAndApplyPatterns(getOperation(),
-                               std::move(patternsBootstrapWaterLine));
-
-    // when other binary op operands level mismatch
-    //
-    // See also MatchCrossLevel documentation
-    int idCounter = 0;  // for making adjust_scale op different to avoid cse
-    RewritePatternSet patternsAddModReduce(&getContext());
-    patternsAddModReduce
-        .add<MatchCrossLevel<arith::AddIOp>, MatchCrossLevel<arith::SubIOp>,
-             MatchCrossLevel<arith::MulIOp>, MatchCrossLevel<arith::AddFOp>,
-             MatchCrossLevel<arith::SubFOp>, MatchCrossLevel<arith::MulFOp>>(
-            &getContext(), &idCounter, getOperation(), &solver);
-    (void)walkAndApplyPatterns(getOperation(), std::move(patternsAddModReduce));
-
-    // when other binary op operands mulDepth mismatch
-    // this only happen for before-mul but not include-first-mul case
-    // at the first level, a Value can be both mulResult or not mulResult
-    // we should match their scale by adding one adjust scale op
-    //
-    // See also MatchCrossMulDepth documentation
-    if (!beforeMulIncludeFirstMul && !afterMul) {
-      RewritePatternSet patternsMulDepth(&getContext());
-      patternsMulDepth.add<
-          MatchCrossMulDepth<arith::MulIOp>, MatchCrossMulDepth<arith::AddIOp>,
-          MatchCrossMulDepth<arith::SubIOp>, MatchCrossMulDepth<arith::MulFOp>,
-          MatchCrossMulDepth<arith::AddFOp>, MatchCrossMulDepth<arith::SubFOp>>(
-          &getContext(), &idCounter, getOperation(), &solver);
-      (void)walkAndApplyPatterns(getOperation(), std::move(patternsMulDepth));
-    }
+    LLVM_DEBUG(llvm::dbgs() << "Post secret-insert-mgmt pipeline cleanup\n");
 
     // 1. Canonicalizer reorders mgmt ops like Rescale/LevelReduce/AdjustScale.
     //    This is important for AnnotateMgmt.

--- a/tests/Regression/BUILD
+++ b/tests/Regression/BUILD
@@ -6,5 +6,10 @@ glob_lit_tests(
     name = "all_tests",
     data = ["@heir//tests:test_utilities"],
     driver = "@heir//tests:run_lit.sh",
+    tags_override = {
+        "issue_2384.mlir": [
+            "nofastbuild",
+        ],
+    },
     test_file_exts = ["mlir"],
 )


### PR DESCRIPTION
Improves the runtime of `secret-insert-mgmt-*` passes by avoiding the need to re-run the data flow solver after each pattern.

Instead of clearing all solver analysis states at the end of the pattern and re-running, it manually sets the relevant solver state of the result of the op under consideration. This works because the patterns are all run via `walkAndApplyPatterns`, so the next operation visited will have to have all its operands handled by previous steps in the walk. Then, at the end of each walk, I re-run the data flow analysis so the next walk has fresh data for everything.

This should be a nonfunctional change with regards to the logic of `insert-mgmt`. But to keep the manual state-setting code consistent across all the variants of this pass and other uses of the same analyses, I refactored the passes into a "pipeline" helper, and refactored the analysis visitor logic into standalone functions that could be called outside of the DataFlow framework.

After the changes, the execution time report for the reproducer in #2384 is

```
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 4.9360 seconds

  ----Wall Time----  ----Name----
    0.0127 (  0.3%)  Parser
    ...
    0.7847 ( 15.9%)  LayoutPropagation
    1.5731 ( 31.9%)  LayoutOptimization
    0.1531 (  3.1%)  ConvertToCiphertextSemantics
    0.0092 (  0.2%)  ApplyFolders
    0.6836 ( 13.8%)  Canonicalizer
    ...
    0.2633 (  5.3%)  SecretInsertMgmtCKKS
    ...
    0.7725 ( 15.7%)  SecretDistributeGeneric
    4.9360 (100.0%)  Total
```

Note that the test is still failing due to requiring https://github.com/google/heir/pull/2390

Fixes https://github.com/google/heir/issues/2384