### PR TITLE
Add extended basis rotation operations for OpenFHE dialect

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -435,6 +435,17 @@ def KeySwitchInPlaceOp : Openfhe_Op<"key_switch_inplace",
   let extraClassDeclaration = "int getInPlaceOperandIndex() { return 1; }";
 }
 
+def KeySwitchDownOp : Openfhe_Op<"key_switch_down", [Pure,
+  AllTypesMatch<["ciphertext", "output"]>
+]> {
+  let summary = "Key switch down from extended (P*Q) basis to normal (Q) basis.";
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    Openfhe_Ciphertext:$ciphertext
+  );
+  let results = (outs Openfhe_Ciphertext:$output);
+}
+
 // No in-place bootstrap variant
 def BootstrapOp : Openfhe_UnaryOp<"bootstrap"> {
   let summary = "OpenFHE bootstrap operation of a ciphertext. (For CKKS)";
@@ -465,6 +476,25 @@ def FastRotationOp : Openfhe_Op<"fast_rotation", [Pure,
     Index:$index,
     IndexAttr:$cyclotomicOrder,
     Openfhe_DigitDecomposition:$precomputedDigitDecomp
+  );
+  let results = (outs Openfhe_Ciphertext:$output);
+}
+
+def FastRotationExtOp : Openfhe_Op<"fast_rotation_ext", [Pure,
+  AllTypesMatch<["input", "output"]>,
+  BatchVectorizableOpInterface,
+  DeclareOpInterfaceMethods<ElementwiseByOperandOpInterface>,
+  DeclareOpInterfaceMethods<
+      BatchVectorizableOpInterface,
+      ["isBatchCompatible", "buildBatchedOperation"]>
+]> {
+  let summary = "Fast (hoisted) rotation in extended (P*Q) CRT basis.";
+  let arguments = (ins
+    Openfhe_CryptoContext:$cryptoContext,
+    Openfhe_Ciphertext:$input,
+    Index:$index,
+    Openfhe_DigitDecomposition:$precomputedDigitDecomp,
+    DefaultValuedAttr<BoolAttr, "true">:$addFirst
   );
   let results = (outs Openfhe_Ciphertext:$output);
 }

