### PR TITLE
Peel first iteration of loops with ciphertext iter-args (Halo Solution A-1)

### DIFF
--- a/lib/Transforms/Halo/BUILD
+++ b/lib/Transforms/Halo/BUILD
@@ -1,0 +1,65 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":ReconcileMixedSecretnessIterArgs",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:SCFDialect",
+    ],
+)
+
+cc_library(
+    name = "Patterns",
+    srcs = ["Patterns.cpp"],
+    hdrs = [
+        "Patterns.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SCFTransforms",
+        "@llvm-project//mlir:SCFUtils",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "ReconcileMixedSecretnessIterArgs",
+    srcs = ["ReconcileMixedSecretnessIterArgs.cpp"],
+    hdrs = [
+        "ReconcileMixedSecretnessIterArgs.h",
+    ],
+    deps = [
+        ":Patterns",
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "Halo",
+    td_file = "Passes.td",
+)

--- a/lib/Transforms/Halo/Passes.h
+++ b/lib/Transforms/Halo/Passes.h
@@ -1,0 +1,20 @@
+#ifndef LIB_TRANSFORMS_HALO_PASSES_H_
+#define LIB_TRANSFORMS_HALO_PASSES_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+#include "lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.h"
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"           // @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_HALO_PASSES_H_

--- a/lib/Transforms/Halo/Passes.td
+++ b/lib/Transforms/Halo/Passes.td
@@ -1,0 +1,24 @@
+#ifndef LIB_TRANSFORMS_HALO_PASSES_TD_
+#define LIB_TRANSFORMS_HALO_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ReconcileMixedSecretnessIterArgs : Pass<"reconcile-mixed-secretness-iter-args"> {
+  let summary = "Peel the first iteration of loops with mixed secretness iter args";
+  let description = [{
+  Loops that involve secret iter args may have iter args whose initial values are
+  plaintexts. For example, a loop that sums a set of ciphertexts may start from
+  a plaintext initial value, not necessarily zero.
+
+  In this situation, lowering the loop to ciphertext types would fail because of
+  a ciphertext/plaintext type mismatch. This pass avoids this issue by peeling
+  the first iteration of any such loops.
+  }];
+  let dependentDialects = [
+    "mlir::heir::secret::SecretDialect",
+    "mlir::affine::AffineDialect",
+    "mlir::scf::SCFDialect",
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_HALO_PASSES_TD_

--- a/lib/Transforms/Halo/Patterns.cpp
+++ b/lib/Transforms/Halo/Patterns.cpp
@@ -1,0 +1,131 @@
+#include "lib/Transforms/Halo/Patterns.h"
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/LoopUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h"  // @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/Utils/Utils.h"  // @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+
+#define DEBUG_TYPE "halo-patterns"
+
+namespace mlir {
+namespace heir {
+
+using affine::AffineForOp;
+
+// Test if the two lists of values have mismatching secretness. Nb., a secret
+// init with a non-secret iter arg is probably not a meaningful outcome of this
+// function, but it doesn't hurt to support it.
+static bool hasMismatch(ArrayRef<Value> inits, ArrayRef<Value> yieldedValues,
+                        DataFlowSolver* solver) {
+  for (int i = 0; i < inits.size(); ++i) {
+    Value init = inits[i];
+    Value yield = yieldedValues[i];
+
+    auto* initLattice = solver->lookupState<SecretnessLattice>(init);
+    if (!initLattice || !initLattice->getValue().isInitialized()) {
+      continue;
+    }
+
+    auto* yieldLattice = solver->lookupState<SecretnessLattice>(yield);
+    if (!yieldLattice || !yieldLattice->getValue().isInitialized()) {
+      continue;
+    }
+
+    if (initLattice->getValue().getSecretness() !=
+        yieldLattice->getValue().getSecretness()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+LogicalResult PeelPlaintextAffineForInit::matchAndRewrite(
+    AffineForOp forOp, PatternRewriter& rewriter) const {
+  // Determine if the inits are public while the yielded values are secret
+  SmallVector<Value> inits(forOp.getInits());
+  SmallVector<Value> yieldedValues(forOp.getYieldedValues());
+  bool mismatch = hasMismatch(inits, yieldedValues, solver);
+
+  if (!mismatch) {
+    return rewriter.notifyMatchFailure(
+        forOp, "No ciphertext/plaintext mismatch detected");
+  }
+
+  LLVM_DEBUG(
+      llvm::dbgs() << "Found mismatch between init types and iter arg types\n");
+
+  if (!forOp.hasConstantBounds())
+    return rewriter.notifyMatchFailure(
+        forOp, "Only affine.for ops with constant bounds are supported");
+
+  int64_t lb = forOp.getConstantLowerBound();
+  int64_t ub = forOp.getConstantUpperBound();
+  int64_t step = forOp.getStep().getSExtValue();
+  int64_t splitBound = lb + step;
+
+  if (ceil(float(ub - lb) / step) <= 1) {
+    return rewriter.notifyMatchFailure(
+        forOp, "Peeling is not needed if there is one or less iteration.");
+  }
+
+  // Split the loop into two loops, the first of which has just one iteration,
+  // and then unroll the single-iteration loop.
+  AffineForOp firstIteration =
+      cast<AffineForOp>(rewriter.clone(*forOp.getOperation()));
+  rewriter.modifyOpInPlace(firstIteration, [&]() {
+    firstIteration.setConstantUpperBound(splitBound);
+  });
+
+  rewriter.modifyOpInPlace(forOp, [&]() {
+    forOp.getInitsMutable().assign(firstIteration->getResults());
+    forOp.setConstantLowerBound(splitBound);
+  });
+
+  rewriter.modifyOpInPlace(firstIteration, [&]() {
+    if (failed(loopUnrollFull(firstIteration))) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Failed to unroll single-iteration affine.for!\n");
+    }
+  });
+  return success();
+}
+
+LogicalResult PeelPlaintextScfForInit::matchAndRewrite(
+    scf::ForOp forOp, PatternRewriter& rewriter) const {
+  // Determine if the inits are public while the yielded values are secret
+  SmallVector<Value> inits(forOp.getInits());
+  SmallVector<Value> yieldedValues(forOp.getYieldedValues());
+  bool mismatch = hasMismatch(inits, yieldedValues, solver);
+
+  if (!mismatch) {
+    return rewriter.notifyMatchFailure(
+        forOp, "No ciphertext/plaintext mismatch detected");
+  }
+
+  LLVM_DEBUG(
+      llvm::dbgs() << "Found mismatch between init types and iter arg types\n");
+
+  scf::ForOp firstIteration;
+  LogicalResult result =
+      peelForLoopFirstIteration(rewriter, forOp, firstIteration);
+  if (failed(result)) {
+    return failure();
+  }
+
+  rewriter.modifyOpInPlace(firstIteration, [&]() {
+    if (failed(loopUnrollFull(firstIteration))) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Failed to unroll single-iteration affine.for!\n");
+    }
+  });
+
+  return success();
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/Halo/Patterns.h
+++ b/lib/Transforms/Halo/Patterns.h
@@ -1,0 +1,43 @@
+#ifndef LIB_TRANSFORMS_HALO_PATTERNS_H_
+#define LIB_TRANSFORMS_HALO_PATTERNS_H_
+
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"     // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"        // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+struct PeelPlaintextAffineForInit
+    : public OpRewritePattern<affine::AffineForOp> {
+  using OpRewritePattern<affine::AffineForOp>::OpRewritePattern;
+  PeelPlaintextAffineForInit(MLIRContext* context, DataFlowSolver* solver)
+      : OpRewritePattern(context), solver(solver) {}
+
+ public:
+  LogicalResult matchAndRewrite(affine::AffineForOp op,
+                                PatternRewriter& rewriter) const override;
+
+ private:
+  DataFlowSolver* solver;
+};
+
+struct PeelPlaintextScfForInit : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+  PeelPlaintextScfForInit(MLIRContext* context, DataFlowSolver* solver)
+      : OpRewritePattern(context), solver(solver) {}
+
+ public:
+  LogicalResult matchAndRewrite(scf::ForOp op,
+                                PatternRewriter& rewriter) const override;
+
+ private:
+  DataFlowSolver* solver;
+};
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_HALO_PATTERNS_H_

--- a/lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.cpp
+++ b/lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.cpp
@@ -1,0 +1,48 @@
+#include "lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.h"
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Transforms/Halo/Patterns.h"
+#include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+// IWYU pragma: end_keep
+
+#define DEBUG_TYPE "reconcile-mixed-secretness-iter-args"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_RECONCILEMIXEDSECRETNESSITERARGS
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+struct ReconcileMixedSecretnessIterArgs
+    : impl::ReconcileMixedSecretnessIterArgsBase<
+          ReconcileMixedSecretnessIterArgs> {
+  using ReconcileMixedSecretnessIterArgsBase::
+      ReconcileMixedSecretnessIterArgsBase;
+
+  void runOnOperation() override {
+    MLIRContext* context = &getContext();
+    RewritePatternSet patterns(context);
+
+    DataFlowSolver solver;
+    dataflow::loadBaselineAnalyses(solver);
+    solver.load<SecretnessAnalysis>();
+
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    patterns.add<PeelPlaintextAffineForInit, PeelPlaintextScfForInit>(context,
+                                                                      &solver);
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.h
+++ b/lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.h
@@ -1,0 +1,15 @@
+#ifndef LIB_TRANSFORMS_HALO_RECONCILEMIXEDSECRETNESSITERARGS_H_
+#define LIB_TRANSFORMS_HALO_RECONCILEMIXEDSECRETNESSITERARGS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL_RECONCILEMIXEDSECRETNESSITERARGS
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_HALO_RECONCILEMIXEDSECRETNESSITERARGS_H_

--- a/tests/Transforms/halo/BUILD
+++ b/tests/Transforms/halo/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/halo/reconcile_mixed_secretness_iter_args.mlir
+++ b/tests/Transforms/halo/reconcile_mixed_secretness_iter_args.mlir
@@ -1,0 +1,126 @@
+// RUN: heir-opt --reconcile-mixed-secretness-iter-args %s | FileCheck %s
+
+// CHECK: @peel_first_iter([[arg0:%[^:]*]]: !secret.secret<i32>)
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32):
+// CHECK:     [[peeled:%[^ ]*]] = arith.addi [[c1]], [[arg0_val]]
+// CHECK:     [[res:%[^ ]*]] = affine.for [[i:[^ ]*]] = 1 to 10 iter_args([[iter_arg:%[^ ]*]] = [[peeled]]) -> (i32) {
+// CHECK:       arith.addi
+// CHECK:       affine.yield
+func.func @peel_first_iter(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%arg0_val: i32):
+    %res = affine.for %i = 0 to 10 iter_args(%sum_iter = %c1) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      affine.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}
+
+
+// CHECK: @dont_peel_secret([[arg0:%[^:]*]]: !secret.secret<i32>, [[init:%[^ ]*]]: !secret.secret<i32>
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32, [[init_val:%[^:]*]]: i32):
+// CHECK-NEXT:     affine.for [[i:[^ ]*]] = 0 to 10 iter_args([[iter_arg:%[^ ]*]] = [[init_val]]) -> (i32) {
+// CHECK:       arith.addi
+// CHECK:       affine.yield
+func.func @dont_peel_secret(%arg0: !secret.secret<i32>, %init: !secret.secret<i32>) -> !secret.secret<i32> {
+  %0 = secret.generic(%arg0: !secret.secret<i32>, %init: !secret.secret<i32>) {
+  ^body(%arg0_val: i32, %init_val: i32):
+    %res = affine.for %i = 0 to 10 iter_args(%sum_iter = %init_val) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      affine.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}
+
+
+// CHECK: @dont_peel_nonsecret([[arg0:%[^:]*]]: i32
+// CHECK-NEXT:  arith.constant
+// CHECK-NEXT:  affine.for [[i:[^ ]*]] = 0 to 10
+func.func @dont_peel_nonsecret(%arg0: i32) -> i32 {
+  %init = arith.constant 1 : i32
+  %0 = affine.for %i = 0 to 10 iter_args(%sum_iter = %init) -> i32 {
+    %sum = arith.addi %sum_iter, %arg0 : i32
+    affine.yield %sum : i32
+  }
+  return %0 : i32
+}
+
+// CHECK: @peel_first_iter_scf([[arg0:%[^:]*]]: !secret.secret<i32>)
+// CHECK:   [[c0:%[^ ]*]] = arith.constant 0 : index
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : index
+// CHECK:   [[c1_i32:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   [[c10:%[^ ]*]] = arith.constant 10 : index
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32):
+// CHECK:     [[c1_again:%[^ ]*]] = arith.constant 1 : index
+// CHECK:     [[peeled:%[^ ]*]] = arith.addi [[c1_i32]], [[arg0_val]]
+// CHECK:     [[res:%[^ ]*]] = scf.for [[i:[^ ]*]] = [[c1_again]] to [[c10]] step [[c1]] iter_args([[iter_arg:%[^ ]*]] = [[peeled]]) -> (i32) {
+// CHECK:       arith.addi
+// CHECK:       scf.yield
+func.func @peel_first_iter_scf(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c1_i32 = arith.constant 1 : i32
+  %c10 = arith.constant 10 : index
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%arg0_val: i32):
+    %res = scf.for %i = %c0 to %c10 step %c1 iter_args(%sum_iter = %c1_i32) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      scf.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}
+
+
+// CHECK: @dont_peel_secret_scf([[arg0:%[^:]*]]: !secret.secret<i32>, [[init:%[^ ]*]]: !secret.secret<i32>
+// CHECK:   [[c0:%[^ ]*]] = arith.constant 0 : index
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : index
+// CHECK:   [[c10:%[^ ]*]] = arith.constant 10 : index
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32, [[init_val:%[^:]*]]: i32):
+// CHECK-NEXT:     scf.for [[i:[^ ]*]] = [[c0]] to [[c10]] step [[c1]] iter_args([[iter_arg:%[^ ]*]] = [[init_val]]) -> (i32) {
+// CHECK:       arith.addi
+// CHECK:       scf.yield
+func.func @dont_peel_secret_scf(%arg0: !secret.secret<i32>, %init: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %0 = secret.generic(%arg0: !secret.secret<i32>, %init: !secret.secret<i32>) {
+  ^body(%arg0_val: i32, %init_val: i32):
+    %res = scf.for %i = %c0 to %c10 step %c1 iter_args(%sum_iter = %init_val) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      scf.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}
+
+
+// CHECK: @dont_peel_nonsecret_scf([[arg0:%[^:]*]]: i32
+// CHECK:   [[c0:%[^ ]*]] = arith.constant 0 : index
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : index
+// CHECK:   [[c10:%[^ ]*]] = arith.constant 10 : index
+// CHECK:   [[init:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   scf.for [[i:[^ ]*]] = [[c0]] to [[c10]] step [[c1]] iter_args(%{{.*}} = [[init]])
+func.func @dont_peel_nonsecret_scf(%arg0: i32) -> i32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %init = arith.constant 1 : i32
+  %0 = scf.for %i = %c0 to %c10 step %c1 iter_args(%sum_iter = %init) -> i32 {
+    %sum = arith.addi %sum_iter, %arg0 : i32
+    scf.yield %sum : i32
+  }
+  return %0 : i32
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -126,6 +126,7 @@ cc_binary(
         "@heir//lib/Transforms/ForwardStoreToLoad",
         "@heir//lib/Transforms/FullLoopUnroll",
         "@heir//lib/Transforms/GenerateParam",
+        "@heir//lib/Transforms/Halo:Transforms",
         "@heir//lib/Transforms/InlineActivations",
         "@heir//lib/Transforms/LayoutOptimization",
         "@heir//lib/Transforms/LayoutOptimization:InterfaceImpl",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -79,6 +79,7 @@
 #include "lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.h"
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
 #include "lib/Transforms/GenerateParam/GenerateParam.h"
+#include "lib/Transforms/Halo/Passes.h"
 #include "lib/Transforms/InlineActivations/InlineActivations.h"
 #include "lib/Transforms/LayoutOptimization/InterfaceImpl.h"
 #include "lib/Transforms/LayoutOptimization/LayoutOptimization.h"
@@ -292,6 +293,7 @@ int main(int argc, char** argv) {
   registerForwardInsertToExtractPasses();
   registerForwardStoreToLoadPasses();
   registerGenerateParamPasses();
+  registerHaloPasses();
   registerOperationBalancerPasses();
   registerPopulateScalePasses();
   registerStraightLineVectorizerPasses();


### PR DESCRIPTION
Adds patterns to peel the first iteration of an `affine.for` or `scf.for` loop when the secretness of the init value and the yielded iter-arg disagree.

This is intended to be used at the `secret` + `arith` level, possibly with `mgmt` ops in the mix. I think this pattern will ultimately be used as part of the `insert-mgmt` pipeline, since that is where the bootstrap and level analysis occurs. But for now it's an independent pattern with a thin wrapper pass for testing.