### PR TITLE
[Interpreter] Implement thread-safe parallelization for scf.forall

### DIFF
--- a/lib/Target/OpenFhePke/BUILD
+++ b/lib/Target/OpenFhePke/BUILD
@@ -1,5 +1,6 @@
 # OpenFhePke Emitter
 
+load("@heir//bazel/openfhe:copts.bzl", "OPENMP_COPTS", "OPENMP_LINKOPTS")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
@@ -124,7 +125,8 @@ cc_library(
     copts = select({
         "@heir//:config_openfhe_enable_timing": ["-DOPENFHE_ENABLE_TIMING"],
         "//conditions:default": [],
-    }),
+    }) + OPENMP_COPTS,
+    linkopts = OPENMP_LINKOPTS,
     deps = [
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
@@ -150,6 +152,8 @@ cc_library(
 cc_test(
     name = "InterpreterTest",
     srcs = ["InterpreterTest.cpp"],
+    copts = OPENMP_COPTS,
+    linkopts = OPENMP_LINKOPTS,
     deps = [
         ":Interpreter",
         "@googletest//:gtest_main",

--- a/lib/Target/OpenFhePke/Interpreter.h
+++ b/lib/Target/OpenFhePke/Interpreter.h
@@ -110,7 +110,7 @@ struct TypedCppValue {
 
 class Interpreter {
  public:
-  Interpreter(ModuleOp module) : module(module), liveness(module) {}
+  Interpreter(ModuleOp module);
 
   std::vector<TypedCppValue> interpret(const std::string& entryFunction,
                                        ArrayRef<TypedCppValue> inputValues);
@@ -246,7 +246,8 @@ class Interpreter {
   llvm::DenseMap<Value, EvalKeyT> evalKeys;
   llvm::DenseMap<Value, FastRotPrecompT> fastRotPrecomps;
 
-  Liveness liveness;
+  // liveness as shared_ptr to avoid expensive copying
+  std::shared_ptr<Liveness> liveness;
   llvm::DenseMap<Value, std::shared_ptr<CCParamsT>> params_;
 
   // Jump table for fast operation dispatch


### PR DESCRIPTION
Previously, scf.forall executed sequentially. Naive OpenMP parallelization caused data races on shared maps.
This PR fixes #2544 by cloning the interpreter per thread.

Improvements / Fixes
Interpreter now holds read-only liveness analysis via std::shared_ptr (no deep copy).
visit(scf::ForallOp) updated with #pragma omp parallel for.
TestOpenfheParallelFastRotation passes under parallel execution.


Fixes #2544 