### PR TITLE
Add extended basis rotation passes for OpenFHE (ConvertToExtendedBasis + HoistKeySwitchDown)

### DIFF
--- a/lib/Dialect/Openfhe/IR/OpenfheOps.cpp
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.cpp
@@ -164,6 +164,13 @@ FailureOr<Operation*> FastRotationExtOp::buildBatchedOperation(
                                        batchedOperations);
 }
 
+// Idempotency fold: key_switch_down(key_switch_down(x)) => key_switch_down(x).
+OpFoldResult KeySwitchDownOp::fold(FoldAdaptor adaptor) {
+  if (auto inner = getCiphertext().getDefiningOp<KeySwitchDownOp>())
+    return inner.getResult();
+  return {};
+}
+
 LogicalResult RotOp::verify() {
   return containsExactlyOneOrEmitError(getOperation(), getDynamicShift(),
                                        getStaticShift());

--- a/lib/Dialect/Openfhe/IR/OpenfheOps.td
+++ b/lib/Dialect/Openfhe/IR/OpenfheOps.td
@@ -447,6 +447,7 @@ def KeySwitchDownOp : Openfhe_Op<"key_switch_down", [Pure,
     Openfhe_Ciphertext:$ciphertext
   );
   let results = (outs Openfhe_Ciphertext:$output);
+  let hasFolder = 1;
 }
 
 // No in-place bootstrap variant

