### PR TITLE
Update LWEToPolynomial lowering

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
@@ -12,6 +12,7 @@
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTypes.h"
+#include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/Random/IR/RandomEnums.h"
 #include "lib/Dialect/Random/IR/RandomOps.h"
 #include "lib/Dialect/Random/IR/RandomTypes.h"


### PR DESCRIPTION
The primary goal of this PR is to update the LWE->Polynomial lowering in light of the new LWE ops introduced in #2602. This required the addition of two new `Polynomial` ops: `ExtractSliceOp` and `ConvertBasisOp`.

I did some light housekeeping along the way:
- Converted several `cast`s to `dyn_casts` with a check. I found that without this, errors were impenetrable.
- Extracted the core of `ExtractSliceOp` type inference logic and moved it to a template in RNSOps.h. This is now used in `rns::ExtractSliceOp`, `lwe::ExtractSliceOp`, and `polynomial::ExtractSliceOp`.
- Made `ExtractSliceOp` consistent across RNS, LWE, and Polynomial dialects
- Added several `assemblyFormat`s to new ops for consistency and test readability
- Added missing op descriptions

The main impetus for this PR was the ability to lower from `ckks.relinearize` to `Polynomial`. I added a "test", but I haven't really done a test like this before. I think the goal of the test should be that it doesn't crash, rather than specifying any specific output (since each step is verified already). I'm not sure where it should go, or what it should look like.