### PR TITLE
Bootstrap loop iter args (Halo Solution A-2)

### DIFF
--- a/lib/Dialect/Mgmt/IR/MgmtOps.td
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.td
@@ -62,6 +62,20 @@ def Mgmt_LevelReduceOp : Mgmt_Op<"level_reduce"> {
   let hasCanonicalizer = 1;
 }
 
+def Mgmt_LevelReduceMinOp : Mgmt_Op<"level_reduce_min"> {
+  let summary = "Reduce the level of input ciphertext to the minimum level";
+  let description = [{
+    This scheme-agonistic operation reduces the ciphertext level
+    to the minimum allowable level (typically 1 RNS limb). This is used in
+    HALO-style optimizations to ensure loop iter args and inits are invariant
+    across loop iterations.
+  }];
+  let arguments = (ins AnyType:$input);
+  let results = (outs AnyType:$output);
+  let assemblyFormat = "operands attr-dict `:` type($output)";
+}
+
+
 def Mgmt_RelinearizeOp : Mgmt_Op<"relinearize"> {
   let summary = "Relinearize the input ciphertext to be _linear_";
 

--- a/lib/Transforms/Halo/BUILD
+++ b/lib/Transforms/Halo/BUILD
@@ -10,8 +10,10 @@ cc_library(
     name = "Transforms",
     hdrs = ["Passes.h"],
     deps = [
+        ":BootstrapLoopIterArgs",
         ":ReconcileMixedSecretnessIterArgs",
         ":pass_inc_gen",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:SCFDialect",
@@ -26,6 +28,8 @@ cc_library(
     ],
     deps = [
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
@@ -54,6 +58,26 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+cc_library(
+    name = "BootstrapLoopIterArgs",
+    srcs = ["BootstrapLoopIterArgs.cpp"],
+    hdrs = [
+        "BootstrapLoopIterArgs.h",
+    ],
+    deps = [
+        ":Patterns",
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/lib/Transforms/Halo/BootstrapLoopIterArgs.cpp
+++ b/lib/Transforms/Halo/BootstrapLoopIterArgs.cpp
@@ -1,0 +1,48 @@
+#include "lib/Transforms/Halo/BootstrapLoopIterArgs.h"
+
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Transforms/Halo/Patterns.h"
+#include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+// IWYU pragma: end_keep
+
+#define DEBUG_TYPE "bootstrap-loop-iter-args"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_BOOTSTRAPLOOPITERARGS
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+struct BootstrapLoopIterArgs
+    : impl::BootstrapLoopIterArgsBase<BootstrapLoopIterArgs> {
+  using BootstrapLoopIterArgsBase::BootstrapLoopIterArgsBase;
+
+  void runOnOperation() override {
+    MLIRContext* context = &getContext();
+    RewritePatternSet patterns(context);
+
+    DataFlowSolver solver;
+    dataflow::loadBaselineAnalyses(solver);
+    solver.load<SecretnessAnalysis>();
+
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    patterns.add<BootstrapIterArgsPattern<affine::AffineForOp>,
+                 BootstrapIterArgsPattern<scf::ForOp>>(context, &solver);
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/Halo/BootstrapLoopIterArgs.h
+++ b/lib/Transforms/Halo/BootstrapLoopIterArgs.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_HALO_BOOTSTRAPLOOPITERARGS_H_
+#define LIB_TRANSFORMS_HALO_BOOTSTRAPLOOPITERARGS_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL_BOOTSTRAPLOOPITERARGS
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_HALO_BOOTSTRAPLOOPITERARGS_H_

--- a/lib/Transforms/Halo/Passes.h
+++ b/lib/Transforms/Halo/Passes.h
@@ -2,7 +2,9 @@
 #define LIB_TRANSFORMS_HALO_PASSES_H_
 
 // IWYU pragma: begin_keep
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Secret/IR/SecretDialect.h"
+#include "lib/Transforms/Halo/BootstrapLoopIterArgs.h"
 #include "lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.h"
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project

--- a/lib/Transforms/Halo/Passes.td
+++ b/lib/Transforms/Halo/Passes.td
@@ -13,6 +13,8 @@ def ReconcileMixedSecretnessIterArgs : Pass<"reconcile-mixed-secretness-iter-arg
   In this situation, lowering the loop to ciphertext types would fail because of
   a ciphertext/plaintext type mismatch. This pass avoids this issue by peeling
   the first iteration of any such loops.
+
+  (* example filepath=tests/Transforms/halo/reconcile_mixed_secretness_iter_args_doctest.mlir *)
   }];
   let dependentDialects = [
     "mlir::heir::secret::SecretDialect",
@@ -20,5 +22,34 @@ def ReconcileMixedSecretnessIterArgs : Pass<"reconcile-mixed-secretness-iter-arg
     "mlir::scf::SCFDialect",
   ];
 }
+
+def BootstrapLoopIterArgs : Pass<"bootstrap-loop-iter-args"> {
+  let summary = "Bootstrap loop-carried iter args at the start of each loop iteration";
+  let description = [{
+  Loops that involve secret iter-args have to have invariant ciphertext management
+  properties across iterations of the loop. To enforce this, this pass inserts
+  bootstrap ops of all loop-carried variables at the start of each loop iteration,
+  while also ensuring:
+
+  - All loop initializers are mod-switched to the lowest level before entering the loop
+  - All values yielded to the next iteration of the loop are mod-switched to the lowest
+    level before yielding.
+
+  This pass is intended to preface further optimizations of a loop, by bringing
+  a loop to a consistent state where the ciphertext level is invariant across
+  iterations of the loop. In particular, this requires the loop has already been
+  processed by a pass (such as `reconcile-mixed-secretness-iter-args`) that ensures
+  iter args and initializers have equal types.
+
+  (* example filepath=tests/Transforms/halo/bootstrap_loop_iter_args_doctest.mlir *)
+  }];
+  let dependentDialects = [
+    "mlir::heir::secret::SecretDialect",
+    "mlir::affine::AffineDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::heir::mgmt::MgmtDialect",
+  ];
+}
+
 
 #endif  // LIB_TRANSFORMS_HALO_PASSES_TD_

--- a/lib/Transforms/Halo/Patterns.h
+++ b/lib/Transforms/Halo/Patterns.h
@@ -1,6 +1,8 @@
 #ifndef LIB_TRANSFORMS_HALO_PATTERNS_H_
 #define LIB_TRANSFORMS_HALO_PATTERNS_H_
 
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
@@ -32,6 +34,72 @@ struct PeelPlaintextScfForInit : public OpRewritePattern<scf::ForOp> {
  public:
   LogicalResult matchAndRewrite(scf::ForOp op,
                                 PatternRewriter& rewriter) const override;
+
+ private:
+  DataFlowSolver* solver;
+};
+
+/// For docs, see the tablegen description in Passes.td for
+/// bootstrap-loop-iter-args.
+template <typename T>
+struct BootstrapIterArgsPattern : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+  BootstrapIterArgsPattern(MLIRContext* context, DataFlowSolver* solver)
+      : OpRewritePattern<T>(context), solver(solver) {}
+
+ public:
+  LogicalResult matchAndRewrite(T forOp,
+                                PatternRewriter& rewriter) const override {
+    // Determine which inits are secret and need to be bootstrapped
+    SmallVector<int> secretInitIndices;
+    secretInitIndices.reserve(forOp.getInits().size());
+
+    for (auto [i, init] : llvm::enumerate(forOp.getInits())) {
+      auto* initLattice = solver->lookupState<SecretnessLattice>(init);
+      if (initLattice && initLattice->getValue().isInitialized() &&
+          initLattice->getValue().getSecretness()) {
+        secretInitIndices.push_back(i);
+      }
+    }
+
+    if (secretInitIndices.empty()) {
+      return rewriter.notifyMatchFailure(
+          forOp, "No ciphertext values need bootstrapping");
+    }
+
+    // Insert a leading mgmt.level_reduce_min for each secret init
+    rewriter.setInsertionPoint(forOp);
+    for (auto i : secretInitIndices) {
+      auto& initMutable = forOp.getInitsMutable()[i];
+      auto reduceMinOp = mgmt::LevelReduceMinOp::create(
+          rewriter, forOp.getLoc(), initMutable.get());
+      rewriter.modifyOpInPlace(
+          forOp, [&]() { initMutable.set(reduceMinOp.getResult()); });
+    }
+
+    // Insert a bootstrap for each secret yielded iter arg.
+    rewriter.setInsertionPointToStart(forOp.getBody());
+    for (auto i : secretInitIndices) {
+      Value iterArg = forOp.getRegionIterArgs()[i];
+      auto bootstrapOp =
+          mgmt::BootstrapOp::create(rewriter, forOp.getLoc(), iterArg);
+      rewriter.replaceAllUsesExcept(iterArg, bootstrapOp.getResult(),
+                                    bootstrapOp);
+    }
+
+    // Insert a trailing mgmt.level_reduce_min for each secret yielded iter arg.
+    Operation* yieldOp = forOp.getBody()->getTerminator();
+    rewriter.setInsertionPoint(yieldOp);
+    for (auto i : secretInitIndices) {
+      auto& yieldedValue = yieldOp->getOpOperand(i);
+      auto reduceMinOp = mgmt::LevelReduceMinOp::create(
+          rewriter, forOp.getLoc(), yieldedValue.get());
+      rewriter.modifyOpInPlace(
+          yieldOp, [&]() { yieldedValue.set(reduceMinOp.getResult()); });
+    }
+
+    return success();
+  }
 
  private:
   DataFlowSolver* solver;

--- a/tests/Transforms/halo/bootstrap_loop_iter_args.mlir
+++ b/tests/Transforms/halo/bootstrap_loop_iter_args.mlir
@@ -1,0 +1,92 @@
+// RUN: heir-opt --bootstrap-loop-iter-args %s | FileCheck %s
+
+// CHECK: @doctest([[arg0:%[^:]*]]: !secret.secret<i32>)
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32):
+// CHECK:     [[peeled:%[^ ]*]] = arith.addi [[c1]], [[arg0_val]]
+// CHECK:     [[level_reduced:%[^ ]*]] = mgmt.level_reduce_min [[peeled]]
+// CHECK:     [[res:%[^ ]*]] = affine.for [[i:[^ ]*]] = 1 to 10 iter_args([[iter_arg:%[^ ]*]] = [[level_reduced]]) -> (i32) {
+// CHECK:       mgmt.bootstrap [[iter_arg]]
+// CHECK:       arith.addi
+// CHECK:       mgmt.level_reduce_min
+// CHECK:       affine.yield
+func.func @doctest(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%arg0_val: i32):
+    %init = arith.addi %c1, %arg0_val : i32
+    %res = affine.for %i = 1 to 10 iter_args(%sum_iter = %init) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      affine.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}
+
+// CHECK: @doctest_scf([[arg0:%[^:]*]]: !secret.secret<i32>)
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32):
+// CHECK:     [[peeled:%[^ ]*]] = arith.addi [[c1]], [[arg0_val]]
+// CHECK:     [[level_reduced:%[^ ]*]] = mgmt.level_reduce_min [[peeled]]
+// CHECK:     [[res:%[^ ]*]] = scf.for [[i:[^ ]*]] = %c1 to %c10 step %c1 iter_args([[iter_arg:%[^ ]*]] = [[level_reduced]]) -> (i32) {
+// CHECK:       mgmt.bootstrap [[iter_arg]]
+// CHECK:       arith.addi
+// CHECK:       mgmt.level_reduce_min
+// CHECK:       scf.yield
+func.func @doctest_scf(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %c1_i32 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%arg0_val: i32):
+    %init = arith.addi %c1_i32, %arg0_val : i32
+    %res = scf.for %i = %c1 to %c10 step %c1 iter_args(%sum_iter = %init) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      scf.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}
+
+// CHECK: @four_iter_args_two_secret
+// CHECK:         [[C0:%[^ ]*]] = arith.constant 0
+// CHECK:         [[C1:%[^ ]*]] = arith.constant 1
+// CHECK:         secret.generic
+// CHECK:         ^body([[S0:%[^:]*]]: i32, [[S1:%[^:]*]]: i32):
+// CHECK:           [[INIT_S0:%[^ ]*]] = arith.addi [[S0]], [[S0]]
+// CHECK:           [[INIT_S1:%[^ ]*]] = arith.addi [[S1]], [[S1]]
+// CHECK:           [[LRM0:%[^ ]*]] = mgmt.level_reduce_min [[INIT_S0]]
+// CHECK:           [[LRM1:%[^ ]*]] = mgmt.level_reduce_min [[INIT_S1]]
+// CHECK:           affine.for {{.*}} iter_args([[ARG0:%[^ ]*]] = [[C0]], [[ARG1:%[^ ]*]] = [[LRM0]], [[ARG2:%[^ ]*]] = [[C1]], [[ARG3:%[^ ]*]] = [[LRM1]])
+// CHECK:             [[BS0:%[^ ]*]] = mgmt.bootstrap [[ARG1]]
+// CHECK:             [[BS1:%[^ ]*]] = mgmt.bootstrap [[ARG3]]
+// CHECK:             [[ADD0:%[^ ]*]] = arith.addi [[ARG0]], [[C0]]
+// CHECK:             [[ADD1:%[^ ]*]] = arith.addi [[BS0]], [[S0]]
+// CHECK:             [[ADD2:%[^ ]*]] = arith.addi [[ARG2]], [[C1]]
+// CHECK:             [[ADD3:%[^ ]*]] = arith.addi [[BS1]], [[S1]]
+// CHECK:             [[LRM2:%[^ ]*]] = mgmt.level_reduce_min [[ADD1]]
+// CHECK:             [[LRM3:%[^ ]*]] = mgmt.level_reduce_min [[ADD3]]
+// CHECK:             affine.yield [[ADD0]], [[LRM2]], [[ADD2]], [[LRM3]]
+// CHECK:           secret.yield
+func.func @four_iter_args_two_secret(%arg0: !secret.secret<i32>, %arg1: !secret.secret<i32>) -> (!secret.secret<i32>, !secret.secret<i32>) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %0:2 = secret.generic(%arg0: !secret.secret<i32>, %arg1: !secret.secret<i32>) {
+  ^body(%s0: i32, %s1: i32):
+    %init_s0 = arith.addi %s0, %s0 : i32
+    %init_s1 = arith.addi %s1, %s1 : i32
+    %res:4 = affine.for %i = 1 to 10 iter_args(%iter0 = %c0, %iter1 = %init_s0, %iter2 = %c1, %iter3 = %init_s1) -> (i32, i32, i32, i32) {
+      %add0 = arith.addi %iter0, %c0 : i32
+      %add1 = arith.addi %iter1, %s0 : i32
+      %add2 = arith.addi %iter2, %c1 : i32
+      %add3 = arith.addi %iter3, %s1 : i32
+      affine.yield %add0, %add1, %add2, %add3 : i32, i32, i32, i32
+    }
+    secret.yield %res#1, %res#3 : i32, i32
+  } -> (!secret.secret<i32>, !secret.secret<i32>)
+  return %0#0, %0#1 : !secret.secret<i32>, !secret.secret<i32>
+}

