### PR TITLE
Partially unrolling loops for better level consumption (Halo B-2)

### DIFF
--- a/lib/Transforms/Halo/BUILD
+++ b/lib/Transforms/Halo/BUILD
@@ -11,6 +11,7 @@ cc_library(
     hdrs = ["Passes.h"],
     deps = [
         ":BootstrapLoopIterArgs",
+        ":PartialUnrollForLevelConsumption",
         ":ReconcileMixedSecretnessIterArgs",
         ":pass_inc_gen",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
@@ -27,6 +28,7 @@ cc_library(
         "Patterns.h",
     ],
     deps = [
+        "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
@@ -34,6 +36,7 @@ cc_library(
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",
@@ -80,6 +83,28 @@ cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+cc_library(
+    name = "PartialUnrollForLevelConsumption",
+    srcs = ["PartialUnrollForLevelConsumption.cpp"],
+    hdrs = [
+        "PartialUnrollForLevelConsumption.h",
+    ],
+    deps = [
+        ":Patterns",
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/LevelAnalysis",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/lib/Transforms/Halo/PartialUnrollForLevelConsumption.cpp
+++ b/lib/Transforms/Halo/PartialUnrollForLevelConsumption.cpp
@@ -1,0 +1,55 @@
+#include "lib/Transforms/Halo/PartialUnrollForLevelConsumption.h"
+
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Transforms/Halo/Patterns.h"
+#include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+// IWYU pragma: end_keep
+
+#define DEBUG_TYPE "partial-unroll-for-level-consumption"
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_PARTIALUNROLLFORLEVELCONSUMPTION
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+struct PartialUnrollForLevelConsumption
+    : impl::PartialUnrollForLevelConsumptionBase<
+          PartialUnrollForLevelConsumption> {
+  using PartialUnrollForLevelConsumptionBase::
+      PartialUnrollForLevelConsumptionBase;
+
+  void runOnOperation() override {
+    MLIRContext* context = &getContext();
+
+    DataFlowSolver solver;
+    dataflow::loadBaselineAnalyses(solver);
+    solver.load<SecretnessAnalysis>();
+    solver.load<LevelAnalysis>();
+
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    RewritePatternSet patterns(context);
+    patterns.add<PartialUnrollForLevelConsumptionAffineFor,
+                 PartialUnrollForLevelConsumptionSCFFor>(context, forceMaxLevel,
+                                                         &solver);
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+
+    RewritePatternSet cleanupPatterns(context);
+    cleanupPatterns.add<DeleteAnnotatedOps>(context);
+    walkAndApplyPatterns(getOperation(), std::move(cleanupPatterns));
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/Halo/PartialUnrollForLevelConsumption.h
+++ b/lib/Transforms/Halo/PartialUnrollForLevelConsumption.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_HALO_PARTIALUNROLLFORLEVELCONSUMPTION_H_
+#define LIB_TRANSFORMS_HALO_PARTIALUNROLLFORLEVELCONSUMPTION_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL_PARTIALUNROLLFORLEVELCONSUMPTION
+#include "lib/Transforms/Halo/Halo.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_HALO_PARTIALUNROLLFORLEVELCONSUMPTION_H_

--- a/lib/Transforms/Halo/Passes.h
+++ b/lib/Transforms/Halo/Passes.h
@@ -5,6 +5,7 @@
 #include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
 #include "lib/Dialect/Secret/IR/SecretDialect.h"
 #include "lib/Transforms/Halo/BootstrapLoopIterArgs.h"
+#include "lib/Transforms/Halo/PartialUnrollForLevelConsumption.h"
 #include "lib/Transforms/Halo/ReconcileMixedSecretnessIterArgs.h"
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project

--- a/lib/Transforms/Halo/Passes.td
+++ b/lib/Transforms/Halo/Passes.td
@@ -51,5 +51,39 @@ def BootstrapLoopIterArgs : Pass<"bootstrap-loop-iter-args"> {
   ];
 }
 
+def PartialUnrollForLevelConsumption : Pass<"partial-unroll-for-level-consumption"> {
+  let summary = "Partially unroll a loop over ciphertexts to better utilize level consumption.";
+  let description = [{
+  The `bootstrap-loop-iter-args` pass inserts a bootstrap operation at the start of each
+  loop ieration, for each loop-carried iter arg. The loop body may not be sufficiently
+  large to utilize all the levels provided by a bootstrap operation. This pass compensates
+  for that by partially unrolling the loop so that level utilization is improved, and
+  bootstraps are not required for every iteration. After unrolling, unnecessary bootstrap
+  ops and `level_reduce_min` ops are removed.
+
+  In order for a loop to qualify for this pass, it must satisfy the following properties:
+
+  - All secret iter args have `mgmt.bootstrap` as their only use.
+  - All secret values yielded in the loop body are op results of `mgmt.level_reduce_min` ops.
+
+  This pass operates by analyzing how many levels are consumed by a loop body, and combining
+  that with the maximum level in the IR to determine how much the loop can be unrolled.
+  However, because this pass may be applied before the final level in the IR is chosen,
+  it accepts an option `force-max-level` that allows the pass pipeline to force the loop
+  unrolling calculation to use a particular value for its max level.
+
+  (* example filepath=tests/Transforms/halo/partial_unroll_for_level_consumption_doctest.mlir *)
+  }];
+  let options = [
+    Option<"forceMaxLevel", "force-max-level", "int", /*default=*/"0",
+           "If nonzero, forces the inferred maximum level to the given value.">,
+  ];
+  let dependentDialects = [
+    "mlir::heir::secret::SecretDialect",
+    "mlir::affine::AffineDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::heir::mgmt::MgmtDialect",
+  ];
+}
 
 #endif  // LIB_TRANSFORMS_HALO_PASSES_TD_

--- a/lib/Transforms/Halo/Patterns.cpp
+++ b/lib/Transforms/Halo/Patterns.cpp
@@ -3,11 +3,14 @@
 #include <cmath>
 #include <cstdint>
 
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Affine/Analysis/LoopAnalysis.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/LoopUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/Transforms/Transforms.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/Utils/Utils.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
@@ -19,6 +22,7 @@ namespace mlir {
 namespace heir {
 
 using affine::AffineForOp;
+using affine::loopUnrollByFactor;
 
 // Test if the two lists of values have mismatching secretness. Nb., a secret
 // init with a non-secret iter arg is probably not a meaningful outcome of this
@@ -128,6 +132,241 @@ LogicalResult PeelPlaintextScfForInit::matchAndRewrite(
     }
   });
 
+  return success();
+}
+
+// Helper for rejecting a loop unroll pattern. Check:
+//
+// - all secret iter args are immediately bootstrapped and have no other uses
+// - all secret iter args level_reduce_min just before being yielded
+//
+// If successful, the SSA values corresponding to secret iter args are returned.
+template <typename ForLoop>
+FailureOr<SmallVector<Value>> isLoopStructuredForHaloUnroll(
+    ForLoop forOp, DataFlowSolver* solver) {
+  SmallVector<Value> secretIterArgs;
+
+  for (Value iterArg : forOp.getRegionIterArgs()) {
+    if (isSecret(iterArg, solver)) {
+      if (!iterArg.hasOneUse()) {
+        return failure();
+      }
+      if (!isa<mgmt::BootstrapOp>(*iterArg.getUsers().begin())) {
+        return failure();
+      }
+
+      Value yieldedValue =
+          forOp.getTiedLoopYieldedValue(cast<BlockArgument>(iterArg))->get();
+      if (!isa<mgmt::LevelReduceMinOp>(yieldedValue.getDefiningOp())) {
+        return failure();
+      }
+
+      secretIterArgs.push_back(iterArg);
+    }
+  }
+
+  if (secretIterArgs.empty()) {
+    return failure();
+  }
+
+  return secretIterArgs;
+}
+
+// Inject an scf::ForOp overload of this function, which exists upstream for
+// affine already.
+FailureOr<int64_t> getConstantTripCount(scf::ForOp forOp) {
+  if (auto step = forOp.getConstantStep();
+      !step.has_value() || !step->isOne()) {
+    if (step.has_value()) {
+      return mlir::failure();
+    }
+    return mlir::failure();
+  }
+  APInt lowerBound;
+  if (!matchPattern(forOp.getLowerBound(), m_ConstantInt(&lowerBound))) {
+    return mlir::failure();
+  }
+
+  APInt upperBound;
+  if (!matchPattern(forOp.getUpperBound(), m_ConstantInt(&upperBound))) {
+    return mlir::failure();
+  }
+
+  return (upperBound - lowerBound).getLimitedValue();
+}
+
+template <typename ForOp>
+LogicalResult doPartialUnroll(ForOp forOp, PatternRewriter& rewriter,
+                              int forceMaxLevel, DataFlowSolver* solver) {
+  FailureOr<SmallVector<Value>> secretIterArgsResult =
+      isLoopStructuredForHaloUnroll(forOp, solver);
+  if (failed(secretIterArgsResult)) {
+    return rewriter.notifyMatchFailure(forOp, "Loop preconditions not met");
+  }
+  SmallVector<Value> secretIterArgs = secretIterArgsResult.value();
+
+  std::optional<uint64_t> maybeTripCount = getConstantTripCount(forOp);
+  if (!maybeTripCount.has_value()) return failure();
+  int64_t tripCount = maybeTripCount.value();
+
+  // Now we need to compute how many loop iterations we can unroll.
+  //
+  // To start, assume we have just one iter arg. It is assumed to be the result
+  // of a mgmt.level_reduce_min op just before being yielded. The quantity we
+  // need to compute is the difference between the level just after the
+  // bootstrap op (the "effective level" of bootstrap) and the level just before
+  // the level_reduce_min op.
+  //
+  //  %2 = mgmt.level_reduce_min %1 : i32
+  //  %3 = affine.for %arg1 = 1 to 12 iter_args(%arg2 = %2) -> (i32) {
+  //     %4 = mgmt.bootstrap %arg2 : i32
+  //     LEVEL_START[%arg2] = level(%4)
+  //
+  //     ...
+  //
+  //     LEVEL_END[%arg2] = level(%5)
+  //     %6 = mgmt.level_reduce_min %5 : i32
+  //     affine.yield %6 : i32
+  //  }
+  //
+  // If LEVEL_END > 0, then we can unroll if and only if LEVEL_START / T > 1,
+  // and (int) LEVEL_START / T is the factor we can unroll by.
+  //
+  // If we have many iter args, the allowable loop unroll factor is the minimum
+  // among all iter args.
+  //
+  // TODO(#2556): Use smarter unroll strategies for multiple iter_args.
+
+  SmallVector<int> unrollFactors;
+  for (Value iterArg : secretIterArgs) {
+    auto bootstrapOp = cast<mgmt::BootstrapOp>(*iterArg.getUsers().begin());
+    auto* levelStart =
+        solver->lookupState<LevelLattice>(bootstrapOp.getResult());
+
+    Value yieldedValue =
+        forOp.getTiedLoopYieldedValue(cast<BlockArgument>(iterArg))->get();
+    mgmt::LevelReduceMinOp levelReduceOp =
+        cast<mgmt::LevelReduceMinOp>(yieldedValue.getDefiningOp());
+    auto* levelEnd =
+        solver->lookupState<LevelLattice>(levelReduceOp.getInput());
+
+    if (!levelStart || !levelEnd || !levelStart->getValue().isInt() ||
+        !levelEnd->getValue().isInt()) {
+      return rewriter.notifyMatchFailure(
+          forOp,
+          "Start and end levels were not inferable to be concrete integers");
+    }
+
+    // In the LevelAnalysis, the levels start from 0 and go up, so the
+    // difference is the ending level minus the starting level.
+    int levelEndVal = levelEnd->getValue().getInt();
+    int levelStartVal = levelStart->getValue().getInt();
+
+    // TODO(#2557): consider effective bootstrap level
+    int levelAfterBootstrap =
+        getMaxLevel(forOp->template getParentOfType<func::FuncOp>(), solver);
+    if (forceMaxLevel > 0) {
+      levelAfterBootstrap = forceMaxLevel;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Using forced max level of " << forceMaxLevel << "\n");
+    }
+    int levelsUsedInLoop = levelEndVal - levelStartVal;
+    if (levelAfterBootstrap / levelsUsedInLoop > 1) {
+      unrollFactors.push_back(levelAfterBootstrap / levelsUsedInLoop);
+    }
+  }
+
+  if (unrollFactors.empty()) {
+    return rewriter.notifyMatchFailure(forOp,
+                                       "No unroll factors could be found.");
+  }
+
+  int chosenUnrollFactor = *llvm::min_element(unrollFactors);
+  chosenUnrollFactor =
+      tripCount < chosenUnrollFactor ? tripCount : chosenUnrollFactor;
+  if (chosenUnrollFactor > 1) {
+    // The function_ref<void(unsigned, Operation *, OpBuilder)> annotateFn that
+    // we pass to the loop unroll step ensures that we can tell which bootstrap
+    // ops and level_reduce_min ops are safe to remove post-unroll.
+    LLVM_DEBUG(llvm::dbgs() << "Applying Halo-style unroll by a factor of "
+                            << chosenUnrollFactor << "\n");
+
+    // First mark the special loop invariance ops with an attribute, so that any
+    // other operations of the same type in the loop body are not accidentally
+    // deleted by cleanup. The name of the attribute is arbitrary as it will be
+    // cleaned up before this pattern is complete.
+    std::string specialOpKey = "halo.invariance";
+    for (Value iterArg : forOp.getRegionIterArgs()) {
+      if (isSecret(iterArg, solver)) {
+        auto bootstrapOp = cast<mgmt::BootstrapOp>(*iterArg.getUsers().begin());
+        rewriter.modifyOpInPlace(bootstrapOp, [&]() {
+          bootstrapOp->setAttr(specialOpKey, rewriter.getUnitAttr());
+        });
+
+        Value yieldedValue =
+            forOp.getTiedLoopYieldedValue(cast<BlockArgument>(iterArg))->get();
+        auto levelReduceOp =
+            cast<mgmt::LevelReduceMinOp>(yieldedValue.getDefiningOp());
+        rewriter.modifyOpInPlace(levelReduceOp, [&]() {
+          levelReduceOp->setAttr(specialOpKey, rewriter.getUnitAttr());
+        });
+      }
+    }
+
+    if (failed(loopUnrollByFactor(
+            forOp, chosenUnrollFactor,
+            [&](unsigned index, Operation* clonedOp, OpBuilder builder) {
+              if (!clonedOp->hasAttr(specialOpKey)) return;
+
+              // Internally, loopUnrollByFactor starts the passed `index` at 1
+              // and goes up to unrollFactor (exclusive). This index 1
+              // corresponds to the second loop iteration, but this callable is
+              // never called for index 0 because the original loop body
+              // is left intact and the additional unrolled iterations are
+              // inserted after it. However, this is an implementation detail
+              // that we try not to rely on.
+              if (index > 0 && isa<mgmt::BootstrapOp>(clonedOp)) {
+                // We cannot remove the op in the middle of the loop unrolling
+                // process, so instead mark it for later removal.
+                rewriter.modifyOpInPlace(clonedOp, [&]() {
+                  clonedOp->setAttr("halo.remove", builder.getUnitAttr());
+                });
+              } else if (index < chosenUnrollFactor - 1 &&
+                         isa<mgmt::LevelReduceMinOp>(clonedOp)) {
+                rewriter.modifyOpInPlace(clonedOp, [&]() {
+                  clonedOp->setAttr("halo.remove", builder.getUnitAttr());
+                });
+              }
+              rewriter.modifyOpInPlace(
+                  clonedOp, [&]() { clonedOp->removeAttr(specialOpKey); });
+            })))
+      return failure();
+  }
+
+  return success();
+}
+
+LogicalResult PartialUnrollForLevelConsumptionAffineFor::matchAndRewrite(
+    affine::AffineForOp forOp, PatternRewriter& rewriter) const {
+  return doPartialUnroll(forOp, rewriter, forceMaxLevel, solver);
+}
+
+LogicalResult PartialUnrollForLevelConsumptionSCFFor::matchAndRewrite(
+    scf::ForOp forOp, PatternRewriter& rewriter) const {
+  return doPartialUnroll(forOp, rewriter, forceMaxLevel, solver);
+}
+
+LogicalResult DeleteAnnotatedOps::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  if (!op->hasAttrOfType<UnitAttr>("halo.remove")) {
+    return failure();
+  }
+
+  if (op->getNumResults() != 1 || op->getNumOperands() != 1) {
+    return failure();
+  }
+
+  rewriter.replaceOp(op, op->getOperand(0));
   return success();
 }
 

--- a/tests/Transforms/halo/partial_unroll_for_level_consumption_affine_4.mlir
+++ b/tests/Transforms/halo/partial_unroll_for_level_consumption_affine_4.mlir
@@ -1,0 +1,61 @@
+// RUN: heir-opt --partial-unroll-for-level-consumption=force-max-level=4 %s | FileCheck %s
+
+// CHECK: @affine_loop
+
+// The pre-existing loop preamble
+// CHECK: arith.addi
+// CHECK-NEXT: mgmt.level_reduce_min
+
+// Unrolled loop
+// CHECK-NEXT: affine.for {{.*}} = 1 to 9 step 4
+// iteration 1
+// CHECK-NEXT:  mgmt.bootstrap
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 2
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 3
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 4
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// CHECK-NEXT:  mgmt.level_reduce_min
+// CHECK-NEXT:  affine.yield
+// CHECK-NEXT:  }
+
+// cleanup loop
+// CHECK-NEXT:   affine.for [[arg1:.*]] = 9 to 12
+// CHECK-NEXT:    mgmt.bootstrap
+// CHECK-NEXT:    arith.muli
+// CHECK-NEXT:    mgmt.relinearize
+// CHECK-NEXT:    mgmt.modreduce
+// CHECK-NEXT:    mgmt.level_reduce_min
+// CHECK-NEXT:    affine.yield
+func.func @affine_loop(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%input0: i32):
+    %1 = arith.addi %c1_i32, %input0 : i32
+    %2 = mgmt.level_reduce_min %1 : i32
+    %3 = affine.for %arg1 = 1 to 12 iter_args(%arg2 = %2) -> (i32) {
+      %4 = mgmt.bootstrap %arg2 : i32
+      %5 = arith.muli %4, %input0 : i32
+      %6 = mgmt.relinearize %5 : i32
+      %7 = mgmt.modreduce %6 : i32
+      %8 = mgmt.level_reduce_min %7 : i32
+      affine.yield %8 : i32
+    }
+    secret.yield %3 : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}

--- a/tests/Transforms/halo/partial_unroll_for_level_consumption_affine_8.mlir
+++ b/tests/Transforms/halo/partial_unroll_for_level_consumption_affine_8.mlir
@@ -1,0 +1,78 @@
+// RUN: heir-opt --partial-unroll-for-level-consumption=force-max-level=8 %s | FileCheck %s
+
+// CHECK: @affine_loop
+
+// The pre-existing loop preamble
+// CHECK: arith.addi
+// CHECK-NEXT: mgmt.level_reduce_min
+
+// The first iteration (the unrolled portion of the loop was fully unrolled in this case)
+// CHECK-NEXT:  mgmt.bootstrap
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 2
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 3
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 4
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 5
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 6
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 7
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 8
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// End of the unrolled loop has a level_reduce_min to ensure invariant
+// is upheld, in this case for the "cleanup loop" from the unroll
+
+// CHECK-NEXT:  mgmt.level_reduce_min
+// CHECK-NEXT:   affine.for [[arg1:.*]] = 9 to 12
+// CHECK-NEXT:    mgmt.bootstrap
+// CHECK-NEXT:    arith.muli
+// CHECK-NEXT:    mgmt.relinearize
+// CHECK-NEXT:    mgmt.modreduce
+// CHECK-NEXT:    mgmt.level_reduce_min
+// CHECK-NEXT:    affine.yield
+func.func @affine_loop(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%input0: i32):
+    %1 = arith.addi %c1_i32, %input0 : i32
+    %2 = mgmt.level_reduce_min %1 : i32
+    %3 = affine.for %arg1 = 1 to 12 iter_args(%arg2 = %2) -> (i32) {
+      %4 = mgmt.bootstrap %arg2 : i32
+      %5 = arith.muli %4, %input0 : i32
+      %6 = mgmt.relinearize %5 : i32
+      %7 = mgmt.modreduce %6 : i32
+      %8 = mgmt.level_reduce_min %7 : i32
+      affine.yield %8 : i32
+    }
+    secret.yield %3 : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}

--- a/tests/Transforms/halo/partial_unroll_for_level_consumption_affine_full_unroll.mlir
+++ b/tests/Transforms/halo/partial_unroll_for_level_consumption_affine_full_unroll.mlir
@@ -1,0 +1,86 @@
+// RUN: heir-opt --partial-unroll-for-level-consumption=force-max-level=100 %s | FileCheck %s
+
+// CHECK: @affine_loop
+
+// The pre-existing loop preamble
+// CHECK: arith.addi
+// CHECK-NEXT: mgmt.level_reduce_min
+
+// Fully unrolled loop because the level budget is large enough to handle it all
+// iteration 1
+// CHECK-NEXT:  mgmt.bootstrap
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 2
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 3
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 4
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 5
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 6
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 7
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 8
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 9
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 10
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// iteration 11
+// CHECK-NEXT:  arith.muli
+// CHECK-NEXT:  mgmt.relinearize
+// CHECK-NEXT:  mgmt.modreduce
+
+// CHECK-NEXT:  mgmt.level_reduce_min
+// CHECK-NEXT:  secret.yield
+
+func.func @affine_loop(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%input0: i32):
+    %1 = arith.addi %c1_i32, %input0 : i32
+    %2 = mgmt.level_reduce_min %1 : i32
+    %3 = affine.for %arg1 = 1 to 12 iter_args(%arg2 = %2) -> (i32) {
+      %4 = mgmt.bootstrap %arg2 : i32
+      %5 = arith.muli %4, %input0 : i32
+      %6 = mgmt.relinearize %5 : i32
+      %7 = mgmt.modreduce %6 : i32
+      %8 = mgmt.level_reduce_min %7 : i32
+      affine.yield %8 : i32
+    }
+    secret.yield %3 : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}

--- a/tests/Transforms/halo/partial_unroll_for_level_consumption_doctest.mlir
+++ b/tests/Transforms/halo/partial_unroll_for_level_consumption_doctest.mlir
@@ -1,0 +1,40 @@
+// RUN: heir-opt --partial-unroll-for-level-consumption=force-max-level=4 %s | FileCheck %s
+
+// CHECK: @doctest
+// CHECK: scf.for
+// CHECK-NEXT: mgmt.bootstrap
+// CHECK-NEXT: arith.muli
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK-NEXT: arith.muli
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK-NEXT: arith.muli
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK-NEXT: arith.muli
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK-NEXT: mgmt.level_reduce_min
+// CHECK-NEXT: scf.yield
+func.func @doctest(%arg0: !secret.secret<i32>) -> !secret.secret<i32> {
+  %c1_i32 = arith.constant 1 : i32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c12 = arith.constant 12 : index
+  %0 = secret.generic(%arg0: !secret.secret<i32>) {
+  ^body(%input0: i32):
+    %1 = arith.addi %c1_i32, %input0 : i32
+    %2 = mgmt.level_reduce_min %1 : i32
+    %3 = scf.for %arg1 = %c0 to %c12 step %c1 iter_args(%arg2 = %2) -> (i32) {
+      %4 = mgmt.bootstrap %arg2 : i32
+      %5 = arith.muli %4, %input0 : i32
+      %6 = mgmt.relinearize %5 : i32
+      %7 = mgmt.modreduce %6 : i32
+      %8 = mgmt.level_reduce_min %7 : i32
+      scf.yield %8 : i32
+    }
+    secret.yield %3 : i32
+  } -> !secret.secret<i32>
+  return %0 : !secret.secret<i32>
+}


### PR DESCRIPTION
This PR implements Solution B-2 from the HALO paper:

> Solution B-2: Unrolling the loops reflecting the required level. Loop unrolling reduces its iteration count, thus reducing the number of bootstrap. If computation in a loop iteration does not fully consume ciphertext levels, HALO unrolls the loop to fully utilize the levels recovered from bootstrap.

## Implementation notes

### When is the level budget decided?

The loop unrolling logic from HALO asks you to determine if the body of the loop "exhausts the level budget." HEIR, however, is choosing the level budget. I haven't figured out exactly how the integration will work at this point: will the level budget be fixed before the loop is attempted to be unrolled? Or will the loop unrolling logic happen simultaneously with the level budget selection? To avoid answering this question now, I punted by adding a "forceMaxLevel" pass option that lets tests behave as if this level budget were decided in advance.

The reason this is nontrivial is that, if I were to just call `getMaxLevel` on the entire IR to decide what my level budget is for unrolling, it may have a max level of 1. This was the case for my simple lit tests, where the entire program was the one (rolled) loop with a single mul (+ ops to maintain loop invariance): if you leave it rolled and bootstrap at every iteration, you never need more than one level (really, one level more than the number of levels required to bootstrap), and so you would never have enough levels to unroll. In this case it would be more optimal to increase the level budget _so that_ you could unroll more and avoid bootstrapping as often.

### Effective bootstrap level vs "max level"

The "forceMaxLevel" flag implies that we're still ignoring the "effective bootstrap level," i..e, the difference between the max level of the IR and the level after bootstrap is applied (which is less than the max level because bootstrap consumes levels).

I want to change this to an "effective bootstrap level", but I need the backend-specific data about how many levels bootstrap consumes. This is hinted at in simple_ckks_bootstrapping_test.cpp, that it depends on some configurable parameters (levelBudgetEncode and levelBudgetDecode, usually 3) and some implementation details (such as how many levels are used to implement mod1, in OpenFHE's case I think it's 14).

Because we compensate for this manually in `ConfigureCryptoContext.cpp`, making the change here would also require updating it there, and the corresponding integration fixes that go along with it.

### Multiple `iter_args`

Most of the use cases we have for rolled loops are FHE kernels that involve a single accumulated ciphertext. However, if there are multiple iter_arg ciphertexts, this pass may be inefficient. Currently it calculates the largest allowable unroll factor for each iter arg, and then unrolls the loop according to the min. If there are two iter args with two very different unroll factors, e.g., `X` that can be unrolled by 2 and `Y` that can be unrolled by 10, then we could instead unroll by 10 (beneficial to bootstrap the `Y` path less), and insert bootstrap ops for the parts of the `X` path that require additional bootstrapping. Overall this would be less bootstrapping. However, it requires a bootstrapping placement method that can be applied to the loop body in isolation, and probably should be smarter than waterline bootstrapping. I'm punting here to a TODO.