### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,7 +87,7 @@ jobs:
         run: cp CNAME public/CNAME
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # pin@v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -23,7 +23,7 @@ jobs:
         run: bazel mod deps --lockfile_mode=update
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # pin@v7.0.8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725  # v8
         with:
           commit-message: "automated bazel lockfile update"
           title: "[deps] update bazel lockfile"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
             gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag
 
       - name: GH Release
-        uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0 #pin@v2.0.6
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
         with:
           prerelease: true
           tag_name: nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create Release
         id: release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # pin@v2.3.2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
         with:
           tag_name: v${{ steps.date.outputs.date }}
           generate_release_notes: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,4 +73,4 @@ jobs:
           path: dist
           pattern: dist-*
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@v1


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peaceiris/actions-gh-pages` | [`373f7f2`](https://github.com/peaceiris/actions-gh-pages/commit/373f7f263a76c20808c831209c920827a82a2847) | [`4f9cc66`](https://github.com/peaceiris/actions-gh-pages/commit/4f9cc6602d3f66b9c108549d475ec49e8ef4d45e) | [Release](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | docs.yml |
| `peter-evans/create-pull-request` | [`271a8d0`](https://github.com/peter-evans/create-pull-request/commit/271a8d0340265f705b14b6d32b9829c1cb33d45e) | [`98357b1`](https://github.com/peter-evans/create-pull-request/commit/98357b18bf14b5342f975ff684046ec3b2a07725) | [Release](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | lockfile.yml |
| `pypa/gh-action-pypi-publish` | [`release/v1`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/release/v1) | [`v1`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1) | [Release](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1) | wheels.yml |
| `softprops/action-gh-release` | [`72f2c25`](https://github.com/softprops/action-gh-release/commit/72f2c25fcb47643c292f7107632f7a47c1df5cd8), [`a74c6b7`](https://github.com/softprops/action-gh-release/commit/a74c6b72af54cfa997e81df42d94703d6313a2d0) | [`a06a81a`](https://github.com/softprops/action-gh-release/commit/a06a81a03ee405af7f2048a818ed3f03bbf83c7b) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | nightly.yml, release.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
