### PR TITLE
pre-commit: use python3 instead of python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
   hooks:
     - id: disable-mdformat
       name: Ensure google-internal mdformat is disabled on md files
-      entry: python scripts/disable_mdformat.py
+      entry: python3 scripts/disable_mdformat.py
       language: system
       types: [markdown]
       pass_filenames: false # Run on all relevant files


### PR DESCRIPTION
I realized that on a freshly set-up macOS, vscode would fail to run the pre-commit checks because `python` isn't set up as an alias for `python3` by default. Actually, I think the same might be true on a fresh ubuntu machine (but I always use python-is-python3 so never tested 🤷)

EDIT 1: ignore the force-pushing, didn't have gpg, git and gh lined up properly so the signature didn't verify
EDIT 2: unrelated build failure means no CI, but it works on my machine (TM) ;)