### PR TITLE
Silence most external and auto-generated code warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,10 @@ build --action_env=CXX=clang++
 build --host_action_env=CC=clang
 build --host_action_env=CXX=clang++
 
+# Only show warnings for targets defined in HEIR code.
+# Warnings for external repos and generated code is (mostly) hidden; see #2616
+build --output_filter="^//(benchmark|frontend|lib|tests|tools)/"
+
 # linux-specific options
 build:linux --linkopt="-fuse-ld=lld"
 


### PR DESCRIPTION
The build log for #2612 generated 5606 lines of output, the vast majority of which is warnings in external project code or auto-generated code. This PR attempts to dramatically reduce those bogus warnings.

The following warnings are still generated by the build:
- The Rust tests generate some code that triggers warnings; this PR does not address them.
- MLIR warnings; see #2620
- Two warnings on tablegen'erated code in the tests/ directory:
    ```
    INFO: From Compiling tests/Examples/openfhe/ckks/convolution/convolution_test_lib.inc.cc:
    bazel-out/k8-opt/bin/tests/Examples/openfhe/ckks/convolution/convolution_test_lib.inc.cc:444:9: warning: explicitly assigning value of variable of type 'std::vector<CiphertextT>' (aka 'vector<shared_ptr<CiphertextImpl<DCRTPolyImpl<BigVectorFixedT<BigIntegerFixedT<unsigned int, 3500>>>>>>') to itself [-Wself-assign-overloaded]
  444 |     v54 = v54;
        |     ~~~ ^ ~~~
    1 warning generated.
    INFO: From Compiling tests/Examples/openfhe/ckks/convolution/convolution_test_lib.inc.cc:
    bazel-out/k8-opt/bin/tests/Examples/openfhe/ckks/convolution/convolution_test_lib.inc.cc:444:9: warning: explicitly assigning value of variable of type 'std::vector<CiphertextT>' (aka 'vector<shared_ptr<CiphertextImpl<DCRTPolyImpl<BigVectorFixedT<BigIntegerFixedT<unsigned int, 3500>>>>>>') to itself [-Wself-assign-overloaded]
  444 |     v54 = v54;
        |     ~~~ ^ ~~~
    1 warning generated.
    ```
Overall, this is a massive reduction in the number of emitted warnings. The build log went from 5606 lines to ~700 (though Github can't count? 678, 679, 3315, 3316, ...).