### PR TITLE
Improve Chebyshev Paterson-Stockmeyer evaluation

### DIFF
--- a/lib/Utils/Polynomial/BUILD
+++ b/lib/Utils/Polynomial/BUILD
@@ -117,3 +117,16 @@ cc_test(
         "@heir//lib/Kernel:ArithmeticDag",
     ],
 )
+
+cc_test(
+    name = "ChebyshevPatersonStockmeyerFuzzTest",
+    srcs = ["ChebyshevPatersonStockmeyerFuzzTest.cpp"],
+    deps = [
+        ":ChebyshevPatersonStockmeyer",
+        ":PolynomialTestVisitors",
+        "@fuzztest//fuzztest",
+        "@googletest//:gtest_main",
+        "@heir//lib/Kernel:AbstractValue",
+        "@heir//lib/Kernel:ArithmeticDag",
+    ],
+)

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h
@@ -2,6 +2,7 @@
 #define LIB_UTILS_POLYNOMIAL_CHEBYSHEVPATERSONSTOCKMEYER_H_
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -10,7 +11,6 @@
 
 #include "lib/Kernel/AbstractValue.h"
 #include "lib/Kernel/ArithmeticDag.h"
-#include "lib/Kernel/KernelImplementation.h"
 #include "lib/Utils/Polynomial/ChebyshevDecomposition.h"
 #include "llvm/include/llvm/ADT/ArrayRef.h"  // from @llvm-project
 
@@ -21,6 +21,76 @@ namespace polynomial {
 // The minimum absolute value of a coefficient to be considered in the
 // evaluation of the Chebyshev polynomial.
 constexpr double kMinCoeffs = 1e-15;
+
+// A C++ port of Lattigo's `bignum.OptimalSplit` function. This function
+// determines the optimal split point for the Paterson-Stockmeyer algorithm by
+// calculating the number of multiplications for two possible split points and
+// choosing the better one.
+//
+// Warning: this function expresses a particular cost model counting
+// multiplications when choosing two splits of the baby-step giant-step
+// algorithm. However, it's not obviously clear how the calculations below
+// correspond to counting multiplications, and the original author communicated
+// to me (j2kun) that he doesn't remember exactly what he did here. However, he
+// suspects the cost model was not perfect, and while I confirmed this was more
+// optimal than what HEIR was doing earlier for a variety of test polynomials,
+// we would welcome contributions to clarify the existing method, understand
+// where it may fall short, and improve it.
+//
+// Args:
+//   logDegree: std::bit_width(degree) of the polynomial degree (matching
+//   golang's bits.Len64)
+//
+// Returns:
+//   The log2 of the optimal split parameter.
+inline int64_t optimalSplit(int64_t logDegree) {
+  int64_t logSplit = logDegree >> 1;
+  int64_t a = (1LL << logSplit) + (1LL << (logDegree - logSplit)) + logDegree -
+              logSplit - 3;
+  int64_t b = (1LL << (logSplit + 1)) + (1LL << (logDegree - logSplit - 1)) +
+              logDegree - logSplit - 4;
+  if (a > b) {
+    logSplit += 1;
+  }
+  return logSplit;
+}
+
+// Returns a + b = n such that |a-b| is minimized.
+//
+// For Chebyshev basis, tries to keep a and/or b odd if possible to
+// maximize the number of odd terms.
+//
+// Based on [Lee et al. 2020]: High-Precision and Low-Complexity Approximate
+// Homomorphic Encryption by Error Variance Minimization
+//
+// Args:
+//   n: The degree to split
+//
+// Returns:
+//   Pair (a, b) where a + b = n and |a-b| is minimized
+inline std::pair<int64_t, int64_t> splitDegree(int64_t n) {
+  if (n <= 0) {
+    throw std::invalid_argument("n should be greater than zero");
+  }
+
+  // Check if n is a power of 2
+  if ((n & (n - 1)) == 0) {
+    // Necessary for optimal depth
+    return {n / 2, n / 2};
+  } else {
+    // [Lee et al. 2020] : Maximize the number of odd terms of Chebyshev basis
+    // Find k = floor(log2(n-1))
+    int64_t k = 0;
+    int64_t temp = n - 1;
+    while (temp > 1) {
+      temp >>= 1;
+      k++;
+    }
+    int64_t a = (1LL << k) - 1;
+    int64_t b = n - a;
+    return {a, b};
+  }
+}
 
 // Computes Arithmetic DAGs of x^0, x^1, ..., x^k.
 // The multiplicative depth is ceil(log2(k)).
@@ -44,6 +114,94 @@ std::vector<std::shared_ptr<kernel::ArithmeticDagNode<T>>> computePowers(
     }
   }
   return result;
