### PR TITLE
Refactor of NTT/iNTT to make inputs and outputs both Polynomials

### DIFF
--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -12,16 +12,19 @@ package(
 cc_library(
     name = "Dialect",
     srcs = [
+        "ModArithAttributes.cpp",
         "ModArithDialect.cpp",
         "ModArithOps.cpp",
         "ModArithTypes.cpp",
     ],
     hdrs = [
+        "ModArithAttributes.h",
         "ModArithDialect.h",
         "ModArithOps.h",
         "ModArithTypes.h",
     ],
     deps = [
+        ":attributes_inc_gen",
         ":canonicalization_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
@@ -39,6 +42,7 @@ cc_library(
 td_library(
     name = "td_files",
     srcs = [
+        "ModArithAttributes.td",
         "ModArithCanonicalization.td",
         "ModArithDialect.td",
         "ModArithOps.td",
@@ -62,6 +66,16 @@ add_heir_dialect_library(
     dialect = "ModArith",
     kind = "dialect",
     td_file = "ModArithDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "ModArith",
+    kind = "attribute",
+    td_file = "ModArithAttributes.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/ModArith/IR/ModArithAttributes.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithAttributes.cpp
@@ -1,0 +1,43 @@
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
+
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Dialect/ModArith/IR/ModArithTypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/OpImplementation.h"       // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace mod_arith {
+
+void ModArithAttr::print(mlir::AsmPrinter &printer) const {
+  // Output: <1925 : !mod_arith.int<7681 : i32>>
+  printer << "<" << getValue().getValue() << " : " << getType() << ">";
+}
+
+// syntax is <3 : type>
+mlir::Attribute ModArithAttr::parse(mlir::AsmParser &parser, mlir::Type type) {
+  APInt value;
+  ModArithType modType;
+
+  if (parser.parseLess()) return {};
+  if (parser.parseInteger(value)) return {};
+  if (parser.parseColon()) return {};
+  if (parser.parseType(modType)) return {};
+  if (parser.parseGreater()) return {};
+
+  mlir::Type integerType = modType.getModulus().getType();
+  unsigned targetBitWidth = integerType.getIntOrFloatBitWidth();
+  value = value.zextOrTrunc(targetBitWidth);
+
+  // 4. Construct the IntegerAttr using the element type of the ModArithType
+  // This ensures the bitwidth of the value matches the modulus storage
+  auto integerAttr = mlir::IntegerAttr::get(integerType, value);
+
+  return ModArithAttr::get(parser.getContext(), modType, integerAttr);
+}
+
+}  // namespace mod_arith
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/ModArith/IR/ModArithAttributes.h
+++ b/lib/Dialect/ModArith/IR/ModArithAttributes.h
@@ -1,0 +1,10 @@
+#ifndef LIB_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_H_
+#define LIB_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_H_
+
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Dialect/ModArith/IR/ModArithTypes.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h.inc"
+
+#endif  // LIB_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_H_

--- a/lib/Dialect/ModArith/IR/ModArithAttributes.td
+++ b/lib/Dialect/ModArith/IR/ModArithAttributes.td
@@ -1,0 +1,37 @@
+#ifndef LIB_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_TD_
+#define LIB_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_TD_
+
+include "lib/Dialect/ModArith/IR/ModArithDialect.td"
+include "lib/Dialect/ModArith/IR/ModArithTypes.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+
+class ModArith_Attr<string name, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<ModArith_Dialect, name, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+def ModArith_ModArithAttr : ModArith_Attr<"ModArith", "value"> {
+  let summary = "a typed modular arithmetic value";
+  let description = [{
+    A typed modular arithmetic value.
+
+    The `type` parameter is expected to be a modular arithmetic coefficient
+    type, and `value` is the corresponding integer representative.
+
+    Example:
+
+    ```mlir
+    #v = #mod_arith.value<17 : !mod_arith.int<...>>
+    ```
+  }];
+  let parameters = (ins
+    "::mlir::heir::mod_arith::ModArithType":$type,
+    "::mlir::IntegerAttr":$value
+  );
+  let hasCustomAssemblyFormat = 1;
+}
+
+#endif  // LIB_DIALECT_MODARITH_IR_MODARITHATTRIBUTES_TD_

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -4,6 +4,7 @@
 
 // NOLINTBEGIN(misc-include-cleaner): Required to define
 // ModArithDialect, ModArithTypes, ModArithOps,
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
 #include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
@@ -13,6 +14,9 @@
 
 // Generated definitions
 #include "lib/Dialect/ModArith/IR/ModArithDialect.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.cpp.inc"
 
 #define GET_TYPEDEF_CLASSES
 #include "lib/Dialect/ModArith/IR/ModArithTypes.cpp.inc"
@@ -25,6 +29,10 @@ namespace heir {
 namespace mod_arith {
 
 void ModArithDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.cpp.inc"
+      >();
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "lib/Dialect/ModArith/IR/ModArithTypes.cpp.inc"

--- a/lib/Dialect/ModArith/IR/ModArithDialect.td
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.td
@@ -12,6 +12,7 @@ def ModArith_Dialect : Dialect {
 
   let cppNamespace = "::mlir::heir::mod_arith";
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
   let hasConstantMaterializer = 1;
 
   let dependentDialects = [

--- a/lib/Dialect/Polynomial/IR/BUILD
+++ b/lib/Dialect/Polynomial/IR/BUILD
@@ -18,6 +18,7 @@ cc_library(
         ":ops_inc_gen",
         ":types_inc_gen",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:RNSOps",
         "@heir//lib/Dialect/RNS/IR:RNSTypes",
         "@heir//lib/Utils/Polynomial",
@@ -42,6 +43,7 @@ td_library(
     includes = ["../../../.."],
     deps = [
         "@heir//lib/Dialect/ModArith/IR:td_files",
+        "@heir//lib/Dialect/RNS/IR:td_files",
         "@llvm-project//mlir:ArithOpsTdFiles",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.h
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.h
@@ -1,7 +1,9 @@
 #ifndef LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALATTRIBUTES_H_
 #define LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALATTRIBUTES_H_
 
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "lib/Dialect/RNS/IR/RNSAttributes.h"
 #include "lib/Utils/Polynomial/Polynomial.h"
 
 #define GET_ATTRDEF_CLASSES

--- a/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialAttributes.td
@@ -232,12 +232,31 @@ def Polynomial_RingAttr : Polynomial_Attr<"Ring", "ring", [OpAsmAttrInterface]> 
   }];
 }
 
-def Polynomial_PrimitiveRootAttr: Polynomial_Attr<"PrimitiveRoot", "primitive_root"> {
-  let summary = "an attribute containing an integer and its degree as a root of unity";
+def Polynomial_FormAttr : Polynomial_Attr<"Form", "form"> {
+  let summary = "an attribute describing the polynomial representation form";
   let description = [{
-    A primitive root attribute stores an integer root `value` and an integer
-    `degree`, corresponding to a primitive root of unity of the given degree in
-    an unspecified ring.
+    Indicates whether a polynomial value is represented in coefficient form or
+    evaluation (NTT) form.
+
+    Example:
+
+    ```mlir
+    #form = #polynomial.form<isCoeffForm = true>
+    ```
+  }];
+  let parameters = (ins "bool":$isCoeffForm);
+  let assemblyFormat = "`<` `isCoeffForm` `=` $isCoeffForm `>`";
+}
+
+def Polynomial_PrimitiveRootAttr: Polynomial_Attr<"PrimitiveRoot", "primitive_root"> {
+  let summary = "an attribute containing a typed root value and its degree as a root of unity";
+  let description = [{
+    A primitive root attribute stores a typed root `value` and an integer
+    `degree`, corresponding to a primitive root of unity of the given degree.
+
+    The root value is represented as either:
+    - `#mod_arith.value<...>` for a single modular coefficient ring, or
+    - `#rns.value<...>` for an RNS coefficient ring.
 
     This is used as an attribute on `polynomial.ntt` and `polynomial.intt` ops
     to specify the root of unity used in lowering the transform.
@@ -245,12 +264,13 @@ def Polynomial_PrimitiveRootAttr: Polynomial_Attr<"PrimitiveRoot", "primitive_ro
     Example:
 
     ```mlir
-    #poly = #polynomial.primitive_root<value=123 : i32, degree : 7 index>
+    #v = #mod_arith.value<type=!mod_arith.int<17 : i32>, value=3 : i32>
+    #poly = #polynomial.primitive_root<value=#v, degree=8 : i32>
     ```
   }];
   let parameters = (ins
-    "::mlir::IntegerAttr":$value,
-    "::mlir::IntegerAttr":$degree
+    "::mlir::Attribute":$value,
+    "IntegerAttr":$degree
   );
   let assemblyFormat = "`<` struct(params) `>`";
 }

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.td
@@ -313,7 +313,7 @@ def Polynomial_ConstantOp : Op<Polynomial_Dialect, "constant",
   let hasCustomAssemblyFormat = 1;
 }
 
-def Polynomial_NTTOp : Polynomial_Op<"ntt", [Pure]> {
+def Polynomial_NTTOp : Polynomial_Op<"ntt", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
   let summary = "Computes point-value tensor representation of a polynomial.";
   let description = [{
     `polynomial.ntt` computes the forward integer Number Theoretic Transform
@@ -334,13 +334,13 @@ def Polynomial_NTTOp : Polynomial_Op<"ntt", [Pure]> {
     Polynomial_PolynomialType:$input,
     OptionalAttr<Polynomial_PrimitiveRootAttr>:$root
   );
-  let results = (outs RankedTensorOf<[ModArith_ModArithType]>:$output);
-  let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` type($output)";
+  let results = (outs Polynomial_PolynomialType:$output);
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
 }
 
-def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure]> {
+def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
   let summary = "Computes the reverse integer Number Theoretic Transform (NTT).";
   let description = [{
     `polynomial.intt` computes the reverse integer Number Theoretic Transform
@@ -355,11 +355,11 @@ def Polynomial_INTTOp : Polynomial_Op<"intt", [Pure]> {
     The choice of primitive root may be optionally specified.
   }];
   let arguments = (
-    ins RankedTensorOf<[ModArith_ModArithType]>:$input,
+    ins Polynomial_PolynomialType:$input,
     OptionalAttr<Polynomial_PrimitiveRootAttr>:$root
   );
   let results = (outs Polynomial_PolynomialType:$output);
-  let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` type($output)";
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
 }

--- a/lib/Dialect/Polynomial/IR/PolynomialTypes.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialTypes.td
@@ -15,10 +15,31 @@ def Polynomial_PolynomialType : Polynomial_Type<"Polynomial", "polynomial", [OpA
   let description = [{
     A type for polynomials in a polynomial quotient ring.
   }];
-  let parameters = (ins Polynomial_RingAttr:$ring);
+  let parameters = (ins
+    Polynomial_RingAttr:$ring,
+    DefaultValuedParameter<
+      "::mlir::heir::polynomial::FormAttr",
+      "FormAttr::get($_ctxt, true)">:$form
+  );
   let assemblyFormat = "`<` struct(params) `>`";
 
   let extraClassDeclaration = [{
+    // Backward-compatible builder: defaults to coefficient form.
+    static PolynomialType get(
+        ::mlir::MLIRContext *context,
+        ::mlir::heir::polynomial::RingAttr ring) {
+      return PolynomialType::get(context, ring, FormAttr::get(context, true));
+    }
+
+    // Convenience builder from a boolean form flag.
+    static PolynomialType get(
+        ::mlir::MLIRContext *context,
+        ::mlir::heir::polynomial::RingAttr ring,
+        bool isCoeffForm) {
+      return PolynomialType::get(context, ring,
+                                 FormAttr::get(context, isCoeffForm));
+    }
+
     // OpAsmTypeInterface methods.
     ::mlir::OpAsmDialectInterface::AliasResult getAlias(::llvm::raw_ostream &os) const {
       os << "poly";

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -12,9 +12,11 @@ package(
 cc_library(
     name = "Dialect",
     srcs = [
+        "RNSAttributes.cpp",
         "RNSDialect.cpp",
     ],
     hdrs = [
+        "RNSAttributes.h",
         "RNSDialect.h",
         "RNSOps.h",
         "RNSTypeInterfaces.h",
@@ -23,6 +25,7 @@ cc_library(
     deps = [
         ":RNSOps",
         ":RNSTypes",
+        ":attributes_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":type_interfaces_inc_gen",
@@ -101,6 +104,7 @@ cc_library(
 td_library(
     name = "td_files",
     srcs = [
+        "RNSAttributes.td",
         "RNSDialect.td",
         "RNSOps.td",
         "RNSTypeInterfaces.td",
@@ -120,6 +124,16 @@ add_heir_dialect_library(
     dialect = "RNS",
     kind = "dialect",
     td_file = "RNSDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "attributes_inc_gen",
+    dialect = "RNS",
+    kind = "attribute",
+    td_file = "RNSAttributes.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/RNS/IR/RNSAttributes.cpp
+++ b/lib/Dialect/RNS/IR/RNSAttributes.cpp
@@ -1,0 +1,60 @@
+#include "lib/Dialect/RNS/IR/RNSAttributes.h"
+
+#include "mlir/include/mlir/IR/Attributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"    // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rns {
+
+LogicalResult RNSAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                              ArrayRef<Attribute> values, RNSType type) {
+  auto basisSize = type.getBasisTypes().size();
+  if (values.size() != basisSize) {
+    return emitError() << "expected " << basisSize
+                       << " values to match the RNS basis size, but found "
+                       << values.size();
+  }
+  return success();
+}
+
+void RNSAttr::print(AsmPrinter &printer) const {
+  printer << "<[";
+  // Use llvm::interleaveComma to handle the commas between elements nicely
+  llvm::interleaveComma(getValues(), printer,
+                        [&](Attribute attr) { printer << attr; });
+  printer << "]>";
+}
+
+Attribute RNSAttr::parse(AsmParser &parser, Type type) {
+  SmallVector<TypedAttr> attrs;
+
+  if (parser.parseLess() || parser.parseLSquare()) return {};
+  auto elementParser = [&]() {
+    Attribute val;
+    if (parser.parseAttribute(val)) return failure();
+    if (auto typedVal = dyn_cast<TypedAttr>(val)) {
+      attrs.push_back(typedVal);
+      return success();
+    }
+    return failure();
+  };
+  if (parser.parseCommaSeparatedList(elementParser)) return {};
+  if (parser.parseRSquare() || parser.parseGreater()) return {};
+
+  // The rns type can be inferred from the types of the attribute values
+  SmallVector<Type> basisTypes =
+      map_to_vector(attrs, [](TypedAttr attr) { return attr.getType(); });
+  RNSType rnsType = RNSType::get(parser.getContext(), basisTypes);
+  SmallVector<Attribute> attrValues = map_to_vector(
+      attrs, [](TypedAttr attr) { return cast<Attribute>(attr); });
+
+  return RNSAttr::getChecked(
+      [&]() { return parser.emitError(parser.getNameLoc()); },
+      parser.getContext(), ArrayRef<Attribute>(attrValues), rnsType);
+}
+
+}  // namespace rns
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/IR/RNSAttributes.h
+++ b/lib/Dialect/RNS/IR/RNSAttributes.h
@@ -1,0 +1,10 @@
+#ifndef LIB_DIALECT_RNS_IR_RNSATTRIBUTES_H_
+#define LIB_DIALECT_RNS_IR_RNSATTRIBUTES_H_
+
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/RNS/IR/RNSTypes.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/RNS/IR/RNSAttributes.h.inc"
+
+#endif  // LIB_DIALECT_RNS_IR_RNSATTRIBUTES_H_

--- a/lib/Dialect/RNS/IR/RNSAttributes.td
+++ b/lib/Dialect/RNS/IR/RNSAttributes.td
@@ -1,0 +1,41 @@
+#ifndef LIB_DIALECT_RNS_IR_RNSATTRIBUTES_TD_
+#define LIB_DIALECT_RNS_IR_RNSATTRIBUTES_TD_
+
+include "lib/Dialect/RNS/IR/RNSDialect.td"
+include "lib/Dialect/RNS/IR/RNSTypes.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+
+class RNS_Attr<string name, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<RNS_Dialect, name, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+def RNS_RNSAttr : RNS_Attr<"RNS", "value"> {
+  let summary = "a typed RNS value";
+  let description = [{
+    A typed RNS value with one integer per basis limb.
+
+    The `type` parameter is expected to be an RNS coefficient type, and
+    `values` stores one residue for each limb.
+
+    Example:
+
+    ```mlir
+    #v1 = #mod_arith.value<17 : !mod_arith.int<256 : i32>>
+    #v2 = #mod_arith.value<19 : !mod_arith.int<256 : i32>>
+    #v = #rns.value<[#v1, #v2]>
+    ```
+  }];
+  let parameters = (ins
+    ArrayRefParameter<"Attribute">:$values,
+    "::mlir::heir::rns::RNSType":$type
+  );
+  let genVerifyDecl = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+#endif  // LIB_DIALECT_RNS_IR_RNSATTRIBUTES_TD_

--- a/lib/Dialect/RNS/IR/RNSDialect.cpp
+++ b/lib/Dialect/RNS/IR/RNSDialect.cpp
@@ -4,6 +4,7 @@
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 
 // NOLINTNEXTLINE(misc-include-cleaner): Required to define RNSOps
+#include "lib/Dialect/RNS/IR/RNSAttributes.h"
 #include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypeInterfaces.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
@@ -13,6 +14,8 @@
 #include "mlir/include/mlir/IR/OpImplementation.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Types.h"             // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"         // from @llvm-project
+#define GET_ATTRDEF_CLASSES
+#include "lib/Dialect/RNS/IR/RNSAttributes.cpp.inc"
 #define GET_TYPEDEF_CLASSES
 #include "lib/Dialect/RNS/IR/RNSTypes.cpp.inc"
 #define GET_OP_CLASSES
@@ -24,6 +27,10 @@ namespace heir {
 namespace rns {
 
 void RNSDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "lib/Dialect/RNS/IR/RNSAttributes.cpp.inc"
+      >();
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "lib/Dialect/RNS/IR/RNSTypes.cpp.inc"

--- a/lib/Dialect/RNS/IR/RNSDialect.td
+++ b/lib/Dialect/RNS/IR/RNSDialect.td
@@ -23,6 +23,7 @@ def RNS_Dialect : Dialect {
   let cppNamespace = "::mlir::heir::rns";
 
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif  // LIB_DIALECT_RNS_IR_RNSDIALECT_TD_

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_ntt.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_ntt.mlir
@@ -6,8 +6,10 @@
 #cycl = #polynomial.int_polynomial<1 + x**4>
 !coeff_ty = !mod_arith.int<7681:i32>
 #ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl>
-#root = #polynomial.primitive_root<value=1925:i32, degree=8:i32>
+#root_val = #mod_arith.value<1925:!coeff_ty>
+#root = #polynomial.primitive_root<value=#root_val, degree=8:i32>
 !poly_ty = !polynomial.polynomial<ring=#ring>
+!ntt_poly_ty = !polynomial.polynomial<ring=#ring, form=<isCoeffForm=false>>
 
 // CHECK-DAG: #[[ID_MAP:.*]] = affine_map<(d0) -> (d0)>
 
@@ -70,10 +72,10 @@
 // CHECK:       %[[RES_CAST:.*]] = tensor.cast %[[RES]]#0 : [[MOD_TYPE]] to [[OUTPUT_TYPE]]
 // CHECK:       return %[[RES_CAST]] : [[OUTPUT_TYPE]]
 
-func.func @lower_ntt() -> tensor<4x!coeff_ty, #ring> {
+func.func @lower_ntt() -> !ntt_poly_ty {
   %coeffsRaw = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
   %coeffs = mod_arith.encapsulate %coeffsRaw : tensor<4xi32> -> tensor<4x!coeff_ty>
   %poly = polynomial.from_tensor %coeffs : tensor<4x!coeff_ty> -> !poly_ty
-  %ret = polynomial.ntt %poly {root=#root} : !poly_ty -> tensor<4x!coeff_ty, #ring>
-  return %ret : tensor<4x!coeff_ty, #ring>
+  %ret = polynomial.ntt %poly {root=#root} : !poly_ty
+  return %ret : !ntt_poly_ty
 }

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/lower_intt.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/lower_intt.mlir
@@ -4,13 +4,15 @@
 #cycl = #polynomial.int_polynomial<1 + x**4>
 !coeff_ty = !mod_arith.int<7681:i32>
 #ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl>
-#root = #polynomial.primitive_root<value=1925:i32, degree=8:i32>
+#root_val = #mod_arith.value<1925:!coeff_ty>
+#root = #polynomial.primitive_root<value=#root_val, degree=8:i32>
 !poly_ty = !polynomial.polynomial<ring=#ring>
+!ntt_poly_ty = !polynomial.polynomial<ring=#ring, form=<isCoeffForm = false>>
 
 func.func public @test_intt() -> !poly_ty {
-  %coeffsRaw = arith.constant dense<[1467,2807,3471,7621]> : tensor<4xi32>
-  %coeffs = tensor.cast %coeffsRaw : tensor<4xi32> to tensor <4xi32, #ring>
-  %coeffs_enc = mod_arith.encapsulate %coeffs : tensor<4xi32, #ring> -> tensor<4x!coeff_ty, #ring>
-  %0 = polynomial.intt %coeffs_enc {root=#root} : tensor<4x!coeff_ty, #ring> -> !poly_ty
+  %coeffs = arith.constant dense<[1467,2807,3471,7621]> : tensor<4xi32>
+  %coeffs_enc = mod_arith.encapsulate %coeffs : tensor<4xi32> -> tensor<4x!coeff_ty>
+  %poly = polynomial.from_tensor %coeffs_enc : tensor<4x!coeff_ty> -> !ntt_poly_ty
+  %0 = polynomial.intt %poly {root=#root} : !ntt_poly_ty
   return %0 : !poly_ty
 }

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/lower_ntt.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/lower_ntt.mlir
@@ -4,13 +4,15 @@
 #cycl = #polynomial.int_polynomial<1 + x**4>
 !coeff_ty = !mod_arith.int<7681:i32>
 #ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl>
-#root = #polynomial.primitive_root<value=1925:i32, degree=8:i32>
+#root_val = #mod_arith.value<1925:!coeff_ty>
+#root = #polynomial.primitive_root<value=#root_val, degree=8:i32>
 !poly_ty = !polynomial.polynomial<ring=#ring>
+!ntt_poly_ty = !polynomial.polynomial<ring=#ring, form=<isCoeffForm = false>>
 
-func.func public @test_ntt() -> tensor<4x!coeff_ty, #ring> {
+func.func public @test_ntt() -> !ntt_poly_ty {
   %coeffsRaw = arith.constant dense<[1,2,3,4]> : tensor<4xi32>
   %coeffs = mod_arith.encapsulate %coeffsRaw : tensor<4xi32> -> tensor<4x!coeff_ty>
   %poly = polynomial.from_tensor %coeffs : tensor<4x!coeff_ty> -> !poly_ty
-  %res = polynomial.ntt %poly {root=#root} : !poly_ty -> tensor<4x!coeff_ty, #ring>
-  return %res : tensor<4x!coeff_ty, #ring>
+  %res = polynomial.ntt %poly {root=#root} : !poly_ty
+  return %res : !ntt_poly_ty
 }

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/ntt_benchmark.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/ntt_benchmark.mlir
@@ -1,8 +1,10 @@
 !coeff_ty = !mod_arith.int<786433:i32>
 #cycl = #polynomial.int_polynomial<1 + x**65536>
 #ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#cycl>
-#root = #polynomial.primitive_root<value=283965:i32, degree=131072:i32>
+#root_val = #mod_arith.value<283965:!coeff_ty>
+#root = #polynomial.primitive_root<value=#root_val, degree=131072:i32>
 !poly_ty = !polynomial.polynomial<ring=#ring>
+!ntt_poly_ty = !polynomial.polynomial<ring=#ring, form=<isCoeffForm=false>>
 
 func.func @input_generation() -> !poly_ty attributes { llvm.emit_c_interface } {
   %rand_coeffs = arith.constant dense<[82466, 284102, 230668, 726464, 689117, 138714, 365947, 689485, 446187, 553091, 780346, 411551, 281642, 459186, 220603, 654511, 59260, 764961, 16666, 685313, 185494, 496060, 115841, 252683, 240479, 594524, 416523, 15494, 599774, 602830, 747394, 26308, 114781, 332978, 68665, 68778, 284638, 391464, 520202, 457892, 311791, 592237, 431, 355444, 570435, 281966, 455422, 734625, 410275, 585604, 342610, 252937, 500915, 185942, 350739, 503473, 503734, 299480, 274387, 731481, 221528, 248143, 42922, 376637, 375877, 7330, 52495, 392501, 506041, 585691, 419166, 572553, 443650, 195220, 778694, 189969, 70437, 767512, 88039, 102191, 533715, 71537, 299910, 421484, 778028, 331670, 49663, 476567, 770219, 142409, 17515, 334750, 191359, 756857, 138776, 189860, 310377, 269922, 123155, 322425, 196530, 572988, 387881, 693640, 649776, 180305, 190535, 671521, 500677, 572629, 639529, 7917, 496775, 754601, 342810, 352620, 566306, 192070, 411491, 314939, 65466, 746207, 74857, 323561, 684125, 410365, 403750, 86735, 609582, 589955, 168067, 182598, 372487, 426906, 280440, 93888, 459279, 340251, 61319, 425866, 96770, 757022, 599341, 550851, 150353, 279359, 514129, 470867, 634484, 71518, 359067, 663842, 358108, 255984, 743819, 498698, 338391, 618044, 205702, 536924, 551736, 198363, 87452, 46470, 585248, 53857, 443489, 387573, 549213, 461919, 341020, 557268, 104295, 510410, 422064, 41391, 399312, 356900, 82705, 43467, 289311, 403719, 348615, 325627, 401499, 501031, 41324, 743151, 558730, 487703, 692004, 691852, 215177, 212269, 251863, 170361, 768210, 250989, 195699, 531621, 255600, 370065, 26502, 201868, 125163, 363038, 700427, 30487, 391928, 52856, 452124, 759967, 531073, 116689, 362042, 255716, 315098, 391743, 38415, 367529, 504177, 343228, 496991, 442943, 362269, 661169, 394207, 476331, 361445, 67053, 730805, 597631, 3379, 238251, 159057, 287526, 671488, 618631, 525038, 695869, 91737, 47054, 509029, 227973, 127210, 689448, 370642, 79893, 400573, 206914, 428506, 778137, 563541, 644030, 376996, 612443]> : tensor<256xi32>
@@ -15,14 +17,16 @@ func.func @input_generation() -> !poly_ty attributes { llvm.emit_c_interface } {
   return %poly : !poly_ty
 }
 
-func.func @ntt(%arg0 : !poly_ty) -> tensor<65536xi32, #ring> attributes { llvm.emit_c_interface } {
-  %0 = polynomial.ntt %arg0 {root=#root} : !poly_ty -> tensor<65536x!coeff_ty, #ring>
-  %1 = mod_arith.extract %0 : tensor<65536x!coeff_ty, #ring> -> tensor<65536xi32, #ring>
-  return %1 : tensor<65536xi32, #ring>
+func.func @ntt(%arg0 : !poly_ty) -> tensor<65536xi32> attributes { llvm.emit_c_interface } {
+  %0 = polynomial.ntt %arg0 {root=#root} : !poly_ty
+  %1 = polynomial.to_tensor %0 : !ntt_poly_ty -> tensor<65536x!coeff_ty>
+  %2 = mod_arith.extract %1 : tensor<65536x!coeff_ty> -> tensor<65536xi32>
+  return %2 : tensor<65536xi32>
 }
 
-func.func @intt(%arg0 : tensor<65536xi32, #ring>) -> !poly_ty attributes { llvm.emit_c_interface } {
-  %0 = mod_arith.encapsulate %arg0 : tensor<65536xi32, #ring> -> tensor<65536x!coeff_ty, #ring>
-  %1 = polynomial.intt %0 {root=#root} : tensor<65536x!coeff_ty, #ring> -> !poly_ty
-  return %1 :!poly_ty
+func.func @intt(%arg0 : tensor<65536xi32>) -> !poly_ty attributes { llvm.emit_c_interface } {
+  %0 = mod_arith.encapsulate %arg0 : tensor<65536xi32> -> tensor<65536x!coeff_ty>
+  %1 = polynomial.from_tensor %0 : tensor<65536x!coeff_ty> -> !ntt_poly_ty
+  %2 = polynomial.intt %1 {root=#root} : !ntt_poly_ty
+  return %2 :!poly_ty
 }

--- a/tests/Dialect/Polynomial/IR/canonicalization.mlir
+++ b/tests/Dialect/Polynomial/IR/canonicalization.mlir
@@ -3,32 +3,34 @@
 #ntt_poly = #polynomial.int_polynomial<-1 + x**8>
 !coeff_ty = !mod_arith.int<256:i32>
 #ntt_ring = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#ntt_poly>
-#root = #polynomial.primitive_root<value=31:i32, degree=8:index>
-!ntt_poly_ty = !polynomial.polynomial<ring=#ntt_ring>
+#root_val = #mod_arith.value<31:!coeff_ty>
+#root = #polynomial.primitive_root<value=#root_val, degree=8:i32>
+!poly_ty = !polynomial.polynomial<ring=#ntt_ring>
+!ntt_poly_ty = !polynomial.polynomial<ring=#ntt_ring, form=<isCoeffForm=false>>
 !tensor_ty = tensor<8x!coeff_ty, #ntt_ring>
 
 // CHECK: @test_canonicalize_intt_after_ntt
 // CHECK: (%[[P:.*]]: [[T:.*]]) -> [[T]]
-func.func @test_canonicalize_intt_after_ntt(%p0 : !ntt_poly_ty) -> !ntt_poly_ty {
+func.func @test_canonicalize_intt_after_ntt(%p0 : !poly_ty) -> !poly_ty {
   // CHECK-NOT: polynomial.ntt
   // CHECK-NOT: polynomial.intt
   // CHECK: %[[RESULT:.+]] = polynomial.add %[[P]], %[[P]]  : [[T]]
-  %t0 = polynomial.ntt %p0 {root=#root} : !ntt_poly_ty -> !tensor_ty
-  %p1 = polynomial.intt %t0 {root=#root} : !tensor_ty -> !ntt_poly_ty
-  %p2 = polynomial.add %p1, %p1 : !ntt_poly_ty
+  %t0 = polynomial.ntt %p0 {root=#root} : !poly_ty
+  %p1 = polynomial.intt %t0 {root=#root} : !ntt_poly_ty
+  %p2 = polynomial.add %p1, %p1 : !poly_ty
   // CHECK: return %[[RESULT]] : [[T]]
-  return %p2 : !ntt_poly_ty
+  return %p2 : !poly_ty
 }
 
 // CHECK: @test_canonicalize_ntt_after_intt
 // CHECK: (%[[X:.*]]: [[T:.*]]) -> [[T]]
-func.func @test_canonicalize_ntt_after_intt(%t0 : !tensor_ty) -> !tensor_ty {
+func.func @test_canonicalize_ntt_after_intt(%t0 : !ntt_poly_ty) -> !ntt_poly_ty {
   // CHECK-NOT: polynomial.intt
   // CHECK-NOT: polynomial.ntt
-  // CHECK: %[[RESULT:.+]] = mod_arith.add %[[X]], %[[X]] : [[T]]
-  %p0 = polynomial.intt %t0 {root=#root} : !tensor_ty -> !ntt_poly_ty
-  %t1 = polynomial.ntt %p0 {root=#root} : !ntt_poly_ty -> !tensor_ty
-  %t2 = mod_arith.add %t1, %t1 : !tensor_ty
+  // CHECK: %[[RESULT:.+]] = polynomial.add %[[X]], %[[X]] : [[T]]
+  %p0 = polynomial.intt %t0 {root=#root} : !ntt_poly_ty
+  %t1 = polynomial.ntt %p0 {root=#root} : !poly_ty
+  %t2 = polynomial.add %t1, %t1 : !ntt_poly_ty
   // CHECK: return %[[RESULT]] : [[T]]
-  return %t2 : !tensor_ty
+  return %t2 : !ntt_poly_ty
 }

--- a/tests/Dialect/Polynomial/IR/mod_arith_coefficients.mlir
+++ b/tests/Dialect/Polynomial/IR/mod_arith_coefficients.mlir
@@ -13,17 +13,20 @@
 !coeff_ty2 = !mod_arith.int<256:i32>
 #ideal = #polynomial.int_polynomial<-1 + x**1024>
 #ring = #polynomial.ring<coefficientType=!coeff_ty2, polynomialModulus=#ideal>
-!poly_ty = !polynomial.polynomial<ring=#ring>
 
 #ntt_poly = #polynomial.int_polynomial<-1 + x**8>
 #ntt_ring = #polynomial.ring<coefficientType=!coeff_ty2, polynomialModulus=#ntt_poly>
-!ntt_poly_ty = !polynomial.polynomial<ring=#ntt_ring>
+!poly_ty = !polynomial.polynomial<ring=#ntt_ring>
+!ntt_poly_ty = !polynomial.polynomial<ring=#ntt_ring, form=<isCoeffForm=false>>
+#ntt_ring_1_root_val = #mod_arith.value<31:!coeff_ty2>
+#ntt_ring_1_root = #polynomial.primitive_root<value=#ntt_ring_1_root_val, degree=8:i32>
 
 !coeff_ty3 = !mod_arith.int<786433:i32>
 #ntt_poly_2 = #polynomial.int_polynomial<1 + x**65536>
 #ntt_ring_2 = #polynomial.ring<coefficientType=!coeff_ty3, polynomialModulus=#ntt_poly_2>
-#ntt_ring_2_root = #polynomial.primitive_root<value=283965:i32, degree=131072:i32>
-!ntt_poly_ty_2 = !polynomial.polynomial<ring=#ntt_ring_2>
+#ntt_ring_2_root_val = #mod_arith.value<283965:!coeff_ty3>
+#ntt_ring_2_root = #polynomial.primitive_root<value=#ntt_ring_2_root_val, degree=131072:i32>
+!poly_ty_2 = !polynomial.polynomial<ring=#ntt_ring_2>
 
 module {
   func.func @test_multiply() -> !polynomial.polynomial<ring=#ring1> {
@@ -99,18 +102,18 @@ module {
     return
   }
 
-  func.func @test_ntt(%0 : !ntt_poly_ty) {
-    %1 = polynomial.ntt %0 {root=#polynomial.primitive_root<value=31:i32, degree=8:index>} : !ntt_poly_ty -> tensor<8x!coeff_ty2, #ntt_ring>
+  func.func @test_ntt(%0 : !poly_ty) {
+    %1 = polynomial.ntt %0 {root=#ntt_ring_1_root} : !poly_ty
     return
   }
 
-  func.func @test_ntt_with_overflowing_root(%0 : !ntt_poly_ty_2) {
-    %1 = polynomial.ntt %0 {root=#ntt_ring_2_root} : !ntt_poly_ty_2 -> tensor<65536x!coeff_ty3, #ntt_ring_2>
+  func.func @test_ntt_with_overflowing_root(%0 : !poly_ty_2) {
+    %1 = polynomial.ntt %0 {root=#ntt_ring_2_root} : !poly_ty_2
     return
   }
 
-  func.func @test_intt(%0 : tensor<8x!coeff_ty2, #ntt_ring>) {
-    %1 = polynomial.intt %0 {root=#polynomial.primitive_root<value=31:i32, degree=8:index>} : tensor<8x!coeff_ty2, #ntt_ring> -> !ntt_poly_ty
+  func.func @test_intt(%0 : !ntt_poly_ty) {
+    %1 = polynomial.intt %0 {root=#ntt_ring_1_root} : !ntt_poly_ty
     return
   }
 }


### PR DESCRIPTION
The primary goal of this PR is to make inputs and outputs of NTT/INTT both Polynomial, and to support the creation of NTT nodes with an RNS root of unity. To that end:
- Created ModArithAttr for ModArith roots of unity (single modulus)
- Created RNSAttr for RNS roots of unity
- Added a "form" attribute to polynomials indicating whether the polynomial is in coefficient or evaluation (NTT) form.
- Changed NTTOp and INTTOp to take polynomials and produce polynomials (with a different form)
- Added type inference to NTTOp/INTTOp
- Updated corresponding verifiers
- Updated NTT lowering in PolynomialToModArith. Note that the lowering does not support RNS-NTT ops yet; that will be in another PR.
- Updated tests