### PR TITLE
Workaround for #2591

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,3 +54,7 @@ build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
 
 try-import %workspace%/fuzztest.bazelrc
+
+# Workaround for #2591
+test --strategy=TestRunner=sandboxed
+test --sandbox_tmpfs_path=/dev/shm


### PR DESCRIPTION
This PR is a workaround for #2591. It does not address the root cause, which I was unable to identify, but it does appear to prevent test failures due to OMP collisions.