--- a/tests/Transforms/halo/bootstrap_loop_iter_args_doctest.mlir
+++ b/tests/Transforms/halo/bootstrap_loop_iter_args_doctest.mlir
@@ -1,0 +1,26 @@
+// RUN: heir-opt --bootstrap-loop-iter-args %s | FileCheck %s
+
+// CHECK: @doctest([[arg0:%[^:]*]]: !secret.secret<i32>)
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32):
+// CHECK:     [[peeled:%[^ ]*]] = arith.addi [[c1]], [[arg0_val]]
+// CHECK:     [[level_reduced:%[^ ]*]] = mgmt.level_reduce_min [[peeled]]
+// CHECK:     [[res:%[^ ]*]] = affine.for [[i:[^ ]*]] = 1 to 10 iter_args([[iter_arg:%[^ ]*]] = [[level_reduced]]) -> (i32) {
+// CHECK:       mgmt.bootstrap [[iter_arg]]
+// CHECK:       arith.addi
+// CHECK:       mgmt.level_reduce_min
+// CHECK:       affine.yield
+func.func @doctest(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%arg0_val: i32):
+    %init = arith.addi %c1, %arg0_val : i32
+    %res = affine.for %i = 1 to 10 iter_args(%sum_iter = %init) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      affine.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}

