### PR TITLE
Integrate Halo loop patterns into secret-insert-mgmt

### DIFF
--- a/benchmark/BUILD
+++ b/benchmark/BUILD
@@ -24,3 +24,21 @@ cc_binary(
         "@llvm-project//mlir:Support",
     ],
 )
+
+cc_library(
+    name = "bootstrap_example",
+    srcs = ["bootstrap_example.cpp"],
+    hdrs = ["bootstrap_example.h"],
+    deps = [
+        "@openfhe//:core",
+        "@openfhe//:pke",
+    ],
+)
+
+cc_binary(
+    name = "bootstrap_example_main",
+    srcs = ["bootstrap_example_main.cpp"],
+    deps = [
+        ":bootstrap_example",
+    ],
+)

--- a/benchmark/bootstrap_example.cpp
+++ b/benchmark/bootstrap_example.cpp
@@ -1,0 +1,180 @@
+
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+using namespace lbcrypto;
+using CiphertextT = Ciphertext<DCRTPoly>;
+using ConstCiphertextT = ConstCiphertext<DCRTPoly>;
+using CCParamsT = CCParams<CryptoContextCKKSRNS>;
+using CryptoContextT = CryptoContext<DCRTPoly>;
+using EvalKeyT = EvalKey<DCRTPoly>;
+using PlaintextT = Plaintext;
+using PrivateKeyT = PrivateKey<DCRTPoly>;
+using PublicKeyT = PublicKey<DCRTPoly>;
+
+std::vector<float> _assign_layout_15700164067060511435(std::vector<float> v0) {
+  [[maybe_unused]] size_t v1 = 0;
+  std::vector<float> v2(8, 0);
+  [[maybe_unused]] int32_t v3 = 0;
+  [[maybe_unused]] int32_t v4 = 1;
+  [[maybe_unused]] int32_t v5 = 8;
+  std::vector<float> v6 = v2;
+  for (auto v7 = 0; v7 < 8; ++v7) {
+    size_t v9 = static_cast<size_t>(v7);
+    float v10 = v0[v9];
+    v6[v9 + 8 * (0)] = v10;
+  }
+  return v6;
+}
+std::vector<CiphertextT> loop(CryptoContextT cc, std::vector<CiphertextT> v0) {
+  std::vector<double> v1(8, 1);
+  [[maybe_unused]] size_t v2 = 0;
+  std::vector<float> v3(8, 1);
+  const auto& v4 = _assign_layout_15700164067060511435(v3);
+  std::vector<float> v5(8);
+  for (int64_t v5_i0 = 0; v5_i0 < 1; ++v5_i0) {
+    for (int64_t v5_i1 = 0; v5_i1 < 8; ++v5_i1) {
+      v5[v5_i1 + 8 * (v5_i0)] = v4[0 + v5_i1 * 1 + 8 * (0 + v5_i0 * 1)];
+    }
+  }
+  std::vector<double> v6(std::begin(v5), std::end(v5));
+  auto pt_filled_n =
+      cc->GetCryptoParameters()->GetElementParams()->GetRingDimension() / 2;
+  auto pt_filled = v6;
+  pt_filled.clear();
+  pt_filled.reserve(pt_filled_n);
+  for (auto i = 0; i < pt_filled_n; ++i) {
+    pt_filled.push_back(v6[i % v6.size()]);
+  }
+  auto pt = cc->MakeCKKSPackedPlaintext(pt_filled);
+  auto ct = v0[0];
+  auto ct1 = cc->EvalMult(ct, pt);
+  cc->ModReduceInPlace(ct1);
+  cc->EvalSubInPlace(ct1, pt);
+  std::vector<CiphertextT> v7(1);
+  cc->LevelReduceInPlace(ct1, nullptr, 2);
+  v7[0] = ct1;
+  // std::vector<CiphertextT> v9 = v7;
+  for (auto v10 = 0; v10 < 2; ++v10) {
+    const auto& ct5 = v7[0];
+    const auto& ct6 = cc->EvalBootstrap(ct5);
+    auto ct7 = cc->EvalMultNoRelin(ct, ct6);
+    cc->RelinearizeInPlace(ct7);
+    cc->ModReduceInPlace(ct7);
+    cc->EvalSubInPlace(ct7, pt);
+    auto pt1_filled_n =
+        cc->GetCryptoParameters()->GetElementParams()->GetRingDimension() / 2;
+    auto pt1_filled = v1;
+    pt1_filled.clear();
+    pt1_filled.reserve(pt1_filled_n);
+    for (auto i = 0; i < pt1_filled_n; ++i) {
+      pt1_filled.push_back(v1[i % v1.size()]);
+    }
+    auto pt1 = cc->MakeCKKSPackedPlaintext(pt1_filled);
+    auto ct11 = cc->EvalMult(ct, pt1);
+    cc->ModReduceInPlace(ct11);
+    auto ct13 = cc->EvalMultNoRelin(ct11, ct7);
+    cc->RelinearizeInPlace(ct13);
+    cc->ModReduceInPlace(ct13);
+    cc->EvalSubInPlace(ct13, pt);
+    cc->LevelReduceInPlace(ct, nullptr, 1);
+    auto ct18 = cc->EvalMult(ct, pt1);
+    cc->ModReduceInPlace(ct18);
+    auto ct20 = cc->EvalMultNoRelin(ct18, ct13);
+    cc->RelinearizeInPlace(ct20);
+    cc->ModReduceInPlace(ct20);
+    cc->EvalSubInPlace(ct20, pt);
+    v7[0] = ct20;
+  }
+  const auto& ct24 = v7[0];
+  const auto& ct25 = cc->EvalBootstrap(ct24);
+  auto ct26 = cc->EvalMultNoRelin(ct, ct25);
+  cc->RelinearizeInPlace(ct26);
+  cc->ModReduceInPlace(ct26);
+  cc->EvalSubInPlace(ct26, pt);
+  cc->LevelReduceInPlace(ct26, nullptr, 2);
+  v7[0] = ct26;
+  return v7;
+}
+std::vector<CiphertextT> loop__encrypt__arg0(CryptoContextT cc,
+                                             std::vector<float> v0,
+                                             PublicKeyT pk) {
+  [[maybe_unused]] size_t v1 = 0;
+  std::vector<float> v2(8, 0);
+  [[maybe_unused]] int32_t v3 = 0;
+  [[maybe_unused]] int32_t v4 = 1;
+  [[maybe_unused]] int32_t v5 = 8;
+  std::vector<float> v6 = v2;
+  for (auto v7 = 0; v7 < 8; ++v7) {
+    size_t v9 = static_cast<size_t>(v7);
+    float v10 = v0[v9];
+    v6[v9 + 8 * (0)] = v10;
+  }
+  std::vector<float> v12(8);
+  for (int64_t v12_i0 = 0; v12_i0 < 1; ++v12_i0) {
+    for (int64_t v12_i1 = 0; v12_i1 < 8; ++v12_i1) {
+      v12[v12_i1 + 8 * (v12_i0)] = v6[0 + v12_i1 * 1 + 8 * (0 + v12_i0 * 1)];
+    }
+  }
+  std::vector<double> v13(std::begin(v12), std::end(v12));
+  auto pt_filled_n =
+      cc->GetCryptoParameters()->GetElementParams()->GetRingDimension() / 2;
+  auto pt_filled = v13;
+  pt_filled.clear();
+  pt_filled.reserve(pt_filled_n);
+  for (auto i = 0; i < pt_filled_n; ++i) {
+    pt_filled.push_back(v13[i % v13.size()]);
+  }
+  auto pt = cc->MakeCKKSPackedPlaintext(pt_filled);
+  const auto& ct = cc->Encrypt(pk, pt);
+  const std::vector<CiphertextT> v14 = {ct};
+  return v14;
+}
+std::vector<float> loop__decrypt__result0(CryptoContextT cc,
+                                          std::vector<CiphertextT> v0,
+                                          PrivateKeyT sk) {
+  [[maybe_unused]] size_t v1 = 0;
+  [[maybe_unused]] int32_t v2 = 8;
+  [[maybe_unused]] int32_t v3 = 1;
+  [[maybe_unused]] int32_t v4 = 0;
+  std::vector<float> v5(8, 0);
+  const auto& ct = v0[0];
+  PlaintextT pt;
+  cc->Decrypt(sk, ct, &pt);
+  pt->SetLength(8);
+  const auto& v6_cast = pt->GetCKKSPackedValue();
+  std::vector<float> v6(v6_cast.size());
+  std::transform(std::begin(v6_cast), std::end(v6_cast), std::begin(v6),
+                 [](const std::complex<double>& c) { return c.real(); });
+  std::vector<float> v7 = v5;
+  for (auto v8 = 0; v8 < 8; ++v8) {
+    size_t v10 = static_cast<size_t>(v8);
+    float v11 = v6[v10 + 8 * (0)];
+    v7[v10] = v11;
+  }
+  return v7;
+}
+CryptoContextT loop__generate_crypto_context() {
+  CCParamsT params;
+  params.SetMultiplicativeDepth(23);
+  params.SetKeySwitchTechnique(HYBRID);
+  params.SetScalingTechnique(FIXEDMANUAL);
+  params.SetScalingModSize(55);
+  params.SetFirstModSize(60);
+  params.SetRingDim(2048);
+  params.SetBatchSize(1024);
+  params.SetSecurityLevel(HEStd_NotSet);
+  CryptoContextT cc = GenCryptoContext(params);
+  cc->Enable(PKE);
+  cc->Enable(KEYSWITCH);
+  cc->Enable(LEVELEDSHE);
+  cc->Enable(ADVANCEDSHE);
+  cc->Enable(FHE);
+  return cc;
+}
+CryptoContextT loop__configure_crypto_context(CryptoContextT cc,
+                                              PrivateKeyT sk) {
+  cc->EvalMultKeyGen(sk);
+  cc->EvalBootstrapSetup({3, 3});
+  cc->EvalBootstrapKeyGen(sk, 1024);
+  return cc;
+}

