### PR TITLE
Update op creation style

### DIFF
--- a/lib/Dialect/Secret/Conversions/SecretToCGGI/SecretToCGGI.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToCGGI/SecretToCGGI.cpp
@@ -165,8 +165,8 @@ Operation* convertWriteOpInterface(
         SmallVector<OpFoldResult> strides(rank, oneIdxAttr);
         SmallVector<OpFoldResult> sizes(rank - 1, oneIdxAttr);
         sizes.push_back(rewriter.getIndexAttr(toTensorTy.getShape()[rank - 1]));
-        return b.create<tensor::InsertSliceOp>(valueToStore, toTensor, offsets,
-                                               sizes, strides);
+        return tensor::InsertSliceOp::create(b, valueToStore, toTensor, offsets,
+                                             sizes, strides);
       });
   llvm_unreachable("expected integer or tensor to store in ciphertext tensor");
 }
@@ -195,8 +195,8 @@ Operation* convertReadOpInterface(
   SmallVector<OpFoldResult> sizes(rank - 1, oneIdxAttr);
   sizes.push_back(rewriter.getIndexAttr(fromTensorType.getShape()[rank - 1]));
 
-  return b.create<tensor::ExtractSliceOp>(outputTy, fromTensor, offsets, sizes,
-                                          strides);
+  return tensor::ExtractSliceOp::create(b, outputTy, fromTensor, offsets, sizes,
+                                        strides);
 }
 
 SmallVector<Value> encodeInputs(
@@ -227,12 +227,11 @@ SmallVector<Value> encodeInputs(
       IntegerType integerTy = dyn_cast<IntegerType>(input.getType());
       assert(integerTy && integerTy.getWidth() == 1 &&
              "LUT inputs should be single-bit integers");
-      return rewriter
-          .create<lwe::TrivialEncryptOp>(
-              op->getLoc(), ctxtTy,
-              lwe::EncodeOp::create(rewriter, op->getLoc(), ptxtTy, input,
-                                    plaintextBits, overflow),
-              ciphertextBits)
+      return lwe::TrivialEncryptOp::create(
+                 rewriter, op->getLoc(), ctxtTy,
+                 lwe::EncodeOp::create(rewriter, op->getLoc(), ptxtTy, input,
+                                       plaintextBits, overflow),
+                 ciphertextBits)
           .getResult();
     }
     return input;

--- a/lib/Kernel/IRMaterializingVisitor.cpp
+++ b/lib/Kernel/IRMaterializingVisitor.cpp
@@ -92,16 +92,16 @@ Value IRMaterializingVisitor::operator()(const MultiplyNode<SSAValue>& node) {
 
 Value IRMaterializingVisitor::operator()(const LeftRotateNode<SSAValue>& node) {
   Value operand = this->process(node.operand);
-  Value shift = builder.create<arith::ConstantIndexOp>(node.shift);
+  Value shift = arith::ConstantIndexOp::create(builder, node.shift);
   auto rotateOp =
-      builder.create<tensor_ext::RotateOp>(evaluatedType, operand, shift);
+      tensor_ext::RotateOp::create(builder, evaluatedType, operand, shift);
   createdOpCallback(rotateOp);
   return rotateOp;
 }
 
 Value IRMaterializingVisitor::operator()(const ExtractNode<SSAValue>& node) {
   Value operand = this->process(node.operand);
-  Value index = builder.create<arith::ConstantIndexOp>(node.index);
+  Value index = arith::ConstantIndexOp::create(builder, node.index);
 
   RankedTensorType tensorType = cast<RankedTensorType>(operand.getType());
 
@@ -122,8 +122,8 @@ Value IRMaterializingVisitor::operator()(const ExtractNode<SSAValue>& node) {
                                     builder.getIndexAttr(1));
 
   if (auto tensorTy = dyn_cast<RankedTensorType>(evaluatedType)) {
-    auto extractOp = builder.create<tensor::ExtractSliceOp>(
-        tensorTy, operand, offsets, sizes, strides);
+    auto extractOp = tensor::ExtractSliceOp::create(builder, tensorTy, operand,
+                                                    offsets, sizes, strides);
     createdOpCallback(extractOp);
     return extractOp;
   }
@@ -131,7 +131,7 @@ Value IRMaterializingVisitor::operator()(const ExtractNode<SSAValue>& node) {
   // Otherwise let the type be inferred, though this will likely result in an
   // issue because the row index is preserved in the result type
   auto extractOp =
-      builder.create<tensor::ExtractSliceOp>(operand, offsets, sizes, strides);
+      tensor::ExtractSliceOp::create(builder, operand, offsets, sizes, strides);
   createdOpCallback(extractOp);
   return extractOp;
 }

--- a/lib/Transforms/FoldConstantTensors/FoldConstantTensors.cpp
+++ b/lib/Transforms/FoldConstantTensors/FoldConstantTensors.cpp
@@ -174,8 +174,8 @@ class InsertIntoFromElements final : public OpRewritePattern<tensor::InsertOp> {
 
     rewriter.replaceAllUsesWith(
         opsToErase.back()->getResult(0),
-        rewriter
-            .create<tensor::FromElementsOp>(insertOp.getLoc(), destType, values)
+        tensor::FromElementsOp::create(rewriter, insertOp.getLoc(), destType,
+                                       values)
             .getResult());
     for (auto op : llvm::reverse(opsToErase)) {
       op->erase();

--- a/lib/Utils/ConversionUtils.h
+++ b/lib/Utils/ConversionUtils.h
@@ -78,8 +78,8 @@ struct ConvertBinOp : public OpConversionPattern<SourceOpTy> {
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto result = b.create<TargetOpTy>(adaptor.getLhs().getType(),
-                                       adaptor.getLhs(), adaptor.getRhs());
+    auto result = TargetOpTy::create(b, adaptor.getLhs().getType(),
+                                     adaptor.getLhs(), adaptor.getRhs());
     rewriter.replaceOp(op, result);
     return success();
   }


### PR DESCRIPTION
This PR updates a few op-creation commands from using the deprecated style (`b.create<FooOp>(...)`) to the preferred style (`FooOp::create(b, ...)`). This fixes compile-time warnings generated directly by HEIR code. (There are still numerous warnings generated by third-party code and by tablegen'erated code, but I haven't figured out how to reliably suppress them).