--- a/tests/Transforms/halo/reconcile_mixed_secretness_iter_args_doctest.mlir
+++ b/tests/Transforms/halo/reconcile_mixed_secretness_iter_args_doctest.mlir
@@ -1,0 +1,22 @@
+// RUN: heir-opt --reconcile-mixed-secretness-iter-args %s | FileCheck %s
+
+// CHECK: @peel_first_iter([[arg0:%[^:]*]]: !secret.secret<i32>)
+// CHECK:   [[c1:%[^ ]*]] = arith.constant 1 : i32
+// CHECK:   [[res:%[^ ]*]] = secret.generic([[arg0]]
+// CHECK:   ^[[body:[^(]*]]([[arg0_val:%[^:]*]]: i32):
+// CHECK:     [[peeled:%[^ ]*]] = arith.addi [[c1]], [[arg0_val]]
+// CHECK:     [[res:%[^ ]*]] = affine.for [[i:[^ ]*]] = 1 to 10 iter_args([[iter_arg:%[^ ]*]] = [[peeled]]) -> (i32) {
+// CHECK:       arith.addi
+// CHECK:       affine.yield
+func.func @peel_first_iter(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%arg0_val: i32):
+    %res = affine.for %i = 0 to 10 iter_args(%sum_iter = %c1) -> i32 {
+      %sum = arith.addi %sum_iter, %arg0_val : i32
+      affine.yield %sum : i32
+    }
+    secret.yield %res : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}


