### PR TITLE
Cornami MX2 systolic array backend

### DIFF
--- a/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/BUILD
+++ b/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/BUILD
@@ -1,0 +1,52 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CGGIToSCIFRBool",
+    srcs = [
+        "CGGIToSCIFRBool.cpp",
+    ],
+    hdrs = [
+        "CGGIToSCIFRBool.h",
+    ],
+    deps = [
+        ":cggi_to_scifrbool_pass_inc_gen",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/IR:Dialect",
+        "@heir//lib/Utils",
+        "@heir//lib/Utils:ConversionUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "cggi_to_scifrbool_pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=CGGIToSCIFRBool",
+            ],
+            "CGGIToSCIFRBool.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "CGGIToSCIFRBool.td",
+    deps = [
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.cpp
+++ b/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.cpp
@@ -1,0 +1,166 @@
+#include "lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h"
+
+#include <cstdint>
+#include <ratio>
+#include <utility>
+
+#include "lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h.inc"
+#include "lib/Dialect/CGGI/IR/CGGIDialect.h"
+#include "lib/Dialect/CGGI/IR/CGGIOps.h"
+#include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.h"
+#include "lib/Utils/ConversionUtils.h"
+#include "lib/Utils/Utils.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypeInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+#define DEBUG_TYPE "cggi-to-scifrbool"
+
+using namespace mlir;
+using namespace heir;
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+#define GEN_PASS_DEF_CGGITOSCIFRBOOL
+#include "lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h.inc"
+
+class CGGIToSCIFRBoolTypeConverter : public TypeConverter {
+ public:
+  CGGIToSCIFRBoolTypeConverter(MLIRContext *ctx) {
+    addConversion([](Type type) { return type; });
+    addConversion([this](ShapedType type) -> Type {
+      return type.cloneWith(type.getShape(),
+                            this->convertType(type.getElementType()));
+    });
+  }
+};
+
+/// Convert a func by adding key arguments
+struct AddKeyArgs : public OpConversionPattern<func::FuncOp> {
+  AddKeyArgs(mlir::MLIRContext *context)
+      : OpConversionPattern<func::FuncOp>(context, /* benefit= */ 2) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      func::FuncOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (!containsDialects<lwe::LWEDialect, cggi::CGGIDialect>(op)) {
+      return failure();
+    }
+
+    Type bskType = scifrbool::SCIFRBoolBootstrapKeyType::get(getContext());
+    Type kskType = scifrbool::SCIFRBoolKeySwitchKeyType::get(getContext());
+    Type serverParamsType =
+        scifrbool::SCIFRBoolServerParametersType::get(getContext());
+
+    rewriter.modifyOpInPlace(op, [&] {
+      (void)op.insertArgument(0, bskType, nullptr, op.getLoc());
+      (void)op.insertArgument(1, kskType, nullptr, op.getLoc());
+      (void)op.insertArgument(2, serverParamsType, nullptr, op.getLoc());
+    });
+    return success();
+  }
+};
+
+template <typename BinOp, typename SCIFRBoolBinOp>
+struct ConvertCGGITRBBinOp : public OpConversionPattern<BinOp> {
+  using OpConversionPattern<BinOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      BinOp op, typename BinOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op->getLoc(), rewriter);
+
+    rewriter.replaceOp(
+        op, SCIFRBoolBinOp::create(b, adaptor.getLhs(), adaptor.getRhs()));
+    return success();
+  }
+};
+
+struct ConvertBoolNotOp : public OpConversionPattern<cggi::NotOp> {
+  ConvertBoolNotOp(mlir::MLIRContext *context)
+      : OpConversionPattern<cggi::NotOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      cggi::NotOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder b(op->getLoc(), rewriter);
+
+    rewriter.replaceOp(op, b.create<scifrbool::NotOp>(adaptor.getInput()));
+    return success();
+  }
+};
+
+struct CGGIToSCIFRBool : impl::CGGIToSCIFRBoolBase<CGGIToSCIFRBool> {
+  using CGGIToSCIFRBoolBase::CGGIToSCIFRBoolBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto *op = getOperation();
+
+    CGGIToSCIFRBoolTypeConverter typeConverter(context);
+    RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+    addStructuralConversionPatterns(typeConverter, patterns, target);
+
+    target.addLegalDialect<scifrbool::SCIFRBoolDialect>();
+    target.addIllegalDialect<cggi::CGGIDialect>();
+    target.addIllegalDialect<lwe::LWEDialect>();
+
+    target.addDynamicallyLegalOp<memref::AllocOp, memref::DeallocOp,
+                                 memref::StoreOp, memref::LoadOp,
+                                 memref::SubViewOp, memref::CopyOp,
+                                 tensor::FromElementsOp, tensor::ExtractOp>(
+        [&](Operation *op) {
+          return typeConverter.isLegal(op->getOperandTypes()) &&
+                 typeConverter.isLegal(op->getResultTypes());
+        });
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      bool hasKeyArg = op.getFunctionType().getNumInputs() > 0 &&
+                       mlir::isa<scifrbool::SCIFRBoolBootstrapKeyType>(
+                           *op.getFunctionType().getInputs().begin());
+      return (!containsDialects<lwe::LWEDialect, cggi::CGGIDialect>(op) ||
+              hasKeyArg);
+    });
+
+    target.addLegalOp<mlir::arith::ConstantOp>();
+
+    patterns.add<AddKeyArgs, ConvertCGGITRBBinOp<cggi::AndOp, scifrbool::AndOp>,
+                 ConvertCGGITRBBinOp<cggi::NandOp, scifrbool::NandOp>,
+                 ConvertCGGITRBBinOp<cggi::OrOp, scifrbool::OrOp>,
+                 ConvertCGGITRBBinOp<cggi::NorOp, scifrbool::NorOp>,
+                 ConvertCGGITRBBinOp<cggi::XorOp, scifrbool::XorOp>,
+                 ConvertCGGITRBBinOp<cggi::XNorOp, scifrbool::XNorOp>,
+                 ConvertBoolNotOp, ConvertAny<memref::AllocOp>,
+                 ConvertAny<memref::DeallocOp>, ConvertAny<memref::StoreOp>,
+                 ConvertAny<memref::LoadOp>, ConvertAny<memref::SubViewOp>,
+                 ConvertAny<memref::CopyOp>, ConvertAny<tensor::FromElementsOp>,
+                 ConvertAny<tensor::ExtractOp> >(typeConverter, context);
+
+    if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h
+++ b/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_SCIFRBOOL_CONVERSIONS_CGGITOSCIFRBOOL_H_
+#define LIB_DIALECT_SCIFRBOOL_CONVERSIONS_CGGITOSCIFRBOOL_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+#define GEN_PASS_REGISTRATION
+#define GEN_PASS_DECL_CGGITOSCIFRBOOL
+#include "lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h.inc"
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_SCIFRBOOL_CONVERSIONS_CGGITOSCIFRBOOL_H_

--- a/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.td
+++ b/lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.td
@@ -1,0 +1,16 @@
+#ifndef LIB_DIALECT_SCIFRBOOL_CONVERSIONS_CGGITOSCIFRBOOL_TD_
+#define LIB_DIALECT_SCIFRBOOL_CONVERSIONS_CGGITOSCIFRBOOL_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CGGIToSCIFRBool : Pass<"cggi-to-scifrbool"> {
+  let summary = "Lower `cggi` to `scifrbool` dialect.";
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::heir::cggi::CGGIDialect",
+    "mlir::heir::lwe::LWEDialect",
+    "mlir::cornami::scifrbool::SCIFRBoolDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_SCIFRBOOL_CONVERSIONS_CGGITOSCIFRBOOL_TD_

--- a/lib/Dialect/SCIFRBool/IR/BUILD
+++ b/lib/Dialect/SCIFRBool/IR/BUILD
@@ -1,0 +1,90 @@
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "SCIFRBoolDialect.cpp",
+    ],
+    hdrs = [
+        "SCIFRBoolDialect.h",
+        "SCIFRBoolOps.h",
+        "SCIFRBoolTypes.h",
+    ],
+    deps = [
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        ":types_inc_gen",
+        "@heir//lib/Dialect:HEIRInterfaces",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:BytecodeOpInterface",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "SCIFRBoolDialect.td",
+        "SCIFRBoolOps.td",
+        "SCIFRBoolTypes.td",
+    ],
+    # include from the heir-root to enable fully-qualified include-paths
+    includes = ["../../../.."],
+    deps = [
+        "@llvm-project//mlir:ArithOpsTdFiles",
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:BytecodeOpInterface",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "dialect_inc_gen",
+    dialect = "SCIFRBool",
+    kind = "dialect",
+    td_file = "SCIFRBoolDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "SCIFRBool",
+    kind = "op",
+    td_file = "SCIFRBoolOps.td",
+    deps = [
+        ":td_files",
+        "@heir//lib/Dialect:td_files",
+        "@heir//lib/Dialect/LWE/IR:td_files",
+        "@heir//lib/Dialect/Polynomial/IR:td_files",
+        "@llvm-project//mlir:BytecodeOpInterface",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "types_inc_gen",
+    dialect = "SCIFRBool",
+    kind = "type",
+    td_file = "SCIFRBoolTypes.td",
+    deps = [
+        ":td_files",
+    ],
+)

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.cpp
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.cpp
@@ -1,0 +1,49 @@
+//===- CFAIRDialect.cpp - CFAIR dialect ---------------*- C++ -*-===//
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+
+#include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.cpp.inc"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.h"
+#include "llvm/include/llvm/Support/CommandLine.h"     // from @llvm-project
+#include "llvm/include/llvm/Support/InitLLVM.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/SourceMgr.h"       // from @llvm-project
+#include "llvm/include/llvm/Support/ToolOutputFile.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"         // from @llvm-project
+#include "mlir/include/mlir/Parser/Parser.h"           // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"               // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"        // from @llvm-project
+#include "mlir/include/mlir/Support/FileUtilities.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/TypeID.h"          // from @llvm-project
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.cpp.inc"
+#define GET_OP_CLASSES
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// SCIFRBool dialect.
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+void SCIFRBoolDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.cpp.inc"
+      >();
+}
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h
@@ -1,0 +1,23 @@
+#ifndef SCIFRBool_SCIFRBoolDialect_H
+#define SCIFRBool_SCIFRBoolDialect_H
+
+#include "llvm/include/llvm/Support/CommandLine.h"     // from @llvm-project
+#include "llvm/include/llvm/Support/InitLLVM.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/SourceMgr.h"       // from @llvm-project
+#include "llvm/include/llvm/Support/ToolOutputFile.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"         // from @llvm-project
+#include "mlir/include/mlir/Parser/Parser.h"           // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"               // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"        // from @llvm-project
+#include "mlir/include/mlir/Support/FileUtilities.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/TypeID.h"          // from @llvm-project
+
+// clang-format off
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h.inc"
+// clang-format on
+
+#endif  // SCIFRBool_SCIFRBoolDialect_H

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.td
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.td
@@ -1,0 +1,27 @@
+//===- SCIFRBoolDialect.td - Cornami SCIFR Boolean Dialect -*- tablegen -*-===//
+//     This dialect is an exit dialect for targeting Cornami's FracTLCore(R) hardware accelerator for CGGI programs.
+//===----------------------------------------------------------------------===//
+
+// Ref: Resource Estimation of CGGI and CKKS scheme workloads on
+// FracTLcore Computing Fabric, ArXiV: https://arxiv.org/abs/2510.16025, 2025.
+
+#ifndef SCIFRBOOL_DIALECT
+#define SCIFRBOOL_DIALECT
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// Cornami SCIFR Boolean dialect definition.
+//===----------------------------------------------------------------------===//
+
+def SCIFRBool_Dialect : Dialect {
+    let name = "scifrbool";
+    let summary = "Cornami SCIFR Boolean dialect for FHE Applications.";
+    let cppNamespace = "::mlir::cornami::scifrbool";
+    let useDefaultTypePrinterParser = 1;
+}
+
+
+#endif // SCIFRBOOL_DIALECT

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.cpp
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.cpp
@@ -1,0 +1,12 @@
+//===- CFAIROps.cpp - CFAIR dialect ops ---------------*- C++ -*-===//
+
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+#include "mlir/include/mlir/IR/OpImplementation.h"  // from @llvm-project
+
+using namespace mlir;
+using namespace mlir::heir;
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.cpp.inc"

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h
@@ -1,0 +1,20 @@
+#ifndef SCFIRBool_SCFIRBoolOps_H
+#define SCFIRBool_SCFIRBoolOps_H
+
+#include "lib/Dialect/CGGI/IR/CGGIAttributes.h"
+#include "lib/Dialect/CGGI/IR/CGGIDialect.h"
+#include "lib/Dialect/HEIRInterfaces.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "mlir/include/mlir/Bytecode/BytecodeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h.inc"
+
+#endif

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.td
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.td
@@ -1,0 +1,86 @@
+//===- SCIFRBoolOps.td - SCIFRBool Dialect ops -----------*- tablegen -*-===//
+
+#ifndef SCIFRBool_OPS
+#define SCIFRBool_OPS
+
+include "SCIFRBoolDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/CastInterfaces.td"
+
+include "lib/Dialect/HEIRInterfaces.td"
+
+include "lib/Dialect/LWE/IR/LWETypes.td"
+
+class SCIFRBool_Op<string mnemonic, list<Trait> traits = []> :
+        Op<SCIFRBool_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+  let cppNamespace = "::mlir::cornami::scifrbool";
+}
+
+// --- Operations for a gate-bootstrapping API of a SCIFRBool library ---
+class SCIFRBool_BinaryGateOp<string mnemonic>
+  : SCIFRBool_Op<mnemonic, [
+    Pure,
+    Commutative,
+    SameOperandsAndResultType
+]> {
+  let arguments = (ins LWECiphertext:$lhs, LWECiphertext:$rhs);
+  let results = (outs LWECiphertext:$output);
+  let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
+}
+
+def SCIFRBool_AndOp : SCIFRBool_BinaryGateOp<"and"> { let summary = "Logical AND of two ciphertexts."; }
+def SCIFRBool_NandOp : SCIFRBool_BinaryGateOp<"nand"> { let summary = "Logical NAND of two ciphertexts."; }
+def SCIFRBool_NorOp  : SCIFRBool_BinaryGateOp<"nor">  { let summary = "Logical NOR of two ciphertexts."; }
+def SCIFRBool_OrOp  : SCIFRBool_BinaryGateOp<"or">  { let summary = "Logical OR of two ciphertexts."; }
+def SCIFRBool_XorOp : SCIFRBool_BinaryGateOp<"xor"> { let summary = "Logical XOR of two ciphertexts."; }
+def SCIFRBool_XNorOp : SCIFRBool_BinaryGateOp<"xnor"> { let summary = "Logical XNOR of two ciphertexts."; }
+
+def SCIFRBool_NotOp : SCIFRBool_Op<"not", [
+    Pure,
+    Involution,
+    SameOperandsAndResultType,
+]> {
+  let arguments = (ins LWECiphertext:$input);
+  let results = (outs LWECiphertext:$output);
+  let assemblyFormat = "operands attr-dict `:` qualified(type($output))";
+  let summary = "Logical NOT of two ciphertexts";
+}
+
+//===----------------------------------------------------------------------===//
+def SCIFRBOOL_AnyNumber : AnyTypeOf<[AnyFloat],
+                               "number">;
+
+
+// Operator for kernel outlining pass; this pass will contain all the ops
+// that are able to be scheduled on the currently available hardware resources
+def SCIFRBOOL_SectionOp : SCIFRBool_Op<"section",[NoTerminator]> {
+  let summary = "Wraps a single operation";
+  let description = [{
+      Section op is intended to handle kernel outlining, move kernels of instructions. Section contains the code scheduled to Fractal Array.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$input
+  );
+
+  let results = (outs
+    Variadic<AnyType>:$output
+  );
+
+  let regions = (region AnyRegion:$body);
+
+  let assemblyFormat = "`(` operands `)` $body attr-dict `:` functional-type(operands, results)";
+  let hasCustomAssemblyFormat = 1;
+}
+
+#endif // SCIFRBool_OpS

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.h
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.h
@@ -1,0 +1,9 @@
+#ifndef SCFIRBool_SCFIRBoolTypes_H
+#define SCFIRBool_SCFIRBoolTypes_H
+
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.h.inc"
+
+#endif

--- a/lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.td
+++ b/lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.td
@@ -1,0 +1,32 @@
+//===- SCIFRBoolTypes.td - SCIFRBool Dialect Types -----------*- tablegen -*-===//
+
+#ifndef SCIFRBool_TYPES
+#define SCIFRBool_TYPES
+
+include "SCIFRBoolDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+class SCIFRBool_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<SCIFRBool_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def SCIFRBool_Bootstrap_Key : SCIFRBool_Type<"SCIFRBoolBootstrapKey", "bootstrap_key"> {
+  let summary = "The key required to perform Bootstrap operation in SCIFRBool.";
+}
+
+def SCIFRBool_Key_Switch_Key : SCIFRBool_Type<"SCIFRBoolKeySwitchKey", "key_switch_key"> {
+  let summary = "The key required to perform Keyswitch operation in SCIFRBool.";
+}
+
+def SCIFRBool_Server_Parameters : SCIFRBool_Type<"SCIFRBoolServerParameters", "server_parameters"> {
+  let summary = "The server parameters required to map to cornami hardware in SCIFRBool.";
+}
+
+#endif // SCIFRBool_Types