--- a/benchmark/bootstrap_example.h
+++ b/benchmark/bootstrap_example.h
@@ -1,0 +1,38 @@
+// This file and the corresponding cpp file were copied from the compiled
+// output of the e2e test in tests/Examples/openfhe/ckks/loop_support
+
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+using namespace lbcrypto;
+using CiphertextT = Ciphertext<DCRTPoly>;
+using ConstCiphertextT = ConstCiphertext<DCRTPoly>;
+using CCParamsT = CCParams<CryptoContextCKKSRNS>;
+using CryptoContextT = CryptoContext<DCRTPoly>;
+using EvalKeyT = EvalKey<DCRTPoly>;
+using PlaintextT = Plaintext;
+using PrivateKeyT = PrivateKey<DCRTPoly>;
+using PublicKeyT = PublicKey<DCRTPoly>;
+
+std::vector<float> _assign_layout_6191183397986546506(std::vector<float> v0);
+
+// A simple test for loop support.
+//
+// Computes the function
+//
+//     def f(x):
+//       sum = 1.0
+//       for i in range(8):
+//         sum = sum * x - 1.0
+//       return sum
+//
+std::vector<CiphertextT> loop(CryptoContextT cc, std::vector<CiphertextT> v0);
+
+std::vector<CiphertextT> loop__encrypt__arg0(CryptoContextT cc,
+                                             std::vector<float> v0,
+                                             PublicKeyT pk);
+std::vector<float> loop__decrypt__result0(CryptoContextT cc,
+                                          std::vector<CiphertextT> v0,
+                                          PrivateKeyT sk);
+CryptoContextT loop__generate_crypto_context();
+CryptoContextT loop__configure_crypto_context(CryptoContextT cc,
+                                              PrivateKeyT sk);

--- a/benchmark/bootstrap_example_main.cpp
+++ b/benchmark/bootstrap_example_main.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <vector>
+
+#include "benchmark/bootstrap_example.h"
+
+// A simple test for loop support.
+//
+// Computes the function
+//
+//     def f(x):
+//       sum = 1.0
+//       for i in range(8):
+//         sum = sum * x - 1.0
+//       return sum
+//
+int main(int argc, char** argv) {
+  std::cout << "Bootstrap Example Main\n";
+  std::cout << "Generating crypto context\n";
+  auto cryptoContext = loop__generate_crypto_context();
+  std::cout << "Generating keys\n";
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  std::cout << "Configuring crypto context\n";
+  cryptoContext = loop__configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<float> arg0 = {0.,         0.14285714, 0.28571429, 0.42857143,
+                             0.57142857, 0.71428571, 0.85714286, 1.};
+  std::vector<float> expected = {-1.,         -1.16666629, -1.39989342,
+                                 -1.74687019, -2.29543899, -3.19507837,
+                                 -4.66914279, -7.};
+
+  std::cout << "Encrypting arg\n";
+  auto arg0Encrypted = loop__encrypt__arg0(cryptoContext, arg0, publicKey);
+  std::cout << "Running loop\n";
+  auto outputEncrypted = loop(cryptoContext, arg0Encrypted);
+  std::cout << "Decrypting result\n";
+  auto actual =
+      loop__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  for (size_t i = 0; i < actual.size(); i++) {
+    std::cout << "actual[" << i << "] = " << actual[i] << ", expected[" << i
+              << "] = " << expected[i] << "\n";
+  }
+
+  return 0;
+}

--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -96,6 +96,7 @@ class LevelState {
   bool isInt() const { return std::holds_alternative<int>(value); }
 
   bool isMaxLevel() const { return std::holds_alternative<MaxLevel>(value); }
+  bool isExhausted() const { return isMaxLevel(); }
 
   int64_t getInt() const { return std::get<int>(value); }
 

--- a/lib/Analysis/ScaleAnalysis/ScaleAnalysis.cpp
+++ b/lib/Analysis/ScaleAnalysis/ScaleAnalysis.cpp
@@ -16,6 +16,7 @@
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"              // from @llvm-project
 #include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
+#include "llvm/include/llvm/Support/DebugLog.h"            // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
@@ -192,6 +193,11 @@ LogicalResult ScaleAnalysis<ScaleModelT>::visitOperation(
           propagate(initOp.getResult(), ScaleState(mgmtAttr.getScale()));
         }
       })