### PR DESCRIPTION
From 4.2 of https://dl.acm.org/doi/10.1145/3669940.3707275

> Solution A-2: Bootstrapping all the loop-carried variables at the beginning of each iteration. Regardless of consumed levels of ciphertexts, bootstrapping reinitializes their level. Therefore, inserting the bootstrap operation at the beginning of the loop iteration can resolve the level type mismatch problem. Figure 2: Solution A-2 depicts the level matching process of the input and output of the loop body. Before entering the loop body, HALO reduces each level of y and a to the minimum level using modswitch for live-in and loop-carried variables. Then, HALO recovers the levels of the loop inputs to 10 by bootstrapping all loop inputs at the beginning of the loop. After type matching process, the loop is transformed to a type-matched loop (repeatable). However, the type-matched loops are inefficient. For efficient loop execution, bootstrap-based loop restructuring is required.

For this PR I introduced a new `mgmt` op: `mgmt.level_reduce_min` which corresponds to "reducing the level to the minimum allowable level." I suspect we need this op in this situation because we will be inserting this `level_reduce_min` before knowing what the actual level budget is, and this ensures that our level analysis can reach a fixpoint when processing the loops that will be present after the HALO implementation is integrated.

Rebased over https://github.com/google/heir/pull/2534, and similar to that PR, I just created a pattern to handle the core operation, wrapped it in a dedicated pass for testing, and will figure out how to integrate it into the mgmt pipeline once all the remaining pieces of the Halo paper are implemented.