### PR TITLE
Add type inference for LWE/CKKS ops

### DIFF
--- a/lib/Dialect/CKKS/IR/CKKSOps.cpp
+++ b/lib/Dialect/CKKS/IR/CKKSOps.cpp
@@ -79,6 +79,12 @@ LogicalResult RelinearizeOp::inferReturnTypes(
   return lwe::inferRelinearizeOpReturnTypes(ctx, adaptor, inferredReturnTypes);
 }
 
+LogicalResult LevelReduceOp::inferReturnTypes(
+    MLIRContext* ctx, std::optional<Location>, LevelReduceOp::Adaptor adaptor,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  return lwe::inferLevelReduceOpReturnTypes(ctx, adaptor, inferredReturnTypes);
+}
+
 void MulPlainOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                              MLIRContext* context) {
   results.add<lwe::PutCiphertextInFirstOperand<MulPlainOp>>(context);

--- a/lib/Dialect/CKKS/IR/CKKSOps.td
+++ b/lib/Dialect/CKKS/IR/CKKSOps.td
@@ -47,7 +47,7 @@ def CKKS_AddOp : CKKS_Op<"add", [ElementwiseMappable, Commutative, SameOperandsA
 }
 
 def CKKS_AddPlainOp : CKKS_CiphertextPlaintextOp<"add_plain", [ElementwiseMappable, AllCiphertextTypesMatch,
-      SameOperandsAndResultPlaintextTypes, Commutative]> {
+      SameOperandsAndResultPlaintextTypes, Commutative, InferTypeOpAdaptor]> {
   let summary = "Addition operation between ciphertext-plaintext.";
   let hasCanonicalizer = 1;
 }
@@ -67,7 +67,7 @@ def CKKS_SubOp : CKKS_Op<"sub", [ElementwiseMappable, SameOperandsAndResultRings
 }
 
 def CKKS_SubPlainOp : CKKS_CiphertextPlaintextOp<"sub_plain", [ElementwiseMappable, AllCiphertextTypesMatch,
-      SameOperandsAndResultPlaintextTypes]> {
+      SameOperandsAndResultPlaintextTypes, InferTypeOpAdaptor]> {
   let summary = "Subtraction operation between ciphertext-plaintext.";
 }
 
@@ -188,7 +188,7 @@ def CKKS_RescaleOp : CKKS_Op<"rescale", [ElementwiseMappable]> {
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 
-def CKKS_LevelReduceOp : CKKS_Op<"level_reduce", [ElementwiseMappable, SameOperandsAndResultPlaintextTypes]> {
+def CKKS_LevelReduceOp : CKKS_Op<"level_reduce", [ElementwiseMappable, SameOperandsAndResultPlaintextTypes, InferTypeOpAdaptor]> {
   let summary = "Lower the modulus level of the ciphertext via dropping RNS limbs.";
 
   let arguments = (ins

--- a/lib/Dialect/LWE/IR/LWEAttributes.h
+++ b/lib/Dialect/LWE/IR/LWEAttributes.h
@@ -30,6 +30,15 @@ PlaintextSpaceAttr inferModulusSwitchOrRescaleOpPlaintextSpaceAttr(
 Attribute getEncodingAttrWithNewScalingFactor(Attribute encoding,
                                               int64_t newScale);
 
+polynomial::RingAttr getRlweRNSRingWithLevel(polynomial::RingAttr ringAttr,
+                                             int level);
+
+// Get the ring attribute corresponding to the current level of the given
+// modulus chain.
+polynomial::RingAttr getRingFromModulusChain(
+    ModulusChainAttr chainAttr,
+    polynomial::IntPolynomialAttr polynomialModulus);
+
 }  // namespace lwe
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/LWE/IR/LWETraits.h
+++ b/lib/Dialect/LWE/IR/LWETraits.h
@@ -67,7 +67,8 @@ class SameOperandsAndResultPlaintextTypes
       }
       if (plaintextTypes != ps) {
         op->emitOpError() << "requires all operands and results to have "
-                             "the same plaintextTypes";
+                             "the same plaintextTypes, but found "
+                          << plaintextTypes << " and " << ps;
         return failure();
       }
       return success();

--- a/lib/Dialect/LWE/IR/LWETypes.cpp
+++ b/lib/Dialect/LWE/IR/LWETypes.cpp
@@ -5,9 +5,12 @@
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Utils/Polynomial/Polynomial.h"
 #include "llvm/include/llvm/ADT/STLFunctionalExtras.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"          // from @llvm-project
 #include "mlir/include/mlir/IR/Diagnostics.h"           // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+
+#define DEBUG_TYPE "lwe-types"
 
 namespace mlir {
 namespace heir {
@@ -15,10 +18,9 @@ namespace lwe {
 
 LogicalResult LWECiphertextType::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
-    mlir::heir::lwe::ApplicationDataAttr, mlir::heir::lwe::PlaintextSpaceAttr,
-    mlir::heir::lwe::CiphertextSpaceAttr ciphertextSpace,
-    mlir::heir::lwe::KeyAttr keyAttr,
-    mlir::heir::lwe::ModulusChainAttr modulusChain) {
+    ApplicationDataAttr, PlaintextSpaceAttr,
+    CiphertextSpaceAttr ciphertextSpace, KeyAttr keyAttr,
+    ModulusChainAttr modulusChain) {
   if (keyAttr.getSlotIndex() != 0 && (ciphertextSpace.getSize() != 2)) {
     return emitError() << "a ciphertext with nontrivial slot rotation must "
                           "have size 2, but found size "
@@ -27,10 +29,10 @@ LogicalResult LWECiphertextType::verify(
   if (auto rnsType = mlir::dyn_cast<rns::RNSType>(
           ciphertextSpace.getRing().getCoefficientType())) {
     if (rnsType.getBasisTypes().size() - 1 != modulusChain.getCurrent()) {
-      return emitError() << "the level in the ciphertext ring "
-                            "must match the modulus chain's current, but found "
-                         << rnsType.getBasisTypes().size() - 1 << " and "
-                         << modulusChain.getCurrent();
+      return emitError()
+             << "the level in the ciphertext ring "
+                "must match the modulus chain's current, but found rns="
+             << rnsType << " and modulus chain=" << modulusChain;
     }
   }
   return success();
@@ -61,6 +63,53 @@ LWECiphertextType getDefaultCGGICiphertextType(MLIRContext* ctx,
                                     lwe::LweEncryptionType::msb,
                                     /*dimension=*/742),
       lwe::KeyAttr::get(ctx, 0), /*modulusChain=*/nullptr);
+}
+
+FailureOr<LWECiphertextType> applyModReduce(LWECiphertextType inputType) {
+  auto* ctx = inputType.getContext();
+  int currentLevel = inputType.getModulusChain().getCurrent();
+  int newLevel = inputType.getModulusChain().getCurrent() - 1;
+  LLVM_DEBUG(llvm::dbgs() << "Applying mod reduce from level " << currentLevel
+                          << " to " << newLevel << "\n");
+  if (newLevel < 0) {
+    return failure();
+  }
+  auto ring = inputType.getCiphertextSpace().getRing();
+  auto newRing = getRlweRNSRingWithLevel(ring, newLevel);
+  LLVM_DEBUG(llvm::dbgs() << "New ring is " << newRing << "\n");
+
+  APInt dividedModulus =
+      inputType.getModulusChain().getElements()[currentLevel].getValue();
+  lwe::ModulusChainAttr moddedDownChain = lwe::ModulusChainAttr::get(
+      ctx, inputType.getModulusChain().getElements(), newLevel);
+  LLVM_DEBUG(llvm::dbgs() << "Modded down chain=" << moddedDownChain << "\n");
+  lwe::PlaintextSpaceAttr newPlaintextSpace =
+      inferModulusSwitchOrRescaleOpPlaintextSpaceAttr(
+          ctx, inputType.getPlaintextSpace(), dividedModulus);
+
+  LLVM_DEBUG(llvm::dbgs() << "new plaintext space=" << newPlaintextSpace
+                          << "\n");
+  return lwe::LWECiphertextType::get(
+      ctx, inputType.getApplicationData(), newPlaintextSpace,
+      lwe::CiphertextSpaceAttr::get(
+          ctx, newRing, inputType.getCiphertextSpace().getEncryptionType(),
+          inputType.getCiphertextSpace().getSize()),
+      lwe::KeyAttr::get(ctx, 0),
+      lwe::ModulusChainAttr::get(ctx, moddedDownChain.getElements(), newLevel));
+}
+
+LWECiphertextType cloneAtLevel(LWECiphertextType inputType, int64_t level) {
+  auto* ctx = inputType.getContext();
+  auto ring = inputType.getCiphertextSpace().getRing();
+  lwe::ModulusChainAttr newChain = lwe::ModulusChainAttr::get(
+      ctx, inputType.getModulusChain().getElements(), level);
+  auto newRing = getRingFromModulusChain(newChain, ring.getPolynomialModulus());
+  return lwe::LWECiphertextType::get(
+      ctx, inputType.getApplicationData(), inputType.getPlaintextSpace(),
+      lwe::CiphertextSpaceAttr::get(
+          ctx, newRing, inputType.getCiphertextSpace().getEncryptionType(),
+          inputType.getCiphertextSpace().getSize()),
+      lwe::KeyAttr::get(ctx, 0), newChain);
 }
 
 }  // namespace lwe

--- a/lib/Dialect/LWE/IR/LWETypes.h
+++ b/lib/Dialect/LWE/IR/LWETypes.h
@@ -17,13 +17,29 @@ namespace lwe {
 // ciphertext modulus of 32 bits. The default 4-bit message space from tfhe-rs
 // has LWE dimension 742. The messageWidth parameter specifies the width of the
 // application data.
-// FIXME: add reference
 LWECiphertextType getDefaultCGGICiphertextType(MLIRContext* ctx,
                                                int messageWidth,
                                                int plaintextBits = 3);
 
+inline LWEPlaintextType getCorrespondingPlaintextType(
+    LWECiphertextType ctType) {
+  MLIRContext* ctx = ctType.getContext();
+  return LWEPlaintextType::get(
+      ctx, ctType.getApplicationData(),
+      PlaintextSpaceAttr::get(ctx, ctType.getCiphertextSpace().getRing(),
+                              ctType.getPlaintextSpace().getEncoding()));
+}
+
+// Return the LWECiphertextType resulting from removing one limb (i.e.,
+// the result type of a modulus switch or rescale op). Returns a failure
+// if the input type does not have enough limbs.
+FailureOr<LWECiphertextType> applyModReduce(LWECiphertextType inputType);
+
+// Return the LWECiphertextType resulting from setting the level to a specific
+// value.
+LWECiphertextType cloneAtLevel(LWECiphertextType inputType, int64_t level);
+
 }  // namespace lwe
 }  // namespace heir
 }  // namespace mlir
-
 #endif  // LIB_DIALECT_LWE_IR_LWETYPES_H_

--- a/tests/Dialect/BGV/Conversions/bgv_to_openfhe/invalid.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_openfhe/invalid.mlir
@@ -58,7 +58,7 @@ func.func @test_relin_to_basis_error(%x: !ct1) -> !ct {
 !ct2 = !lwe.lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
 func.func @test_modswitch_level_error(%x: !ct2) -> !ct {
-  // expected-error@+1 {{output ring should match to_ring}}
+  // expected-error@+1 {{output ciphertext_space ring should match to_ring}}
   %relin_error = bgv.modulus_switch %x  {to_ring=#ring_rns_L0_1_x1024_}: !ct2 -> !ct
   return %relin_error : !ct
 }

--- a/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/invalid.mlir
+++ b/tests/Dialect/CKKS/Conversions/ckks_to_openfhe/invalid.mlir
@@ -58,7 +58,7 @@ func.func @test_relin_to_basis_error(%x: !ct1) -> !ct {
 !ct2 = !lwe.lwe_ciphertext<application_data = <message_type = i3>, plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
 
 func.func @test_modswitch_level_error(%x: !ct2) -> !ct {
-  // expected-error@+1 {{output ring should match to_ring}}
+  // expected-error@+1 {{output ciphertext_space ring should match to_ring}}
   %relin_error = bgv.modulus_switch %x  {to_ring=#ring_rns_L0_1_x1024_}: !ct2 -> !ct
   return %relin_error : !ct
 }

--- a/tests/Dialect/LWE/IR/attributes_errors.mlir
+++ b/tests/Dialect/LWE/IR/attributes_errors.mlir
@@ -50,5 +50,5 @@
 #ciphertext_space = #lwe.ciphertext_space<ring = #ring, encryption_type = msb, size = 3>
 #modulus_chain = #lwe.modulus_chain<elements = <7917 : i32, 65537 : i32>, current = 1>
 
-// expected-error@below {{the level in the ciphertext ring must match the modulus chain's current, but found 0 and 1}}
+// expected-error@below {{the level in the ciphertext ring must match the modulus chain's current}}
 !lwe_ciphertext = !lwe.lwe_ciphertext<application_data = #application_data, plaintext_space = #plaintext_space, key = #key, ciphertext_space = #ciphertext_space, modulus_chain = #modulus_chain>


### PR DESCRIPTION
This came up in the conversion from Orion to CKKS (https://github.com/google/heir/issues/2326). That line of work requires me to reimplement chebyshev evaluation and the halevi-shoup kernel, but at the level of CKKS with parameters pre-selected.

https://github.com/google/heir/pull/2338 is addressing the finer points of that conversion, but in the mean time it has proven helpful to extend the result type inference capabilities of the LWE/CKKS dialects, because when I insert ciphertext mgmt ops at the CKKS level, I need to re-walk the IR and re-infer result types for all ops.

Yes, I know this is what @ZenithalHourlyRate warned against and why we have mgmt at the higher level. Normally I wouldn't want to do this either, but for comparing against another compiler that handles ciphertext management and parameter selection itself, I don't see another way :)