### PR TITLE
Frontend literal upcasting

### DIFF
--- a/frontend/mixed_bitwidth_test.py
+++ b/frontend/mixed_bitwidth_test.py
@@ -1,5 +1,5 @@
 from heir import compile
-from heir.mlir import I32, Secret
+from heir.mlir import I32, I16, Secret
 
 from absl.testing import absltest  # fmt: skip
 
@@ -22,6 +22,36 @@ class EndToEndTest(absltest.TestCase):
       return -1 * x
 
     self.assertEqual(-5, foo(5))
+
+  def test_literal_extension(self):
+
+    @compile()
+    def foo(x: Secret[I32]):
+      a = 45  # 45 fits inside int8
+      b = 10 * a  # 10 fits inside int8
+      # but 450 does not, so we must upcast
+      return x + b
+
+    self.assertEqual(455, foo(5))
+
+  def test_intentional_overflow(self):
+
+    @compile()
+    def foo(x: Secret[I16]):
+      a = 32762  # 32762 fits inside int16
+      b = a + 5  # so does 32767 (barely)
+      return x + b  # but this will overflow for non-zero x
+
+    self.assertEqual(-(2**15), foo(1))
+
+  def test_literal_variable_extension(self):
+
+    @compile()
+    def foo(x: Secret[I32]):
+      a = x * 10  # i32 * i8 -> i32
+      return a + 5
+
+    self.assertEqual(455, foo(45))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While we still prevent numba from doing its default upcasting of literals to int32, there is now some logic that ensures that the inputs to binary operations on literals/constants do get upcast to prevent overflow (fixes #2525)

This is necessary, despite Python's eager constant folding pre-bytecode, because of examples like this:
```python
a = 45 # or a = 3 * 15, which will be constant-folded to 45 in the byte code already
b = 10 * a
```
This will be translated to a binop (mul) between two literals (each of type int8, because we overwrite numba to pick the smallest numba type that matches), and since binop rules in numba don't promote, computed as int8 * int8 = int8 which will overflow and give -62 instead of 450. I.e., we would get:

```llvm
%0 = arith.constant 45 : i8
%1 = arith.constant 10 : i8
%2 = arith.muli %0, %1 : i8
```

The fix works in two parts:
* The binop emitter now takes a result type, and if that's wider than the input types, emits extensions for the input operands. This by itself would be a no-op change, as the result type would be the same as the input types by numba's rules.

* Therefore, our numba typing override now introduces a special exception for binary operations where both inputs are literal integers, and assigns the output type based on the result, which will then cause the emitter code above to actually emit the extensions:

```llvm
%0 = arith.constant 45 : i8
%1 = arith.constant 10 : i8
%2 = arith.extsi %1 : i8 to i16
%3 = arith.extsi %0 : i8 to i16
%4 = arith.muli %2, %3 : i16
```

Note: the second part is pretty much entirely LLM generated as I don't remember much from my deep dive into numba's typing system last year. ~~Marking as draft until I can look at that code a second/third time~~ Had a look and it, imho, checks out, also added a few more tests. I'm not certain this is the last time we'll run into bitwidth issues, but at least for this issue, this seems like a solid fix. 