--- a/lib/Target/OpenFhePke/Interpreter.cpp
+++ b/lib/Target/OpenFhePke/Interpreter.cpp
@@ -156,6 +156,7 @@ void Interpreter::initializeDispatchTable() {
   REGISTER_OP(DecryptOp);
   REGISTER_OP(EncryptOp);
   REGISTER_OP(FastRotationOp);
+  REGISTER_OP(FastRotationExtOp);
   REGISTER_OP(FastRotationPrecomputeOp);
   REGISTER_OP(GenBootstrapKeyOp);
   REGISTER_OP(GenContextOp);
@@ -164,6 +165,7 @@ void Interpreter::initializeDispatchTable() {
   REGISTER_OP(GenRotKeyOp);
   REGISTER_OP(KeySwitchInPlaceOp);
   REGISTER_OP(KeySwitchOp);
+  REGISTER_OP(KeySwitchDownOp);
   REGISTER_OP(LevelReduceInPlaceOp);
   REGISTER_OP(LevelReduceOp);
   REGISTER_OP(MakeCKKSPackedPlaintextOp);
@@ -1935,6 +1937,22 @@ void Interpreter::visit(FastRotationPrecomputeOp op) {
   auto ct = ciphertexts.at(op.getInput());
   TIME_OPERATION_NONCT("FastRotationPrecompute", op.getResult(),
                        cc->EvalFastRotationPrecompute(ct), fastRotPrecomps);
+}
+
+void Interpreter::visit(FastRotationExtOp op) {
+  auto cc = cryptoContexts.at(op.getCryptoContext());
+  auto ct = ciphertexts.at(op.getInput());
+  auto index = intValues.at(op.getIndex());
+  auto digits = fastRotPrecomps.at(op.getPrecomputedDigitDecomp());
+  bool addFirst = op.getAddFirst();
+  TIME_OPERATION("FastRotationExt", op.getResult(),
+                 cc->EvalFastRotationExt(ct, index, digits, addFirst));
+}
+
+void Interpreter::visit(KeySwitchDownOp op) {
+  auto cc = cryptoContexts.at(op.getCryptoContext());
+  auto ct = ciphertexts.at(op.getCiphertext());
+  TIME_OPERATION("KeySwitchDown", op.getResult(), cc->KeySwitchDown(ct));
 }
 
 void Interpreter::decodeCore(Operation* op, Value input, Value result,

--- a/lib/Target/OpenFhePke/Interpreter.h
+++ b/lib/Target/OpenFhePke/Interpreter.h
@@ -172,6 +172,7 @@ class Interpreter {
   void visit(DecryptOp op);
   void visit(EncryptOp op);
   void visit(FastRotationOp op);
+  void visit(FastRotationExtOp op);
   void visit(FastRotationPrecomputeOp op);
   void visit(GenBootstrapKeyOp op);
   void visit(GenContextOp op);
@@ -180,6 +181,7 @@ class Interpreter {
   void visit(GenRotKeyOp op);
   void visit(KeySwitchInPlaceOp op);
   void visit(KeySwitchOp op);
+  void visit(KeySwitchDownOp op);
   void visit(LevelReduceInPlaceOp op);
   void visit(LevelReduceOp op);
   void visit(MakeCKKSPackedPlaintextOp op);

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -256,15 +256,15 @@ LogicalResult OpenFhePkeEmitter::translate(Operation& op) {
           // OpenFHE ops
           .Case<AddInPlaceOp, AddOp, AddPlainInPlaceOp, AddPlainOp, AutomorphOp,
                 BootstrapOp, DecryptOp, EncryptOp, FastRotationOp,
-                FastRotationPrecomputeOp, GenBootstrapKeyOp, GenContextOp,
-                GenMulKeyOp, GenParamsOp, GenRotKeyOp, KeySwitchInPlaceOp,
-                KeySwitchOp, LevelReduceInPlaceOp, LevelReduceOp,
-                MakeCKKSPackedPlaintextOp, MakePackedPlaintextOp,
-                ModReduceInPlaceOp, ModReduceOp, MulConstInPlaceOp, MulConstOp,
-                MulNoRelinOp, MulOp, MulPlainOp, NegateInPlaceOp, NegateOp,
-                RelinInPlaceOp, RelinOp, RotOp, SetupBootstrapOp,
-                SquareInPlaceOp, SquareOp, SubInPlaceOp, SubOp,
-                SubPlainInPlaceOp, SubPlainOp>(
+                FastRotationExtOp, FastRotationPrecomputeOp, GenBootstrapKeyOp,
+                GenContextOp, GenMulKeyOp, GenParamsOp, GenRotKeyOp,
+                KeySwitchDownOp, KeySwitchInPlaceOp, KeySwitchOp,
+                LevelReduceInPlaceOp, LevelReduceOp, MakeCKKSPackedPlaintextOp,
+                MakePackedPlaintextOp, ModReduceInPlaceOp, ModReduceOp,
+                MulConstInPlaceOp, MulConstOp, MulNoRelinOp, MulOp, MulPlainOp,
+                NegateInPlaceOp, NegateOp, RelinInPlaceOp, RelinOp, RotOp,
+                SetupBootstrapOp, SquareInPlaceOp, SquareOp, SubInPlaceOp,
+                SubOp, SubPlainInPlaceOp, SubPlainOp>(
               [&](auto op) { return printOperation(op); })
           .Default([&](Operation&) {
             return emitError(op.getLoc(), "unable to find printer for op");
@@ -817,6 +817,29 @@ LogicalResult OpenFhePkeEmitter::printOperation(FastRotationOp op) {
      << ", " << getConstantOrValue(op.getIndex()) << ", "
      << "2 * cc->GetRingDimension(), "
      << variableNames->getNameForValue(op.getPrecomputedDigitDecomp())
+     << ");\n";
+  return success();
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(FastRotationExtOp op) {
+  auto getConstantOrValue = [&](Value value) -> std::string {
+    return getStringForConstant(value).value_or(
+        variableNames->getNameForValue(value));
+  };
+
+  emitAutoAssignPrefix(op.getResult());
+  os << variableNames->getNameForValue(op.getCryptoContext()) << "->"
+     << "EvalFastRotationExt(" << variableNames->getNameForValue(op.getInput())
+     << ", " << getConstantOrValue(op.getIndex()) << ", "
+     << variableNames->getNameForValue(op.getPrecomputedDigitDecomp()) << ", "
+     << (op.getAddFirst() ? "true" : "false") << ");\n";
+  return success();
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(KeySwitchDownOp op) {
+  emitAutoAssignPrefix(op.getResult());
+  os << variableNames->getNameForValue(op.getCryptoContext()) << "->"
+     << "KeySwitchDown(" << variableNames->getNameForValue(op.getCiphertext())
      << ");\n";
   return success();
 }

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -145,6 +145,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(DecryptOp op);
   LogicalResult printOperation(EncryptOp op);
   LogicalResult printOperation(FastRotationOp op);
+  LogicalResult printOperation(FastRotationExtOp op);
   LogicalResult printOperation(FastRotationPrecomputeOp op);
   LogicalResult printOperation(GenBootstrapKeyOp op);
   LogicalResult printOperation(GenContextOp op);
@@ -153,6 +154,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(GenRotKeyOp op);
   LogicalResult printOperation(KeySwitchInPlaceOp op);
   LogicalResult printOperation(KeySwitchOp op);
+  LogicalResult printOperation(KeySwitchDownOp op);
   LogicalResult printOperation(LevelReduceInPlaceOp op);
   LogicalResult printOperation(LevelReduceOp op);
   LogicalResult printOperation(MakeCKKSPackedPlaintextOp op);


### PR DESCRIPTION
## Summary

This PR adds support for extended basis operations in the OpenFHE dialect, allowing the use of an optimization technique where multiple rotations are performed in a larger (P*Q) CRT basis and combined before a single `key_switch_down` converts the result back to the normal (Q) basis.

This is groundwork for addressing #2519.

## New Operations

| Operation | Description |
|-----------|-------------|
| `openfhe.fast_rotation_ext` | Fast rotation in extended P*Q basis (defers key switching) |
| `openfhe.key_switch_down` | Converts ciphertext from extended to normal basis |
| `openfhe.add_ext` | Addition of ciphertexts in extended basis |
| `openfhe.add_ext_inplace` | In-place addition in extended basis |
| `openfhe.mul_ext` | Multiplication in extended basis (uses `EvalMultNoRelin`) |