+      .template Case<mgmt::BootstrapOp>([&](auto bootstrapOp) {
+        // inputScale is either Delta or Delta^2 depending on the analysis
+        // initialization.
+        propagate(bootstrapOp.getResult(), ScaleState(inputScale));
+      })
       .Default([&](auto& op) {
         // condition on result secretness
         SmallVector<OpResult> secretResults;
@@ -254,10 +260,18 @@ LogicalResult ScaleAnalysisBackward<ScaleModelT>::visitOperation(
 
   auto getSecretOrInittedOperands =
       [&](Operation* op, SmallVectorImpl<OpOperand*>& secretOperands) {
-        this->getSecretOperands(op, secretOperands);
+        LLVM_DEBUG(
+            { llvm::dbgs() << "secretness of operands for " << *op << ":\n"; });
         for (auto& opOperand : op->getOpOperands()) {
-          if (!this->isSecretInternal(op, opOperand.get()) &&
-              isa_and_nonnull<mgmt::InitOp>(opOperand.get().getDefiningOp())) {
+          bool isSecret = this->isSecretInternal(op, opOperand.get());
+          bool isMgmtDefined =
+              isa_and_nonnull<mgmt::InitOp>(opOperand.get().getDefiningOp());
+          LLVM_DEBUG({
+            llvm::dbgs() << " " << opOperand.getOperandNumber()
+                         << ": isSecret=" << isSecret
+                         << ", isMgmtDefined=" << isMgmtDefined << "\n";
+          });
+          if (isSecret || isMgmtDefined) {
             // Treat it as if it were secret for the purpose of scale
             // propagation
             secretOperands.push_back(&opOperand);
@@ -311,8 +325,7 @@ LogicalResult ScaleAnalysisBackward<ScaleModelT>::visitOperation(
     LLVM_DEBUG(llvm::dbgs() << "\n");
   };
 
-  LLVM_DEBUG(llvm::dbgs() << "Backward analysis visiting: " << op->getName()
-                          << "\n");
+  LDBG() << "Backward analysis visiting: " << *op;
   llvm::TypeSwitch<Operation&>(*op)
       .template Case<arith::MulIOp, arith::MulFOp>([&](auto mulOp) {
         SmallVector<int64_t> resultScales;
@@ -335,11 +348,15 @@ LogicalResult ScaleAnalysisBackward<ScaleModelT>::visitOperation(
         }
         auto presentScale = operandScales[0];
 
-        // propagate scale to other operand
-        auto scaleOther = ScaleModelT::evalMulScaleBackward(
-            getLocalParam(mulOp.getResult()), resultScales[0], presentScale);
-        propagate(mulOp->getOperand(operandWithoutScaleIndices[0]),
-                  ScaleState(scaleOther));
+        // propagate scale to other operand; this is guarded
+        // by the loop for a weird reason: the secretness of the
+        // non-scale-holding operand might not be initialized yet, depending
+        // on the order in which the analyses run.
+        for (auto otherIndex : operandWithoutScaleIndices) {
+          auto scaleOther = ScaleModelT::evalMulScaleBackward(
+              getLocalParam(mulOp.getResult()), resultScales[0], presentScale);
+          propagate(mulOp->getOperand(otherIndex), ScaleState(scaleOther));
+        }
       })
       .template Case<mgmt::ModReduceOp>([&](auto modReduceOp) {
         SmallVector<int64_t> resultScales;

--- a/lib/Analysis/ScaleAnalysis/ScaleAnalysis.h
+++ b/lib/Analysis/ScaleAnalysis/ScaleAnalysis.h
@@ -170,10 +170,10 @@ class ScaleAnalysis
 template <typename ScaleModelT>
 class ScaleAnalysisBackward
     : public dataflow::SparseBackwardDataFlowAnalysis<ScaleLattice>,
-      public SecretnessAnalysisDependent<ScaleAnalysis<ScaleModelT>> {
+      public SecretnessAnalysisDependent<ScaleAnalysisBackward<ScaleModelT>> {
  public:
   using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
-  friend class SecretnessAnalysisDependent<ScaleAnalysis<ScaleModelT>>;
+  friend class SecretnessAnalysisDependent<ScaleAnalysisBackward<ScaleModelT>>;
 
   using SchemeParamType = typename ScaleModelT::SchemeParam;
   using LocalParamType = typename ScaleModelT::LocalParam;

--- a/lib/Dialect/CKKS/IR/CKKSOps.td
+++ b/lib/Dialect/CKKS/IR/CKKSOps.td
@@ -204,7 +204,7 @@ def CKKS_LevelReduceOp : CKKS_Op<"level_reduce", [ElementwiseMappable, SameOpera
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 
-def CKKS_BootstrapOp : CKKS_Op<"bootstrap", [ElementwiseMappable]> {
+def CKKS_BootstrapOp : CKKS_Op<"bootstrap", [ElementwiseMappable, ResetsMulDepthOpInterface]> {
   let summary = "Bootstrap the ciphertext to reduce noise and refresh its parameters.";
 
   let description = [{

--- a/lib/Dialect/HEIRInterfaces.td
+++ b/lib/Dialect/HEIRInterfaces.td
@@ -26,6 +26,14 @@ def IncreasesMulDepthOpInterface : OpInterface<"IncreasesMulDepthOpInterface"> {
   // https://discourse.llvm.org/t/how-to-add-addtional-traits-to-existing-ops/62039
 }
 
+def ResetsMulDepthOpInterface : OpInterface<"ResetsMulDepthOpInterface"> {
+  let cppNamespace = "::mlir::heir";
+  let description = [{
+    An interface that signals when an operation resets multiplicative depth
+    among its results, such as a `mgmt.bootstrap`.
+  }];
+}
+
 def LUTOpInterface : OpInterface<"LUTOpInterface"> {
   let cppNamespace = "::mlir::heir";
   let description = [{

--- a/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.cpp
@@ -367,9 +367,10 @@ struct ConvertBootstrapOp : public OpConversionPattern<ckks::BootstrapOp> {
           op, "variadic bootstrapping is not supported in OpenFHE");
     }
 
+    Type resultType = convertLWEType(op.getResult().getType());
     Value cryptoContext = result.value();
     rewriter.replaceOpWithNewOp<openfhe::BootstrapOp>(
-        op, op.getOutput().getType(), cryptoContext, adaptor.getInput());
+        op, resultType, cryptoContext, adaptor.getInput());
     return success();
   }
 };

--- a/lib/Dialect/LWE/IR/LWEOps.h
+++ b/lib/Dialect/LWE/IR/LWEOps.h
@@ -219,7 +219,7 @@ LogicalResult verifyLevelReduceOp(Op* op) {
   auto x = getCtTy(op->getInput());
   auto out = getCtTy(op->getOutput());
 
-  if (x.getModulusChain().getCurrent() <= levelToDrop) {
+  if (x.getModulusChain().getCurrent() < levelToDrop) {
     return op->emitOpError() << "level_to_drop is out of bounds";
   }
 

--- a/lib/Dialect/Mgmt/IR/BUILD
+++ b/lib/Dialect/Mgmt/IR/BUILD
@@ -1,5 +1,3 @@
-# Mgmt dialect implementation
-
 load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
@@ -18,6 +16,7 @@ cc_library(
         "MgmtAttributes.h",
         "MgmtDialect.h",
         "MgmtOps.h",
+        "MgmtPatterns.h",
     ],
     deps = [
         "attributes_inc_gen",
@@ -25,6 +24,7 @@ cc_library(
         "ops_inc_gen",
         ":MgmtAttributes",
         ":MgmtOps",
+        ":MgmtPatterns",
         "@heir//lib/Dialect:HEIRInterfaces",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
@@ -62,6 +62,7 @@ cc_library(
     hdrs = [
         "MgmtDialect.h",
         "MgmtOps.h",
+        "MgmtPatterns.h",
     ],
     deps = [
         ":canonicalize_inc_gen",
@@ -70,6 +71,21 @@ cc_library(
         "@heir//lib/Dialect:HEIRInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+    ],
+)
+
+cc_library(
+    name = "MgmtPatterns",
+    srcs = ["MgmtPatterns.cpp"],
+    hdrs = ["MgmtPatterns.h"],
+    deps = [
+        ":MgmtAttributes",
+        ":MgmtOps",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Utils:AttributeUtils",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
     ],
 )
 

--- a/lib/Dialect/Mgmt/IR/MgmtOps.cpp
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.cpp
@@ -1,5 +1,6 @@
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 
+#include "lib/Dialect/Mgmt/IR/MgmtPatterns.h"
 #include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
 
@@ -30,6 +31,11 @@ void LevelReduceOp::getCanonicalizationPatterns(RewritePatternSet& results,
 void AdjustScaleOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                                 MLIRContext* context) {
   results.add<ModReduceAfterAdjustScale>(context);
+}
+
+void LevelReduceMinOp::getCanonicalizationPatterns(RewritePatternSet& results,
+                                                   MLIRContext* context) {
+  results.add<ReplaceWithLevelReduce>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Mgmt/IR/MgmtOps.td
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.td
@@ -71,6 +71,7 @@ def Mgmt_LevelReduceMinOp : Mgmt_Op<"level_reduce_min"> {
   let arguments = (ins AnyType:$input);
   let results = (outs AnyType:$output);
   let assemblyFormat = "operands attr-dict `:` type($output)";
+  let hasCanonicalizer = 1;
 }
 
 def Mgmt_RelinearizeOp : Mgmt_Op<"relinearize"> {
@@ -98,7 +99,7 @@ def Mgmt_RelinearizeOp : Mgmt_Op<"relinearize"> {
   let assemblyFormat = "operands attr-dict `:` type($output)";
 }
 
-def Mgmt_BootstrapOp : Mgmt_Op<"bootstrap"> {
+def Mgmt_BootstrapOp : Mgmt_Op<"bootstrap", [ResetsMulDepthOpInterface]> {
   let summary = "Bootstrap the input ciphertext to refresh its noise budget";
 
   let description = [{

--- a/lib/Dialect/Mgmt/IR/MgmtPatterns.cpp
+++ b/lib/Dialect/Mgmt/IR/MgmtPatterns.cpp
@@ -1,0 +1,38 @@
+#include "lib/Dialect/Mgmt/IR/MgmtPatterns.h"
+
+#include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace mgmt {
+
+LogicalResult ReplaceWithLevelReduce::matchAndRewrite(
+    LevelReduceMinOp op, mlir::PatternRewriter& rewriter) const {
+  auto resultMgmtAttr = findMgmtAttrAssociatedWith(op.getResult());
+  auto operandMgmtAttr = findMgmtAttrAssociatedWith(op.getInput());
+  if (!resultMgmtAttr || !operandMgmtAttr) {
+    return failure();
+  }
+
+  if (resultMgmtAttr.getLevel() == operandMgmtAttr.getLevel()) {
+    rewriter.replaceOp(op, op.getInput());
+    return success();
+  }
+
+  // This is an invalid state: the op reduces level by definition
+  if (resultMgmtAttr.getLevel() > operandMgmtAttr.getLevel()) {
+    return failure();
+  }
+
+  int64_t levelDiff = operandMgmtAttr.getLevel() - resultMgmtAttr.getLevel();
+  auto levelReduceOp = rewriter.replaceOpWithNewOp<LevelReduceOp>(
+      op, op.getInput(), rewriter.getI64IntegerAttr(levelDiff));
+  setMgmtAttrAssociatedWith(levelReduceOp.getResult(), resultMgmtAttr);
+
+  return success();
+}
+
+}  // namespace mgmt
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Mgmt/IR/MgmtPatterns.h
+++ b/lib/Dialect/Mgmt/IR/MgmtPatterns.h
@@ -1,0 +1,24 @@
+#ifndef LIB_DIALECT_MGMT_IR_MGMTPATTERNS_H_
+#define LIB_DIALECT_MGMT_IR_MGMTPATTERNS_H_
+
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace mgmt {
+
+struct ReplaceWithLevelReduce
+    : public mlir::OpRewritePattern<LevelReduceMinOp> {
+ public:
+  using OpRewritePattern<LevelReduceMinOp>::OpRewritePattern;
+
+  llvm::LogicalResult matchAndRewrite(
+      LevelReduceMinOp op, mlir::PatternRewriter& rewriter) const override;
+};
+
+}  // namespace mgmt
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_MGMT_IR_MGMTPATTERNS_H_

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -436,7 +436,7 @@ def KeySwitchInPlaceOp : Openfhe_Op<"key_switch_inplace",
 }
 
 // No in-place bootstrap variant
-def BootstrapOp : Openfhe_UnaryOp<"bootstrap"> {
+def BootstrapOp : Openfhe_UnaryOp<"bootstrap", [Pure, ResetsMulDepthOpInterface]> {
   let summary = "OpenFHE bootstrap operation of a ciphertext. (For CKKS)";
 }
 

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -49,6 +49,11 @@ struct MlirToRLWEPipelineOptions : public SimdVectorizerOptions {
       llvm::cl::desc("If true, use extended encryption technique (default to "
                      "false)"),
       llvm::cl::init(false)};
+  PassOptions::Option<bool> modulusSwitchAfterMul{
+      *this, "modulus-switch-after-mul",
+      llvm::cl::desc("Modulus switching after the first multiplication "
+                     "(default to false)"),
+      llvm::cl::init(false)};
   PassOptions::Option<bool> modulusSwitchBeforeFirstMul{
       *this, "modulus-switch-before-first-mul",
       llvm::cl::desc("Modulus switching right before the first multiplication "
@@ -84,6 +89,11 @@ struct MlirToRLWEPipelineOptions : public SimdVectorizerOptions {
       *this, "ckks-bootstrap-waterline",
       llvm::cl::desc("The number of levels to keep until bootstrapping in CKKS "
                      "(c.f. --secret-insert-mgmt-ckks)"),
+      llvm::cl::init(10)};
+  PassOptions::Option<int> levelBudget{
+      *this, "level-budget",
+      llvm::cl::desc(
+          "The level budget excluding levels required for bootstrap"),
       llvm::cl::init(10)};
   PassOptions::Option<std::string> plaintextExecutionResultFileName{
       *this, "plaintext-execution-result-file-name",

--- a/lib/Transforms/Halo/Patterns.h
+++ b/lib/Transforms/Halo/Patterns.h
@@ -3,6 +3,7 @@
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project

--- a/lib/Transforms/PopulateScale/PopulateScaleCKKS.cpp
+++ b/lib/Transforms/PopulateScale/PopulateScaleCKKS.cpp
@@ -10,6 +10,7 @@
 #include "lib/Parameters/CKKS/Params.h"
 #include "lib/Transforms/PopulateScale/PopulateScale.h"
 #include "lib/Transforms/PopulateScale/PopulateScalePatterns.h"
+#include "llvm/include/llvm/Support/DebugLog.h"            // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
@@ -22,6 +23,8 @@
 #include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
 #include "mlir/include/mlir/Transforms/Passes.h"           // from @llvm-project
 #include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+#define DEBUG_TYPE "populate-scale-ckks"
 
 namespace mlir {
 namespace heir {
@@ -39,53 +42,90 @@ class CKKSAdjustScaleMaterializer : public AdjustScaleMaterializer {
 #define GEN_PASS_DEF_POPULATESCALECKKS
 #include "lib/Transforms/PopulateScale/PopulateScale.h.inc"
 
+LogicalResult createAndRunDataflow(Operation* op, DataFlowSolver& solver,
+                                   int64_t logDefaultScale,
+                                   ckks::SchemeParamAttr ckksSchemeParamAttr,
+                                   bool beforeMulIncludeFirstMul) {
+  SymbolTableCollection symbolTable;
+  dataflow::loadBaselineAnalyses(solver);
+  solver.load<SecretnessAnalysis>();
+  auto inputScale = logDefaultScale;
+  if (beforeMulIncludeFirstMul) {
+    LDBG() << "Encoding at scale^2 due to 'include-first-mul' config";
+    inputScale *= 2;
+  }
+  solver.load<ScaleAnalysis<CKKSScaleModel>>(
+      ckks::SchemeParam::getSchemeParamFromAttr(ckksSchemeParamAttr),
+      /*inputScale*/ inputScale);
+  // Back-prop ScaleAnalysis depends on (forward) ScaleAnalysis
+  solver.load<ScaleAnalysisBackward<CKKSScaleModel>>(
+      symbolTable,
+      ckks::SchemeParam::getSchemeParamFromAttr(ckksSchemeParamAttr));
+
+  return solver.initializeAndRun(op);
+}
+
 struct PopulateScaleCKKS : impl::PopulateScaleCKKSBase<PopulateScaleCKKS> {
   using PopulateScaleCKKSBase::PopulateScaleCKKSBase;
 
   void runOnOperation() override {
-    // skip scale management for openfhe
-    if (moduleIsOpenfhe(getOperation())) {
-      return;
-    }
-
     auto ckksSchemeParamAttr = mlir::dyn_cast<ckks::SchemeParamAttr>(
         getOperation()->getAttr(ckks::CKKSDialect::kSchemeParamAttrName));
     auto logDefaultScale = ckksSchemeParamAttr.getLogDefaultScale();
 
     DataFlowSolver solver;
-    SymbolTableCollection symbolTable;
-    dataflow::loadBaselineAnalyses(solver);
-    // ScaleAnalysis depends on SecretnessAnalysis
-    solver.load<SecretnessAnalysis>();
-    // set input scale to logDefaultScale
-    auto inputScale = logDefaultScale;
-    if (beforeMulIncludeFirstMul) {
-      // encode at double degree
-      inputScale *= 2;
-    }
-    solver.load<ScaleAnalysis<CKKSScaleModel>>(
-        ckks::SchemeParam::getSchemeParamFromAttr(ckksSchemeParamAttr),
-        /*inputScale*/ inputScale);
-    // Back-prop ScaleAnalysis depends on (forward) ScaleAnalysis
-    solver.load<ScaleAnalysisBackward<CKKSScaleModel>>(
-        symbolTable,
-        ckks::SchemeParam::getSchemeParamFromAttr(ckksSchemeParamAttr));
-
-    if (failed(solver.initializeAndRun(getOperation()))) {
-      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+    if (failed(createAndRunDataflow(getOperation(), solver, logDefaultScale,
+                                    ckksSchemeParamAttr,
+                                    beforeMulIncludeFirstMul))) {
       signalPassFailure();
       return;
     }
+
     // at this time all adjust_scale should have ScaleLattice for its result.
     // all plaintext (mgmt.init) should have ScaleLattice for its result.
+    // However, due to the naivete of the scale analysis, there can be
+    // sections of IR in which no scale could be propagated through. E.g., an
+    // op surrounded by two adjust_scale ops that block propagation. In this
+    // case these adjust_scale ops should be removed.
+    getOperation()->walk([&](mgmt::AdjustScaleOp op) {
+      auto* lattice = solver.lookupState<ScaleLattice>(op.getResult());
+      if (!lattice || !lattice->getValue().isInitialized()) {
+        op.emitOpError() << "Dataflow analysis failed to populate scale "
+                            "lattice for result\n";
+        op->replaceAllUsesWith(ValueRange{op.getInput()});
+        op->erase();
+      }
+    });
 
-    // pass scale to AnnotateMgmt pass
-    annotateScale(getOperation(), &solver);
+    DataFlowSolver solver2;
+    if (failed(createAndRunDataflow(getOperation(), solver2, logDefaultScale,
+                                    ckksSchemeParamAttr,
+                                    beforeMulIncludeFirstMul))) {
+      signalPassFailure();
+      return;
+    }
+
+    getOperation()->walk([&](mgmt::InitOp op) {
+      auto* lattice = solver.lookupState<ScaleLattice>(op.getResult());
+      if (!lattice || !lattice->getValue().isInitialized()) {
+        op.emitOpError() << "Dataflow analysis failed to populate scale "
+                            "lattice for result\n";
+        signalPassFailure();
+      }
+    });
+
+    LDBG() << "Running annotate-mgmt sub-pass";
+    annotateScale(getOperation(), &solver2);
     OpPassManager annotateMgmt("builtin.module");
     annotateMgmt.addPass(mgmt::createAnnotateMgmt());
     (void)runPipeline(annotateMgmt, getOperation());
 
-    // convert adjust scale to mul plain
+    LLVM_DEBUG({
+      llvm::dbgs() << "Dumping op after annotate-mgmt pass:\n";
+      getOperation()->dump();
+    });
+
+    LDBG() << "convert adjust_scale to mul_plain";
     RewritePatternSet patterns(&getContext());
     CKKSAdjustScaleMaterializer materializer;
     // TODO(#1641): handle arith.muli in CKKS

--- a/lib/Transforms/SecretInsertMgmt/BUILD
+++ b/lib/Transforms/SecretInsertMgmt/BUILD
@@ -61,6 +61,7 @@ cc_library(
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Transforms/Halo:Patterns",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",

--- a/lib/Transforms/SecretInsertMgmt/Passes.td
+++ b/lib/Transforms/SecretInsertMgmt/Passes.td
@@ -52,6 +52,8 @@ def SecretInsertMgmtBGV : Pass<"secret-insert-mgmt-bgv", "ModuleOp"> {
            /*default=*/"false", "Modulus switching after each multiplication (default to false)">,
     Option<"beforeMulIncludeFirstMul", "before-mul-include-first-mul", "bool",
            /*default=*/"false", "Modulus switching before each multiplication, including the first multiplication (default to false)">,
+    Option<"levelBudget", "level-budget", "int", /*default=*/"0",
+           "An optional maximum level budget for the pipeline to assume">,
   ];
 }
 
@@ -109,6 +111,8 @@ def SecretInsertMgmtCKKS : Pass<"secret-insert-mgmt-ckks", "ModuleOp"> {
            /*default=*/"1024", "Default number of slots use for ciphertext space.">,
     Option<"bootstrapWaterline", "bootstrap-waterline", "int",
            /*default=*/"10", "Waterline for insert bootstrap op">,
+    Option<"levelBudget", "level-budget", "int", /*default=*/"0",
+           "An optional maximum level budget for the pipeline to assume">,
   ];
 }
 

--- a/lib/Transforms/SecretInsertMgmt/Pipeline.h
+++ b/lib/Transforms/SecretInsertMgmt/Pipeline.h
@@ -1,9 +1,8 @@
 #ifndef LIB_TRANSFORMS_SECRETINSERTMGMT_PIPELINE_H_
 #define LIB_TRANSFORMS_SECRETINSERTMGMT_PIPELINE_H_
 
-#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
-#include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"      // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -13,6 +12,7 @@ struct InsertMgmtPipelineOptions {
   bool modReduceAfterMul;
   bool modReduceBeforeMulIncludeFirstMul;
   std::optional<int64_t> bootstrapWaterline;
+  int64_t levelBudget;
 };
 
 // Run the secret-insert-mgmt pipeline.
@@ -25,27 +25,23 @@ struct InsertMgmtPipelineOptions {
 LogicalResult runInsertMgmtPipeline(Operation* top,
                                     const InsertMgmtPipelineOptions& options);
 
-void rerunDataflow(DataFlowSolver& solver, Operation* top);
+void insertMgmtInitForPlaintexts(Operation* top, bool includeFloats);
 
-void insertMgmtInitForPlaintexts(Operation* top, DataFlowSolver& solver,
-                                 bool includeFloats);
-
-void insertModReduceBeforeOrAfterMult(Operation* top, DataFlowSolver& solver,
-                                      bool afterMul,
+void insertModReduceBeforeOrAfterMult(Operation* top, bool afterMul,
                                       bool beforeMulIncludeFirstMul,
                                       bool includeFloats);
 
-void insertRelinearizeAfterMult(Operation* top, DataFlowSolver& solver,
-                                bool includeFloats);
+void insertRelinearizeAfterMult(Operation* top, bool includeFloats);
 
-void handleCrossLevelOps(Operation* top, DataFlowSolver& solver, int* idCounter,
-                         bool includeFloats);
+void handleCrossLevelOps(Operation* top, int* idCounter, bool includeFloats);
 
-void handleCrossMulDepthOps(Operation* top, DataFlowSolver& solver,
-                            int* idCounter, bool includeFloats);
+void handleCrossMulDepthOps(Operation* top, int* idCounter, bool includeFloats);
 
-void insertBootstrapWaterLine(Operation* top, DataFlowSolver& solver,
-                              int bootstrapWaterline);
+void insertBootstrapWaterLine(Operation* top, int bootstrapWaterline);
+
+void makeLoopsTypeAndLevelInvariant(Operation* top);
+
+void unrollLoopsForLevelUtilization(Operation* top, int levelBudget);
 
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBFV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBFV.cpp
@@ -73,8 +73,8 @@ struct SecretInsertMgmtBFV
       maxMulDepth = getMaxMulDepth(getOperation(), solver);
     }
 
-    insertMgmtInitForPlaintexts(getOperation(), solver, true);
-    insertRelinearizeAfterMult(getOperation(), solver, false);
+    insertMgmtInitForPlaintexts(getOperation(), true);
+    insertRelinearizeAfterMult(getOperation(), false);
 
     auto level = maxMulDepth;
     // 1. Canonicalizer moves mgmt::InitOp out of secret.generic.

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtBGV.cpp
@@ -57,6 +57,7 @@ struct SecretInsertMgmtBGV
 
     InsertMgmtPipelineOptions options;
     options.includeFloats = true;
+    options.levelBudget = levelBudget;
     options.modReduceAfterMul = afterMul;
     options.modReduceBeforeMulIncludeFirstMul = beforeMulIncludeFirstMul;
     LogicalResult result = runInsertMgmtPipeline(getOperation(), options);

--- a/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_ckks/loop.mlir
@@ -1,45 +1,75 @@
-// RUN: heir-opt --secretize --annotate-module="backend=openfhe scheme=ckks" --secret-insert-mgmt-ckks=slot-number=1024 --generate-param-ckks --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
+// RUN: heir-opt --secret-distribute-generic --canonicalize --secret-to-ckks %s | FileCheck %s
 
-module {
-// CHECK: ![[ct_ty:.*]] = !lwe.lwe_ciphertext
-// CHECK: func @hv_matmul
-// CHECK-SAME:    %[[ct:.*]]: tensor<1x![[ct_ty]]>
-// CHECK:      %[[extracted:.*]] = tensor.extract %[[ct]]
-// CHECK:      %[[pt:.*]] = lwe.rlwe_encode
-// CHECK-NEXT: %[[ct2:.*]] = ckks.mul_plain %[[extracted]], %[[pt]]
-// CHECK:      %[[pt3:.*]] = lwe.rlwe_encode
-// CHECK-NEXT: %[[ct4:.*]] = ckks.add_plain %[[ct2]], %[[pt3]]
-// CHECK:      %[[ct5:.*]], %[[ct6:.*]] = affine.for %[[arg0:.*]] = 1 to 1024 iter_args(%[[ct7:.*]] = %[[ct4]], %[[ct8:.*]] = %[[extracted]])
-// CHECK-NEXT:   %[[ct9:.*]] = ckks.rotate %[[ct8]] {offset = 1
-// CHECK-NEXT:   %[[extracted_slice:.*]] = tensor.extract_slice
-// CHECK:        %[[pt10:.*]] = lwe.rlwe_encode %[[extracted_slice]]
-// CHECK-NEXT:   %[[ct11:.*]] = ckks.mul_plain %[[ct9]], %[[pt10]]
-// CHECK-NEXT:   %[[ct12:.*]] = ckks.add %[[ct7]], %[[ct11]]
-// CHECK-NEXT:   affine.yield %[[ct12]], %[[ct9]]
-// CHECK:      %[[empty:.*]] = tensor.empty
-// CHECK:      %[[result:.*]] = tensor.insert %[[ct5]] into %[[empty]]
-// CHECK:      return %[[result]]
-  func.func @hv_matmul(%arg0: !secret.secret<tensor<1x1024xf32>>) -> !secret.secret<tensor<1x1024xf32>> attributes {llvm.emit_c_interface} {
-    %cst = arith.constant dense_resource<__elided__> : tensor<1024xf32>
-    %c1 = arith.constant 1 : index
-    %cst_0 = arith.constant dense_resource<__elided__> : tensor<1024x1024xf32>
-    %cst_1 = arith.constant dense<0.000000e+00> : tensor<1024xf32>
-    %empty = tensor.empty() : tensor<1x1024xf32>
-    %0 = secret.generic(%arg0 : !secret.secret<tensor<1x1024xf32>>) {
-    ^body(%input0: tensor<1x1024xf32>):
-      %collapsed = tensor.extract_slice %input0[0, 0] [1, 1024] [1, 1] : tensor<1x1024xf32> to tensor<1024xf32>
-      %1 = arith.mulf %collapsed, %cst : tensor<1024xf32>
-      %2 = arith.addf %1, %cst_1 : tensor<1024xf32>
-      %3:2 = affine.for %arg1 = 1 to 1024 iter_args(%arg2 = %2, %arg3 = %collapsed) -> (tensor<1024xf32>, tensor<1024xf32>) {
-        %4 = tensor_ext.rotate %arg3, %c1 : tensor<1024xf32>, index
-        %extracted_slice = tensor.extract_slice %cst_0[%arg1, 0] [1, 1024] [1, 1] : tensor<1024x1024xf32> to tensor<1024xf32>
-        %5 = arith.mulf %4, %extracted_slice : tensor<1024xf32>
-        %6 = arith.addf %arg2, %5 : tensor<1024xf32>
-        affine.yield %6, %4 : tensor<1024xf32>, tensor<1024xf32>
-      }
-      %expanded = tensor.insert_slice %3#0 into %empty[0, 0] [1, 1024] [1, 1] : tensor<1024xf32> into tensor<1x1024xf32>
-      secret.yield %expanded : tensor<1x1024xf32>
-    } -> !secret.secret<tensor<1x1024xf32>>
-    return %0 : !secret.secret<tensor<1x1024xf32>>
+// This test was extracted from just before distribute-generic in the e2e loop test.
+
+#layout = #tensor_ext.layout<"{ [i0] -> [ct, slot] : ct = 0 and (-i0 + slot) mod 8 = 0 and 0 <= i0 <= 7 and 0 <= slot <= 7 }">
+#original_type = #tensor_ext.original_type<originalType = tensor<8xf32>, layout = #layout>
+module attributes {backend.openfhe, ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [1152921504606748673, 36028797019488257, 36028797017456641, 36028797019389953], P = [1152921504607338497, 1152921504608747521], logDefaultScale = 55>, scheme.ckks} {
+  func.func private @_assign_layout_13348573087261549848(%arg0: tensor<8xf32>) -> tensor<1x8xf32> attributes {client.pack_func = {func_name = "loop"}} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x8xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = scf.for %arg1 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1x8xf32>)  : i32 {
+      %1 = arith.index_cast %arg1 : i32 to index
+      %extracted = tensor.extract %arg0[%1] : tensor<8xf32>
+      %inserted = tensor.insert %extracted into %arg2[%c0, %1] : tensor<1x8xf32>
+      scf.yield %inserted : tensor<1x8xf32>
+    }
+    return %0 : tensor<1x8xf32>
+  }
+
+  // CHECK: @loop
+  func.func @loop(%arg0: !secret.secret<tensor<1x8xf32>> {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 55>, tensor_ext.original_type = #original_type}) -> (!secret.secret<tensor<1x8xf32>> {mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>, tensor_ext.original_type = #original_type}) {
+    %cst = arith.constant dense<1.000000e+00> : tensor<1x8xf32>
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<8xf32>
+    %0 = call @_assign_layout_13348573087261549848(%cst_0) : (tensor<8xf32>) -> tensor<1x8xf32>
+    %1 = mgmt.init %0 {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 55>} : tensor<1x8xf32>
+    %2 = mgmt.init %0 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+    %3 = mgmt.init %0 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+    %4 = secret.generic(%arg0: !secret.secret<tensor<1x8xf32>> {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 55>}) {
+    ^body(%input0: tensor<1x8xf32>):
+      %5 = arith.mulf %input0, %1 {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 110>} : tensor<1x8xf32>
+      %6 = mgmt.modreduce %5 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+      %7 = arith.subf %6, %2 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+      %8 = mgmt.level_reduce %7 {levelToDrop = 2 : i64, mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>} : tensor<1x8xf32>
+
+      // CHECK: affine.for
+      %9 = affine.for %arg1 = 1 to 7 step 3 iter_args(%arg2 = %8) -> (tensor<1x8xf32>) {
+        %16 = mgmt.bootstrap %arg2 {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 55>} : tensor<1x8xf32>
+        %17 = arith.mulf %input0, %16 {mgmt.mgmt = #mgmt.mgmt<level = 3, dimension = 3, scale = 110>} : tensor<1x8xf32>
+        %18 = mgmt.relinearize %17 {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 110>} : tensor<1x8xf32>
+        %19 = mgmt.modreduce %18 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+        %20 = mgmt.init %0 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+        %21 = arith.subf %19, %20 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+        %22 = mgmt.init %cst {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 55>} : tensor<1x8xf32>
+        %23 = arith.mulf %input0, %22 {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 110>} : tensor<1x8xf32>
+        %24 = mgmt.modreduce %23 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+        %25 = arith.mulf %24, %21 {mgmt.mgmt = #mgmt.mgmt<level = 2, dimension = 3, scale = 110>} : tensor<1x8xf32>
+        %26 = mgmt.relinearize %25 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 110>} : tensor<1x8xf32>
+        %27 = mgmt.modreduce %26 {mgmt.mgmt = #mgmt.mgmt<level = 1, scale = 55>} : tensor<1x8xf32>
+        %28 = mgmt.init %0 {mgmt.mgmt = #mgmt.mgmt<level = 1, scale = 55>} : tensor<1x8xf32>
+        %29 = arith.subf %27, %28 {mgmt.mgmt = #mgmt.mgmt<level = 1, scale = 55>} : tensor<1x8xf32>
+        %30 = mgmt.level_reduce %input0 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+        %31 = mgmt.init %cst {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+        %32 = arith.mulf %30, %31 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 110>} : tensor<1x8xf32>
+        %33 = mgmt.modreduce %32 {mgmt.mgmt = #mgmt.mgmt<level = 1, scale = 55>} : tensor<1x8xf32>
+        %34 = arith.mulf %33, %29 {mgmt.mgmt = #mgmt.mgmt<level = 1, dimension = 3, scale = 110>} : tensor<1x8xf32>
+        %35 = mgmt.relinearize %34 {mgmt.mgmt = #mgmt.mgmt<level = 1, scale = 110>} : tensor<1x8xf32>
+        %36 = mgmt.modreduce %35 {mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>} : tensor<1x8xf32>
+        %37 = mgmt.init %0 {mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>} : tensor<1x8xf32>
+        %38 = arith.subf %36, %37 {mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>} : tensor<1x8xf32>
+        affine.yield %38 : tensor<1x8xf32>
+      } {__argattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>}], __resattrs = [{mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>}]}
+      %10 = mgmt.bootstrap %9 {halo.invariance, mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 55>} : tensor<1x8xf32>
+      %11 = arith.mulf %input0, %10 {mgmt.mgmt = #mgmt.mgmt<level = 3, dimension = 3, scale = 110>} : tensor<1x8xf32>
+      %12 = mgmt.relinearize %11 {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 110>} : tensor<1x8xf32>
+      %13 = mgmt.modreduce %12 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+      %14 = arith.subf %13, %3 {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 55>} : tensor<1x8xf32>
+      %15 = mgmt.level_reduce %14 {levelToDrop = 2 : i64, mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>} : tensor<1x8xf32>
+      secret.yield %15 : tensor<1x8xf32>
+    } -> (!secret.secret<tensor<1x8xf32>> {mgmt.mgmt = #mgmt.mgmt<level = 0, scale = 55>})
+    return %4 : !secret.secret<tensor<1x8xf32>>
   }
 }

--- a/tests/Examples/common/loop.mlir
+++ b/tests/Examples/common/loop.mlir
@@ -1,0 +1,28 @@
+// A simple test for loop support.
+//
+// Computes the function
+//
+//     def f(x):
+//       sum = 1.0
+//       for i in range(8):
+//         sum = sum * x - 1.0
+//       return sum
+//
+// In particular,
+//
+//   >>> np.linspace(0, 1, 8)
+//   array([0.        , 0.14285714, 0.28571429, 0.42857143, 0.57142857,
+//          0.71428571, 0.85714286, 1.        ])
+//   >>> f(np.linspace(0, 1, 8))
+//   array([-1.        , -1.16666629, -1.39989342, -1.74687019, -2.29543899,
+//          -3.19507837, -4.66914279, -7.        ])
+
+func.func @loop(%arg0: tensor<8xf32> {secret.secret}) -> tensor<8xf32> {
+  %c1_f32 = arith.constant dense<1.0> : tensor<8xf32>
+  %0 = affine.for %i = 0 to 8 iter_args(%sum_iter = %c1_f32) -> tensor<8xf32> {
+    %2 = arith.mulf %arg0, %sum_iter : tensor<8xf32>
+    %3 = arith.subf %2, %c1_f32 : tensor<8xf32>
+    affine.yield %3 : tensor<8xf32>
+  }
+  return %0 : tensor<8xf32>
+}

--- a/tests/Examples/openfhe/ckks/loop_support/BUILD
+++ b/tests/Examples/openfhe/ckks/loop_support/BUILD
@@ -1,0 +1,31 @@
+load("@heir//tests/Examples/openfhe:test.bzl", "openfhe_end_to_end_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+openfhe_end_to_end_test(
+    name = "loop_test",
+    generated_lib_header = "loop_lib.h",
+    heir_opt_flags = [
+        "--annotate-module=backend=openfhe scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=8 scaling-mod-bits=55 first-mod-bits=60 level-budget=3 modulus-switch-after-mul=true experimental-disable-loop-unroll=true",
+        "--scheme-to-openfhe=insert-debug-handler-calls=true",
+    ],
+    heir_translate_flags = [
+        "--openfhe-debug-helper-include-path=tests/Examples/openfhe/ckks/loop_support/debug_helper.h",
+    ],
+    mlir_src = "@heir//tests/Examples/common:loop.mlir",
+    test_src = "loop_test.cpp",
+    deps = [
+        "@heir//tests/Examples/openfhe/ckks/loop_support:debug_helper",
+    ],
+)
+
+cc_library(
+    name = "debug_helper",
+    srcs = ["debug_helper.cpp"],
+    hdrs = ["debug_helper.h"],
+    deps = [
+        "@openfhe//:core",
+        "@openfhe//:pke",
+    ],
+)

--- a/tests/Examples/openfhe/ckks/loop_support/debug_helper.cpp
+++ b/tests/Examples/openfhe/ckks/loop_support/debug_helper.cpp
@@ -1,0 +1,43 @@
+#include "tests/Examples/openfhe/ckks/loop_support/debug_helper.h"
+
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "src/core/include/lattice/hal/lat-backend.h"  // from @openfhe
+#include "src/pke/include/encoding/plaintext-fwd.h"    // from @openfhe
+
+using lbcrypto::DCRTPoly;
+using PlaintextT = lbcrypto::Plaintext;
+
+void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct,
+                  const std::map<std::string, std::string>& debugAttrMap) {
+  auto isBlockArgument = debugAttrMap.at("asm.is_block_arg");
+  if (isBlockArgument == "1") {
+    std::cout << "Input" << std::endl;
+  } else {
+    std::cout << debugAttrMap.at("asm.result_ssa_format") << std::endl;
+  }
+
+  PlaintextT ptxt;
+  cc->Decrypt(sk, ct, &ptxt);
+  ptxt->SetLength(std::stod(debugAttrMap.at("message.size")));
+  std::vector<double> result;
+  result.reserve(ptxt->GetLength());
+  for (size_t i = 0; i < ptxt->GetLength(); i++) {
+    result.push_back(ptxt->GetRealPackedValue()[i]);
+  }
+
+  std::cout << "  Decrypted: [";
+  for (double val : result) {
+    std::cout << std::setprecision(3) << val << ", ";
+  }
+  std::cout << "]\n";
+  std::cout << "  Scale: " << log2(ct->GetScalingFactor()) << std::endl;
+}

--- a/tests/Examples/openfhe/ckks/loop_support/debug_helper.h
+++ b/tests/Examples/openfhe/ckks/loop_support/debug_helper.h
@@ -1,0 +1,16 @@
+#ifndef TESTS_EXAMPLES_OPENFHE_CKKS_LOOP_SUPPORT_DEBUG_HELPER_H_
+#define TESTS_EXAMPLES_OPENFHE_CKKS_LOOP_SUPPORT_DEBUG_HELPER_H_
+
+#include <map>
+#include <string>
+
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+using CiphertextT = lbcrypto::Ciphertext<lbcrypto::DCRTPoly>;
+using CryptoContextT = lbcrypto::CryptoContext<lbcrypto::DCRTPoly>;
+using PrivateKeyT = lbcrypto::PrivateKey<lbcrypto::DCRTPoly>;
+
+void __heir_debug(CryptoContextT cc, PrivateKeyT sk, CiphertextT ct,
+                  const std::map<std::string, std::string>& debugAttrMap);
+
+#endif  // TESTS_EXAMPLES_OPENFHE_CKKS_LOOP_SUPPORT_DEBUG_HELPER_H_

--- a/tests/Examples/openfhe/ckks/loop_support/loop_test.cpp
+++ b/tests/Examples/openfhe/ckks/loop_support/loop_test.cpp
@@ -1,0 +1,72 @@
+#include <vector>
+
+#include "gmock/gmock.h"              // from @googletest
+#include "gtest/gtest.h"              // from @googletest
+#include "src/pke/include/openfhe.h"  // from @openfhe
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/ckks/loop_support/loop_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+using namespace lbcrypto;
+using ::testing::DoubleNear;
+using ::testing::Pointwise;
+using CCParamsT = CCParams<CryptoContextCKKSRNS>;
+using CryptoContextT = CryptoContext<DCRTPoly>;
+using PrivateKeyT = PrivateKey<DCRTPoly>;
+
+CryptoContextT override_crypto_context() {
+  CCParamsT params;
+  params.SetMultiplicativeDepth(23);
+  params.SetKeySwitchTechnique(HYBRID);
+  params.SetScalingTechnique(FIXEDMANUAL);
+  params.SetScalingModSize(55);
+  params.SetFirstModSize(60);
+  params.SetRingDim(2048);
+  params.SetBatchSize(1024);
+  params.SetSecurityLevel(HEStd_NotSet);
+  CryptoContextT cc = GenCryptoContext(params);
+  cc->Enable(PKE);
+  cc->Enable(KEYSWITCH);
+  cc->Enable(LEVELEDSHE);
+  cc->Enable(ADVANCEDSHE);
+  cc->Enable(FHE);
+  return cc;
+}
+CryptoContextT override_configure_crypto_context(CryptoContextT cc,
+                                                 PrivateKeyT sk) {
+  cc->EvalMultKeyGen(sk);
+  cc->EvalBootstrapSetup({3, 3});
+  cc->EvalBootstrapKeyGen(sk, 1024);
+  return cc;
+}
+
+TEST(LoopTest, RunTest) {
+  // auto cryptoContext = loop__generate_crypto_context();
+  auto cryptoContext = override_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  // cryptoContext = loop__configure_crypto_context(cryptoContext, secretKey);
+  cryptoContext = override_configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<float> arg0 = {0.,         0.14285714, 0.28571429, 0.42857143,
+                             0.57142857, 0.71428571, 0.85714286, 1.};
+  std::vector<float> expected = {-1.,         -1.16666629, -1.39989342,
+                                 -1.74687019, -2.29543899, -3.19507837,
+                                 -4.66914279, -7.};
+
+  auto arg0Encrypted = loop__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto outputEncrypted = loop(cryptoContext, secretKey, arg0Encrypted);
+  auto actual =
+      loop__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_THAT(actual, Pointwise(DoubleNear(1e-03), expected));
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/Examples/plaintext/loop_support/BUILD
+++ b/tests/Examples/plaintext/loop_support/BUILD
@@ -1,0 +1,14 @@
+load("@heir//tests/llvm_runner:llvm_runner.bzl", "llvm_runner_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+llvm_runner_test(
+    name = "loop",
+    heir_opt_flags = [
+        "--mlir-to-plaintext-backend=plaintext-size=8 insert-debug-handler-calls=true",
+    ],
+    log_file_name = "loop_support_debug.log",
+    log_file_visibility = ["@heir//tests/Examples:__subpackages__"],
+    main_c_src = "loop_test.cpp",
+    mlir_src = "@heir//tests/Examples/common:loop.mlir",
+)

--- a/tests/Examples/plaintext/loop_support/loop_test.cpp
+++ b/tests/Examples/plaintext/loop_support/loop_test.cpp
@@ -1,0 +1,93 @@
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "tests/llvm_runner/memref_types.h"
+
+FILE* output;
+
+extern "C" {
+void _mlir_ciface_loop(StridedMemRefType<float, 2>* result,
+                       StridedMemRefType<float, 2>* arg0);
+
+void _mlir_ciface_loop__encrypt__arg0(StridedMemRefType<float, 2>* result,
+                                      StridedMemRefType<float>* arg);
+
+void _mlir_ciface_loop__decrypt__result0(StridedMemRefType<float, 2>* result,
+                                         StridedMemRefType<float, 2>* arg);
+
+void __heir_debug_tensor_8xf32_(
+    /* arg 0*/
+    float* allocated, float* aligned, int64_t offset, int64_t size,
+    int64_t stride) {
+  for (int i = 0; i < size; i++) {
+    std::fprintf(output, "%.10f ", *(aligned + i * stride));
+  }
+  std::fprintf(output, "\n");
+}
+
+// debug handler
+void __heir_debug_tensor_1x8xf32_(
+    /* arg 0*/
+    float* allocated, float* aligned, int64_t offset, int64_t size,
+    int64_t stride) {
+  for (int i = 0; i < size; i++) {
+    __heir_debug_tensor_8xf32_(allocated, aligned + i * stride, offset, 8, 1);
+  }
+}
+
+void __heir_debug_f32(float value) { std::fprintf(output, "%.15f \n", value); }
+
+void __heir_debug_i1(bool value) { std::fprintf(output, "%d \n", value); }
+
+void __heir_debug_index(int64_t value) {
+  std::fprintf(output, "%ld \n", value);
+}
+}
+
+int main(int argc, char** argv) {
+  // the first argument is the output file
+  if (argc > 1) {
+    output = fopen(argv[1], "w");
+    if (output == nullptr) {
+      fprintf(stderr, "Error opening file\n");
+      return 1;
+    }
+  } else {
+    output = stderr;
+  }
+
+  float arg0[8] = {0.,         0.14285714, 0.28571429, 0.42857143,
+                   0.57142857, 0.71428571, 0.85714286, 1.};
+  float expected[8] = {-1.,         -1.16666629, -1.39989342, -1.74687019,
+                       -2.29543899, -3.19507837, -4.66914279, -7.};
+
+  StridedMemRefType<float, 2> encArg0;
+  StridedMemRefType<float> input0{arg0, arg0, 0, 8, 1};
+  _mlir_ciface_loop__encrypt__arg0(&encArg0, &input0);
+
+  StridedMemRefType<float, 2> packedRes;
+  _mlir_ciface_loop(&packedRes, &encArg0);
+
+  StridedMemRefType<float, 2> decRes;
+  _mlir_ciface_loop__decrypt__result0(&decRes, &packedRes);
+  float* res = decRes.data;
+
+  for (int i = 0; i < 8; ++i) {
+    std::cout << "res[" << i << "] = " << res[i] << ", expected[" << i
+              << "] = " << expected[i] << std::endl;
+
+    if (fabs(res[i] - expected[i]) > 1e-5) {
+      printf("Test failed %f != %f\n", res[i], expected[i]);
+      return 1;
+    }
+  }
+
+  free(encArg0.basePtr);
+  free(packedRes.basePtr);
+  free(decRes.basePtr);
+
+  return 0;
+}

--- a/tests/Regression/issue_1929.mlir
+++ b/tests/Regression/issue_1929.mlir
@@ -39,9 +39,6 @@ func.func @float_secret_loop_signless_integer_step(%arg0: f32 {secret.secret}, %
 
 // TODO (#1641): enable i32-based tests once CKKS pipeline allows integer types
 // func.func @secret_loop_index_step(%arg0: i32 {secret.secret}, %arg1: i32 {secret.secret}) -> i32 {
-// TODO (#1641): enable i32-based tests once CKKS pipeline allows integer types
-// func.func @secret_loop_index_step(%arg0: i32 {secret.secret}, %arg1: i32 {secret.secret}) -> i32 {
-// func.func @secret_loop_index_step(%arg0: i32 {secret.secret}, %arg1: i32 {secret.secret}) -> i32 {
 //     %c1 = arith.constant 1 : index
 //     %c1_i32 = arith.constant 1 : i32
 //     %0 = arith.index_cast %arg0 : i32 to index

--- a/tests/Regression/issue_2466.mlir
+++ b/tests/Regression/issue_2466.mlir
@@ -1,6 +1,5 @@
 // RUN: heir-opt --secretize='function=main' --torch-linalg-to-ckks='ciphertext-degree=4096' %s | FileCheck %s
 
-
 module {
   func.func @main(%arg0: tensor<1x3x8x8xf32>) -> tensor<1x4x8x8xf32> {
     %cst = arith.constant dense_resource<torch_tensor_4_torch.float32> : tensor<4xf32>

--- a/tests/Transforms/secret_insert_mgmt/ckks/insert_mgmt_ckks.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/insert_mgmt_ckks.mlir
@@ -1,6 +1,4 @@
-// RUN: heir-opt --full-loop-unroll --secret-insert-mgmt-ckks=slot-number=8 %s
-
-// TODO(#1181): make this test work without the loop unroll step
+// RUN: heir-opt --secret-insert-mgmt-ckks=slot-number=8 %s
 
 #scalar_layout = #tensor_ext.layout<"{ [] -> [ct, slot] : ct = 0 and 0 <= slot <= 7 }">
 #scalar_original_type = #tensor_ext.original_type<originalType = f32, layout = #scalar_layout>

--- a/tests/Transforms/secret_insert_mgmt/ckks/loop_modreduce_after_mul.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/loop_modreduce_after_mul.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt --secret-insert-mgmt-ckks="slot-number=8 level-budget=4 after-mul=true" %s | FileCheck %s
+
+module attributes {backend.lattigo, scheme.ckks} {
+  // CHECK: func.func @loop_mul
+  // CHECK-SAME: #mgmt.mgmt<level = 4>
+  // CHECK: affine.for {{[^ ]*}} = 1 to 9 step 4
+  func.func @loop_mul(%arg0: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+  %c2 = arith.constant dense<2.0> : tensor<8xf32>
+  %0 = secret.generic(%arg0: !secret.secret<tensor<8xf32>>) {
+  ^body(%arg0_val: tensor<8xf32>):
+    %res = affine.for %i = 0 to 10 iter_args(%sum_iter = %c2) -> tensor<8xf32> {
+      %sum = arith.mulf %sum_iter, %arg0_val : tensor<8xf32>
+      affine.yield %sum : tensor<8xf32>
+    }
+    secret.yield %res : tensor<8xf32>
+  } -> !secret.secret<tensor<8xf32>>
+  return %0 : !secret.secret<tensor<8xf32>>
+  }
+}

--- a/tests/Transforms/secret_insert_mgmt/ckks/loop_modreduce_before_mul.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/loop_modreduce_before_mul.mlir
@@ -1,0 +1,22 @@
+// RUN: heir-opt --secret-insert-mgmt-ckks="slot-number=8 level-budget=4 after-mul=false" %s | FileCheck %s
+
+// TODO(#2564): consider redesigning "before-mul (skip first mul)" to
+// "before-mul (include first mul)" plus a later optimization pass.
+
+module attributes {backend.lattigo, scheme.ckks} {
+  // CHECK: func.func @loop_mul
+  // CHECK-SAME: #mgmt.mgmt<level = 0>
+  // CHECK: affine.for {{[^ ]*}} = 1 to 10
+  func.func @loop_mul(%arg0: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+  %c2 = arith.constant dense<2.0> : tensor<8xf32>
+  %0 = secret.generic(%arg0: !secret.secret<tensor<8xf32>>) {
+  ^body(%arg0_val: tensor<8xf32>):
+    %res = affine.for %i = 0 to 10 iter_args(%sum_iter = %c2) -> tensor<8xf32> {
+      %sum = arith.mulf %sum_iter, %arg0_val : tensor<8xf32>
+      affine.yield %sum : tensor<8xf32>
+    }
+    secret.yield %res : tensor<8xf32>
+  } -> !secret.secret<tensor<8xf32>>
+  return %0 : !secret.secret<tensor<8xf32>>
+  }
+}

--- a/tests/Transforms/secret_insert_mgmt/ckks/loop_modreduce_before_mul_include_first.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/loop_modreduce_before_mul_include_first.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt --secret-insert-mgmt-ckks="slot-number=8 level-budget=4 after-mul=false before-mul-include-first-mul=true" %s | FileCheck %s
+
+module attributes {backend.lattigo, scheme.ckks} {
+  // CHECK: func.func @loop_mul
+  // CHECK-SAME: #mgmt.mgmt<level = 4>
+  // CHECK: affine.for {{[^ ]*}} = 1 to 9 step 4
+  func.func @loop_mul(%arg0: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+  %c2 = arith.constant dense<2.0> : tensor<8xf32>
+  %0 = secret.generic(%arg0: !secret.secret<tensor<8xf32>>) {
+  ^body(%arg0_val: tensor<8xf32>):
+    %res = affine.for %i = 0 to 10 iter_args(%sum_iter = %c2) -> tensor<8xf32> {
+      %sum = arith.mulf %sum_iter, %arg0_val : tensor<8xf32>
+      affine.yield %sum : tensor<8xf32>
+    }
+    secret.yield %res : tensor<8xf32>
+  } -> !secret.secret<tensor<8xf32>>
+  return %0 : !secret.secret<tensor<8xf32>>
+  }
+}


### PR DESCRIPTION
This PR integrates the HALO loop support patterns into the secret-insert-mgmt pipeline.

The vast majorty of this PR is debug statements added to the insert-mgmt pipeline, guarded by the `experimental-disable-loop-unroll`, and the various analyses so that I could figure out the small number of issues that needed fixing. Those issues are:

1. When an analysis depends on another analysis, the dependence relationship between the two analyses is not established until the first time that one analysis queries a lattice element from another analysis. Moreover, the order in which analyses are run is deterministic, but appears to be arbitrary, so if analysis A depends on analysis B, then A can run before B. When it queries B, the analysis state is not present. You're supposed to default to a pessimistic lattice value, and then due to the change to the dependence structure, the analysis framework will trigger another run of analysis B after analysis A is run on that program point.
2. The default bootstrap params is way too slow, resulting in like a 3 minute bootstrap latency. I overrode the crypto-context params/configure step in the final tests to use faster params so we could at least test correctness. But I also created a benchmark file to experiment with this outside of the context of HEIR's compilation pipeline.
3. We need some way to seed the number of available levels for loop unrolling, otherwise HEIR will be default think that we don't need very many levels at all (i.e., if there are no mul's in the loop, then it thinks we need zero levels). So I added a pipeline flag `level-budget` that gives a total number of levels (excluding what is needed for bootstrap). This is mainly a hack that allows me to get the compilation to work properly.