+}
+
+// Recursively computes T_n(x) for the Chebyshev polynomial T_n.
+//
+// Uses the recurrence relation for Chebyshev polynomials:
+// T_n(x) = 2*T_a(x)*T_b(x) - T_c(x)
+// where n = a+b and c = |a-b|
+//
+// Args:
+//   x: The input node representing the variable
+//   n: The degree of the Chebyshev polynomial to compute
+//   cache: Map caching already computed powers
+//
+// Returns:
+//   Node representing T_n(x)
+template <typename T>
+std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
+    std::shared_ptr<kernel::ArithmeticDagNode<T>> x, int64_t n,
+    std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>>& cache) {
+  using NodeTy = kernel::ArithmeticDagNode<T>;
+
+  // Check cache
+  auto it = cache.find(n);
+  if (it != cache.end()) {
+    return it->second;
+  }
+
+  if (n == 0) {
+    // T_0(x) = 1
+    cache[0] = NodeTy::constantScalar(1);
+    return cache[0];
+  }
+
+  if (n == 1) {
+    // T_1(x) = x
+    cache[1] = x;
+    return x;
+  }
+
+  // Split the degree optimally
+  auto [a, b] = splitDegree(n);
+
+  // Compute T_n(x) = T_a(x) * T_b(x)
+  auto tA = genChebyshevPowerRecursive(x, a, cache);
+  auto tB = genChebyshevPowerRecursive(x, b, cache);
+  auto tN = NodeTy::mul(tA, tB);
+
+  // Apply Chebyshev recurrence: T_n = 2*T_a*T_b - T_c
+  // where c = |a - b|
+  int64_t c = std::abs(a - b);
+  auto two = NodeTy::constantScalar(2);
+  tN = NodeTy::mul(two, tN);
+
+  // Compute T_n = 2*T_a*T_b - T_c
+  if (c == 0) {
+    // T_0 = 1, so subtract 1
+    tN = NodeTy::sub(tN, NodeTy::constantScalar(1));
+  } else {
+    auto tC = genChebyshevPowerRecursive(x, c, cache);
+    tN = NodeTy::sub(tN, tC);
+  }
+
+  // Cache the result
+  cache[n] = tN;
+  return tN;
+}
+
+// Generates Chebyshev polynomials T_0(x), T_1(x), ..., T_maxDegree(x).
+//
+// Args:
+//   x: The input node
+//   maxDegree: Maximum degree to compute
+//
+// Returns:
+//   Map from degree to Node representing T_degree(x)
+template <typename T>
+std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>>
+genChebyshevPowersRecursive(std::shared_ptr<kernel::ArithmeticDagNode<T>> x,
+                            int64_t maxDegree) {
+  std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>> cache;
+
+  // Generate all powers up to maxDegree
+  for (int64_t i = 1; i <= maxDegree; i++) {
+    genChebyshevPowerRecursive(x, i, cache);
+  }
+
+  cache[0] = kernel::ArithmeticDagNode<T>::constantScalar(1);
+  return cache;
 }
 
 // Computes Arithmetic DAGs of T_0(x), T_1(x), ..., T_k(x), where T_i are
