### PR TITLE
frontend: use signed extension when changing bitwidth

### DIFF
--- a/frontend/heir/mlir_emitter.py
+++ b/frontend/heir/mlir_emitter.py
@@ -611,7 +611,7 @@ class TextualMlirEmitter:
 
     tmp = self.get_next_name()
     ext = (
-        f"{tmp} = arith.extui {self.get_name(short)} : "
+        f"{tmp} = arith.extsi {self.get_name(short)} : "
         f"{mlirType(self.typemap.get(str(short)))} "
         f"to {mlirType(self.typemap.get(str(long)))} "
         f"{mlirLoc(short.loc)}\n"

--- a/frontend/mixed_bitwidth_test.py
+++ b/frontend/mixed_bitwidth_test.py
@@ -15,6 +15,14 @@ class EndToEndTest(absltest.TestCase):
 
     self.assertEqual(10, foo(5))
 
+  def test_signed_cast(self):
+
+    @compile()
+    def foo(x: Secret[I32]):
+      return -1 * x
+
+    self.assertEqual(-5, foo(5))
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
This PR fixes an issue in the python frontend related to bit width handling: when the frontend upcasts, it now uses signed extension instead of unsigned (fixes #2496)