--- a/lib/Dialect/Openfhe/Transforms/BUILD
+++ b/lib/Dialect/Openfhe/Transforms/BUILD
@@ -14,8 +14,10 @@ cc_library(
     deps = [
         ":AllocToInPlace",
         ":ConfigureCryptoContext",
+        ":ConvertToExtendedBasis",
         ":CountAddAndKeySwitch",
         ":FastRotationPrecompute",
+        ":HoistKeySwitchDown",
         ":pass_inc_gen",
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
     ],
@@ -102,6 +104,38 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "ConvertToExtendedBasis",
+    srcs = ["ConvertToExtendedBasis.cpp"],
+    hdrs = [
+        "ConvertToExtendedBasis.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+cc_library(
+    name = "HoistKeySwitchDown",
+    srcs = ["HoistKeySwitchDown.cpp"],
+    hdrs = [
+        "HoistKeySwitchDown.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )
 

--- a/lib/Dialect/Openfhe/Transforms/ConvertToExtendedBasis.cpp
+++ b/lib/Dialect/Openfhe/Transforms/ConvertToExtendedBasis.cpp
@@ -1,0 +1,48 @@
+#include "lib/Dialect/Openfhe/Transforms/ConvertToExtendedBasis.h"
+
+#include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"     // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DEF_CONVERTTOEXTENDEDBASIS
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+struct ConvertFastRotationOp : public OpRewritePattern<FastRotationOp> {
+  using OpRewritePattern<FastRotationOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(FastRotationOp op,
+                                PatternRewriter& rewriter) const override {
+    auto fastRotExt = FastRotationExtOp::create(
+        rewriter, op->getLoc(), op.getType(), op.getCryptoContext(),
+        op.getInput(), op.getIndex(), op.getPrecomputedDigitDecomp(),
+        /*addFirst=*/true);
+
+    auto keySwitchDown =
+        KeySwitchDownOp::create(rewriter, op->getLoc(), op.getType(),
+                                op.getCryptoContext(), fastRotExt.getResult());
+
+    rewriter.replaceOp(op, keySwitchDown.getResult());
+    return success();
+  }
+};
+
+struct ConvertToExtendedBasis
+    : impl::ConvertToExtendedBasisBase<ConvertToExtendedBasis> {
+  using ConvertToExtendedBasisBase::ConvertToExtendedBasisBase;
+
+  void runOnOperation() override {
+    MLIRContext* context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<ConvertFastRotationOp>(context);
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Openfhe/Transforms/ConvertToExtendedBasis.h
+++ b/lib/Dialect/Openfhe/Transforms/ConvertToExtendedBasis.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_OPENFHE_TRANSFORMS_CONVERTTOEXTENDEDBASIS_H_
+#define LIB_DIALECT_OPENFHE_TRANSFORMS_CONVERTTOEXTENDEDBASIS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DECL_CONVERTTOEXTENDEDBASIS
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_CONVERTTOEXTENDEDBASIS_H_

--- a/lib/Dialect/Openfhe/Transforms/HoistKeySwitchDown.cpp
+++ b/lib/Dialect/Openfhe/Transforms/HoistKeySwitchDown.cpp
@@ -1,0 +1,65 @@
+#include "lib/Dialect/Openfhe/Transforms/HoistKeySwitchDown.h"
+
+#include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"     // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DEF_HOISTKEYSWITCHDOWN
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+// Pushes key_switch_down past binary operations to reduce key-switch count.
+// Matches when at least one operand is key_switch_down (with single use).
+// Example: add(key_switch_down(a), b) => key_switch_down(add(a, b))
+template <typename OpTy>
+struct HoistKeySwitchThrough : public OpRewritePattern<OpTy> {
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter& rewriter) const override {
+    auto lhsKs = op.getLhs().template getDefiningOp<KeySwitchDownOp>();
+    auto rhsKs = op.getRhs().template getDefiningOp<KeySwitchDownOp>();
+
+    if (!lhsKs && !rhsKs) return failure();
+    if (lhsKs && !lhsKs->hasOneUse()) return failure();
+    if (rhsKs && !rhsKs->hasOneUse()) return failure();
+
+    Value newLhs = lhsKs ? lhsKs.getCiphertext() : op.getLhs();
+    Value newRhs = rhsKs ? rhsKs.getCiphertext() : op.getRhs();
+
+    auto newOp = OpTy::create(rewriter, op.getLoc(), op.getType(),
+                              op.getCryptoContext(), newLhs, newRhs);
+    auto newKs =
+        KeySwitchDownOp::create(rewriter, op.getLoc(), op.getType(),
+                                op.getCryptoContext(), newOp.getResult());
+
+    rewriter.replaceOp(op, newKs.getResult());
+    if (lhsKs) rewriter.eraseOp(lhsKs);
+    if (rhsKs) rewriter.eraseOp(rhsKs);
+
+    return success();
+  }
+};
+
+struct HoistKeySwitchDown : impl::HoistKeySwitchDownBase<HoistKeySwitchDown> {
+  using HoistKeySwitchDownBase::HoistKeySwitchDownBase;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<HoistKeySwitchThrough<AddOp>>(&getContext());
+    patterns.add<HoistKeySwitchThrough<AddInPlaceOp>>(&getContext());
+    patterns.add<HoistKeySwitchThrough<MulOp>>(&getContext());
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Openfhe/Transforms/HoistKeySwitchDown.h
+++ b/lib/Dialect/Openfhe/Transforms/HoistKeySwitchDown.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_OPENFHE_TRANSFORMS_HOISTKEYSWITCHDOWN_H_
+#define LIB_DIALECT_OPENFHE_TRANSFORMS_HOISTKEYSWITCHDOWN_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DECL_HOISTKEYSWITCHDOWN
+#include "lib/Dialect/Openfhe/Transforms/Passes.h.inc"
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_OPENFHE_TRANSFORMS_HOISTKEYSWITCHDOWN_H_

--- a/lib/Dialect/Openfhe/Transforms/Passes.h
+++ b/lib/Dialect/Openfhe/Transforms/Passes.h
@@ -5,8 +5,10 @@
 #include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
 #include "lib/Dialect/Openfhe/Transforms/AllocToInPlace.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
+#include "lib/Dialect/Openfhe/Transforms/ConvertToExtendedBasis.h"
 #include "lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h"
 #include "lib/Dialect/Openfhe/Transforms/FastRotationPrecompute.h"
+#include "lib/Dialect/Openfhe/Transforms/HoistKeySwitchDown.h"
 // IWYU pragma: end_keep
 
 namespace mlir {

--- a/lib/Dialect/Openfhe/Transforms/Passes.td
+++ b/lib/Dialect/Openfhe/Transforms/Passes.td
@@ -81,6 +81,27 @@ def FastRotationPrecompute : Pass<"openfhe-fast-rotation-precompute"> {
   }];
 }
 
+def ConvertToExtendedBasis : Pass<"openfhe-convert-to-extended-basis"> {
+  let summary = "Convert rotation operations to extended (P*Q) basis";
+  let description = [{
+    This pass converts `openfhe.fast_rotation` operations to use extended basis
+    operations. Each `fast_rotation` is replaced with `fast_rotation_ext` followed
+    by `key_switch_down`, enabling subsequent optimization to defer key-switches.
+  }];
+  let dependentDialects = ["mlir::heir::openfhe::OpenfheDialect"];
+}
+
+def HoistKeySwitchDown : Pass<"openfhe-hoist-key-switch-down"> {
+  let summary = "Push key_switch_down operations later in the IR";
+  let description = [{
+    Greedily pushes `key_switch_down` past Add, AddInPlace, and Mul operations
+    to reduce total key-switch count. When both operands of a binary operation
+    are `key_switch_down`, this pass swaps them so the operation is performed
+    in extended basis followed by a single `key_switch_down`.
+  }];
+  let dependentDialects = ["mlir::heir::openfhe::OpenfheDialect"];
+}
+
 def AllocToInPlace : Pass<"openfhe-alloc-to-inplace"> {
   let summary = "Utilize OpenFHE's in-place operations when possible";
   let description = [{

--- a/tests/Dialect/Openfhe/Transforms/convert_to_extended_basis.mlir
+++ b/tests/Dialect/Openfhe/Transforms/convert_to_extended_basis.mlir
@@ -1,0 +1,36 @@
+// RUN: heir-opt --openfhe-convert-to-extended-basis %s | FileCheck %s
+
+!cc = !openfhe.crypto_context
+!ct = !openfhe.ciphertext
+!digit_decomp = !openfhe.digit_decomp
+
+module {
+  // CHECK: @test_convert_single_rotation
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: openfhe.key_switch_down
+  // CHECK-NOT: openfhe.fast_rotation {{.*}}cyclotomicOrder
+  func.func @test_convert_single_rotation(%cc: !cc, %ct: !ct) -> !ct {
+    %c4 = arith.constant 4 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %rot = openfhe.fast_rotation %cc, %ct, %c4, %precomp {cyclotomicOrder = 64 : index} : (!cc, !ct, index, !digit_decomp) -> !ct
+    return %rot : !ct
+  }
+
+  // CHECK: @test_convert_multiple_rotations
+  // CHECK: openfhe.fast_rotation_precompute
+  // CHECK: openfhe.fast_rotation_ext
+  // CHECK: openfhe.key_switch_down
+  // CHECK: openfhe.fast_rotation_ext
+  // CHECK: openfhe.key_switch_down
+  // CHECK-NOT: openfhe.fast_rotation {{.*}}cyclotomicOrder
+  func.func @test_convert_multiple_rotations(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1 = openfhe.fast_rotation %cc, %ct, %c1, %precomp {cyclotomicOrder = 64 : index} : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.fast_rotation %cc, %ct, %c2, %precomp {cyclotomicOrder = 64 : index} : (!cc, !ct, index, !digit_decomp) -> !ct
+    %sum = openfhe.add %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    return %sum : !ct
+  }
+}

--- a/tests/Dialect/Openfhe/Transforms/hoist_key_switch_down.mlir
+++ b/tests/Dialect/Openfhe/Transforms/hoist_key_switch_down.mlir
@@ -1,0 +1,171 @@
+// RUN: heir-opt --openfhe-hoist-key-switch-down %s | FileCheck %s
+
+!cc = !openfhe.crypto_context
+!ct = !openfhe.ciphertext
+!digit_decomp = !openfhe.digit_decomp
+
+module {
+  // CHECK: @test_hoist_add_two_rotations
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: %[[R1_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[R2_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[SUM:.*]] = openfhe.add %{{.*}}, %[[R1_EXT]], %[[R2_EXT]]
+  // CHECK: %{{.*}} = openfhe.key_switch_down %{{.*}}, %[[SUM]]
+  // CHECK-NOT: openfhe.key_switch_down{{.*}}openfhe.add
+  // Typical pattern after convert-to-extended-basis: two rotations added together
+  func.func @test_hoist_add_two_rotations(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r1 = openfhe.key_switch_down %cc, %r1_ext : (!cc, !ct) -> !ct
+    %r2_ext = openfhe.fast_rotation_ext %cc, %ct, %c2, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.key_switch_down %cc, %r2_ext : (!cc, !ct) -> !ct
+    %sum = openfhe.add %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    return %sum : !ct
+  }
+
+  // CHECK: @test_hoist_mul_two_rotations
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: %[[R1_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[R2_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[PROD:.*]] = openfhe.mul %{{.*}}, %[[R1_EXT]], %[[R2_EXT]]
+  // CHECK: %{{.*}} = openfhe.key_switch_down %{{.*}}, %[[PROD]]
+  // CHECK-NOT: openfhe.key_switch_down{{.*}}openfhe.mul
+  func.func @test_hoist_mul_two_rotations(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r1 = openfhe.key_switch_down %cc, %r1_ext : (!cc, !ct) -> !ct
+    %r2_ext = openfhe.fast_rotation_ext %cc, %ct, %c2, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.key_switch_down %cc, %r2_ext : (!cc, !ct) -> !ct
+    %prod = openfhe.mul %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    return %prod : !ct
+  }
+
+  // CHECK: @test_hoist_add_inplace
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: %[[R1_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[R2_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[SUM:.*]] = openfhe.add_inplace %{{.*}}, %[[R1_EXT]], %[[R2_EXT]]
+  // CHECK: %{{.*}} = openfhe.key_switch_down %{{.*}}, %[[SUM]]
+  func.func @test_hoist_add_inplace(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r1 = openfhe.key_switch_down %cc, %r1_ext : (!cc, !ct) -> !ct
+    %r2_ext = openfhe.fast_rotation_ext %cc, %ct, %c2, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.key_switch_down %cc, %r2_ext : (!cc, !ct) -> !ct
+    %sum = openfhe.add_inplace %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    return %sum : !ct
+  }
+
+  // CHECK: @test_hoist_rotation_plus_ciphertext
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: %[[R_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %{{.*}}, %[[PRECOMP]]
+  // CHECK: %[[SUM:.*]] = openfhe.add %{{.*}}, %[[R_EXT]], %{{.*}}
+  // CHECK: %{{.*}} = openfhe.key_switch_down %{{.*}}, %[[SUM]]
+  // Hoisting when only one operand is a rotation (common pattern)
+  func.func @test_hoist_rotation_plus_ciphertext(%cc: !cc, %ct: !ct, %other: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r = openfhe.key_switch_down %cc, %r_ext : (!cc, !ct) -> !ct
+    %sum = openfhe.add %cc, %r, %other : (!cc, !ct, !ct) -> !ct
+    return %sum : !ct
+  }
+
+  // CHECK: @test_sum_of_multiple_rotations
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: %[[R1_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c1, %[[PRECOMP]]
+  // CHECK: %[[R2_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c2, %[[PRECOMP]]
+  // CHECK: %[[R3_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c3, %[[PRECOMP]]
+  // CHECK: %[[R4_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c4, %[[PRECOMP]]
+  // CHECK: %[[SUM1:.*]] = openfhe.add %{{.*}}, %[[R1_EXT]], %[[R2_EXT]]
+  // CHECK: %[[SUM2:.*]] = openfhe.add %{{.*}}, %[[SUM1]], %[[R3_EXT]]
+  // CHECK: %[[SUM3:.*]] = openfhe.add %{{.*}}, %[[SUM2]], %[[R4_EXT]]
+  // CHECK: %{{.*}} = openfhe.key_switch_down %{{.*}}, %[[SUM3]]
+  // CHECK-NOT: openfhe.key_switch_down{{.*}}openfhe.add
+  // Realistic pattern: sum of multiple rotations (e.g., dot product)
+  func.func @test_sum_of_multiple_rotations(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r1 = openfhe.key_switch_down %cc, %r1_ext : (!cc, !ct) -> !ct
+    %r2_ext = openfhe.fast_rotation_ext %cc, %ct, %c2, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.key_switch_down %cc, %r2_ext : (!cc, !ct) -> !ct
+    %r3_ext = openfhe.fast_rotation_ext %cc, %ct, %c3, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r3 = openfhe.key_switch_down %cc, %r3_ext : (!cc, !ct) -> !ct
+    %r4_ext = openfhe.fast_rotation_ext %cc, %ct, %c4, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r4 = openfhe.key_switch_down %cc, %r4_ext : (!cc, !ct) -> !ct
+    %sum1 = openfhe.add %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    %sum2 = openfhe.add %cc, %sum1, %r3 : (!cc, !ct, !ct) -> !ct
+    %sum3 = openfhe.add %cc, %sum2, %r4 : (!cc, !ct, !ct) -> !ct
+    return %sum3 : !ct
+  }
+
+  // CHECK: @test_no_hoist_multiple_uses
+  // CHECK: openfhe.fast_rotation_ext
+  // CHECK: %[[R1:.*]] = openfhe.key_switch_down
+  // CHECK: openfhe.fast_rotation_ext
+  // CHECK: openfhe.key_switch_down
+  // CHECK: openfhe.add
+  // No hoisting when key_switch_down result is used elsewhere
+  func.func @test_no_hoist_multiple_uses(%cc: !cc, %ct: !ct) -> (!ct, !ct) {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r1 = openfhe.key_switch_down %cc, %r1_ext : (!cc, !ct) -> !ct
+    %r2_ext = openfhe.fast_rotation_ext %cc, %ct, %c2, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.key_switch_down %cc, %r2_ext : (!cc, !ct) -> !ct
+    %sum = openfhe.add %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    // %r1 is used twice, so no hoisting should occur
+    return %sum, %r1 : !ct, !ct
+  }
+
+  // CHECK: @test_eliminate_redundant_key_switch
+  // CHECK: openfhe.fast_rotation_ext
+  // CHECK-NEXT: %[[KS:.*]] = openfhe.key_switch_down
+  // CHECK-NEXT: return %[[KS]]
+  // CHECK-NOT: openfhe.key_switch_down{{.*}}openfhe.key_switch_down
+  // Eliminate redundant nested key_switch_down (edge case)
+  func.func @test_eliminate_redundant_key_switch(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r = openfhe.key_switch_down %cc, %r_ext : (!cc, !ct) -> !ct
+    %redundant = openfhe.key_switch_down %cc, %r : (!cc, !ct) -> !ct
+    return %redundant : !ct
+  }
+
+  // CHECK: @test_mixed_operations
+  // CHECK: %[[PRECOMP:.*]] = openfhe.fast_rotation_precompute
+  // CHECK: %[[R1_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c1, %[[PRECOMP]]
+  // CHECK: %[[R2_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c2, %[[PRECOMP]]
+  // CHECK: %[[R3_EXT:.*]] = openfhe.fast_rotation_ext %{{.*}}, %{{.*}}, %c3, %[[PRECOMP]]
+  // CHECK: %[[SUM:.*]] = openfhe.add %{{.*}}, %[[R1_EXT]], %[[R2_EXT]]
+  // CHECK: %[[PROD:.*]] = openfhe.mul %{{.*}}, %[[SUM]], %[[R3_EXT]]
+  // CHECK: %{{.*}} = openfhe.key_switch_down %{{.*}}, %[[PROD]]
+  // Mixed add and mul operations with rotations
+  func.func @test_mixed_operations(%cc: !cc, %ct: !ct) -> !ct {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %precomp = openfhe.fast_rotation_precompute %cc, %ct : (!cc, !ct) -> !digit_decomp
+    %r1_ext = openfhe.fast_rotation_ext %cc, %ct, %c1, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r1 = openfhe.key_switch_down %cc, %r1_ext : (!cc, !ct) -> !ct
+    %r2_ext = openfhe.fast_rotation_ext %cc, %ct, %c2, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r2 = openfhe.key_switch_down %cc, %r2_ext : (!cc, !ct) -> !ct
+    %r3_ext = openfhe.fast_rotation_ext %cc, %ct, %c3, %precomp : (!cc, !ct, index, !digit_decomp) -> !ct
+    %r3 = openfhe.key_switch_down %cc, %r3_ext : (!cc, !ct) -> !ct
+    %sum = openfhe.add %cc, %r1, %r2 : (!cc, !ct, !ct) -> !ct
+    %prod = openfhe.mul %cc, %sum, %r3 : (!cc, !ct, !ct) -> !ct
+    return %prod : !ct
+  }
+}


### PR DESCRIPTION
## Summary
Continuation of #2574, related to #2519.
Adds two new passes for optimizing rotation-heavy FHE programs by deferring expensive key-switch operations:
1. `--openfhe-convert-to-extended-basis` - Converts `fast_rotation` → `fast_rotation_ext` + `key_switch_down`
2. `--openfhe-hoist-key-switch-down`

## Changes
### Pass 1: ConvertToExtendedBasis
- Converts each `openfhe.fast_rotation` to `openfhe.fast_rotation_ext` + `openfhe.key_switch_down`
- Semantically equivalent transformation that enables further optimization
### Pass 2: HoistKeySwitchDown
- Pushes `key_switch_down` operations later in the IR to reduce key-switch count.
- Works on `Add`, `AddInPlace`, and `Mul` operations.
- When **at least one** operand is `key_switch_down` (with single use), the pass swaps:

```mlir
// Case 1: Both operands are key_switch_down
%a = key_switch_down(%a_ext)
%b = key_switch_down(%b_ext)
%sum = add(%a, %b)
```
to:
```mlir
%sum_ext = add(%a_ext, %b_ext)
%sum = key_switch_down(%sum_ext)
```
and,
```mlir
// Case 2: One operand is key_switch_down (enables chained optimization)
%a = key_switch_down(%a_ext)
%sum = add(%a, %ct)  // %ct is not key_switch_down
```
to:
```mlir
%sum_ext = add(%a_ext, %ct)
%sum = key_switch_down(%sum_ext)
```

Through greedy iteration, this reduces multiple key-switches in chained operations to a single final key-switch.