--- a/lib/Dialect/SCIFRBool/Transforms/BUILD
+++ b/lib/Dialect/SCIFRBool/Transforms/BUILD
@@ -1,0 +1,145 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=SCIFRBoolEstimationAnalysis",
+            ],
+            "Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "EstimationAnalysis",
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":CGGIEstimator",
+        ":DialectResourceMap",
+        ":PerfCounter",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/IR:Dialect",
+    ],
+)
+
+cc_library(
+    name = "CGGIEstimator",
+    srcs = [
+        "CGGIEstimator.cpp",
+    ],
+    hdrs = [
+        "CGGIEstimator.h",
+    ],
+    deps = [
+        ":DialectResourceMap",
+        ":PerfCounter",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Utils/Graph",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+cc_library(
+    name = "PerfCounter",
+    srcs = [
+        "PerfCounter.cpp",
+    ],
+    hdrs = [
+        "PerfCounter.h",
+    ],
+    deps = [
+    ],
+)
+
+cc_library(
+    name = "DialectResourceMap",
+    srcs = [
+        "DialectResourceMap.cpp",
+    ],
+    hdrs = [
+        "DialectResourceMap.h",
+    ],
+    deps = [
+        "@heir//lib/Utils/Graph",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+cc_library(
+    name = "ReplaceOpWithSection",
+    srcs = [
+        "ReplaceOpWithSection.cpp",
+    ],
+    hdrs = [
+        "ReplaceOpWithSection.h",
+    ],
+    deps = [
+        ":replace_op_with_section_pass_inc_gen",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/IR:Dialect",
+        "@heir//lib/Utils",
+        "@heir//lib/Utils:ConversionUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+gentbl_cc_library(
+    name = "replace_op_with_section_pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=ReplaceOpWithSection",
+            ],
+            "ReplaceOpWithSection.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ReplaceOpWithSection.td",
+    deps = [
+        "@heir//lib/Dialect/SCIFRBool/IR:ops_inc_gen",
+        "@heir//lib/Dialect/SCIFRBool/IR:td_files",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.cpp
+++ b/lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.cpp
@@ -1,0 +1,262 @@
+#include "lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.h"
+
+#include <string>
+
+#include "lib/Dialect/CGGI/IR/CGGIAttributes.h"
+#include "lib/Dialect/CGGI/IR/CGGIOps.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/SCIFRBool/Transforms/PerfCounter.h"
+#include "lib/Utils/Graph/Graph.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"           // from @llvm-project
+#include "mlir/include/mlir/Analysis/SliceAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/TopologicalSortUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+// clang-format off
+#include "lib/Dialect/SCIFRBool/Transforms/Passes.h.inc"
+// clang-format on
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+void CGGIOpsData::reset() {
+  n_andop = {
+      0,
+  };  //::mlir::heir::cggi::AndOp;
+  n_lut2op = {
+      0,
+  };  //::mlir::heir::cggi::Lut2Op;
+  n_lut3op = {
+      0,
+  };  //::mlir::heir::cggi::Lut3Op,
+  n_lutlincombop = {
+      0,
+  };  //::mlir::heir::cggi::LutLinCombOp,
+  n_multilutlincombop = {
+      0,
+  };  //::mlir::heir::cggi::MultiLutLinCombOp,
+  n_nandop = {
+      0,
+  };  //::mlir::heir::cggi::NandOp,
+  n_norop = {
+      0,
+  };  //::mlir::heir::cggi::NorOp,
+  n_notop = {
+      0,
+  };  //::mlir::heir::cggi::NotOp,
+  n_orop = {
+      0,
+  };  //::mlir::heir::cggi::OrOp,
+  n_packedop = {
+      0,
+  };  //::mlir::heir::cggi::PackedOp,
+  n_xnorop = {
+      0,
+  };  //::mlir::heir::cggi::XNorOp,
+  n_xorop = {
+      0,
+  };  //::mlir::heir::cggi::XorOp
+};
+
+void CGGIOpsData::display() const {
+  uint64_t cumulative_fcs = 0, cumulative_latency = 0;
+
+  for (auto& itr : get_resource_map()) {
+    auto result = get_resource_use(to_enum(itr.first), itr.second);
+    auto fcs = result.first;
+    auto latency = result.second;
+    llvm::outs() << itr.first << " : " << itr.second << " | FC = " << fcs
+                 << " LATENCY = " << latency << "\n";
+    cumulative_fcs += fcs;
+    cumulative_latency += latency;
+  }
+
+  const uint64_t fcs_per_chip = 2048;
+  uint64_t chip_count = (cumulative_fcs + fcs_per_chip - 1) / fcs_per_chip;
+  llvm::outs() << "---------------------------------------------\n";
+  llvm::outs() << "Total FC = " << cumulative_fcs
+               << " | LATENCY = " << cumulative_latency
+               << " | CHIPS = " << chip_count << "\n";
+}
+
+cornami::DialectResourceMap CGGIOpsData::get_resource_map() const {
+  cornami::DialectResourceMap ruse;  // resource use
+  ruse["AND"] = n_andop[0];
+  ruse["LUT2"] = n_lut2op[0];
+  ruse["LUT3"] = n_lut2op[0];
+  ruse["LUTLINCOMB"] = n_lutlincombop[0];
+  ruse["MULTILUTLINCOMB"] = n_multilutlincombop[0];
+  ruse["NAND"] = n_nandop[0];
+  ruse["NOR"] = n_norop[0];
+  ruse["NOT"] = n_notop[0];
+  ruse["OR"] = n_orop[0];
+  ruse["PACKED"] = n_packedop[0];
+  ruse["XNOR"] = n_xnorop[0];
+  ruse["XOR"] = n_xorop[0];
+  return ruse;
+}
+
+bool CGGIOpsData::analyze(mlir::Operation* op) {
+  if (llvm::isa<heir::cggi::AndOp>(op)) {
+    this->n_andop[0]++;
+  } else if (llvm::isa<heir::cggi::Lut2Op>(op)) {
+    this->n_lut2op[0]++;
+  } else if (llvm::isa<heir::cggi::Lut3Op>(op)) {
+    this->n_lut3op[0]++;
+  } else if (llvm::isa<heir::cggi::LutLinCombOp>(op)) {
+    this->n_lutlincombop[0]++;
+  } else if (llvm::isa<heir::cggi::MultiLutLinCombOp>(op)) {
+    this->n_multilutlincombop[0]++;
+  } else if (llvm::isa<heir::cggi::NandOp>(op)) {
+    this->n_nandop[0]++;
+  } else if (llvm::isa<heir::cggi::NotOp>(op)) {
+    this->n_notop[0]++;
+  } else if (llvm::isa<heir::cggi::NorOp>(op)) {
+    this->n_orop[0]++;
+  } else if (llvm::isa<heir::cggi::PackedOp>(op)) {
+    this->n_packedop[0]++;
+  } else if (llvm::isa<heir::cggi::XNorOp>(op)) {
+    this->n_xnorop[0]++;
+  } else if (llvm::isa<heir::cggi::XorOp>(op)) {
+    this->n_xorop[0]++;
+  } else {
+    return false;
+  }
+  return true;
+}
+uint64_t CGGIOpsData::get_bootstrap_resource_fc() const { return 128; }
+
+CGGIOpsData::CGGIOpsEnum CGGIOpsData::get_op_kind(mlir::Operation* op) {
+  if (llvm::isa<heir::cggi::AndOp>(op)) {
+    return CGGIOpsEnum::AND;
+  } else if (llvm::isa<heir::cggi::Lut2Op>(op)) {
+    return CGGIOpsEnum::LUT2;
+  } else if (llvm::isa<heir::cggi::Lut3Op>(op)) {
+    return CGGIOpsEnum::LUT3;
+  } else if (llvm::isa<heir::cggi::LutLinCombOp>(op)) {
+    return CGGIOpsEnum::LUTLINCOMB;
+  } else if (llvm::isa<heir::cggi::MultiLutLinCombOp>(op)) {
+    return CGGIOpsEnum::MULTILUTLINCOMB;
+  } else if (llvm::isa<heir::cggi::NandOp>(op)) {
+    return CGGIOpsEnum::NAND;
+  } else if (llvm::isa<heir::cggi::NotOp>(op)) {
+    return CGGIOpsEnum::NOT;
+  } else if (llvm::isa<heir::cggi::NorOp>(op)) {
+    return CGGIOpsEnum::NOR;
+  } else if (llvm::isa<heir::cggi::PackedOp>(op)) {
+    return CGGIOpsEnum::PACKED;
+  } else if (llvm::isa<heir::cggi::XNorOp>(op)) {
+    return CGGIOpsEnum::XNOR;
+  } else if (llvm::isa<heir::cggi::XorOp>(op)) {
+    return CGGIOpsEnum::XOR;
+  }
+  return UNKNOWN;
+}
+
+uint64_t CGGIOpsData::get_bootstrap_resource_throughput() const {
+  return get_canonical_throughput();
+}
+
+uint64_t CGGIOpsData::get_keyswitch_resource_fc() const { return 128; }
+
+// 10% of cycles of PBS
+uint64_t CGGIOpsData::get_keyswitch_resource_throughput() const {
+  return static_cast<uint64_t>(0.10f * get_canonical_throughput());
+}
+
+cornami::OpCoreCountAndLatencyT CGGIOpsData::get_resource_use(
+    CGGIOpsEnum opkind, uint64_t count) const {
+  cornami::OpCoreCountAndLatencyT resource;
+  // FC use
+  resource.first =
+      (m_bs_and_ks.at(opkind).at(0) ? get_bootstrap_resource_fc() * count : 0) +
+      (m_bs_and_ks.at(opkind).at(1) ? get_keyswitch_resource_fc() * count : 0);
+  // Throughput use
+  resource.second = (m_bs_and_ks.at(opkind).at(0)
+                         ? get_bootstrap_resource_throughput() * count
+                         : 0) +
+                    (m_bs_and_ks.at(opkind).at(1)
+                         ? get_keyswitch_resource_throughput() * count
+                         : 0);
+  return resource;
+}
+
+#define GEN_PASS_DEF_CGGIESTIMATOR
+#include "lib/Dialect/SCIFRBool/Transforms/Passes.h.inc"
+
+struct CGGIEstimator : impl::CGGIEstimatorBase<CGGIEstimator> {
+  using CGGIEstimatorBase::CGGIEstimatorBase;
+  PerfCounter m_data;
+
+  void runOnOperation() override {
+    // MLIRContext &context = getContext();
+    heir::graph::Graph<Operation*> graph;
+    CGGIOpsData m_cggiops(2048, 1, 1, 841);
+    auto m_cp_ccgiops = m_cggiops;
+
+    getOperation()->walk<WalkOrder::PostOrder>([&](Operation* op) {
+      const bool result = m_cggiops.analyze(op);
+      if (!result) {
+        op->emitWarning() << "Unknown operator not counted for Estimate\n";
+        return WalkResult::advance();
+      }
+
+      // op is a strictly CGGI operator only
+      graph.addVertex(op);
+      if (op->getNumOperands() > 0) {
+        llvm::outs() << "Operator : "
+                     << op->getName().getIdentifier().getValue().str()
+                     << " has " << op->getNumOperands() << " operands.\n";
+        for (auto inoperand : op->getOperands()) {
+          if (!inoperand.getDefiningOp()) continue;
+          graph.addVertex(inoperand.getDefiningOp());
+          int latency =
+              (int)m_cggiops.get_resource_use(m_cggiops.get_op_kind(op), 1)
+                  .second;
+          graph.addEdge(inoperand.getDefiningOp(), op, latency);
+        }
+      }
+
+      llvm::outs() << "operation = " << "\n";
+      op->dump();
+      llvm::outs() << "\n";
+      return WalkResult::advance();
+    });
+    m_cggiops.display();
+
+    dump(graph);
+    // auto cp_ = graph.get_longest_source_to_sink_path();
+    auto cp_ = graph.findApproximateCriticalPath();
+    for (auto op : graph.getVertices()) {
+      llvm::outs() << "Op = " << op->getName().getIdentifier().getValue().str()
+                   << "\n";
+    }
+    if (succeeded(cp_) && cp_.value().size() > 0) {
+      llvm::outs() << "============ Critical Path ============\n";
+      auto cp = cp_.value();
+      for (uint64_t idx = 0; idx < cp.size(); idx++) {
+        auto op = cp[idx];
+        m_cp_ccgiops.analyze(op);
+      }
+      m_cggiops.display();
+      llvm::outs() << "=======================================\n";
+    } else {
+      llvm::outs() << "======= Cannot find useful CP =========\n";
+    }
+  }
+};  // struct CGGIEstimator
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.h
+++ b/lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.h
@@ -1,0 +1,149 @@
+#ifndef CORNAMI_CGGIESTIMATOR_PASS_H_
+#define CORNAMI_CGGIESTIMATOR_PASS_H_
+
+#include <array>
+
+#include "lib/Dialect/CGGI/IR/CGGIDialect.h"
+#include "lib/Dialect/CGGI/IR/CGGIOps.h"
+#include "lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.h"
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+struct LWEParameters {
+  uint64_t LWE_N;  // polynomial degree
+  uint64_t LWE_l;  // levels of ciphertext in CGGI
+  uint64_t LWE_k;  // GLWE parameter
+  uint64_t LWE_n;  // LWE dimension
+
+  explicit LWEParameters(uint64_t polynomial_degree, uint64_t levels,
+                         uint64_t glwe_param, uint64_t lwe_dim)
+      : LWE_N(polynomial_degree),
+        LWE_l(levels),
+        LWE_k(glwe_param),
+        LWE_n(lwe_dim) {}
+};
+struct CGGIOpsData : LWEParameters {
+  explicit CGGIOpsData(uint64_t polynomial_degree, uint64_t levels,
+                       uint64_t glwe_param, uint64_t lwe_dim)
+      : LWEParameters(polynomial_degree, levels, glwe_param, lwe_dim){};
+
+  enum CGGIOpsEnum {
+    AND,
+    LUT2,
+    LUT3,
+    LUTLINCOMB,
+    MULTILUTLINCOMB,
+    NAND,
+    NOR,
+    NOT,
+    OR,
+    PACKED,
+    XNOR,
+    XOR,
+    UNKNOWN
+  };
+
+  CGGIOpsEnum get_op_kind(mlir::Operation* op);
+
+  CGGIOpsEnum to_enum(std::string opname) const {
+    if (opname == "AND") return AND;
+    if (opname == "LUT2") return LUT2;
+    if (opname == "LUT3") return LUT3;
+    if (opname == "LUTLINCOMB") return LUTLINCOMB;
+    if (opname == "MULTILUTLINCOMB") return MULTILUTLINCOMB;
+    if (opname == "NAND") return NAND;
+    if (opname == "NOR") return NOR;
+    if (opname == "NOT") return NOT;
+    if (opname == "OR") return OR;
+    if (opname == "PACKED") return PACKED;
+    if (opname == "XNOR") return XNOR;
+    if (opname == "XOR") return XOR;
+    return UNKNOWN;
+  }
+
+  using DialectBootstrapAndKeySwitchMap =
+      std::map<CGGIOpsEnum, std::array<bool, 2>>;  // does operator need
+                                                   // bootstrap and keyswitch ?
+
+  // std::array[3] = count, ncores, ncycles
+  std::array<uint64_t, 3> n_andop = {
+      0,
+  };  //::mlir::heir::cggi::AndOp;
+  std::array<uint64_t, 3> n_lut2op = {
+      0,
+  };  //::mlir::heir::cggi::Lut2Op;
+  std::array<uint64_t, 3> n_lut3op = {
+      0,
+  };  //::mlir::heir::cggi::Lut3Op,
+  std::array<uint64_t, 3> n_lutlincombop = {
+      0,
+  };  //::mlir::heir::cggi::LutLinCombOp,
+  std::array<uint64_t, 3> n_multilutlincombop = {
+      0,
+  };  //::mlir::heir::cggi::MultiLutLinCombOp,
+  std::array<uint64_t, 3> n_nandop = {
+      0,
+  };  //::mlir::heir::cggi::NandOp,
+  std::array<uint64_t, 3> n_norop = {
+      0,
+  };  //::mlir::heir::cggi::NorOp,
+  std::array<uint64_t, 3> n_notop = {
+      0,
+  };  //::mlir::heir::cggi::NotOp,
+  std::array<uint64_t, 3> n_orop = {
+      0,
+  };  //::mlir::heir::cggi::OrOp,
+  std::array<uint64_t, 3> n_packedop = {
+      0,
+  };  //::mlir::heir::cggi::PackedOp,
+  std::array<uint64_t, 3> n_xnorop = {
+      0,
+  };  //::mlir::heir::cggi::XNorOp,
+  std::array<uint64_t, 3> n_xorop = {
+      0,
+  };  //::mlir::heir::cggi::XorOp
+
+  const DialectBootstrapAndKeySwitchMap m_bs_and_ks = {
+      {AND, {true, true}},        {NAND, {true, true}},
+      {NOR, {true, true}},        {OR, {true, true}},
+      {XOR, {true, true}},        {XNOR, {true, true}},
+      {NOT, {false, false}},      {PACKED, {true, true}},
+      {LUT2, {true, true}},       {LUT3, {true, true}},
+      {LUTLINCOMB, {true, true}}, {MULTILUTLINCOMB, {true, true}},
+  };
+
+  uint64_t get_bootstrap_resource_fc() const;
+  uint64_t get_bootstrap_resource_throughput() const;
+  uint64_t get_keyswitch_resource_fc() const;
+  uint64_t get_keyswitch_resource_throughput() const;
+
+  cornami::DialectResourceMap get_resource_map() const;
+
+  cornami::OpCoreCountAndLatencyT get_resource_use(
+      CGGIOpsEnum opkind, uint64_t count) const; /* get FC core */
+
+  // number of clock cycles to get the ciphertext output
+  uint64_t get_canonical_throughput() const {
+    return 2 * LWE_N * LWE_n;  // clocks/sec
+  }
+
+  uint64_t get_canonical_latency(uint64_t batchsize) const {
+    return batchsize * get_canonical_throughput();
+  }
+
+  bool analyze(mlir::Operation* op);
+  void reset();
+  void display() const;
+};
+
+#define GEN_PASS_DECL_CGGIESTIMATOR
+#include "lib/Dialect/SCIFRBool/Transforms/Passes.h.inc"
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir
+
+#endif  // CORNAMI_CGGIESTIMATOR_PASS_H_

--- a/lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.cpp
+++ b/lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.cpp
@@ -1,0 +1,27 @@
+#include "lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.h"
+
+namespace mlir {
+namespace cornami {
+
+void dump(heir::graph::Graph<Operation*>& graph) {
+  size_t n_vertices = graph.getVertices().size();
+  size_t n_out_edges = 0;
+  size_t n_in_edges = 0;
+  for (auto vertexptr : graph.getVertices()) {
+    n_out_edges += graph.getOutDegree(vertexptr);
+  }
+  for (auto vertexptr : graph.getVertices()) {
+    n_in_edges += graph.getInDegree(vertexptr);
+  }
+  auto n_sources = graph.getSources().size();
+  auto n_sinks = graph.getSinks().size();
+  llvm::outs() << "====== graph @ display =====\n";
+  llvm::outs() << "vertices = " << n_vertices << ", in-edges = " << n_in_edges
+               << ", out-edges = " << n_out_edges << ", sinks = " << n_sinks
+               << ", source = " << n_sources << "\n";
+  llvm::outs() << "====== xxxxxxxxxxxxxxx =====\n";
+  return;
+}
+
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.h
+++ b/lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "lib/Utils/Graph/Graph.h"
+#include "mlir/include/mlir/IR/Dialect.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"  // from @llvm-project
+
+namespace mlir {
+namespace cornami {
+using OpCoreCountAndLatencyT = std::pair<uint64_t, uint64_t>;
+using DialectResourceMap = std::map<std::string, uint64_t>;
+using DialectStringBootstrapAndKeySwitchMap =
+    std::map<std::string, std::array<bool, 2>>;  // does operator need bootstrap
+                                                 // and keyswitch ?
+// Operations here with initial Counts
+void dump(heir::graph::Graph<Operation*>& graph);
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/Transforms/Passes.h
+++ b/lib/Dialect/SCIFRBool/Transforms/Passes.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_CGGI_CORNAMI_ANALYSIS_PASSES_H_
+#define LIB_DIALECT_CGGI_CORNAMI_ANALYSIS_PASSES_H_
+
+#include "lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.h"
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+#define GEN_PASS_REGISTRATION
+#define GEN_PASS_DECL_CGGIESTIMATOR
+#include "lib/Dialect/SCIFRBool/Transforms/Passes.h.inc"
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CGGI_CORNAMI_ANALYSIS_PASSES_H_

--- a/lib/Dialect/SCIFRBool/Transforms/Passes.td
+++ b/lib/Dialect/SCIFRBool/Transforms/Passes.td
@@ -1,0 +1,17 @@
+#ifndef LIB_ALL_DIALECT_CORNAMI_ANALYSIS_PASSES_TD_
+#define LIB_ALL_DIALECT_CORNAMI_ANALYSIS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CGGIEstimator : Pass<"cggi-tigris-estimator"> {
+  let summary = "Estimate resources for the CGGI program on Cornami Tigris chip(s)";
+  let description = [{
+    Estimate resources for the CGGI program on Cornami Tigris chip(s)
+    Particularly provide number of operators in program (CGGI) and FC count, latency of
+    each operator in CGGI; provide a cumulative count of resources used in the CGGI program
+    when they are implemented in Cornami Tigris chip(s).
+  }];
+
+  let dependentDialects = ["mlir::heir::cggi::CGGIDialect"];
+}
+#endif  // LIB_ALL_DIALECT_CORNAMI_ANALYSIS_PASSES_TD_

--- a/lib/Dialect/SCIFRBool/Transforms/PerfCounter.cpp
+++ b/lib/Dialect/SCIFRBool/Transforms/PerfCounter.cpp
@@ -1,0 +1,21 @@
+#include "lib/Dialect/SCIFRBool/Transforms/PerfCounter.h"
+
+namespace mlir {
+namespace cornami {
+SWCounter& SWCounter::operator+=(const SWCounter& that) {
+  this->mult += that.mult;
+  this->add += that.add;
+  this->ntt += that.ntt;
+
+  return *this;
+}
+
+PerfCounter& PerfCounter::operator+=(const PerfCounter& that) {
+  this->arch_emu += that.arch_emu;
+  this->arch_asic += that.arch_asic;
+  this->sw += that.sw;
+  return *this;
+}
+
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/Transforms/PerfCounter.h
+++ b/lib/Dialect/SCIFRBool/Transforms/PerfCounter.h
@@ -1,0 +1,114 @@
+#pragma once
+#include <utility>
+#include <vector>
+
+namespace mlir {
+namespace cornami {
+
+enum OpType { READ, WRITE, AUTO_READ, KICK_OUT };
+
+struct ArchCounter {
+  int cyc = 0;
+  int add_cyc = 0;
+  int mult_cyc = 0;
+
+  // ntt cycles for all of bootstrapping
+  // otf cycles for all twiddle factors
+  int ntt_cyc = 0;
+  int ntt_otf = 0;
+
+  // basis conversion
+  int bsc_cyc = 0;
+
+  // worst-case and best-case automorphism
+  int auto_cyc_wc = 0;
+  int auto_cyc_bc = 0;
+
+  /**
+  """
+  Reads are reads in from external memory
+  Writes are writes out to external memory
+  Untagged dram tracks local storage needed in external memory
+
+  The default model is that nothing is stored on chip.
+  """
+  */
+
+  std::vector<std::pair<OpType, int>> op_list;
+  int min_bytes = 0;
+
+  // # dram_limb_rd: int = 0
+  int _dram_limb_rd = 0;
+
+  // # dram_limb_wr: int = 0
+  int _dram_limb_wr = 0;
+
+  // number of read and write ports used during program
+  int rd_ports = 0;
+  int wr_ports = 0;
+
+  int dram_limb = 0;
+  int dram_ntt_rd = 0;
+  int dram_ntt = 0;
+
+  int _dram_auto_rd = 0;
+
+  int dram_limb_rd() const { return _dram_limb_rd; }
+
+  void set_dram_limb_rd(int value) {
+    op_list.emplace_back(
+        std::make_pair(OpType::READ, (int)(value - _dram_limb_rd)));
+    _dram_limb_rd = value;
+  }
+
+  int dram_limb_wr() const { return _dram_limb_wr; }
+
+  void set_dram_limb_wr(int value) {
+    op_list.emplace_back(
+        std::make_pair(OpType::WRITE, (int)(value - _dram_limb_wr)));
+    _dram_limb_wr = value;
+  }
+
+  int dram_auto_rd() const { return _dram_auto_rd; }
+
+  void set_dram_auto_rd(int value) {
+    op_list.emplace_back(
+        std::make_pair(OpType::AUTO_READ, (int)(value - _dram_auto_rd)));
+    _dram_auto_rd = value;
+  }
+
+  int dram_total_rdwr_small() {
+    return (dram_limb_rd() + dram_limb_wr() + dram_auto_rd());
+  }
+
+  int total_cycle_bc() { return add_cyc + mult_cyc + auto_cyc_bc; }
+
+  int total_cycle_wc() { return add_cyc + mult_cyc + auto_cyc_wc; }
+
+  ArchCounter& operator+=(const ArchCounter& other) {
+    _dram_limb_rd = dram_limb_rd() + other.dram_limb_rd(),
+    _dram_limb_wr = dram_limb_wr() + other.dram_limb_wr(),
+    _dram_auto_rd = dram_auto_rd() + other.dram_auto_rd(),
+    // op_list=op_list + other.op_list,
+        add_cyc += other.add_cyc;
+    mult_cyc += other.mult_cyc;
+    return *this;
+  }
+};
+
+struct SWCounter {
+  int mult = 0;
+  int add = 0;
+  int ntt = 0;
+  SWCounter& operator+=(const SWCounter& that);
+};
+
+struct PerfCounter {
+  SWCounter sw;
+  ArchCounter arch_emu, arch_asic;
+
+  PerfCounter& operator+=(const PerfCounter& that);
+};
+
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.cpp
+++ b/lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.cpp
@@ -1,0 +1,99 @@
+#include "lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h"
+
+#include <cstdint>
+#include <unordered_set>
+
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+#include "llvm/include/llvm/Support/Debug.h"            // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/ValueRange.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"              // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"        // from @llvm-project
+
+// clang-format off
+#include "lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h.inc"
+// clang-format on
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+#define GEN_PASS_DEF_REPLACEOPWITHSECTION
+#include "lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h.inc"
+
+struct ReplaceOpWithSection
+    : impl::ReplaceOpWithSectionBase<ReplaceOpWithSection> {
+  using ReplaceOpWithSectionBase::ReplaceOpWithSectionBase;
+
+  // TODO: Fuse Not op to the previous section greedily
+  void runOnOperation() override {
+    Operation* op = getOperation();
+    MLIRContext& context = getContext();
+
+    op->walk([&](func::FuncOp op) { convertFunc(op, context); });
+  }
+  std::string getValueName(mlir::Value val) {
+    std::string opName;
+    llvm::raw_string_ostream ss(opName);
+    mlir::OpPrintingFlags pFlags;
+
+    val.printAsOperand(ss, pFlags);
+    return opName;
+  }
+
+  void convertFunc(Operation* funcOp, MLIRContext& context) {
+    uint32_t nChipsPerOp = 2;
+    uint32_t nOpsPerSection = nChips / nChipsPerOp;
+    std::vector<Operation*> opList;
+    funcOp->walk([&](Operation* op) {
+      if (isa<SCIFRBoolDialect>(op->getDialect()) && !isa<SectionOp>(op)) {
+        opList.push_back(op);
+      }
+    });
+    OpBuilder builder(&context);
+
+    for (uint32_t i = 0; i < (uint32_t)opList.size(); i += nOpsPerSection) {
+      auto startInsertionPoint = opList[i];
+      // Collect the inputs and input types of the original operation
+      SmallVector<Type, 4> inputTypes;
+      SmallVector<Value, 4> inputTensors;
+      std::unordered_set<std::string> inputNames;
+      for (uint32_t j = 0; j < nOpsPerSection && i + j < opList.size(); j++) {
+        Operation* scifrOp = opList[i + j];
+        // Assuming the operation has operands (inputs)
+        for (Value operand : scifrOp->getOperands()) {
+          std::string opName = getValueName(operand);
+          if (inputNames.find(opName) == inputNames.end()) {
+            inputNames.insert(opName);
+            inputTypes.push_back(operand.getType());
+            // TODO: Do not add operands that will be created inside this
+            // section as arguments
+            inputTensors.push_back(operand);
+          }
+        }
+      }
+      builder.setInsertionPoint(startInsertionPoint);
+      // Create a new SectionOp to wrap the original operator
+      Operation* sectionOp = SectionOp::create(
+          builder, startInsertionPoint->getLoc(), inputTypes[0], inputTensors);
+
+      Region& region = sectionOp->getRegion(0);
+      builder.createBlock(&region);
+      Block* sectionOpBlock = &region.front();
+
+      builder.setInsertionPointToStart(sectionOpBlock);
+      for (uint32_t j = 0; j < nOpsPerSection && i + j < opList.size(); j++) {
+        Operation* scifrOp = opList[i + j];
+        Operation* scifrOpCopy = builder.clone(*scifrOp);
+        scifrOpCopy->getBlock()->moveBefore(sectionOpBlock);
+        scifrOp->replaceAllUsesWith(sectionOp->getResults());
+        scifrOp->erase();
+      }
+    }
+  }
+};  // struct ReplaceOpWithSection
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h
+++ b/lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h
@@ -1,0 +1,21 @@
+#ifndef SCIFRBOOL_TRANSFORMS_REPLACEOPWITHSECTION_H
+#define SCIFRBOOL_TRANSFORMS_REPLACEOPWITHSECTION_H
+
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/Matchers.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"        // from @llvm-project
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+#define GEN_PASS_REGISTRATION
+#define GEN_PASS_DECL_REPLACEOPWITHSECTION
+#include "lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h.inc"
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir
+#endif /* SCIFRBOOL_TRANSFORMS_REPLACEOPWITHSECTION_H */

--- a/lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.td
+++ b/lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.td
@@ -1,0 +1,22 @@
+#ifndef LIB_DIALECT_SCIFRBOOL_CONVERSIONS_REPLACEOPWITHSECTION_TD_
+#define LIB_DIALECT_SCIFRBOOL_CONVERSIONS_REPLACEOPWITHSECTION_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ReplaceOpWithSection : Pass<"replace-op-with-section"> {
+  let summary = "Move each CGGI/SCIFRBool Operation inside a Section Operation";
+  let description = [{
+      Move each CGGI/SCIFRBool Operation inside a Section Operation.
+      We generate mlir with sections for larger boolean circuits.
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::cggi::CGGIDialect",
+    "mlir::cornami::scifrbool::SCIFRBoolDialect"
+  ];
+  let options = [
+    Option<"nChips", "nChips", "uint32_t", "2", "number of available chips">
+  ];
+}
+
+#endif  // LIB_DIALECT_SCIFRBOOL_CONVERSIONS_REPLACEOPWITHSECTION_TD_

--- a/lib/Dialect/SCIFRCkks/IR/BUILD
+++ b/lib/Dialect/SCIFRCkks/IR/BUILD
@@ -1,0 +1,90 @@
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "SCIFRCkksDialect.cpp",
+    ],
+    hdrs = [
+        "SCIFRCkksDialect.h",
+        "SCIFRCkksOps.h",
+        "SCIFRCkksTypes.h",
+    ],
+    deps = [
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        ":types_inc_gen",
+        "@heir//lib/Dialect:HEIRInterfaces",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:BytecodeOpInterface",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "SCIFRCkksDialect.td",
+        "SCIFRCkksOps.td",
+        "SCIFRCkksTypes.td",
+    ],
+    # include from the heir-root to enable fully-qualified include-paths
+    includes = ["../../../.."],
+    deps = [
+        "@llvm-project//mlir:ArithOpsTdFiles",
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:BytecodeOpInterface",
+        "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "dialect_inc_gen",
+    dialect = "SCIFRCkks",
+    kind = "dialect",
+    td_file = "SCIFRCkksDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "SCIFRCkks",
+    kind = "op",
+    td_file = "SCIFRCkksOps.td",
+    deps = [
+        ":td_files",
+        "@heir//lib/Dialect:td_files",
+        "@heir//lib/Dialect/LWE/IR:td_files",
+        "@heir//lib/Dialect/Polynomial/IR:td_files",
+        "@llvm-project//mlir:BytecodeOpInterface",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "types_inc_gen",
+    dialect = "SCIFRCkks",
+    kind = "type",
+    td_file = "SCIFRCkksTypes.td",
+    deps = [
+        ":td_files",
+    ],
+)

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.cpp
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.cpp
@@ -1,0 +1,53 @@
+//===- CFAIRDialect.cpp - CFAIR dialect ---------------*- C++ -*-===//
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.h"
+
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.cpp.inc"
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.h"
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.h"
+#include "llvm/include/llvm/Support/CommandLine.h"     // from @llvm-project
+#include "llvm/include/llvm/Support/InitLLVM.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/SourceMgr.h"       // from @llvm-project
+#include "llvm/include/llvm/Support/ToolOutputFile.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"         // from @llvm-project
+// #include "mlir/include/mlir/InitAllDialects.h"             // from
+// @llvm-project #include "mlir/include/mlir/InitAllPasses.h"               //
+// from @llvm-project
+#include "mlir/include/mlir/Parser/Parser.h"          // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"              // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"       // from @llvm-project
+#include "mlir/include/mlir/Support/FileUtilities.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/TypeID.h"         // from @llvm-project
+// #include "mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h"  // from
+// @llvm-project
+
+#include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.cpp.inc"
+#define GET_OP_CLASSES
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// SCIFRCkks dialect.
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace scifrckks {
+
+void SCIFRCkksDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.cpp.inc"
+      >();
+}
+}  // namespace scifrckks
+}  // namespace mlir

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.h
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.h
@@ -1,0 +1,23 @@
+#ifndef SCIFRCKKS_SCIFRCKKSDIALECT_H
+#define SCIFRCKKS_SCIFRCKKSDIALECT_H
+
+#include "llvm/include/llvm/Support/CommandLine.h"     // from @llvm-project
+#include "llvm/include/llvm/Support/InitLLVM.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/SourceMgr.h"       // from @llvm-project
+#include "llvm/include/llvm/Support/ToolOutputFile.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"         // from @llvm-project
+#include "mlir/include/mlir/Parser/Parser.h"           // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"               // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"        // from @llvm-project
+#include "mlir/include/mlir/Support/FileUtilities.h"   // from @llvm-project
+#include "mlir/include/mlir/Support/TypeID.h"          // from @llvm-project
+
+// clang-format off
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.h.inc"
+// clang-format on
+
+#endif  // SCIFRCKKS_SCIFRCKKSDIALECT_H

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.td
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.td
@@ -1,0 +1,41 @@
+//===- SCIFRCkksDialect.td - Cornami SCIFR CKKS Arithmetic Dialect -*- tablegen -*-===//
+//===----------------------------------------------------------------------===//
+
+#ifndef SCIFRCKKS_DIALECT
+#define SCIFRCKKS_DIALECT
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// Cornami SCIFR CKKS dialect definition.
+//===----------------------------------------------------------------------===//
+
+def SCIFRCkks_Dialect : Dialect {
+    let name = "scifrckks";
+    let summary = "Cornami SCIFR CKKS dialect for FHE Applications.";
+    let description = [{
+MLIR Dialect for Cornami SCIFR CKKS Dialect
+    Cornami SCIFR CKKS dialect
+    Concepts
+        Section
+            Contains Operators and HBM Regions and memory transfers operations
+            Section can be reduced to FA (for executable) or default (which is not executable)
+        Operator
+            Operators are from AppStream FHE or FractlsBase only
+    }];
+    let cppNamespace = "::mlir::scifrckks";
+    let useDefaultTypePrinterParser = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// SCIFRCkks Attributes.
+//===----------------------------------------------------------------------===//
+
+class SCIFRCkks_Attr<string attrName, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<SCIFRCkks_Dialect, attrName, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+#endif // SCIFRCKKS_DIALECT

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.cpp
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.cpp
@@ -1,0 +1,12 @@
+//===- SCIFRCkksOps.cpp - CFAIR dialect ops ---------------*- C++ -*-===//
+
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.h"
+
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.h"
+#include "mlir/include/mlir/IR/OpImplementation.h"  // from @llvm-project
+
+using namespace mlir;
+using namespace mlir::heir;
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.cpp.inc"

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.h
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.h
@@ -1,0 +1,20 @@
+#ifndef SCFIRCkks_SCFIRCkksOps_H
+#define SCFIRCkks_SCFIRCkksOps_H
+
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/HEIRInterfaces.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "mlir/include/mlir/Bytecode/BytecodeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.h.inc"
+
+#endif

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.td
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksOps.td
@@ -1,0 +1,59 @@
+//===- SCIFRCkksOps.td - SCIFRCkks Dialect ops -----------*- tablegen -*-===//
+
+#ifndef SCIFRCkks_OPS
+#define SCIFRCkks_OPS
+
+include "SCIFRCkksDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/CastInterfaces.td"
+
+include "lib/Dialect/HEIRInterfaces.td"
+
+include "lib/Dialect/LWE/IR/LWETypes.td"
+
+class SCIFRCkks_Op<string mnemonic, list<Trait> traits = []> :
+        Op<SCIFRCkks_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+  let cppNamespace = "::mlir::scifrckks";
+}
+
+// --- Operations for a gate-bootstrapping API of a SCIFRCkks library ---
+
+class SCIFRCkks_BinaryGateOp<string mnemonic>
+  : SCIFRCkks_Op<mnemonic, [
+    Pure,
+    Commutative,
+    SameOperandsAndResultType,
+    ElementwiseMappable,
+    Scalarizable
+]> {
+  let arguments = (ins LWECiphertext:$lhs, LWECiphertext:$rhs);
+  let results = (outs LWECiphertext:$output);
+  // Note: error: type of result #0, named 'output', is not buildable and a buildable type cannot be inferred
+  // LWECiphertext is not buildable?
+  let assemblyFormat = "operands attr-dict `:` qualified(type($output))" ;
+}
+
+def SCIFRCkks_AddOp : SCIFRCkks_BinaryGateOp<"Add"> { let summary = "Add two ciphertexts."; }
+def SCIFRCkks_SubOp : SCIFRCkks_BinaryGateOp<"Sub"> { let summary = "Sub two ciphertexts."; }
+def SCIFRCkks_MulOp : SCIFRCkks_BinaryGateOp<"Mul"> { let summary = "Mul two ciphertexts."; }
+def SCIFRCkks_AddConstOp : SCIFRCkks_BinaryGateOp<"AddC"> { let summary = "Add ciphertext with constant Op."; }
+def SCIFRCkks_SubConstOp  : SCIFRCkks_BinaryGateOp<"SubC">  { let summary = "Subtract ciphertext from a constant Op."; }
+def SCIFRCkks_RelinOp  : SCIFRCkks_Op<"Relin">  { let summary = "Relinearize a ciphertext."; }
+
+//===----------------------------------------------------------------------===//
+def SCIFRCkks_AnyNumber : AnyTypeOf<[AnyFloat],
+                               "number">;
+
+/// SCIFRCKKS Scheme ops in ciphertext ///
+
+#endif // SCIFRCkks_Ops

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.h
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.h
@@ -1,0 +1,9 @@
+#ifndef SCFIRBool_SCFIRBoolTypes_H
+#define SCFIRBool_SCFIRBoolTypes_H
+
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.h.inc"
+
+#endif

--- a/lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.td
+++ b/lib/Dialect/SCIFRCkks/IR/SCIFRCkksTypes.td
@@ -1,0 +1,36 @@
+//===- SCIFRCkksTypes.td - SCIFRCkks Dialect Types -----------*- tablegen -*-===//
+
+#ifndef SCIFRCkks_TYPES
+#define SCIFRCkks_TYPES
+
+include "SCIFRCkksDialect.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
+class SCIFRCkks_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<SCIFRCkks_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def SCIFRCkks_Ciphertext : SCIFRCkks_Type<"SCIFRCkksCiphertext", "ciphertext"> {
+  let summary = "A type for SCIFRCkks Ciphertext";
+}
+
+def SCIFRCkks_Bootstrap_Key : SCIFRCkks_Type<"SCIFRCkksBootstrapKey", "bootstrap_key"> {
+  let summary = "The key required to perform Bootstrap operation in SCIFRCkks.";
+}
+
+def SCIFRCkks_Key_Switch_Key : SCIFRCkks_Type<"SCIFRCkksKeySwitchKey", "key_switch_key"> {
+  let summary = "The key required to perform Keyswitch operation in SCIFRCkks.";
+}
+
+def SCIFRCkks_Server_Parameters : SCIFRCkks_Type<"SCIFRCkksServerParameters", "server_parameters"> {
+  let summary = "The server parameters required to map to cornami hardware in SCIFRCkks.";
+}
+
+#endif // SCIFRCkks_Types

--- a/lib/Dialect/SCIFRCkks/Transforms/BUILD
+++ b/lib/Dialect/SCIFRCkks/Transforms/BUILD
@@ -1,0 +1,88 @@
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = [
+        "Passes.h",
+    ],
+    deps = [
+        ":CKKSEstimator",
+        ":OpenfheEstimator",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/CGGI/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/IR:Dialect",
+    ],
+)
+
+cc_library(
+    name = "CKKSEstimator",
+    srcs = [
+        "CKKSEstimator.cpp",
+    ],
+    hdrs = [
+        "CKKSEstimator.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/Transforms:DialectResourceMap",
+        "@heir//lib/Dialect/SCIFRBool/Transforms:PerfCounter",
+        "@heir//lib/Utils/Graph",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+cc_library(
+    name = "OpenfheEstimator",
+    srcs = [
+        "OpenfheEstimator.cpp",
+    ],
+    hdrs = [
+        "OpenfheEstimator.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/Transforms:DialectResourceMap",
+        "@heir//lib/Utils/Graph",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+gentbl_cc_library(
+    name = "pass_inc_gen",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=SCIFRCkksTransforms",
+            ],
+            "Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)

--- a/lib/Dialect/SCIFRCkks/Transforms/CKKSEstimator.cpp
+++ b/lib/Dialect/SCIFRCkks/Transforms/CKKSEstimator.cpp
@@ -1,0 +1,329 @@
+#include "lib/Dialect/SCIFRCkks/Transforms/CKKSEstimator.h"
+
+#include <iomanip>
+#include <string>
+
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/SCIFRBool/Transforms/PerfCounter.h"
+#include "lib/Utils/Graph/Graph.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"           // from @llvm-project
+#include "mlir/include/mlir/Analysis/SliceAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/TopologicalSortUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+// clang-format off
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+// clang-format on
+
+#define DEBUG_ON 0
+
+namespace mlir {
+namespace heir {
+
+void CKKSLongestChain::reset() {
+  node_indexes.clear();
+  node_names.clear();
+  opcodes.clear();
+}
+
+void CKKSLongestChain::print() const {
+  if (DEBUG_ON) {
+    llvm::outs() << "longest chain \n";
+    llvm::outs() << "longest node index seq \n";
+
+    for (const auto& index : node_indexes) {
+      llvm::outs() << " " << index;
+    }
+    llvm::outs() << "\n";
+
+    llvm::outs() << "longest node name seq \n";
+
+    for (const auto& name : node_names) {
+      llvm::outs() << "\n\n" << name;
+    }
+  }
+
+  llvm::outs() << "\n\nlongest opcode seq \n";
+
+  for (const auto& opcode : opcodes) {
+    llvm::outs() << " " << CKKSOpsData::opcode_name(opcode);
+  }
+
+  llvm::outs() << "\n";
+}
+
+void CKKSOpsData::reset() {
+  core_counts.clear();
+  core_counts.resize(CKKSOpcode::UNKNOWN_CKKS, 0);
+  ops_count.clear();
+  ops_count.resize(CKKSOpcode::UNKNOWN_CKKS, 0);
+
+  n_accumulated_throughput = 0;
+  nodes.clear();
+  adjacencies.clear();
+  longest_chain.reset();
+};
+
+std::string CKKSOpsData::opcode_name(CKKSOpcode opcode) {
+  switch (opcode) {
+    case ADD:
+      return "ADD";
+    case ADDPLAIN:
+      return "ADDPLAIN";
+    case SUB:
+      return "SUB";
+    case SUBPLAIN:
+      return "SUBPLAIN";
+    case MUL:
+      return "MUL";
+    case MULPLAIN:
+      return "MULPLAIN";
+    case ROTATE:
+      return "ROTATE";
+    case EXTRACT:
+      return "EXTRACT";
+    case NEGATE:
+      return "NEGATE";
+    case RELINEARIZE:
+      return "RELINEARIZE";
+    case RESCALE:
+      return "RESCALE";
+    case UNKNOWN_CKKS:
+      return "UNKNOWN";
+  };
+  return "UNKNOWN";
+}
+
+std::vector<CKKSOpcode> CKKSOpsData::opcodes() {
+  return {
+      CKKSOpcode::ADD,         CKKSOpcode::ADDPLAIN, CKKSOpcode::SUB,
+      CKKSOpcode::SUBPLAIN,    CKKSOpcode::MUL,      CKKSOpcode::MULPLAIN,
+      CKKSOpcode::ROTATE,      CKKSOpcode::EXTRACT,  CKKSOpcode::NEGATE,
+      CKKSOpcode::RELINEARIZE, CKKSOpcode::RESCALE,  CKKSOpcode::UNKNOWN_CKKS,
+  };
+}
+
+int CKKSOpsData::get_core_counts(CKKSOpcode opcode) {
+  const auto& count_and_th = get_core_count_and_throughput(opcode);
+  return count_and_th[0];
+}
+
+int CKKSOpsData::get_throughput(CKKSOpcode opcode) {
+  const auto& count_and_th = get_core_count_and_throughput(opcode);
+  return count_and_th[1];
+}
+
+int CKKSOpsData::get_latency(CKKSOpcode opcode) {
+  const auto& count_and_th = get_core_count_and_throughput(opcode);
+  return BATCH_SIZE * count_and_th[1];
+}
+
+std::vector<int> CKKSOpsData::get_core_count_and_throughput(CKKSOpcode opcode) {
+  switch (opcode) {
+    case ADD:
+    case ADDPLAIN:
+      return {2, 4};
+    case SUB:
+    case SUBPLAIN:
+      return {2, 4};
+    case MUL:
+    case MULPLAIN:
+      return {53000, 4};
+    case NEGATE:
+      return {1, 1};
+    case ROTATE:
+      return {300, 5};
+    case RELINEARIZE:
+      return {600, 5};
+    case RESCALE:
+      return {4, 4};
+    case EXTRACT:
+      return {4, 4};
+    case UNKNOWN_CKKS:
+      return {0, 0};
+  }
+
+  return {0, 0};
+}
+
+void CKKSOpsData::display() const { display(opcodes()); }
+
+void CKKSOpsData::display(const std::vector<CKKSOpcode>& opcodes) const {
+  auto set_w_str = [](int width, const std::string& s) -> std::string {
+    std::stringstream ss;
+    ss.width(width);
+    ss << s;
+    return ss.str();
+  };
+
+  auto set_w_int = [](int width, int value) -> std::string {
+    std::stringstream ss;
+    ss.width(width);
+    ss << value;
+    return ss.str();
+  };
+
+  auto set_w_double = [](int width, double value) -> std::string {
+    std::stringstream ss;
+    ss.width(width);
+    ss.precision(2);
+    ss << value;
+    return ss.str();
+  };
+
+  int cumulative_fcs = 0;
+  for (const auto& opcode : opcodes) {
+    if (opcode == CKKSOpcode::UNKNOWN_CKKS) continue;
+    cumulative_fcs += core_counts[opcode];
+    llvm::outs() << set_w_str(15, opcode_name(opcode)) << " : "
+                 << set_w_int(6, ops_count[opcode])
+                 << " | FC = " << set_w_int(6, core_counts[opcode])
+                 << " LATENCY = "
+                 << set_w_double(6, BATCH_SIZE * get_throughput(opcode))
+                 << "\n";
+  }
+
+  double cumulative_latency = (BATCH_SIZE * n_accumulated_throughput);
+  const uint64_t fcs_per_chip = 2048;
+  uint64_t chip_count = (cumulative_fcs + fcs_per_chip - 1) / fcs_per_chip;
+
+  llvm::outs() << "---------------------------------------------\n";
+  llvm::outs() << "Total FC = " << cumulative_fcs
+               << " | LATENCY = " << set_w_double(4, cumulative_latency)
+               << " | CHIPS = " << chip_count << "\n";
+}
+
+cornami::DialectResourceMap CKKSOpsData::get_resource_map() const {
+  cornami::DialectResourceMap ruse;  // resource use
+  ruse["AND"] = 0;
+
+  return ruse;
+}
+}  // namespace heir
+
+namespace cornami {
+#define GEN_PASS_DEF_CKKSESTIMATOR
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+
+using namespace mlir::heir;
+
+struct CKKSEstimator : impl::CKKSEstimatorBase<CKKSEstimator> {
+  using CKKSEstimatorBase::CKKSEstimatorBase;
+  PerfCounter m_data;
+  CKKSOpsData m_ckksops;
+
+  std::string getOperationAsString(mlir::Operation* op) {
+    std::string opString;
+    llvm::raw_string_ostream ss(opString);
+    op->print(ss);
+    return ss.str();
+  }
+
+  CKKSOpcode getOpcode(Operation* op) {
+    CKKSOpcode opcode = CKKSOpcode::UNKNOWN_CKKS;
+    if (llvm::isa<ckks::AddOp>(op)) {
+      opcode = CKKSOpcode::ADD;
+    } else if (llvm::isa<ckks::AddPlainOp>(op)) {
+      opcode = CKKSOpcode::ADDPLAIN;
+    } else if (llvm::isa<ckks::SubOp>(op)) {
+      opcode = CKKSOpcode::SUB;
+    } else if (llvm::isa<ckks::SubPlainOp>(op)) {
+      opcode = CKKSOpcode::SUBPLAIN;
+    } else if (llvm::isa<ckks::MulOp>(op)) {
+      opcode = CKKSOpcode::MUL;
+    } else if (llvm::isa<ckks::MulPlainOp>(op)) {
+      opcode = CKKSOpcode::MULPLAIN;
+    } else if (llvm::isa<ckks::RotateOp>(op)) {
+      opcode = CKKSOpcode::ROTATE;
+    } else if (llvm::isa<ckks::NegateOp>(op)) {
+      opcode = CKKSOpcode::NEGATE;
+    } else if (llvm::isa<ckks::RelinearizeOp>(op)) {
+      opcode = CKKSOpcode::RELINEARIZE;
+    } else if (llvm::isa<ckks::RescaleOp>(op)) {
+      opcode = CKKSOpcode::RESCALE;
+    }
+    return opcode;
+  }
+
+  void runOnOperation() override {
+    graph::Graph<Operation*> graph;
+    m_ckksops.reset();
+
+    getOperation()->walk<WalkOrder::PostOrder>([&](Operation* op) {
+      CKKSOpcode opcode = getOpcode(op);
+      if (opcode == CKKSOpcode::UNKNOWN_CKKS) {
+        op->emitWarning() << "Unknown operator not counted for Estimate\n";
+      } else {
+        m_ckksops.ops_count[opcode]++;
+        m_ckksops.core_counts[opcode] += CKKSOpsData::get_core_counts(opcode);
+        m_ckksops.n_accumulated_throughput +=
+            CKKSOpsData::get_throughput(opcode);
+      }
+
+      // op should be CKKS operator only
+      graph.addVertex(op);
+      if (op->getNumOperands() > 0) {
+        llvm::outs() << "Operator : "
+                     << op->getName().getIdentifier().getValue().str()
+                     << " has " << op->getNumOperands() << " operands.\n";
+        for (auto inoperand : op->getOperands()) {
+          if (!inoperand.getDefiningOp()) continue;
+          graph.addVertex(inoperand.getDefiningOp());
+          graph.addEdge(inoperand.getDefiningOp(), op,
+                        CKKSOpsData::get_latency(opcode));
+        }
+      }
+
+      llvm::outs() << "operation = " << "\n";
+      op->dump();
+      llvm::outs() << "\n";
+    });
+
+    m_ckksops.display();
+
+    dump(graph);
+    auto cp_ = graph.findApproximateCriticalPath();
+    if (!succeeded(cp_) || cp_.value().empty()) {
+      llvm::outs() << "======= Cannot find useful CP =========\n";
+    } else {
+      llvm::outs() << "======= STATS ALONG CP =========\n";
+
+      m_ckksops.reset();
+      for (const auto& op : cp_.value()) {
+        CKKSOpcode opcode = getOpcode(op);
+        if (opcode == CKKSOpcode::UNKNOWN_CKKS) {
+          op->emitWarning() << "Unknown operator not counted for Estimate\n";
+        } else {
+          m_ckksops.ops_count[opcode]++;
+          m_ckksops.core_counts[opcode] += CKKSOpsData::get_core_counts(opcode);
+          m_ckksops.n_accumulated_throughput +=
+              CKKSOpsData::get_throughput(opcode);
+        }
+      }
+
+      if (DEBUG_ON) {
+        for (const auto& op : cp_.value()) {
+          CKKSOpcode opcode = getOpcode(op);
+          llvm::outs() << CKKSOpsData::opcode_name(opcode) << "\n";
+        }
+      }
+
+      llvm::outs() << "\n";
+
+      m_ckksops.display();
+    }
+    llvm::outs() << "\n";
+  }
+};  // struct CKKSEstimator
+
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRCkks/Transforms/CKKSEstimator.h
+++ b/lib/Dialect/SCIFRCkks/Transforms/CKKSEstimator.h
@@ -1,0 +1,76 @@
+#ifndef CORNAMI_CKKSESTIMATOR_PASS_H_
+#define CORNAMI_CKKSESTIMATOR_PASS_H_
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.h"
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+
+namespace heir {
+
+enum CKKSOpcode {
+  ADD,
+  ADDPLAIN,
+  SUB,
+  SUBPLAIN,
+  MUL,
+  MULPLAIN,
+  ROTATE,
+  EXTRACT,
+  NEGATE,
+  RELINEARIZE,
+  RESCALE,
+  UNKNOWN_CKKS
+};
+
+struct CKKSLongestChain {
+  std::vector<int> node_indexes;
+  std::vector<std::string> node_names;
+  std::vector<CKKSOpcode> opcodes;
+
+  void reset();
+  void print() const;
+};
+
+struct CKKSOpsData {
+  static const int BATCH_SIZE = 4;
+  std::vector<int> core_counts;
+  std::vector<int> ops_count;
+  int n_accumulated_throughput = 0;
+  std::unordered_map<std::string, CKKSOpcode> nodes;
+  std::unordered_map<std::string, std::unordered_set<std::string>> adjacencies;
+  CKKSLongestChain longest_chain;
+
+  CKKSOpsData() {
+    core_counts.resize(CKKSOpcode::UNKNOWN_CKKS, 0);
+    ops_count.resize(CKKSOpcode::UNKNOWN_CKKS, 0);
+  }
+
+  cornami::DialectResourceMap get_resource_map() const;
+  void reset();
+  void display(const std::vector<CKKSOpcode>& opcodes) const;
+  void display() const;
+
+  static std::string opcode_name(CKKSOpcode opcode);
+  static std::vector<CKKSOpcode> opcodes();
+  static int get_core_counts(CKKSOpcode opcode);
+  static int get_throughput(CKKSOpcode opcode);
+  static int get_latency(CKKSOpcode opcode);
+  static std::vector<int> get_core_count_and_throughput(CKKSOpcode opcode);
+};
+
+#define GEN_PASS_DECL_CKKSESTIMATOR
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // CORNAMI_CKKSESTIMATOR_PASS_H_

--- a/lib/Dialect/SCIFRCkks/Transforms/OpenfheEstimator.cpp
+++ b/lib/Dialect/SCIFRCkks/Transforms/OpenfheEstimator.cpp
@@ -1,0 +1,369 @@
+#include "lib/Dialect/SCIFRCkks/Transforms/OpenfheEstimator.h"
+
+#include <iomanip>
+#include <string>
+
+#include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "lib/Utils/Graph/Graph.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"           // from @llvm-project
+#include "mlir/include/mlir/Analysis/SliceAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/TopologicalSortUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+// clang-format off
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+// clang-format on
+
+#define DEBUG_ON 0
+
+namespace mlir {
+namespace heir {
+
+void OpenfheLongestChain::reset() {
+  node_indexes.clear();
+  node_names.clear();
+  opcodes.clear();
+}
+
+void OpenfheLongestChain::print() const {
+  if (DEBUG_ON) {
+    llvm::outs() << "longest chain \n";
+    llvm::outs() << "longest node index seq \n";
+
+    for (const auto& index : node_indexes) {
+      llvm::outs() << " " << index;
+    }
+    llvm::outs() << "\n";
+
+    llvm::outs() << "longest node name seq \n";
+
+    for (const auto& name : node_names) {
+      llvm::outs() << "\n\n" << name;
+    }
+  }
+
+  llvm::outs() << "\n\nlongest opcode seq \n";
+
+  for (const auto& opcode : opcodes) {
+    llvm::outs() << " " << OpenfheOpsData::opcode_name(opcode);
+  }
+
+  llvm::outs() << "\n";
+}
+
+void OpenfheOpsData::reset() {
+  core_counts.clear();
+  core_counts.resize(OpenfheOpcode::UNKNOWN_OPENFHE, 0);
+  ops_count.clear();
+  ops_count.resize(OpenfheOpcode::UNKNOWN_OPENFHE, 0);
+  n_accumulated_throughput = 0;
+  nodes.clear();
+  adjacencies.clear();
+  longest_chain.reset();
+};
+
+std::string OpenfheOpsData::opcode_name(OpenfheOpcode opcode) {
+  switch (opcode) {
+    case AddOp:
+      return "AddOp";
+    case AutomorphOp:
+      return "AutomorphOp";
+    case DecryptOp:
+      return "DecryptOp";
+    case EncryptOp:
+      return "EncryptOp";
+    case GenContextOp:
+      return "GenContextOp";
+    case GenMulKeyOp:
+      return "GenMulKeyOp";
+    case GenParamsOp:
+      return "GenParamsOp";
+    case GenRotKeyOp:
+      return "GenRotKeyOp";
+    case KeySwitchOp:
+      return "KeySwitchOp";
+    case LevelReduceOp:
+      return "LevelReduceOp";
+    case ModReduceOp:
+      return "ModReduceOp";
+    case MulConstOp:
+      return "MulConstOp";
+    case MulNoRelinOp:
+      return "MulNoRelinOp";
+    case MulOp:
+      return "MulOp";
+    case MulPlainOp:
+      return "MulPlainOp";
+    case NegateOp:
+      return "NegateOp";
+    case RelinOp:
+      return "RelinOp";
+    case RotOp:
+      return "RotOp";
+    case SquareOp:
+      return "SquareOp";
+    case SubOp:
+      return "SubOp";
+    case UNKNOWN_OPENFHE:
+      return "UNKNOWN_OPENFHE";
+  };
+  return "UNKNOWN_OPENFHE";
+}
+
+std::vector<OpenfheOpcode> OpenfheOpsData::opcodes() {
+  return {OpenfheOpcode::AddOp,          OpenfheOpcode::AutomorphOp,
+          OpenfheOpcode::DecryptOp,      OpenfheOpcode::EncryptOp,
+          OpenfheOpcode::GenContextOp,   OpenfheOpcode::GenMulKeyOp,
+          OpenfheOpcode::GenParamsOp,    OpenfheOpcode::GenRotKeyOp,
+          OpenfheOpcode::KeySwitchOp,    OpenfheOpcode::LevelReduceOp,
+          OpenfheOpcode::ModReduceOp,    OpenfheOpcode::MulConstOp,
+          OpenfheOpcode::MulNoRelinOp,   OpenfheOpcode::MulOp,
+          OpenfheOpcode::MulPlainOp,     OpenfheOpcode::NegateOp,
+          OpenfheOpcode::RelinOp,        OpenfheOpcode::RotOp,
+          OpenfheOpcode::SquareOp,       OpenfheOpcode::SubOp,
+          OpenfheOpcode::UNKNOWN_OPENFHE};
+}
+
+int OpenfheOpsData::get_core_counts(OpenfheOpcode opcode) {
+  const auto& count_and_th = get_core_count_and_throughput(opcode);
+  return count_and_th[0];
+}
+
+int OpenfheOpsData::get_throughput(OpenfheOpcode opcode) {
+  const auto& count_and_th = get_core_count_and_throughput(opcode);
+  return count_and_th[1];
+}
+
+int OpenfheOpsData::get_latency(OpenfheOpcode opcode) {
+  const auto& count_and_th = get_core_count_and_throughput(opcode);
+  return BATCH_SIZE * count_and_th[1];
+}
+
+std::vector<int> OpenfheOpsData::get_core_count_and_throughput(
+    OpenfheOpcode opcode) {
+  switch (opcode) {
+    case AddOp:
+      return {2, 4};
+    case AutomorphOp:
+      return {2, 4};
+    case DecryptOp:
+      return {2, 4};
+    case EncryptOp:
+      return {2, 4};
+    case GenContextOp:
+      return {2, 4};
+    case GenMulKeyOp:
+      return {2, 4};
+    case GenParamsOp:
+      return {2, 4};
+    case GenRotKeyOp:
+      return {2, 4};
+    case KeySwitchOp:
+      return {2, 4};
+    case LevelReduceOp:
+      return {2, 4};
+    case ModReduceOp:
+      return {2, 4};
+    case MulConstOp:
+      return {2, 4};
+    case MulNoRelinOp:
+      return {2, 4};
+    case MulOp:
+      return {2, 4};
+    case MulPlainOp:
+      return {2, 4};
+    case NegateOp:
+      return {2, 4};
+    case RelinOp:
+      return {2, 4};
+    case RotOp:
+      return {2, 4};
+    case SquareOp:
+      return {2, 4};
+    case SubOp:
+      return {2, 4};
+    case UNKNOWN_OPENFHE:
+      return {0, 0};
+  }
+
+  return {0, 0};
+}
+
+void OpenfheOpsData::display() const { display(opcodes()); }
+
+void OpenfheOpsData::display(const std::vector<OpenfheOpcode>& opcodes) const {
+  auto set_w_str = [](int width, const std::string& s) -> std::string {
+    std::stringstream ss;
+    ss.width(width);
+    ss << s;
+    return ss.str();
+  };
+
+  auto set_w_int = [](int width, int value) -> std::string {
+    std::stringstream ss;
+    ss.width(width);
+    ss << value;
+    return ss.str();
+  };
+
+  auto set_w_double = [](int width, double value) -> std::string {
+    std::stringstream ss;
+    ss.width(width);
+    ss.precision(2);
+    ss << value;
+    return ss.str();
+  };
+
+  int cumulative_fcs = 0;
+  for (const auto& opcode : opcodes) {
+    if (opcode == OpenfheOpcode::UNKNOWN_OPENFHE) continue;
+    cumulative_fcs += core_counts[opcode];
+    llvm::outs() << set_w_str(15, opcode_name(opcode)) << " : "
+                 << set_w_int(6, ops_count[opcode])
+                 << " | FC = " << set_w_int(6, core_counts[opcode])
+                 << " LATENCY = "
+                 << set_w_double(6, BATCH_SIZE * get_throughput(opcode))
+                 << "\n";
+  }
+
+  double cumulative_latency = (BATCH_SIZE * n_accumulated_throughput);
+  const uint64_t fcs_per_chip = 2048;
+  uint64_t chip_count = (cumulative_fcs + fcs_per_chip - 1) / fcs_per_chip;
+
+  llvm::outs() << "---------------------------------------------\n";
+  llvm::outs() << "Total FC = " << cumulative_fcs
+               << " | LATENCY = " << set_w_double(4, cumulative_latency)
+               << " | CHIPS = " << chip_count << "\n";
+}
+}  // namespace heir
+namespace cornami {
+#define GEN_PASS_DEF_OPENFHEESTIMATOR
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+
+using namespace mlir::heir;
+
+struct OpenfheEstimator : impl::OpenfheEstimatorBase<OpenfheEstimator> {
+  using OpenfheEstimatorBase::OpenfheEstimatorBase;
+
+  OpenfheOpsData m_openfheops;
+
+  std::string getOperationAsString(mlir::Operation* op) {
+    std::string opString;
+    llvm::raw_string_ostream ss(opString);
+    op->print(ss);
+    return ss.str();
+  }
+
+  OpenfheOpcode getOpcode(Operation* op) {
+    OpenfheOpcode opcode = OpenfheOpcode::UNKNOWN_OPENFHE;
+    if (llvm::isa<openfhe::AddOp>(op)) return OpenfheOpcode::AddOp;
+    if (llvm::isa<openfhe::AutomorphOp>(op)) return OpenfheOpcode::AutomorphOp;
+    if (llvm::isa<openfhe::DecryptOp>(op)) return OpenfheOpcode::DecryptOp;
+    if (llvm::isa<openfhe::EncryptOp>(op)) return OpenfheOpcode::EncryptOp;
+    if (llvm::isa<openfhe::GenContextOp>(op))
+      return OpenfheOpcode::GenContextOp;
+    if (llvm::isa<openfhe::GenMulKeyOp>(op)) return OpenfheOpcode::GenMulKeyOp;
+    if (llvm::isa<openfhe::GenParamsOp>(op)) return OpenfheOpcode::GenParamsOp;
+    if (llvm::isa<openfhe::GenRotKeyOp>(op)) return OpenfheOpcode::GenRotKeyOp;
+    if (llvm::isa<openfhe::KeySwitchOp>(op)) return OpenfheOpcode::KeySwitchOp;
+    if (llvm::isa<openfhe::LevelReduceOp>(op))
+      return OpenfheOpcode::LevelReduceOp;
+    if (llvm::isa<openfhe::ModReduceOp>(op)) return OpenfheOpcode::ModReduceOp;
+    if (llvm::isa<openfhe::MulConstOp>(op)) return OpenfheOpcode::MulConstOp;
+    if (llvm::isa<openfhe::MulNoRelinOp>(op))
+      return OpenfheOpcode::MulNoRelinOp;
+    if (llvm::isa<openfhe::MulOp>(op)) return OpenfheOpcode::MulOp;
+    if (llvm::isa<openfhe::MulPlainOp>(op)) return OpenfheOpcode::MulPlainOp;
+    if (llvm::isa<openfhe::NegateOp>(op)) return OpenfheOpcode::NegateOp;
+    if (llvm::isa<openfhe::RelinOp>(op)) return OpenfheOpcode::RelinOp;
+    if (llvm::isa<openfhe::RotOp>(op)) return OpenfheOpcode::RotOp;
+    if (llvm::isa<openfhe::SquareOp>(op)) return OpenfheOpcode::SquareOp;
+    if (llvm::isa<openfhe::SubOp>(op)) return OpenfheOpcode::SubOp;
+    return opcode;
+  }
+
+  void runOnOperation() override {
+    // MLIRContext &context = getContext();
+    graph::Graph<Operation*> graph;
+    m_openfheops.reset();
+
+    getOperation()->walk<WalkOrder::PostOrder>([&](Operation* op) {
+      OpenfheOpcode opcode = getOpcode(op);
+      if (opcode == OpenfheOpcode::UNKNOWN_OPENFHE) {
+        op->emitWarning() << "Unknown operator not counted for Estimate\n";
+      } else {
+        m_openfheops.ops_count[opcode]++;
+        m_openfheops.core_counts[opcode] +=
+            OpenfheOpsData::get_core_counts(opcode);
+        m_openfheops.n_accumulated_throughput +=
+            OpenfheOpsData::get_throughput(opcode);
+      }
+
+      // op should be Openfhe operator only
+      graph.addVertex(op);
+      if (op->getNumOperands() > 0) {
+        llvm::outs() << "Operator : "
+                     << op->getName().getIdentifier().getValue().str()
+                     << " has " << op->getNumOperands() << " operands.\n";
+        for (auto inoperand : op->getOperands()) {
+          if (!inoperand.getDefiningOp()) continue;
+          graph.addVertex(inoperand.getDefiningOp());
+          graph.addEdge(inoperand.getDefiningOp(), op,
+                        OpenfheOpsData::get_latency(opcode));
+        }
+      }
+
+      llvm::outs() << "operation = " << "\n";
+      op->dump();
+      llvm::outs() << "\n";
+    });
+
+    m_openfheops.display();
+
+    dump(graph);
+    auto cp_ = graph.findApproximateCriticalPath();
+    if (!succeeded(cp_) || cp_.value().empty()) {
+      llvm::outs() << "======= Cannot find useful CP =========\n";
+    } else {
+      llvm::outs() << "======= STATS ALONG CP =========\n";
+
+      m_openfheops.reset();
+      for (const auto& op : cp_.value()) {
+        OpenfheOpcode opcode = getOpcode(op);
+        if (opcode == OpenfheOpcode::UNKNOWN_OPENFHE) {
+          op->emitWarning() << "Unknown operator not counted for Estimate\n";
+        } else {
+          m_openfheops.ops_count[opcode]++;
+          m_openfheops.core_counts[opcode] +=
+              OpenfheOpsData::get_core_counts(opcode);
+          m_openfheops.n_accumulated_throughput +=
+              OpenfheOpsData::get_throughput(opcode);
+        }
+      }
+
+      if (DEBUG_ON) {
+        for (const auto& op : cp_.value()) {
+          OpenfheOpcode opcode = getOpcode(op);
+          llvm::outs() << OpenfheOpsData::opcode_name(opcode) << "\n";
+        }
+      }
+
+      llvm::outs() << "\n";
+
+      m_openfheops.display();
+    }
+    llvm::outs() << "\n";
+  }
+};  // struct OpenfheEstimator
+
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Dialect/SCIFRCkks/Transforms/OpenfheEstimator.h
+++ b/lib/Dialect/SCIFRCkks/Transforms/OpenfheEstimator.h
@@ -1,0 +1,86 @@
+#ifndef CORNAMI_OPENFHE_ESTIMATOR_PASS_H_
+#define CORNAMI_OPENFHE_ESTIMATOR_PASS_H_
+
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/SCIFRBool/Transforms/DialectResourceMap.h"
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+
+namespace heir {
+
+enum OpenfheOpcode {
+  AddOp,
+  AutomorphOp,
+  DecryptOp,
+  EncryptOp,
+  GenContextOp,
+  GenMulKeyOp,
+  GenParamsOp,
+  GenRotKeyOp,
+  KeySwitchOp,
+  LevelReduceOp,
+  ModReduceOp,
+  MulConstOp,
+  MulNoRelinOp,
+  MulOp,
+  MulPlainOp,
+  NegateOp,
+  RelinOp,
+  RotOp,
+  SquareOp,
+  SubOp,
+  UNKNOWN_OPENFHE
+};
+
+struct OpenfheLongestChain {
+  std::vector<int> node_indexes;
+  std::vector<std::string> node_names;
+  std::vector<OpenfheOpcode> opcodes;
+  void reset();
+  void print() const;
+};
+
+struct OpenfheOpsData {
+  static const int BATCH_SIZE = 4;
+  std::vector<int> core_counts;
+  std::vector<int> ops_count;
+  int n_accumulated_throughput = 0;
+  std::unordered_map<std::string, OpenfheOpcode> nodes;
+  std::unordered_map<std::string, std::unordered_set<std::string>> adjacencies;
+  OpenfheLongestChain longest_chain;
+
+  OpenfheOpsData() {
+    core_counts.resize(OpenfheOpcode::UNKNOWN_OPENFHE, 0);
+    ops_count.resize(OpenfheOpcode::UNKNOWN_OPENFHE, 0);
+  }
+
+  cornami::DialectResourceMap get_resource_map() const;
+  void reset();
+  void display(const std::vector<OpenfheOpcode>& opcodes) const;
+  void display() const;
+
+  static std::string opcode_name(OpenfheOpcode opcode);
+  static std::vector<OpenfheOpcode> opcodes();
+  static int get_core_counts(OpenfheOpcode opcode);
+  static int get_throughput(OpenfheOpcode opcode);
+  static int get_latency(OpenfheOpcode opcode);
+  static std::vector<int> get_core_count_and_throughput(OpenfheOpcode opcode);
+};
+
+#define GEN_PASS_DECL_OPENFHEESTIMATOR
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // CORNAMI_OPENFHE_ESTIMATOR_PASS_H_

--- a/lib/Dialect/SCIFRCkks/Transforms/Passes.h
+++ b/lib/Dialect/SCIFRCkks/Transforms/Passes.h
@@ -1,0 +1,20 @@
+#ifndef LIB_DIALECT_CKKS_SCIFRCKKS_CORNAMI_ANALYSIS_PASSES_H_
+#define LIB_DIALECT_CKKS_SCIFRCKKS_CORNAMI_ANALYSIS_PASSES_H_
+
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/SCIFRCkks/Transforms/CKKSEstimator.h"
+#include "lib/Dialect/SCIFRCkks/Transforms/OpenfheEstimator.h"
+
+namespace mlir {
+namespace cornami {
+
+#define GEN_PASS_REGISTRATION
+#define GEN_PASS_DECL_CKKSESTIMATOR
+#define GEN_PASS_DECL_OPENFHEESTIMATOR
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h.inc"
+
+}  // namespace cornami
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CKKS_SCIFRCKKS_CORNAMI_ANALYSIS_PASSES_H_

--- a/lib/Dialect/SCIFRCkks/Transforms/Passes.td
+++ b/lib/Dialect/SCIFRCkks/Transforms/Passes.td
@@ -1,0 +1,30 @@
+#ifndef LIB_ALL_DIALECT_CORNAMI_SCIFRCKKS_ANALYSIS_PASSES_TD_
+#define LIB_ALL_DIALECT_CORNAMI_SCIFRCKKS_ANALYSIS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CKKSEstimator : Pass<"ckks-tigris-estimator"> {
+  let summary = "Estimate resources for the CKKS program on Cornami Tigris chip(s)";
+  let description = [{
+    Estimate resources for the CKKS program on Cornami Tigris chip(s)
+    Particularly provide number of operators in program (CKKS) and FC count, latency of
+    each operator in CKKS; provide a cumulative count of resources used in the CKKS program
+    when they are implemented in Cornami Tigris chip(s).
+  }];
+  let dependentDialects = ["mlir::heir::ckks::CKKSDialect","mlir::heir::mod_arith::ModArithDialect",
+      "mlir::heir::rns::RNSDialect"];
+}
+
+def OpenfheEstimator : Pass<"openfhe-tigris-estimator"> {
+  let summary = "Estimate resources for the Openfhe program on Cornami Tigris chip(s)";
+  let description = [{
+    Estimate resources for the Openfhe program on Cornami Tigris chip(s)
+    Particularly provide number of operators in program (Openfhe) and FC count, latency of
+    each operator in Openfhe; provide a cumulative count of resources used in the Openfhe program
+    when they are implemented in Cornami Tigris chip(s).
+  }];
+  let dependentDialects = ["mlir::heir::openfhe::OpenfheDialect","mlir::heir::mod_arith::ModArithDialect",
+        "mlir::heir::rns::RNSDialect"];
+}
+
+#endif  // LIB_ALL_DIALECT_CORNAMI_SCIFRCKKS_ANALYSIS_PASSES_TD_

--- a/lib/Target/SCIFRBool/BUILD
+++ b/lib/Target/SCIFRBool/BUILD
@@ -1,0 +1,27 @@
+# SCIFRBool Emitter
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "SCIFRBoolEmitter",
+    srcs = ["SCIFRBoolEmitter.cpp"],
+    hdrs = [
+        "SCIFRBoolEmitter.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/SelectVariableNames",
+        "@heir//lib/Dialect/SCIFRBool/IR:Dialect",
+        "@heir//lib/Utils:TargetUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TranslateLib",
+    ],
+)

--- a/lib/Target/SCIFRBool/SCIFRBoolEmitter.cpp
+++ b/lib/Target/SCIFRBool/SCIFRBoolEmitter.cpp
@@ -1,0 +1,536 @@
+#include "lib/Target/SCIFRBool/SCIFRBoolEmitter.h"
+
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/Tools/mlir-translate/Translation.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "SCIFRBoolEmitter.h"
+#include "lib//Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+#include "lib//Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+#include "lib//Dialect/SCIFRBool/IR/SCIFRBoolTypes.h"
+#include "lib/Dialect/CGGI/IR/CGGIDialect.h"
+#include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Utils/TargetUtils.h"
+#include "llvm/include/llvm/Support/FormatVariadic.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"             // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"            // from @llvm-project
+#include "mlir/include/mlir/Tools/mlir-translate/Translation.h"  // from @llvm-project
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+struct TranslateOptions {
+  llvm::cl::opt<std::string> visualization_dir{
+      "scifrbool-visualization-dir",
+      llvm::cl::desc(
+          "set the Cornami SCIFRBool C++ API visualization directory"),
+      llvm::cl::init("/tmp/viz/")};
+};
+
+static llvm::ManagedStatic<TranslateOptions> options;
+
+void registerTranslateOptions() {
+  // Forces initialization of options.
+  *options;
+}
+
+void registerToSCIFRBoolTranslation() {
+  TranslateFromMLIRRegistration reg(
+      "emit-scifrbool",
+      "translate the SCIFRBool dialect to C++ code against the Concrete Engine "
+      "API",
+      [](Operation *op, llvm::raw_ostream &output) {
+        return translateToSCIFRBool(op, output, options->visualization_dir);
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<scifrbool::SCIFRBoolDialect, arith::ArithDialect,
+                        func::FuncDialect, tensor::TensorDialect,
+                        heir::lwe::LWEDialect, heir::cggi::CGGIDialect,
+                        memref::MemRefDialect,
+                        mlir::heir::mod_arith::ModArithDialect>();
+      });
+}
+
+LogicalResult translateToSCIFRBool(Operation *op, llvm::raw_ostream &os,
+                                   std::string vizdir) {
+  SCIFRBoolEmitter emitter(os, vizdir);
+  emitter.autoGenComment();
+  emitter.beginCode();
+  LogicalResult result = emitter.translate(*op);
+  return result;
+}
+
+LogicalResult SCIFRBoolEmitter::translate(Operation &op) {
+  createVariableNames(&op);
+  LogicalResult status =
+      llvm::TypeSwitch<Operation &, LogicalResult>(op)
+          // Builtin ops
+          .Case<ModuleOp>([&](auto op) { return success(); })
+          // Func ops
+          .Case<func::FuncOp, func::ReturnOp>(
+              [&](auto op) { return success(); })
+          // Arith ops
+          .Case<arith::ConstantOp>([&](auto op) { return printOperation(op); })
+          // SCIFRBool ops
+          .Case<AndOp, NandOp, OrOp, NorOp, NotOp, XorOp, XNorOp, SectionOp>(
+              [&](auto op) { return printOperation(op); })
+          .Case<tensor::FromElementsOp, tensor::ExtractOp>(
+              [&](auto op) { return printOperation(op); })
+          // MemRef ops
+          .Case<memref::AllocOp, memref::LoadOp, memref::StoreOp>(
+              [&](auto op) { return printOperation(op); })
+          .Default([&](Operation &) {
+            return op.emitOpError("unable to find printer for op");
+          });
+
+  if (failed(status)) {
+    op.emitOpError(llvm::formatv("Failed to translate op {0}", op.getName()));
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(ModuleOp moduleOp) {
+  for (Operation &op : moduleOp) {
+    if (failed(translate(op))) {
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(func::FuncOp funcOp) {
+  if (failed(canEmitFuncForSCIFRBool(funcOp))) {
+    // Return success implies print nothing, and note the called function
+    // emits a warning.
+    return success();
+  }
+  if (funcOp.getNumResults() != 1) {
+    return funcOp.emitOpError() << "Only functions with a single return type "
+                                   "are supported, but this function has "
+                                << funcOp.getNumResults();
+    return failure();
+  }
+
+  Type result = funcOp.getResultTypes()[0];
+  if (failed(emitType(result))) {
+    return funcOp.emitOpError() << "Failed to emit type " << result;
+  }
+
+  m_os << " " << funcOp.getName() << "(";
+  m_os.indent();
+
+  for (Value arg : funcOp.getArguments()) {
+    if (failed(convertType(arg.getType()))) {
+      return funcOp.emitOpError() << "Failed to emit type " << arg.getType();
+    }
+  }
+
+  m_os << heir::commaSeparatedValues(funcOp.getArguments(), [&](Value value) {
+    return convertType(value.getType()).value() + " " + getNameForValue(value);
+  });
+  m_os.unindent();
+  m_os << ") {\n";
+  m_os.indent();
+
+  for (Value arg : funcOp.getArguments()) {
+    std::string argType = convertType(arg.getType()).value();
+    if (argType == "BootstrapKeyStandard<uint64_t>") {
+      m_os << argType << " bsk = " << getNameForValue(arg) << ";\n";
+    } else if (argType == "KeySwitchKey<uint64_t>") {
+      m_os << argType << " ksk = " << getNameForValue(arg) << ";\n";
+    } else if (argType == "ServerParameters") {
+      m_os << argType << " serverSetup = " << getNameForValue(arg) << ";\n";
+    }
+  }
+  // create concrete engine
+  m_os << "ConcreteEngine<uint64_t>* pEngine = new "
+          "ConcreteEngine<uint64_t>(bsk, ksk, serverSetup);\n"
+       << "ConcreteEngineBoolean<uint64_t> engineBoolean(pEngine, "
+          "BooleanEncodingType::NegativeOneOne);\n"
+       << "pEngine = NULL;\n\n";
+
+  m_argList.clear();
+  for (Value arg : funcOp.getArguments()) {
+    std::string argType = convertType(arg.getType()).value();
+    if (m_scifrTypes.count(argType)) continue;
+    if (llvm::isa<RankedTensorType>(arg.getType())) continue;
+    m_os << "StreamLwe<uint64_t> strm" << m_strmVarCount
+         << " = engineBoolean.newHostToFabricLweStream();\n";
+    m_oprToStrm[getNameForValue(arg)].push_back("strm" +
+                                                std::to_string(m_strmVarCount));
+    m_strmVarCount++;
+    m_argList.push_back(arg);
+  }
+  m_os << "uint nLweSize = bsk.m_bskInfo.lweInfo.nLWESize;\n";
+
+  for (Block &block : funcOp.getBlocks()) {
+    for (Operation &op : block.getOperations()) {
+      if (failed(translate(op))) {
+        return failure();
+      }
+    }
+  }
+  m_os << m_returnStr;
+  m_fromElementsStr.clear();
+  m_returnStr.clear();
+
+  m_os.unindent();
+  m_os << "}\n";
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(func::ReturnOp op) {
+  if (op.getNumOperands() != 1) {
+    op.emitError() << "Only one return value supported";
+    return failure();
+  }
+  m_returnStr = "";
+  std::string returnVar = getNameForValue(op.getOperands()[0]);
+  m_returnStr += m_fromElementsStr;
+  m_returnStr += "engineBoolean.m_engine->profiler_report();\n";
+  m_returnStr += "return " + returnVar + ";\n";
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printSksMethod(::mlir::ValueRange operands,
+                                               ::mlir::Value result,
+                                               std::string_view operationName) {
+  std::string argList = "";
+  for (Value opr : operands) {
+    std::string opName = getNameForValue(opr);
+    createStream(opName);
+    m_isConsumed.insert(m_oprToStrm[opName].back());
+    if (argList != "") argList += ", ";
+    argList += m_oprToStrm[opName].back();
+  }
+  std::string opName = getNameForValue(result);
+  createStream(opName);
+  if (argList != "") argList += ", ";
+  argList += m_oprToStrm[opName].back();
+
+  m_os << "engineBoolean.binaryBooleanConsumeAll(" << argList
+       << ", BinaryBooleanOp::" << operationName << ", 1);\n";
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(NotOp op) {
+  std::string argList = "";
+  std::string inputName = getNameForValue(op.getInput());
+  createStream(inputName);
+  m_isConsumed.insert(m_oprToStrm[inputName].back());
+  if (argList != "") argList += ", ";
+  argList += m_oprToStrm[inputName].back();
+  std::string resultName = getNameForValue(op.getResult());
+  createStream(resultName);
+  if (argList != "") argList += ", ";
+  argList += m_oprToStrm[resultName].back();
+
+  m_os << "engineBoolean.unaryBooleanConsumeAll(" << argList
+       << ", UnaryBooleanOp::Not, 1);\n";
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(AndOp op) {
+  return printSksMethod(op.getOperands(), op.getResult(), "And");
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(NandOp op) {
+  return printSksMethod(op.getOperands(), op.getResult(), "Nand");
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(OrOp op) {
+  return printSksMethod(op.getOperands(), op.getResult(), "Or");
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(NorOp op) {
+  return printSksMethod(op.getOperands(), op.getResult(), "Nor");
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(XorOp op) {
+  return printSksMethod(op.getOperands(), op.getResult(), "Xor");
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(XNorOp op) {
+  return printSksMethod(op.getOperands(), op.getResult(), "Xnor");
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(SectionOp op) {
+  m_os << "// =================== start of section " << m_sectionCount + 1
+       << " ===================\n\n";
+  if (m_sectionCount > 0)
+    m_os << "engineBoolean.m_engine->resetTopology(true);\n";
+  m_os << "engineBoolean.m_engine->SetDefaultDirTopology(\""
+       << m_visualization_dir << m_sectionCount << "\");\n";
+
+  std::string sectionOpResultName = getNameForValue(op.getResult(0));
+  op.walk([&](Operation *opr) {
+    llvm::TypeSwitch<Operation &>(*opr)
+        .Case<scifrbool::AndOp, scifrbool::OrOp, scifrbool::NotOp,
+              scifrbool::NandOp, scifrbool::NorOp, scifrbool::XorOp,
+              scifrbool::XNorOp>([&](auto operation) {
+          if (failed(printOperation(operation))) {
+            op.emitError() << "Creating Section Op failed";
+          }
+          std::string resultName = getNameForValue(operation.getResult());
+          m_oprToStrm[sectionOpResultName].push_back(
+              m_oprToStrm[resultName].back());
+        })
+        .Default([&](Operation &) {
+          // Do nothing
+        });
+  });
+  m_os << "engineBoolean.m_engine->routeToHost("
+       << m_oprToStrm[sectionOpResultName].back() << ");\n";
+  m_os << "engineBoolean.m_engine->finalizeAndRun();\n";
+  for (Value arg : op.getOperands()) {
+    std::string argType = convertType(arg.getType()).value();
+    std::string argName = getNameForValue(arg);
+    if (llvm::isa<RankedTensorType>(arg.getType())) {
+      for (auto extractedVal : m_extractedValues[argName]) {
+        m_os << "engineBoolean.m_engine->put("
+             << m_oprToStrm[extractedVal].back() << ", &" << extractedVal
+             << "[0], nLweSize);\n";
+      }
+    } else {
+      m_os << "engineBoolean.m_engine->put(" << m_oprToStrm[argName].back()
+           << ", &" << argName << "[0], nLweSize);\n";
+    }
+  }
+  m_os << convertType(op.getOperands()[0].getType()).value() << " "
+       << sectionOpResultName << " = std::vector<uint64_t>(nLweSize, 0);\n";
+  m_os << "engineBoolean.m_engine->get("
+       << m_oprToStrm[sectionOpResultName].back() << ", &"
+       << sectionOpResultName << "[0], nLweSize);\n";
+  m_os << "engineBoolean.m_engine->EndRun();\n";
+  m_os << "// =================== end of section " << m_sectionCount + 1
+       << " ===================\n\n";
+  m_sectionCount++;
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(tensor::FromElementsOp op) {
+  m_fromElementsStr = "";
+  std::string resultVar = getNameForValue(op.getResult());
+  m_fromElementsStr +=
+      convertType(op.getResult().getType()).value() + " " + resultVar + " = ";
+  m_fromElementsStr +=
+      "{" +
+      heir::commaSeparatedValues(
+          op.getOperands(),
+          [&](Value value) { return getNameForValue(value); }) +
+      "};\n";
+  return success();
+}
+
+// Produces a SCIFRBoolCiphertext
+LogicalResult SCIFRBoolEmitter::printOperation(tensor::ExtractOp op) {
+  // Assuming the indices to be SSA values (not integer attributes)
+  if (failed(emitTypedAssignPrefix(op.getResult()))) {
+    return failure();
+  }
+  std::string tensorName = getNameForValue(op.getTensor()),
+              resultName = getNameForValue(op.getResult());
+  m_os << tensorName << "["
+       << heir::commaSeparatedValues(
+              op.getIndices(),
+              [&](Value value) { return getNameForValue(value); })
+       << "];\n";
+  m_os << "StreamLwe<uint64_t> strm" << m_strmVarCount
+       << " = engineBoolean.newHostToFabricLweStream();\n";
+  m_oprToStrm[resultName].push_back("strm" + std::to_string(m_strmVarCount));
+  m_strmVarCount++;
+  m_extractedValues[tensorName].push_back(resultName);
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(memref::AllocOp op) {
+  auto memRefType = op.getMemref().getType();
+  if (failed(emitType(memRefType.getElementType()))) {
+    return op.emitOpError() << "Failed to get memref element type";
+  }
+  std::string resultVar = getNameForValue(op.getMemref());
+  m_os << "std::vector<";
+  m_os << "> " << resultVar << ";\n";
+
+  if (memRefType.hasStaticShape()) {
+    int64_t numElements = 1;
+    if (memRefType.hasStaticShape()) {
+      for (int64_t dim : memRefType.getShape()) {
+        numElements *= dim;
+      }
+    }
+    m_os << resultVar << ".resize( " << numElements << ");\n";
+  }
+
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(memref::LoadOp op) {
+  if (isa<BlockArgument>(op.getMemref())) {
+    if (failed(emitTypedAssignPrefix(op.getResult()))) {
+      return failure();
+    }
+    m_os << getNameForValue(op.getMemRef()) << "["
+         << getNameForValue(op.getIndices()[0]) << "];\n";
+  }
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(memref::StoreOp op) {
+  m_os << getNameForValue(op.getMemref());
+  m_os << ".push_back(" << getNameForValue(op.getValueToStore()) << ");\n";
+
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::printOperation(arith::ConstantOp op) {
+  auto valueAttr = op.getValue();
+  if (auto intAttr = dyn_cast<IntegerAttr>(valueAttr)) {
+    if (failed(emitTypedAssignPrefix(op.getResult()))) {
+      return failure();
+    }
+    m_os << intAttr.getValue() << ";\n";
+  } else {
+    return op.emitError() << "Unknown constant type " << valueAttr.getType();
+  }
+  return success();
+}
+
+void SCIFRBoolEmitter::createStream(std::string opName) {
+  if (m_oprToStrm.find(opName) != m_oprToStrm.end()) {
+    // TODO: Check how to create new stream from Consumed input streams
+    if (m_isConsumed.find(m_oprToStrm[opName].back()) !=
+        m_isConsumed.end()) {  // if the stream has been consumed, clone it
+      // m_os << "StreamLwe<uint64_t> strm" << m_strmVarCount
+      //      << " = engineBoolean.cloneStream(" << m_oprToStrm[opName][0] <<
+      //      ");\n";
+      m_os << "StreamLwe<uint64_t> strm" << m_strmVarCount
+           << " = engineBoolean.newLweStream();\n";
+      m_oprToStrm[opName].push_back("strm" + std::to_string(m_strmVarCount));
+    } else {  // No need to create new stream
+      return;
+    }
+  } else {
+    m_os << "StreamLwe<uint64_t> strm" << m_strmVarCount
+         << " = engineBoolean.newLweStream();\n";
+    m_oprToStrm[opName].push_back("strm" + std::to_string(m_strmVarCount));
+  }
+  m_strmVarCount++;
+}
+
+void SCIFRBoolEmitter::autoGenComment() {
+  m_os << R"cpp(/*=================================================================
+//
+//  This file has been Automatically generated by SCIFRBool C++ Emitter
+//
+=================================================================*/
+  )cpp";
+}
+
+void SCIFRBoolEmitter::errorCheck() {
+  m_os << "if (nResult != 0) {\n";
+  m_os.indent();
+  m_os << "return -1;\n";
+  m_os.unindent();
+  m_os << "}\n";
+}
+
+void SCIFRBoolEmitter::beginCode() {
+  m_os << R"cpp(#include <concrete_engine.hpp>
+#include <concrete_engine_boolean.hpp>
+
+                using cornami::fhe::ServerParameters;
+                using cornami::fhe::concrete::BootstrapKeyStandard;
+                using cornami::fhe::concrete::ConcreteEngine;
+                using cornami::fhe::concrete::KeySwitchKey;
+                using cornami::fhe::concrete::StreamLwe;
+
+                using cornami::fhe::concrete::BinaryBooleanOp;
+                using cornami::fhe::concrete::BooleanEncodingType;
+                using cornami::fhe::concrete::ConcreteEngineBoolean;
+                using cornami::fhe::concrete::UnaryBooleanOp;
+
+                using SCIFRBoolCiphertext = std::vector<uint64_t>;
+  )cpp";
+}
+
+FailureOr<std::string> SCIFRBoolEmitter::convertType(Type type) {
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
+    auto elementTy = convertType(shapedType.getElementType());
+    if (failed(elementTy)) return failure();
+
+    return std::string(std::string("std::vector<") + elementTy.value() + ">");
+  }
+  return llvm::TypeSwitch<Type &, FailureOr<std::string>>(type)
+      .Case<IndexType>([&](auto ty) { return std::string("size_t"); })
+      .Case<IntegerType>([&](auto ty) {
+        auto width = ty.getWidth();
+        if (width != 8 && width != 16 && width != 32 && width != 64) {
+          return FailureOr<std::string>();
+        }
+        SmallString<8> result;
+        llvm::raw_svector_ostream os(result);
+        os << "int" << width << "_t";
+        return FailureOr<std::string>(std::string(result));
+      })
+      .Case<RankedTensorType>([&](auto ty) {
+        if (ty.getRank() != 1) {
+          return FailureOr<std::string>();
+        }
+
+        auto eltTyResult = convertType(ty.getElementType());
+        if (failed(eltTyResult)) {
+          return FailureOr<std::string>();
+        }
+
+        SmallString<8> result;
+        llvm::raw_svector_ostream tmp_os(result);
+        tmp_os << "std::vector<" << eltTyResult.value() << ">";
+        return FailureOr<std::string>(std::string(result));
+      })
+      .Case<SCIFRBoolBootstrapKeyType>([&](auto ty) {
+        return std::string("BootstrapKeyStandard<uint64_t>");
+      })
+      .Case<SCIFRBoolKeySwitchKeyType>(
+          [&](auto ty) { return std::string("KeySwitchKey<uint64_t>"); })
+      .Case<SCIFRBoolServerParametersType>(
+          [&](auto ty) { return std::string("ServerParameters"); })
+      .Default([&](Type &) { return failure(); });
+}
+
+LogicalResult SCIFRBoolEmitter::emitType(Type type) {
+  auto result = convertType(type);
+  if (failed(result)) {
+    return failure();
+  }
+  m_os << result;
+  return success();
+}
+
+LogicalResult SCIFRBoolEmitter::emitTypedAssignPrefix(Value result) {
+  if (failed(emitType(result.getType()))) {
+    return failure();
+  }
+  m_os << " " << getNameForValue(result) << " = ";
+  return success();
+}
+
+SCIFRBoolEmitter::SCIFRBoolEmitter(raw_ostream &os, std::string vizdir)
+    : m_visualization_dir(vizdir), m_os(os) {}
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir

--- a/lib/Target/SCIFRBool/SCIFRBoolEmitter.h
+++ b/lib/Target/SCIFRBool/SCIFRBoolEmitter.h
@@ -1,0 +1,152 @@
+#ifndef SCIFRBOOL_TARGET_SCIFRBOOLEMITTER_H
+#define SCIFRBOOL_TARGET_SCIFRBOOLEMITTER_H
+
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolTypes.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"              // from @llvm-project
+#include "llvm/include/llvm/Support/ManagedStatic.h"     // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/IndentedOstream.h"   // from @llvm-project
+
+namespace mlir {
+namespace cornami {
+namespace scifrbool {
+
+void registerToSCIFRBoolTranslation();
+void registerTranslateOptions();
+
+// Translates the given operation to SCIFRBool.
+::mlir::LogicalResult translateToSCIFRBool(::mlir::Operation *op,
+                                           llvm::raw_ostream &os,
+                                           std::string vizdir);
+
+class SCIFRBoolEmitter {
+ public:
+  SCIFRBoolEmitter(raw_ostream &os, std::string vizdir);
+  LogicalResult translate(Operation &operation);
+  void autoGenComment();
+  void beginCode();
+
+ private:
+  // Output stream to emit to.
+  std::string m_visualization_dir;
+  raw_indented_ostream m_os;
+  llvm::DenseMap<Value, int> m_variableNames;
+  int m_variableCount = 0;
+  int m_sectionCount = 0;
+  std::string m_prefix{"v"};
+  uint32_t m_strmVarCount = 0;
+  std::unordered_map<std::string, std::vector<std::string>> m_oprToStrm;
+  std::unordered_set<std::string> m_isConsumed;
+  std::vector<Value> m_argList;
+  std::string m_returnStr, m_fromElementsStr;
+  std::unordered_set<std::string> m_scifrTypes = {
+      "BootstrapKeyStandard<uint64_t>", "KeySwitchKey<uint64_t>",
+      "ServerParameters"};
+  std::unordered_map<std::string, std::vector<std::string>> m_extractedValues;
+
+  // Functions for printing individual ops
+  LogicalResult printOperation(::mlir::ModuleOp op);
+  LogicalResult printOperation(::mlir::func::FuncOp op);
+  LogicalResult printOperation(::mlir::func::ReturnOp op);
+  LogicalResult printOperation(AndOp op);
+  LogicalResult printOperation(NandOp op);
+  LogicalResult printOperation(OrOp op);
+  LogicalResult printOperation(NorOp op);
+  LogicalResult printOperation(NotOp op);
+  LogicalResult printOperation(XorOp op);
+  LogicalResult printOperation(XNorOp op);
+  LogicalResult printOperation(SectionOp op);
+  LogicalResult printOperation(tensor::FromElementsOp op);
+  LogicalResult printOperation(tensor::ExtractOp op);
+  LogicalResult printOperation(::mlir::arith::ConstantOp op);
+  LogicalResult printOperation(memref::AllocOp op);
+  LogicalResult printOperation(memref::LoadOp op);
+  LogicalResult printOperation(memref::StoreOp op);
+
+  // Helpers for above
+  LogicalResult printSksMethod(::mlir::ValueRange operands,
+                               ::mlir::Value result,
+                               std::string_view operationName);
+
+  // Emit a SCIFRBool type
+  LogicalResult emitType(Type type);
+  LogicalResult emitTypedAssignPrefix(Value result);
+  FailureOr<std::string> convertType(Type type);
+
+  void createStream(std::string opName);
+
+  void createVariableNames(Operation *op) {
+    op->walk<WalkOrder::PreOrder>([&](Operation *opr) {
+      for (Value oprnd : opr->getOperands()) {
+        m_variableNames.try_emplace(oprnd, m_variableCount++);
+      }
+      for (Value result : opr->getResults()) {
+        m_variableNames.try_emplace(result, m_variableCount++);
+      }
+      for (Region &region : opr->getRegions()) {
+        for (Block &block : region) {
+          for (Value arg : block.getArguments()) {
+            m_variableNames.try_emplace(arg, m_variableCount++);
+          }
+        }
+      }
+    });
+  }
+
+  // Return the name assigned to the given value
+  std::string getNameForValue(Value value) const {
+    assert(m_variableNames.contains(value));
+    return m_prefix + std::to_string(m_variableNames.lookup(value));
+  }
+
+  // Return the unique integer assigned to a given value.
+  int getIntForValue(Value value) const {
+    assert(m_variableNames.contains(value));
+    return m_variableNames.lookup(value);
+  }
+
+  void errorCheck();
+
+  LogicalResult canEmitFuncForSCIFRBool(func::FuncOp &funcOp) {
+    WalkResult failIfInterrupted = funcOp.walk([&](Operation *op) {
+      return TypeSwitch<Operation *, WalkResult>(op)
+          .Case<ModuleOp, func::FuncOp, func::ReturnOp, arith::ConstantOp,
+                tensor::ExtractOp, tensor::FromElementsOp, memref::AllocOp,
+                memref::LoadOp, memref::StoreOp, AndOp, NandOp, OrOp, NorOp,
+                NotOp, XorOp, XNorOp, SectionOp>(
+              [&](auto op) { return WalkResult::advance(); })
+          .Default([&](Operation *op) {
+            llvm::errs()
+                << "// Skipping function " << funcOp.getName()
+                << " which cannot be emitted because it has an unsupported op: "
+                << *op << "\n";
+            return WalkResult::interrupt();
+          });
+    });
+
+    if (failIfInterrupted.wasInterrupted()) return failure();
+    return success();
+  }
+};
+
+}  // namespace scifrbool
+}  // namespace cornami
+}  // namespace mlir
+
+#endif /* SCIFRBOOL_TARGET_SCIFRBOOLEMITTER_H */

--- a/scripts/cornami/README_cornami.md
+++ b/scripts/cornami/README_cornami.md
@@ -1,0 +1,33 @@
+# Cornami FHE Compiler
+
+Cornami FHE Compiler is setup as a exit dialect and codegen from one of
+**CGGI**, **TfheRustBool**, **Combinational** from **HEIR** project.
+
+We plan to do this using a custom dialect **SCIFRBool** for boolean operations
+first, then another dialect **SCIFR** for compiling **CKKS** based real number
+dialects.
+
+The Cornami backend focused tools are available by default.
+
+# heir-opt
+
+## Estimations
+
+1. --cggi-tigris-estimator - Estimate resources for the CGGI program on Cornami
+   Tigris chip(s)
+1. --ckks-tigris-estimator - Estimate resources for the CKKS program on Cornami
+   Tigris chip(s)
+
+## Conversions
+
+1. ```
+    --cggi-to-scifrbool                              -   Lower `cggi` to `scifrbool` dialect.
+   ```
+
+# heir-translate
+
+## Codegen
+
+1. --emit-scifrbool option
+
+<!-- mdformat global-off -->

--- a/tests/Dialect/SCIFRBool/Transforms/BUILD
+++ b/tests/Dialect/SCIFRBool/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/SCIFRBool/Transforms/and_gate.mlir
+++ b/tests/Dialect/SCIFRBool/Transforms/and_gate.mlir
@@ -1,0 +1,39 @@
+// RUN: heir-opt --canonicalize --cggi-to-scifrbool | heir-translate --emit-scifrbool --scifrbool-visualization-dir=/tmp/scifrbool/
+// RUN: heir-opt --canonicalize %s --cggi-tigris-estimator
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**1024>>
+
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 :
+i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>
+
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L0_D10_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb, size = 10>
+
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+!ct_ty = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!sk = !lwe.lwe_secret_key<key = #key, ring = #ring_rns_L0_1_x1024_>
+
+func.func @require_post_pass_toposort_lut3(%arg0: tensor<8x!ct_ty>) -> !ct_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+
+  %r1 = cggi.and %0, %1 : !ct_ty
+  %r2 = cggi.and %r1, %1 : !ct_ty
+  %r3 = cggi.and %r2, %0 : !ct_ty
+  %r4 = cggi.and %r1, %r2 : !ct_ty
+  return %r4 : !ct_ty
+}

--- a/tests/Dialect/SCIFRBool/Transforms/convert_and_gate.mlir
+++ b/tests/Dialect/SCIFRBool/Transforms/convert_and_gate.mlir
@@ -1,0 +1,50 @@
+// RUN: heir-opt --canonicalize --cggi-to-scifrbool %s | FileCheck %s
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**1024>>
+
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 :
+i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>
+
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L0_D10_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb, size = 10>
+
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+!ct_ty = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!sk = !lwe.lwe_secret_key<key = #key, ring = #ring_rns_L0_1_x1024_>
+
+//CHECK: module {
+module {
+
+func.func @require_post_pass_toposort_lut3(%arg0: tensor<8x!ct_ty>) -> !ct_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+
+  // CHECK-NOT: cggi.and
+  // CHECK: scifrbool.and
+  %r1 = cggi.and %0, %1 : !ct_ty
+  // CHECK-NOT: cggi.and
+  // CHECK: scifrbool.and
+  %r2 = cggi.and %r1, %1 : !ct_ty
+  // CHECK-NOT: cggi.and
+  // CHECK: [[result:.*]] = scifrbool.and
+  %r3 = cggi.and %r2, %0 : !ct_ty
+
+  // CHECK: [[result:.*]]
+  return %r3 : !ct_ty
+}
+//CHECK: }
+}

--- a/tests/Dialect/SCIFRBool/Transforms/lut_canonicalize.mlir
+++ b/tests/Dialect/SCIFRBool/Transforms/lut_canonicalize.mlir
@@ -1,0 +1,53 @@
+// RUN: heir-opt --canonicalize %s --cggi-tigris-estimator
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**1024>>
+
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 :
+i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>
+
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L0_D10_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb, size = 10>
+
+!pt_ty = !lwe.lwe_plaintext< plaintext_space = #plaintext_space>
+!ct_ty = !lwe.lwe_ciphertext< plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!sk = !lwe.lwe_secret_key<key = #key, ring = #ring_rns_L0_1_x1024_>
+
+func.func @require_post_pass_toposort_lut3(%arg0: tensor<8x!ct_ty>) -> !ct_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+  %2 = tensor.extract %arg0[%c2] : tensor<8x!ct_ty>
+
+  // CHECK: cggi.lut_lincomb %extracted, %extracted_0, %extracted_1 {coefficients = array<i32: 1, 2, 4>, lookup_table = 8 : ui8}
+  %r1 = cggi.lut3 %0, %1, %2 {lookup_table = 8 : ui8} : !ct_ty
+
+  return %r1 : !ct_ty
+}
+
+func.func @require_post_pass_toposort_lut2(%arg0: tensor<8x!ct_ty>) -> !ct_ty {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+
+  %0 = tensor.extract %arg0[%c0] : tensor<8x!ct_ty>
+  %1 = tensor.extract %arg0[%c1] : tensor<8x!ct_ty>
+  %2 = tensor.extract %arg0[%c2] : tensor<8x!ct_ty>
+
+  // CHECK: cggi.lut_lincomb %extracted, %extracted_0 {coefficients = array<i32: 1, 2>, lookup_table = 8 : ui8}
+  %r1 = cggi.lut2 %0, %1 {lookup_table = 8 : ui8} : !ct_ty
+
+  return %r1 : !ct_ty
+}

--- a/tests/Dialect/SCIFRBool/Transforms/scifr_and.mlir
+++ b/tests/Dialect/SCIFRBool/Transforms/scifr_and.mlir
@@ -1,0 +1,23 @@
+//RUN: heir-opt --cggi-to-scifrbool %s
+!Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64 = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C0 = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+!rns_L0 = !rns.rns<!Z1095233372161_i64>
+#ring_Z65537_i64_1_x1024 = #polynomial.ring<coefficientType = !Z65537_i64, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024 = #polynomial.ring<coefficientType = !rns_L0, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L0 = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024, encryption_type = lsb>
+!ct_L0 = !lwe.lwe_ciphertext< plaintext_space = <ring = #ring_Z65537_i64_1_x1024, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L0, key = #key, modulus_chain = #modulus_chain_L5_C0>
+module {
+  func.func @require_post_pass_toposort_lut3(%arg0: !scifrbool.bootstrap_key, %arg1: !scifrbool.key_switch_key, %arg2: !scifrbool.server_parameters, %arg3: tensor<8x!ct_L0>) -> !ct_L0 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %extracted = tensor.extract %arg3[%c0] : tensor<8x!ct_L0>
+    %extracted_0 = tensor.extract %arg3[%c1] : tensor<8x!ct_L0>
+    %ct = scifrbool.and %extracted, %extracted_0 : !ct_L0
+    %ct_1 = scifrbool.and %ct, %extracted_0 : !ct_L0
+    %ct_2 = scifrbool.and %ct, %ct_1 : !ct_L0
+    return %ct_2 : !ct_L0
+  }
+}

--- a/tests/Dialect/SCIFRBool/Transforms/scifr_sectionop.mlir
+++ b/tests/Dialect/SCIFRBool/Transforms/scifr_sectionop.mlir
@@ -1,0 +1,23 @@
+//RUN: heir-opt --cggi-to-scifrbool --replace-op-with-section %s
+!Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64 = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C0 = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+!rns_L0 = !rns.rns<!Z1095233372161_i64>
+#ring_Z65537_i64_1_x1024 = #polynomial.ring<coefficientType = !Z65537_i64, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024 = #polynomial.ring<coefficientType = !rns_L0, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L0 = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024, encryption_type = lsb>
+!ct_L0 = !lwe.lwe_ciphertext< plaintext_space = <ring = #ring_Z65537_i64_1_x1024, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L0, key = #key, modulus_chain = #modulus_chain_L5_C0>
+module {
+  func.func @require_post_pass_toposort_lut3(%arg0: !scifrbool.bootstrap_key, %arg1: !scifrbool.key_switch_key, %arg2: !scifrbool.server_parameters, %arg3: tensor<8x!ct_L0>) -> !ct_L0 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %extracted = tensor.extract %arg3[%c0] : tensor<8x!ct_L0>
+    %extracted_0 = tensor.extract %arg3[%c1] : tensor<8x!ct_L0>
+    %ct = scifrbool.and %extracted, %extracted_0 : !ct_L0
+    %ct_1 = scifrbool.and %ct, %extracted_0 : !ct_L0
+    %ct_2 = scifrbool.and %ct, %ct_1 : !ct_L0
+    return %ct_2 : !ct_L0
+  }
+}

--- a/tests/Dialect/SCIFRCkks/Transforms/BUILD
+++ b/tests/Dialect/SCIFRCkks/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/SCIFRCkks/Transforms/ckksops.mlir
+++ b/tests/Dialect/SCIFRCkks/Transforms/ckksops.mlir
@@ -1,0 +1,57 @@
+// RUN: heir-opt --ckks-tigris-estimator %s
+
+// This simply tests for syntax.
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L0_1_x1024_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+
+#modulus_chain_L5_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 0>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x1024_, encoding = #inverse_canonical_encoding>
+
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+#ciphertext_space_L1_D3_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb, size = 3>
+
+!ct = !lwe.lwe_ciphertext< plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!ct1 = !lwe.lwe_ciphertext< plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_D3_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!ct2 = !lwe.lwe_ciphertext< plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+
+!ct_tensor = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!ct_scalar = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+// CHECK: module
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [36028797019389953, 35184372121601, 35184372744193, 35184373006337, 35184373989377, 35184374874113], P = [36028797019488257, 36028797020209153], logDefaultScale = 45>} {
+  // CHECK: @test_multiply
+  func.func @test_multiply(%arg0 : !ct, %arg1: !ct) -> !ct {
+    %add = ckks.add %arg0, %arg1 : (!ct, !ct) -> !ct
+    %sub = ckks.sub %arg0, %arg1 : (!ct, !ct) -> !ct
+    %neg = ckks.negate %arg0 : !ct
+
+    return %neg : !ct
+  }
+
+  // CHECK: @test_ciphertext_plaintext
+  func.func @test_ciphertext_plaintext(%arg0: !pt, %arg1: !pt, %arg2: !pt, %arg3: !ct) -> !ct {
+    %add = ckks.add_plain %arg3, %arg0 : (!ct, !pt) -> !ct
+    %sub = ckks.sub_plain %add, %arg1 : (!ct, !pt) -> !ct
+    %mul = ckks.mul_plain %sub, %arg2 : (!ct, !pt) -> !ct
+    // CHECK: ring = <coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>, !mod_arith.int<1032955396097 : i64>>, polynomialModulus = <1 + x**1024>>
+    return %mul : !ct
+  }
+
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -35,7 +35,12 @@ cc_binary(
         "//conditions:default": ["HEIR_NO_YOSYS=1"],
     }),
     includes = ["include"],
-    deps = [
+    deps = select({
+        "@heir//:config_enable_yosys": [
+            "@heir//lib/Transforms/YosysOptimizer",
+        ],
+        "//conditions:default": [],
+    }) + [
         "@heir//lib/Analysis/NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseAnalysis",  # buildcleaner: keep
@@ -46,6 +51,7 @@ cc_binary(
         "@heir//lib/Dialect/BGV/Conversions/BGVToLWE",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/CGGI/Conversions/CGGIToJaxite",
+        "@heir//lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool",
         "@heir//lib/Dialect/CGGI/Conversions/CGGIToTfheRust",
         "@heir//lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool",
         "@heir//lib/Dialect/CGGI/IR:Dialect",
@@ -84,6 +90,13 @@ cc_binary(
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:RNSTypeInterfaces",
         "@heir//lib/Dialect/Random/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/IR:Dialect",
+        "@heir//lib/Dialect/SCIFRBool/Transforms:CGGIEstimator",
+        "@heir//lib/Dialect/SCIFRBool/Transforms:EstimationAnalysis",
+        "@heir//lib/Dialect/SCIFRBool/Transforms:ReplaceOpWithSection",
+        "@heir//lib/Dialect/SCIFRCkks/Transforms",
+        "@heir//lib/Dialect/SCIFRCkks/Transforms:CKKSEstimator",
+        "@heir//lib/Dialect/SCIFRCkks/Transforms:OpenfheEstimator",
         "@heir//lib/Dialect/Secret/Conversions/SecretToBGV",
         "@heir//lib/Dialect/Secret/Conversions/SecretToCGGI",
         "@heir//lib/Dialect/Secret/Conversions/SecretToCKKS",
@@ -104,6 +117,7 @@ cc_binary(
         "@heir//lib/Pipelines:ArithmeticPipelineRegistration",
         "@heir//lib/Pipelines:BooleanPipelineRegistration",
         "@heir//lib/Pipelines:PipelineRegistration",
+        "@heir//lib/Target/SCIFRBool:SCIFRBoolEmitter",
         "@heir//lib/Transforms/ActivationCanonicalizations",
         "@heir//lib/Transforms/AddClientInterface",
         "@heir//lib/Transforms/AnnotateModule",
@@ -200,12 +214,7 @@ cc_binary(
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:UBToLLVM",
         "@llvm-project//mlir:VectorToLLVM",
-    ] + select({
-        "@heir//:config_enable_yosys": [
-            "@heir//lib/Transforms/YosysOptimizer",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
 # Custom `mlir-translate` replacement that adds our custom translations
@@ -220,6 +229,7 @@ cc_binary(
         "@heir//lib/Target/Lattigo:LattigoEmitter",
         "@heir//lib/Target/Metadata:MetadataEmitter",
         "@heir//lib/Target/OpenFhePke:OpenFheRegistration",
+        "@heir//lib/Target/SCIFRBool:SCIFRBoolEmitter",
         "@heir//lib/Target/SimFHE:SimFHEEmitter",
         "@heir//lib/Target/TfheRust:TfheRustEmitter",
         "@heir//lib/Target/TfheRustBool:TfheRustBoolEmitter",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -9,6 +9,7 @@
 #include "lib/Dialect/BGV/Conversions/BGVToLWE/BGVToLWE.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/CGGI/Conversions/CGGIToJaxite/CGGIToJaxite.h"
+#include "lib/Dialect/CGGI/Conversions/CGGIToSCIFRBool/CGGIToSCIFRBool.h"
 #include "lib/Dialect/CGGI/Conversions/CGGIToTfheRust/CGGIToTfheRust.h"
 #include "lib/Dialect/CGGI/Conversions/CGGIToTfheRustBool/CGGIToTfheRustBool.h"
 #include "lib/Dialect/CGGI/IR/CGGIDialect.h"
@@ -43,6 +44,11 @@
 #include "lib/Dialect/RNS/IR/RNSDialect.h"
 #include "lib/Dialect/RNS/IR/RNSTypeInterfaces.h"
 #include "lib/Dialect/Random/IR/RandomDialect.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolDialect.h"
+#include "lib/Dialect/SCIFRBool/IR/SCIFRBoolOps.h"
+#include "lib/Dialect/SCIFRBool/Transforms/Passes.h"
+#include "lib/Dialect/SCIFRBool/Transforms/ReplaceOpWithSection.h"
+#include "lib/Dialect/SCIFRCkks/Transforms/Passes.h"
 #include "lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.h"
 #include "lib/Dialect/Secret/Conversions/SecretToCGGI/SecretToCGGI.h"
 #include "lib/Dialect/Secret/Conversions/SecretToCKKS/SecretToCKKS.h"
@@ -58,6 +64,7 @@
 #include "lib/Pipelines/ArithmeticPipelineRegistration.h"
 #include "lib/Pipelines/BooleanPipelineRegistration.h"
 #include "lib/Pipelines/PipelineRegistration.h"
+#include "lib/Target/SCIFRBool/SCIFRBoolEmitter.h"
 #include "lib/Transforms/ActivationCanonicalizations/ActivationCanonicalizations.h"
 #include "lib/Transforms/AddClientInterface/AddClientInterface.h"
 #include "lib/Transforms/AnnotateModule/AnnotateModule.h"
@@ -379,6 +386,16 @@ int main(int argc, char** argv) {
   registerSecretToCGGIPasses();
   registerSecretToCKKSPasses();
   tensor_ext::registerTensorExtToTensorPasses();
+
+  registry.insert<mlir::cornami::scifrbool::SCIFRBoolDialect>();
+  // Register the custom pass to estimate CGGI ops for Cornami MX2
+  mlir::cornami::scifrbool::registerTranslateOptions();
+  mlir::cornami::scifrbool::registerCGGIEstimatorPass();
+  mlir::cornami::registerCKKSEstimatorPass();
+  mlir::cornami::registerOpenfheEstimatorPass();
+  mlir::cornami::scifrbool::registerToSCIFRBoolTranslation();
+  mlir::cornami::scifrbool::registerCGGIToSCIFRBoolPass();
+  mlir::cornami::scifrbool::registerReplaceOpWithSectionPass();
 
   // This comement registers internal passes
 

--- a/tools/heir-translate.cpp
+++ b/tools/heir-translate.cpp
@@ -5,6 +5,7 @@
 #include "lib/Target/Metadata/MetadataEmitter.h"
 #include "lib/Target/OpenFhePke/OpenFheTranslateRegistration.h"
 // This comment includes internal emitters
+#include "lib/Target/SCIFRBool/SCIFRBoolEmitter.h"
 #include "lib/Target/SimFHE/SimFHEEmitter.h"
 #include "lib/Target/TfheRust/TfheRustEmitter.h"
 #include "lib/Target/TfheRustBool/TfheRustBoolEmitter.h"
@@ -44,6 +45,10 @@ int main(int argc, char** argv) {
   mlir::heir::lattigo::registerToLattigoPreprocessingTranslation();
   mlir::heir::lattigo::registerToLattigoPreprocessedTranslation();
   mlir::heir::lattigo::registerTranslateOptions();
+
+  // SCIFRBool
+  mlir::cornami::scifrbool::registerTranslateOptions();
+  mlir::cornami::scifrbool::registerToSCIFRBoolTranslation();
 
   // This comment inserts internal emitters
 


### PR DESCRIPTION
Cornami MX2 systolic array backend for TFHE and CKKS schemes lowering  into SCIFR Bool/Ckks dialects

- map the said dialect into SCIFR Concrete and SCIFR Liberate topologies suitable for hardware

cornami backend: move tests into common area

move scifr-opt and scifr-translate into the parent HEIR tools to avoid rebuild etc.

- update heir-translate to include HEIR_BACKEND_CORNAMI and Target SCIFRBoolEmitter

Cornami: HEIR dialect SCIFRBool emitter and optimizer merged into heir-opt or heir-translate
```bash
$ bazelisk test //tests/Dialect/SCIFRBool/... //tests/Dialect/SCIFRCkks/...
```