@@ -98,55 +256,97 @@ patersonStockmeyerChebyshevPolynomialEvaluation(
     double minCoeffThreshold = kMinCoeffs) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
   int64_t polynomialDegree = coefficients.size() - 1;
-  // Choose k optimally - sqrt of maxDegree is typically a good choice
-  int64_t k =
-      std::max(static_cast<int64_t>(std::ceil(std::sqrt(polynomialDegree))),
-               static_cast<int64_t>(1));
+  if (polynomialDegree < 0) {
+    return nullptr;
+  }
 
-  // Decompose p = coeffs[0] + coeffs[1]*T_k + coeffs[2]*T_k^2 + ... +
-  // coeffs[l]*T_k^l.
+  if (polynomialDegree == 0) {
+    if (std::abs(coefficients[0]) < minCoeffThreshold) {
+      return nullptr;
+    }
+    return NodeTy::constantScalar(coefficients[0]);
+  }
+
+  // Choose k optimally using Lattigo's optimal split
+  int64_t logDegree = std::bit_width(static_cast<uint64_t>(polynomialDegree));
+  int64_t logSplit = optimalSplit(logDegree);
+  int64_t k = 1LL << logSplit;
+
+  // Decompose p = p_0 + p_1 T_k + p_2 T_k^2 + ... + p_l T_k^l,
+  // where each p_i is a Chebyshev polynomial of degree < k.
   polynomial::ChebyshevDecomposition decomposition =
       polynomial::decompose(coefficients, k);
 
-  // Precompute T_0(x), T_1(x), ..., T_k(x).
-  std::vector<std::shared_ptr<NodeTy>> chebPolynomialValues =
-      computeChebyshevPolynomialValues(x, k);
+  // Precompute T_0(x), T_1(x), ..., T_k(x) using recursive approach.
+  auto xNode = NodeTy::leaf(x);
+  auto chebPolynomialValuesMap = genChebyshevPowersRecursive(xNode, k);
 
