### PR TITLE
Add timing table to interpreter mode

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -69,3 +69,17 @@ config_setting(
         ":enable_yosys": "0",
     },
 )
+
+# OpenFHE interpreter
+string_flag(
+    name = "openfhe_enable_timing",
+    build_setting_default = "0",
+)
+
+config_setting(
+    name = "config_openfhe_enable_timing",
+    flag_values = {
+        ":openfhe_enable_timing": "1",
+    },
+    visibility = ["//visibility:public"],
+)

--- a/lib/Target/OpenFhePke/BUILD
+++ b/lib/Target/OpenFhePke/BUILD
@@ -123,6 +123,10 @@ cc_library(
     name = "Interpreter",
     srcs = ["Interpreter.cpp"],
     hdrs = ["Interpreter.h"],
+    copts = select({
+        "//:config_openfhe_enable_timing": ["-DOPENFHE_ENABLE_TIMING"],
+        "//conditions:default": [],
+    }),
     deps = [
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",

--- a/lib/Target/OpenFhePke/Interpreter.h
+++ b/lib/Target/OpenFhePke/Interpreter.h
@@ -5,6 +5,12 @@
 #include <variant>
 #include <vector>
 
+#ifdef OPENFHE_ENABLE_TIMING
+#include <chrono>
+#include <map>
+#include <string>
+#endif
+
 #include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
 #include "llvm/include/llvm/ADT/DenseMap.h"  // from @llvm-project
@@ -81,6 +87,10 @@ class Interpreter {
 
   std::vector<TypedCppValue> interpret(const std::string& entryFunction,
                                        ArrayRef<TypedCppValue> inputValues);
+
+#ifdef OPENFHE_ENABLE_TIMING
+  void printTimingResults();
+#endif
 
   void visit(Operation* op);
 
@@ -160,6 +170,14 @@ class Interpreter {
  private:
   ModuleOp module;
   llvm::DenseMap<Value, TypedCppValue> env;
+
+#ifdef OPENFHE_ENABLE_TIMING
+  struct TimingData {
+    std::chrono::duration<double> totalTime{0};
+    int count{0};
+  };
+  std::map<std::string, TimingData> timingResults;
+#endif
 };
 
 void initContext(MLIRContext& context);
@@ -170,4 +188,4 @@ OwningOpRef<ModuleOp> parse(MLIRContext* context, const std::string& mlirStr);
 }  // namespace heir
 }  // namespace mlir
 
-#endif  // LIB_TARGET_OPENFHEPKE_INTERPRETER_H_
+#endif  // LIB_TARGET_OPENFHEPKE_INTERPRIl INTERPRETER_H_

--- a/tests/Examples/openfhe/ckks/halevi_shoup_matvec/BUILD
+++ b/tests/Examples/openfhe/ckks/halevi_shoup_matvec/BUILD
@@ -20,6 +20,10 @@ openfhe_end_to_end_test(
 
 openfhe_interpreter_test(
     name = "halevi_shoup_matvec_interpreter_test",
+    copts = select({
+        "//:config_openfhe_enable_timing": ["-DOPENFHE_ENABLE_TIMING"],
+        "//conditions:default": [],
+    }),
     generated_heir_opt_filename = "module.openfhe.mlir",
     heir_opt_flags = [
         "--annotate-module=backend=openfhe scheme=ckks",

--- a/tests/Examples/openfhe/ckks/halevi_shoup_matvec/halevi_shoup_matvec_interpreter_test.cpp
+++ b/tests/Examples/openfhe/ckks/halevi_shoup_matvec/halevi_shoup_matvec_interpreter_test.cpp
@@ -58,6 +58,10 @@ TEST(MatmulInterpreterTest, RunTest) {
   TypedCppValue outputEncrypted =
       interpreter.interpret("matvec", {cc, arg0Enc})[0];
 
+#ifdef OPENFHE_ENABLE_TIMING
+  interpreter.printTimingResults();
+#endif
+
   TypedCppValue actualVal =
       interpreter.interpret("matvec__decrypt__result0",
                             {cc, outputEncrypted, TypedCppValue(secretKey)})[0];

--- a/tests/Examples/openfhe/test.bzl
+++ b/tests/Examples/openfhe/test.bzl
@@ -39,7 +39,7 @@ def openfhe_end_to_end_test(name, mlir_src, test_src, generated_lib_header, heir
         **kwargs
     )
 
-def openfhe_interpreter_test(name, mlir_src, test_src, generated_heir_opt_filename = "", heir_opt_flags = [], data = [], tags = [], deps = [], **kwargs):
+def openfhe_interpreter_test(name, mlir_src, test_src, generated_heir_opt_filename = "", heir_opt_flags = [], data = [], tags = [], deps = [], copts = [], **kwargs):
     """A rule for running generating OpenFHE dialect and exposing it to an interpreter.
 
     Args:
@@ -51,6 +51,7 @@ def openfhe_interpreter_test(name, mlir_src, test_src, generated_heir_opt_filena
       data: Data dependencies to be passed to cc_test/heir_opt
       tags: Tags to pass to cc_test
       deps: Deps to pass to cc_test
+      copts: Additional copts to pass to cc_test
       **kwargs: Keyword arguments to pass to cc_test.
     """
     heir_opt_name = "%s_heir_opt" % name
@@ -78,7 +79,7 @@ def openfhe_interpreter_test(name, mlir_src, test_src, generated_heir_opt_filena
         ],
         tags = tags,
         data = data + [":" + generated_heir_opt_filename],
-        copts = MAYBE_OPENMP_COPTS,
+        copts = MAYBE_OPENMP_COPTS + copts,
         linkopts = MAYBE_OPENFHE_LINKOPTS,
         **kwargs
     )


### PR DESCRIPTION
Uses a macro to give 0-cost overhead when the option is not enabled.

Example command:

```
bazel test -c dbg --test_output=all --//:openfhe_enable_timing=1 //tests/Examples/openfhe/ckks/halevi_shoup_matvec/halevi_shoup_matvec_interpreter_test
```

Example output:

```
--- Timing Results ---
Operation                     Total Time (s)      Total Time (%)      Count               Average Latency (s)
MulPlain                      0.868699            42.6597             16                  0.0542937
GenRotKey                     0.31511             15.4743             1                   0.31511
MakeCKKSPackedPlaintext       0.208031            10.2159             18                  0.0115573
FastRotation                  0.201754            9.90766             3                   0.0672513
Rot                           0.2002              9.83135             3                   0.0667334
Encrypt                       0.0911704           4.47716             1                   0.0911704
GenContext                    0.0634968           3.11818             1                   0.0634968
FastRotationPrecompute        0.0415601           2.04092             1                   0.0415601
Add                           0.0268904           1.32052             15                  0.00179269
AddPlain                      0.0194314           0.954228            1                   0.0194314
```