### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,14 +16,14 @@ jobs:
       labels: ubuntu-24.04-64core
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Install dependencies
         run: |
           ./.github/install_clang_version.sh 19
 
       - name: Cache bazel build artifacts
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             ~/.cache/bazel

--- a/.github/workflows/build_and_test_macos.yml
+++ b/.github/workflows/build_and_test_macos.yml
@@ -16,10 +16,10 @@ jobs:
       labels: macos-15
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Cache bazel build artifacts
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             ~/.cache/bazel

--- a/.github/workflows/build_options_matrix.yml
+++ b/.github/workflows/build_options_matrix.yml
@@ -27,7 +27,7 @@ jobs:
       labels: ubuntu-24.04-64core
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/clang_matrix.yml
+++ b/.github/workflows/clang_matrix.yml
@@ -20,7 +20,7 @@ jobs:
       labels: ubuntu-24.04-64core
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -20,7 +20,7 @@ jobs:
       labels: ubuntu-24.04-16core
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Build dev image
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
 
@@ -26,7 +26,7 @@ jobs:
           ./.github/install_clang_version.sh 19
 
       - name: Cache bazel build artifacts
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             ~/.cache/bazel
@@ -64,7 +64,7 @@ jobs:
       # Please update the local install instructions at docs/README.md if
       # changing node version
       - name: Setup Node
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
         with:
           node-version: '18'
           cache: 'npm'

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Run update lockfile
         run: bazel mod deps --lockfile_mode=update

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       labels: ubuntu-24.04-16core
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr_review.yml
+++ b/.github/workflows/pr_review.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Assert single commit
         env:

--- a/.github/workflows/pr_style.yml
+++ b/.github/workflows/pr_style.yml
@@ -9,8 +9,8 @@ jobs:
   pre-commit-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
-      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@v4.7.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # pin@4.3.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Get current date
         id: date
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create issue on failure
         if: steps.wait_for_wheels.outcome == 'failure'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # pin@v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scripts_test.yml
+++ b/.github/workflows/scripts_test.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # pin@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/todo.yaml
+++ b/.github/workflows/todo.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # pin@v3
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
     - name: todo-backlinks
       uses: j2kun/todo-backlinks@12b447ef971f465feb2a7298a1240157e8712942 # pin@v0.0.5
       env:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`1bd1e32`](https://github.com/actions/cache/commit/1bd1e32a3bdc45362d1e726936510720a7c30a57) | [`8b402f5`](https://github.com/actions/cache/commit/8b402f58fbc84540c8b491a91e594a4576fec3d7) | [Release](https://github.com/actions/cache/releases/tag/v5) | build_and_test.yml, build_and_test_macos.yml, docs.yml |
| `actions/checkout` | [`08eba0b`](https://github.com/actions/checkout/commit/08eba0b27e820071cde6df949e0beb9ba4906955), [`11bd719`](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683), [`8e5e7e5`](https://github.com/actions/checkout/commit/8e5e7e5ab8b370d6c329ec480221332ada57f0ab) | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build_and_test.yml, build_and_test_macos.yml, build_options_matrix.yml, clang_matrix.yml, docker-dev.yml, docs.yml, lockfile.yml, nightly.yml, pr_review.yml, pr_style.yml, release.yml, scorecard.yml, scripts_test.yml, todo.yaml |
| `actions/github-script` | [`60a0d83`](https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea) | [`ed59741`](https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd) | [Release](https://github.com/actions/github-script/releases/tag/v8) | release.yml |
| `actions/setup-node` | [`0a44ba7`](https://github.com/actions/setup-node/commit/0a44ba7841725637a19e28fa30b79a866c81b0a6) | [`6044e13`](https://github.com/actions/setup-node/commit/6044e13b5dc448c55e2357c09f80417699197238) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | docs.yml |
| `actions/setup-python` | [`0a5c615`](https://github.com/actions/setup-python/commit/0a5c61591373683505ea898e09a3ea4f39ef2b9c), [`61a6322`](https://github.com/actions/setup-python/commit/61a6322f88396a6271a6ee3565807d608ecaddd1) | [`a309ff8`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | pr_style.yml, scripts_test.yml |
| `actions/upload-artifact` | [`6f51ac0`](https://github.com/actions/upload-artifact/commit/6f51ac03b9356f520e9adb1b1b7802705f340c2b) | [`b7c566a`](https://github.com/actions/upload-artifact/commit/b7c566a772e6b6bfb58ed0dc250532a479d7789f) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | scorecard.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