-  // Precompute (T_k(x))^0, (T_k(x))^1, ..., (T_k(x))^l.
-  int64_t l = decomposition.coeffs.size() - 1;
-  std::vector<std::shared_ptr<NodeTy>> chebKPolynomialPowers =
-      computePowers(chebPolynomialValues.back(), l);
-
-  // Evaluate the polynomial.
-  std::shared_ptr<NodeTy> result;
-  for (int i = 0; i < decomposition.coeffs.size(); ++i) {
-    if (!hasElementsLargerThan(decomposition.coeffs[i], minCoeffThreshold))
+  // Evaluate the baby steps and save them in a list.
+  std::vector<std::shared_ptr<NodeTy>> babySteps;
+  for (const auto& coeffs : decomposition.coeffs) {
+    if (!hasElementsLargerThan(coeffs, minCoeffThreshold)) {
+      babySteps.push_back(nullptr);
       continue;
-    std::shared_ptr<NodeTy> pol;
-    for (int j = 0; j < decomposition.coeffs[i].size(); ++j) {
-      double coeff = decomposition.coeffs[i][j];
-      // Skip coefficients that are too small.
-      if (std::abs(coeff) < minCoeffThreshold) continue;
+    }
 
-      auto coefNode = NodeTy::constantScalar(coeff);
-      auto termNode = NodeTy::mul(coefNode, chebPolynomialValues[j]);
+    std::shared_ptr<NodeTy> pol;
+    for (size_t j = 0; j < coeffs.size(); ++j) {
+      if (std::abs(coeffs[j]) < minCoeffThreshold) {
+        continue;
+      }
+
+      auto termNode = NodeTy::mul(NodeTy::constantScalar(coeffs[j]),
+                                  chebPolynomialValuesMap[j]);
+
       if (pol) {
         pol = NodeTy::add(pol, termNode);
       } else {
         pol = termNode;
       }
     }
-    if (!pol) continue;
-    if (i > 0) {
-      pol = NodeTy::mul(pol, chebKPolynomialPowers[i]);
-    }
-    if (result) {
-      result = NodeTy::add(result, pol);
-    } else {
-      result = pol;
-    }
+    babySteps.push_back(pol);
   }
-  return result;
+
+  // Combine baby steps in tree-like manner.
+  //
+  // Specifically, we're evaluating
+  //
+  //   p = p_0 + p_1 T_k + p_2 T_k^2 + ... + p_l T_k^l,
+  //
+  // where the p_i are the baby steps computed above, and the value of T_k(x)
+  // has been computed and stored as chebPolynomialValuesMap[k].
+  //
+  // This loop reduces the above terms in a tree structure to minimize depth.
+  // Specifically, each round combines two adjacent terms (a, b) as a + b Y,
+  // and then replaces Y with Y^2 for the next round.
+  //
+  // For example, starting with 4 baby steps [p_0, p_1, p_2, p_3],
+  //
+  // The first iteration computes [p_0 + p_1 y, p_2 + p_3 y].
+  //
+  // The second iteration computes [(p_0 + p_1 y) + (p_2 + p_3 y) y^2]
+  //                               = p_0 + p_1 y + p_2 y^2 + p_3 y^3.
+  auto y = chebPolynomialValuesMap[k];
+  auto yPower = y;
+  while (babySteps.size() > 1) {
+    std::vector<std::shared_ptr<NodeTy>> nextBabySteps;
+
+    for (size_t i = 0; i < babySteps.size(); i += 2) {
+      auto combined = babySteps[i];
+
+      if (i + 1 < babySteps.size() && babySteps[i + 1]) {
+        auto scaled = NodeTy::mul(babySteps[i + 1], yPower);
+        combined = combined ? NodeTy::add(combined, scaled) : scaled;
+      }
+
+      nextBabySteps.push_back(combined);
+    }
+
+    babySteps = std::move(nextBabySteps);
+    yPower = NodeTy::mul(yPower, yPower);
+  }
+
+  return babySteps[0];
 }
 
 }  // namespace polynomial

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerFuzzTest.cpp
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerFuzzTest.cpp
@@ -1,0 +1,109 @@
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Kernel/AbstractValue.h"
+#include "lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h"
+#include "lib/Utils/Polynomial/PolynomialTestVisitors.h"
+
+// copybara hack: avoid reordering include
+#include "fuzztest/fuzztest.h"  // from @fuzztest
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+namespace {
+
+// Compute Chebyshev polynomial T_n(x) using the standard recurrence relation.
+// T_0(x) = 1
+// T_1(x) = x
+// T_{n+1}(x) = 2*x*T_n(x) - T_{n-1}(x)
+double computeChebyshevPolynomial(int64_t n, double x) {
+  if (n == 0) return 1.0;
+  if (n == 1) return x;
+
+  double tPrev = 1.0;  // T_0(x)
+  double tCurr = x;    // T_1(x)
+
+  for (int64_t i = 2; i <= n; i++) {
+    double tNext = 2.0 * x * tCurr - tPrev;
+    tPrev = tCurr;
+    tCurr = tNext;
+  }
+
+  return tCurr;
+}
+
+// Naive evaluation of a Chebyshev polynomial using direct computation
+// of each Chebyshev basis polynomial.
+double naiveEvalChebyshevPolynomial(const std::vector<double>& coefficients,
+                                    double x) {
+  if (coefficients.empty()) return 0.0;
+
+  double result = 0.0;
+  for (size_t i = 0; i < coefficients.size(); i++) {
+    result += coefficients[i] * computeChebyshevPolynomial(i, x);
+  }
+  return result;
+}
+
+// Paterson-Stockmeyer evaluation of a Chebyshev polynomial
+double psEvalChebyshevPolynomial(const std::vector<double>& coefficients,
+                                 double x) {
+  if (coefficients.empty()) return 0.0;
+
+  kernel::LiteralDouble xNode = x;
+  auto resultNode =
+      patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
+
+  if (!resultNode) return 0.0;
+
+  test::EvalVisitor visitor;
+  return resultNode->visit(visitor);
+}
+
+void patersonStockmeyerMatchesNaive(const std::vector<double>& coefficients,
+                                    double x) {
+  assert(x >= -1.0 && x <= 1.0);
+  double expected = naiveEvalChebyshevPolynomial(coefficients, x);
+  double actual = psEvalChebyshevPolynomial(coefficients, x);
+  double tolerance = 1e-15;
+  EXPECT_NEAR(expected, actual, tolerance);
+}
+
+// Fuzz test for Paterson-Stockmeyer evaluation
+FUZZ_TEST(ChebyshevPatersonStockmeyerFuzzTest, patersonStockmeyerMatchesNaive)
+    .WithDomains(
+        /*coefficients=*/fuzztest::VectorOf(fuzztest::InRange(-100.0, 100.0))
+            .WithMinSize(1)
+            .WithMaxSize(50),
+        /*x=*/fuzztest::InRange(-1.0, 1.0));
+
+// Throw in some specific cases.
+TEST(ChebyshevPatersonStockmeyerFuzzTest, SingleCoefficient) {
+  patersonStockmeyerMatchesNaive({5.0}, 0.5);
+}
+
+TEST(ChebyshevPatersonStockmeyerFuzzTest, TwoCoefficients) {
+  patersonStockmeyerMatchesNaive({1.0, 2.5}, 0.5);
+}
+
+TEST(ChebyshevPatersonStockmeyerFuzzTest, MultipleCoefficients) {
+  patersonStockmeyerMatchesNaive({3.0, -2.0, 0.5, 1.0, -0.5}, 0.7);
+}
+
+TEST(ChebyshevPatersonStockmeyerFuzzTest, ZeroCoefficients) {
+  patersonStockmeyerMatchesNaive({0.0, 0.0, 1.0, 0.0}, 0.3);
+}
+
+TEST(ChebyshevPatersonStockmeyerFuzzTest, BoundaryValues) {
+  patersonStockmeyerMatchesNaive({1.0, 2.0, 3.0}, -1.0);
+  patersonStockmeyerMatchesNaive({1.0, 2.0, 3.0}, 1.0);
+  patersonStockmeyerMatchesNaive({1.0, 2.0, 3.0}, 0.0);
+}
+
+}  // namespace
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerTest.cpp
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerTest.cpp
@@ -10,22 +10,23 @@ namespace heir {
 namespace polynomial {
 namespace {
 
-double evalChebyshevPolynomial(double x, std::vector<double> coefficients) {
-  kernel::LiteralDouble x_node = x;
-  auto result_node =
-      patersonStockmeyerChebyshevPolynomialEvaluation(x_node, coefficients);
+double evalChebyshevPolynomial(double x,
+                               const std::vector<double>& coefficients) {
+  kernel::LiteralDouble xNode = x;
+  auto resultNode =
+      patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
 
   test::EvalVisitor visitor;
-  return result_node->visit(visitor);
+  return resultNode->visit(visitor);
 }
 
-int evalMultiplicativeDepth(double x, std::vector<double> coefficients) {
-  kernel::LiteralDouble x_node = x;
-  auto result_node =
-      patersonStockmeyerChebyshevPolynomialEvaluation(x_node, coefficients);
+int evalMultiplicativeDepth(double x, const std::vector<double>& coefficients) {
+  kernel::LiteralDouble xNode = x;
+  auto resultNode =
+      patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
 
   test::MultiplicativeDepthVisitor visitor;
-  return static_cast<int>(result_node->visit(visitor));
+  return static_cast<int>(resultNode->visit(visitor));
 }
 
 TEST(PatersonStockmeyerChebyshevPolynomialEvaluation, ConstantPolynomial) {
@@ -82,7 +83,7 @@ TEST(PatersonStockmeyerChebyshevPolynomialEvaluation,
       0.0038349915376337043};
   EXPECT_NEAR(evalChebyshevPolynomial(0.7, coefficients), 0.7013677694556697,
               1e-14);
-  EXPECT_EQ(evalMultiplicativeDepth(0.5, coefficients), 6);
+  EXPECT_EQ(evalMultiplicativeDepth(0.5, coefficients), 5);
 }
 
 }  // namespace

--- a/tests/Pipelines/math_to_polynomial_approximation/polynomial_approximation.mlir
+++ b/tests/Pipelines/math_to_polynomial_approximation/polynomial_approximation.mlir
@@ -5,14 +5,19 @@ func.func @test_maximumf(%x: tensor<10xf32>) -> tensor<10xf32> {
   // CHECK-NOT: arith.maximumf
   // CHECK-NOT: polynomial.eval
 
-  // CHECK-DAG: arith.constant dense<-0.12656936
-  // CHECK-DAG: arith.constant dense<2.0{{0*}}e+00> : tensor<10xf32>
-  // CHECK-DAG: arith.constant dense<0.27865994
-  // CHECK-DAG: arith.constant dense<0.316969961
-  // CHECK: arith.mulf
+  // CHECK-DAG:  arith.constant dense<-0.06328
+  // CHECK-DAG:  arith.constant dense<2.0000
+  // CHECK-DAG:  arith.constant dense<0.2153
+  // CHECK-DAG:  arith.constant dense<5.0000
+  // CHECK-DAG:  arith.constant dense<0.3169
+  // CHECK-DAG:  arith.constant dense<1.0000
   // CHECK: arith.mulf
   // CHECK: arith.addf
   // CHECK: arith.mulf
+  // CHECK: arith.mulf
+  // CHECK: arith.subf
+  // CHECK: arith.mulf
+  // CHECK: arith.addf
   // CHECK: arith.mulf
   // CHECK: arith.mulf
   // CHECK: arith.subf

--- a/tests/Transforms/lower_polynomial_eval/paterson_stockmeyer_chebyshev.mlir
+++ b/tests/Transforms/lower_polynomial_eval/paterson_stockmeyer_chebyshev.mlir
@@ -13,7 +13,7 @@
 
 // CHECK: @test_eval_for_paterson
 func.func @test_eval_for_paterson() -> f64 {
-// CHECK-DAG: [[CST:%.+]] = arith.constant 4.0{{0*}}e-01 : f64
+// CHECK-DAG: [[CST:%.+]] = arith.constant 4.0{{0*}}e-01
 // CHECK-DAG: [[CST_1:%.+]] = arith.constant 1.0
 // CHECK-DAG: [[CST_0:%.+]] = arith.constant 0.32
 // CHECK-NEXT: [[V0:%.+]] = arith.mulf [[CST_0]], [[CST_1]]
@@ -21,31 +21,34 @@ func.func @test_eval_for_paterson() -> f64 {
 // CHECK-NEXT: [[V1:%.+]] = arith.mulf [[CST_2]], [[CST]]
 // CHECK-NEXT: [[V2:%.+]] = arith.addf [[V0]], [[V1]]
 // CHECK-NEXT: [[CST_3:%.+]] = arith.constant 0.177
-// CHECK-NEXT: [[V3:%.+]] = arith.mulf [[CST]], [[CST]]
 // CHECK-NEXT: [[CST_4:%.+]] = arith.constant 2.0
-// CHECK-NEXT: [[V4:%.+]] = arith.mulf [[V3]], [[CST_4]]
-// CHECK-NEXT: [[V5:%.+]] = arith.subf [[V4]], [[CST_1]]
+// CHECK-NEXT: [[V3:%.+]] = arith.mulf [[CST]], [[CST]]
+// CHECK-NEXT: [[V4:%.+]] = arith.mulf [[CST_4]], [[V3]]
+// CHECK-NEXT: [[CST_5:%.+]] = arith.constant 1.0
+// CHECK-NEXT: [[V5:%.+]] = arith.subf [[V4]], [[CST_5]]
 // CHECK-NEXT: [[V6:%.+]] = arith.mulf [[CST_3]], [[V5]]
 // CHECK-NEXT: [[V7:%.+]] = arith.addf [[V2]], [[V6]]
-// CHECK-NEXT: [[CST_5:%.+]] = arith.constant -0.042
-// CHECK-NEXT: [[V8:%.+]] = arith.mulf [[CST_5]], [[CST_1]]
-// CHECK-NEXT: [[CST_6:%.+]] = arith.constant 0.00422
-// CHECK-NEXT: [[V9:%.+]] = arith.mulf [[CST_6]], [[V5]]
+// CHECK-NEXT: [[CST_6:%.+]] = arith.constant -0.0428
+// CHECK-NEXT: [[V8:%.+]] = arith.mulf [[CST_6]], [[CST_1]]
+// CHECK-NEXT: [[CST_7:%.+]] = arith.constant 0.0042
+// CHECK-NEXT: [[V9:%.+]] = arith.mulf [[CST_7]], [[V5]]
 // CHECK-NEXT: [[V10:%.+]] = arith.addf [[V8]], [[V9]]
+// CHECK-NEXT: [[CST_8:%.+]] = arith.constant 2.0
 // CHECK-NEXT: [[V11:%.+]] = arith.mulf [[V5]], [[V5]]
-// CHECK-NEXT: [[V12:%.+]] = arith.mulf [[V11]], [[CST_4]]
-// CHECK-NEXT: [[V13:%.+]] = arith.subf [[V12]], [[CST_1]]
+// CHECK-NEXT: [[V12:%.+]] = arith.mulf [[CST_8]], [[V11]]
+// CHECK-NEXT: [[CST_9:%.+]] = arith.constant 1.0
+// CHECK-NEXT: [[V13:%.+]] = arith.subf [[V12]], [[CST_9]]
 // CHECK-NEXT: [[V14:%.+]] = arith.mulf [[V10]], [[V13]]
 // CHECK-NEXT: [[V15:%.+]] = arith.addf [[V7]], [[V14]]
-// CHECK-NEXT: [[CST_7:%.+]] = arith.constant -0.0215
-// CHECK-NEXT: [[V16:%.+]] = arith.mulf [[CST_7]], [[CST_1]]
-// CHECK-NEXT: [[CST_8:%.+]] = arith.constant 0.0663
-// CHECK-NEXT: [[V17:%.+]] = arith.mulf [[CST_8]], [[V5]]
+// CHECK-NEXT: [[CST_10:%.+]] = arith.constant -0.0215
+// CHECK-NEXT: [[V16:%.+]] = arith.mulf [[CST_10]], [[CST_1]]
+// CHECK-NEXT: [[CST_11:%.+]] = arith.constant 0.0663
+// CHECK-NEXT: [[V17:%.+]] = arith.mulf [[CST_11]], [[V5]]
 // CHECK-NEXT: [[V18:%.+]] = arith.addf [[V16]], [[V17]]
 // CHECK-NEXT: [[V19:%.+]] = arith.mulf [[V13]], [[V13]]
 // CHECK-NEXT: [[V20:%.+]] = arith.mulf [[V18]], [[V19]]
 // CHECK-NEXT: [[V21:%.+]] = arith.addf [[V15]], [[V20]]
-// CHECK-NEXT: return [[V21]]
+// CHECK-NEXT:  return [[V21]]
     %x = arith.constant 0.4 : f64
     %0 = polynomial.eval #poly, %x {domain_lower = -1.0 : f64, domain_upper = 1.0 : f64} : f64
     return %0 : f64


### PR DESCRIPTION
This PR improve the Chebyshev Paterson-Stockmeyer lowering by introducing some key changes present in the lattigo implementation that were missing from HEIR.

1. A more precise calculation of the BSGS splitting factor `k`, which results in 1 less mul depth when n is close to a power of two.
2. A more balanced recursive calculation of the baby step polynomials T_k(x)
3. A more balanced evaluation of the giant steps