### PR TITLE
Add ILP bootstrap placement pass

### DIFF
--- a/lib/Analysis/ILPBootstrapPlacementAnalysis/BUILD
+++ b/lib/Analysis/ILPBootstrapPlacementAnalysis/BUILD
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ILPBootstrapPlacementAnalysis",
+    srcs = ["ILPBootstrapPlacementAnalysis.cpp"],
+    hdrs = ["ILPBootstrapPlacementAnalysis.h"],
+    deps = [
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/time",
+        "@com_google_ortools//ortools/math_opt/cpp:math_opt",
+        "@com_google_ortools//ortools/math_opt/solvers:gscip_solver",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.cpp
+++ b/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.cpp
@@ -1,0 +1,372 @@
+#include "lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h"
+
+#include <algorithm>
+#include <cassert>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/time/time.h"        // from @com_google_absl
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"            // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/Casting.h"         // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"           // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"     // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/ValueRange.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"            // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"   // from @llvm-project
+#include "ortools/math_opt/cpp/math_opt.h"  // from @com_google_ortools
+
+// The level describes the remaining multiplicative depth of a ciphertext.
+// Bootstrap operations reset the level to a maximum value (or a target level
+// if specified), allowing further operations to be performed.
+//
+// This implementation tracks the level state through the computation
+// and uses ILP to determine optimal bootstrap placement to minimize costs
+// while ensuring level constraints are satisfied.
+//
+// ILP Formulation:
+// - Variables: level[value] for each SSA value, input_level[op] for each op,
+//   bootstrap[op] for each operation
+// - Constraints:
+//   * Level bounds: 0 <= level[value] <= bootstrapWaterline (levels
+//   0..bootstrapWaterline)
+//   * Operand matching: for each op, operand_i_level == input_level[op]
+//   * Multiplication: output_level = input_level - 1
+//   * Non-mult: output_level = input_level
+//   * Bootstrap (big-M): if bootstrap[op] = 1, level_after = bootstrapWaterline
+//                        else level_after = level_before
+// - Objective: minimize sum of bootstrap decisions
+
+namespace math_opt = ::operations_research::math_opt;
+
+#define DEBUG_TYPE "ilp-bootstrap-placement"
+
+namespace mlir {
+namespace heir {
+
+// Helper to get secret operands
+static void getSecretOperands(Operation* op, DataFlowSolver* solver,
+                              SmallVector<Value>& secretOperands) {
+  for (OpOperand& operand : op->getOpOperands()) {
+    if (isSecret(operand.get(), solver)) {
+      secretOperands.push_back(operand.get());
+    }
+  }
+}
+
+LogicalResult ILPBootstrapPlacementAnalysis::solve() {
+  math_opt::Model model("ILPBootstrapPlacementAnalysis");
+
+  // Get the secret.generic operation
+  auto genericOp = dyn_cast<secret::GenericOp>(opToRunOn);
+  if (!genericOp) {
+    return failure();
+  }
+
+  Block* body = genericOp.getBody();
+
+  int nextOpaqueId = 0;
+  llvm::DenseMap<Operation*, int> opaqueIds;
+  auto uniqueName = [&](Operation* op) {
+    std::string varName;
+    llvm::raw_string_ostream ss(varName);
+    ss << op->getName().getStringRef() << "_";
+    if (opaqueIds.count(op) == 0)
+      opaqueIds.insert(std::make_pair(op, nextOpaqueId++));
+    ss << opaqueIds.lookup(op);
+    return ss.str();
+  };
+
+  // Map operations to bootstrap decision variables
+  llvm::DenseMap<Operation*, math_opt::Variable> decisionVariables;
+  // Map SSA values to level variables (after bootstrap decision)
+  llvm::DenseMap<Value, math_opt::Variable> levelVars;
+  // Map SSA values to level variables before bootstrap
+  llvm::DenseMap<Value, math_opt::Variable> beforeBootstrapVars;
+  // Input level: level at which operands are consumed
+  llvm::DenseMap<Operation*, math_opt::Variable> inputLevelVars;
+
+  // Big-M constant for big-M method
+  // NOTE: This BIG_M does not account for "freshly encrypted" ciphertexts
+  // starting at a higher level than the bootstrap waterline. This should
+  // be addressed in future work.
+  const int BIG_M = bootstrapWaterline;
+
+  // Create variables for all SSA values in the body
+  // First, handle block arguments (inputs)
+  for (BlockArgument arg : body->getArguments()) {
+    if (!isSecret(arg, solver)) continue;
+
+    std::stringstream ss;
+    ss << "levelArg" << arg.getArgNumber();
+    auto levelVar =
+        model.AddContinuousVariable(0, bootstrapWaterline, ss.str());
+    levelVars.insert(std::make_pair(arg, levelVar));
+    // Inputs start at maximum level (bootstrapWaterline)
+    model.AddLinearConstraint(
+        levelVar == bootstrapWaterline,
+        "initLevelArg" + std::to_string(arg.getArgNumber()));
+  }
+
+  // Walk operations in the body
+  for (Operation& op : body->getOperations()) {
+    // Check if this operation produces secret results
+    if (llvm::none_of(op.getResults(), [&](OpResult result) {
+          return isSecret(result, solver);
+        })) {
+      continue;
+    }
+    if (isa<secret::YieldOp>(op)) continue;
+
+    std::string opName = uniqueName(&op);
+
+    // Create bootstrap decision variable for this operation
+    auto bootstrapVar = model.AddBinaryVariable("bootstrap" + opName);
+    decisionVariables.insert(std::make_pair(&op, bootstrapVar));
+
+    // Create input level variable: level at which operands are consumed
+    auto inputLevelVar = model.AddContinuousVariable(0, bootstrapWaterline,
+                                                     "inputLevel" + opName);
+    inputLevelVars.insert(std::make_pair(&op, inputLevelVar));
+
+    // Create level variables for results
+    for (OpResult result : op.getResults()) {
+      if (!isSecret(result, solver)) continue;
+
+      std::stringstream ss;
+      ss << "level" << opName << result.getResultNumber();
+      auto levelVar =
+          model.AddContinuousVariable(0, bootstrapWaterline, ss.str());
+      levelVars.insert(std::make_pair(result, levelVar));
+
+      std::stringstream ss2;
+      ss2 << "levelBefore" << opName << result.getResultNumber();
+      auto beforeVar =
+          model.AddContinuousVariable(0, bootstrapWaterline, ss2.str());
+      beforeBootstrapVars.insert(std::make_pair(result, beforeVar));
+    }
+  }
+
+  // Add constraints for operations
+  for (auto& [op, _] : opaqueIds) {
+    std::string opName = uniqueName(op);
+
+    // Get secret operands
+    SmallVector<Value> secretOperands;
+    getSecretOperands(op, solver, secretOperands);
+
+    // Operand matching: all operands must be at the same level when consumed.
+    // inputLevel = level at which operands are consumed.
+    auto inputLevelVar = inputLevelVars.at(op);
+    for (size_t i = 0; i < secretOperands.size(); ++i) {
+      Value operand = secretOperands[i];
+      if (!levelVars.contains(operand)) continue;
+
+      std::stringstream ss;
+      ss << "operandMatch" << opName << "Op" << i;
+      model.AddLinearConstraint(levelVars.at(operand) == inputLevelVar,
+                                ss.str());
+    }
+
+    // Output level: for multiplication, output = input - 1; else output = input
+    if (isa<arith::MulFOp>(op) || isa<arith::MulIOp>(op)) {
+      for (OpResult result : op->getResults()) {
+        if (!isSecret(result, solver)) continue;
+        if (!beforeBootstrapVars.contains(result)) continue;
+
+        auto resultBeforeVar = beforeBootstrapVars.at(result);
+        // outputLevel = inputLevel - 1
+        std::stringstream ss;
+        ss << "mulOutput" << opName << result.getResultNumber();
+        model.AddLinearConstraint(resultBeforeVar == inputLevelVar - 1,
+                                  ss.str());
+        std::stringstream ssMin;
+        ssMin << "mulLevelMin" << opName << result.getResultNumber();
+        model.AddLinearConstraint(resultBeforeVar >= 0, ssMin.str());
+      }
+    } else {
+      for (OpResult result : op->getResults()) {
+        if (!isSecret(result, solver)) continue;
+        if (!beforeBootstrapVars.contains(result)) continue;
+
+        auto resultBeforeVar = beforeBootstrapVars.at(result);
+        // outputLevel = inputLevel (level flows through unchanged)
+        std::stringstream ss;
+        ss << "flowOutput" << opName << result.getResultNumber();
+        model.AddLinearConstraint(resultBeforeVar == inputLevelVar, ss.str());
+      }
+    }
+
+    // Add bootstrap constraints using big-M method
+    for (OpResult result : op->getResults()) {
+      if (!isSecret(result, solver)) continue;
+      if (!levelVars.contains(result) || !beforeBootstrapVars.contains(result))
+        continue;
+
+      auto resultLevelVar = levelVars.at(result);
+      auto resultBeforeVar = beforeBootstrapVars.at(result);
+      auto bootstrapVar = decisionVariables.at(op);
+
+      std::stringstream ss;
+      ss << "bootstrapOutput" << opName << result.getResultNumber();
+
+      // If bootstrap = 1: level_after = bootstrapWaterline
+      // If bootstrap = 0: levelAfter = levelBefore
+      // Using big-M:
+      // levelAfter <= bootstrapWaterline + BIG_M * (1 - bootstrap)
+      // levelAfter >= bootstrapWaterline - BIG_M * (1 - bootstrap)
+      // levelAfter <= levelBefore + BIG_M * bootstrap
+      // levelAfter >= levelBefore - BIG_M * bootstrap
+
+      std::string cstName1 = ss.str() + "_1";
+      model.AddLinearConstraint(
+          resultLevelVar <= bootstrapWaterline + BIG_M * (1 - bootstrapVar),
+          cstName1);
+
+      std::string cstName2 = ss.str() + "_2";
+      model.AddLinearConstraint(
+          resultLevelVar >= bootstrapWaterline - BIG_M * (1 - bootstrapVar),
+          cstName2);
+
+      std::string cstName3 = ss.str() + "_3";
+      model.AddLinearConstraint(
+          resultLevelVar <= resultBeforeVar + BIG_M * bootstrapVar, cstName3);
+
+      std::string cstName4 = ss.str() + "_4";
+      model.AddLinearConstraint(
+          resultLevelVar >= resultBeforeVar - BIG_M * bootstrapVar, cstName4);
+    }
+  }
+
+  // Objective: minimize number of bootstraps
+  math_opt::LinearExpression obj;
+  for (auto& [op, decisionVar] : decisionVariables) {
+    obj += decisionVar;
+  }
+  model.Minimize(obj);
+
+  LLVM_DEBUG({
+    std::stringstream ss;
+    ss << model;
+    llvm::dbgs() << "--- ILP model ---\n" << ss.str() << "--- end model ---\n";
+  });
+
+  // Solve the ILP
+  const absl::StatusOr<math_opt::SolveResult> status =
+      math_opt::Solve(model, math_opt::SolverType::kGscip);
+
+  if (!status.ok()) {
+    std::stringstream ss;
+    ss << "Error solving the problem: " << status.status() << "\n";
+    llvm::errs() << ss.str();
+    return failure();
+  }
+
+  const math_opt::SolveResult& result = status.value();
+
+  switch (result.termination.reason) {
+    case math_opt::TerminationReason::kOptimal:
+    case math_opt::TerminationReason::kFeasible:
+      break;
+    default:
+      llvm::errs() << "The problem does not have a feasible solution. "
+                      "Termination status code: "
+                   << (int)result.termination.reason << "\n";
+      return failure();
+  }
+
+  // Extract solution
+  auto varMap = result.variable_values();
+  for (auto& [op, decisionVar] : decisionVariables) {
+    solution.insert(std::make_pair(op, varMap[decisionVar] > 0.5));
+  }
+
+  for (auto& [value, beforeVar] : beforeBootstrapVars) {
+    solutionLevelBeforeBootstrap.insert(
+        std::make_pair(value, (int)std::round(varMap[beforeVar])));
+  }
+  for (auto& [value, levelVar] : levelVars) {
+    solutionLevelAfterBootstrap.insert(
+        std::make_pair(value, (int)std::round(varMap[levelVar])));
+  }
+
+  return success();
+}
+
+llvm::SmallVector<Value, 32>
+ILPBootstrapPlacementAnalysis::getValuesToBootstrap() const {
+  llvm::SmallVector<Value, 32> out;
+  auto genericOp = dyn_cast<secret::GenericOp>(opToRunOn);
+  if (!genericOp || !solver) return out;
+  for (const auto& [op, insert] : solution) {
+    if (!insert) continue;
+    for (OpResult result : op->getResults()) {
+      if (isSecret(result, solver)) out.push_back(result);
+    }
+  }
+  return out;
+}
+
+void ILPBootstrapPlacementAnalysis::printSolution(llvm::raw_ostream& os) const {
+  auto genericOp = dyn_cast<secret::GenericOp>(opToRunOn);
+  if (!genericOp) {
+    os << "(not a secret.generic)\n";
+    return;
+  }
+  Block* body = genericOp.getBody();
+  if (!body) return;
+
+  os << "--- ILP bootstrap placement solution ---\n";
+  os << "bootstrap waterline: " << bootstrapWaterline << "\n\n";
+
+  // Block arguments (inputs): print as in IR, level after only
+  for (BlockArgument arg : body->getArguments()) {
+    auto it = solutionLevelAfterBootstrap.find(arg);
+    if (it != solutionLevelAfterBootstrap.end()) {
+      os << "  ";
+      arg.print(os);
+      os << "  level(after): " << it->second << "\n";
+    }
+  }
+
+  // Ops in body order: print op and operands (as in IR), then bootstrap/levels
+  for (Operation& op : body->getOperations()) {
+    if (isa<secret::YieldOp>(op)) continue;
+    bool insertBootstrap = solution.lookup(&op);
+    os << "  ";
+    op.print(os);
+    os << "  bootstrap=" << (insertBootstrap ? "yes" : "no");
+    for (OpResult result : op.getResults()) {
+      auto beforeIt = solutionLevelBeforeBootstrap.find(result);
+      auto afterIt = solutionLevelAfterBootstrap.find(result);
+      if (beforeIt != solutionLevelBeforeBootstrap.end() ||
+          afterIt != solutionLevelAfterBootstrap.end()) {
+        os << " level(before=";
+        if (beforeIt != solutionLevelBeforeBootstrap.end())
+          os << beforeIt->second;
+        else
+          os << "?";
+        os << " after=";
+        if (afterIt != solutionLevelAfterBootstrap.end())
+          os << afterIt->second;
+        else
+          os << "?";
+        os << ")";
+      }
+    }
+    os << "\n";
+  }
+  os << "--- end solution ---\n";
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h
+++ b/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h
@@ -1,0 +1,59 @@
+#ifndef LIB_ANALYSIS_ILP_BOOTSTRAP_PLACEMENT_ANALYSIS_H
+#define LIB_ANALYSIS_ILP_BOOTSTRAP_PLACEMENT_ANALYSIS_H
+
+#include <cstddef>
+
+#include "llvm/include/llvm/ADT/DenseMap.h"                // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"             // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"                // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace mlir {
+namespace heir {
+class ILPBootstrapPlacementAnalysis {
+ public:
+  ILPBootstrapPlacementAnalysis(Operation* op, DataFlowSolver* solver,
+                                int bootstrapWaterline)
+      : opToRunOn(op), solver(solver), bootstrapWaterline(bootstrapWaterline) {}
+  ~ILPBootstrapPlacementAnalysis() = default;
+
+  LogicalResult solve();
+
+  // Return the set of SSA values that the ILP decided should have a bootstrap
+  // inserted after their definition. Used by the pass to insert bootstraps
+  // without iterating by op index; Values remain valid across modreduce/
+  // relinearize insertion.
+  llvm::SmallVector<Value, 32> getValuesToBootstrap() const;
+
+  // Return the level at the given SSA value, as determined by the
+  // solution to the optimization problem. When the input value is the result
+  // of an op, and the model solution suggests a bootstrap should be
+  // inserted after that op, this function returns the pre-bootstrap level.
+  //
+  // We don't need an "after bootstrap" version because after bootstrap the
+  // level is reset to the maximum level (or a target level if specified).
+  int levelBeforeBootstrap(Value value) const {
+    return solutionLevelBeforeBootstrap.lookup(value);
+  }
+
+  // Debug: print the entire solution (bootstrap decisions and levels) to os.
+  void printSolution(llvm::raw_ostream& os) const;
+
+ private:
+  Operation* opToRunOn;
+  DataFlowSolver* solver;
+  int bootstrapWaterline;
+  llvm::DenseMap<Operation*, bool> solution;
+  llvm::DenseMap<Value, int> solutionLevelBeforeBootstrap;
+  llvm::DenseMap<Value, int> solutionLevelAfterBootstrap;
+};
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_ANALYSIS_ILP_BOOTSTRAP_PLACEMENT_ANALYSIS_H

--- a/lib/Transforms/ILPBootstrapPlacement/BUILD
+++ b/lib/Transforms/ILPBootstrapPlacement/BUILD
@@ -1,0 +1,36 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ILPBootstrapPlacement",
+    srcs = ["ILPBootstrapPlacement.cpp"],
+    hdrs = [
+        "ILPBootstrapPlacement.h",
+    ],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Analysis/ILPBootstrapPlacementAnalysis",
+        "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
+        "@heir//lib/Dialect/Mgmt/Transforms:AnnotateMgmt",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Transforms/SecretInsertMgmt:Pipeline",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "ILPBootstrapPlacement",
+)

--- a/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.cpp
+++ b/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.cpp
@@ -1,0 +1,126 @@
+#include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h"
+
+#include "lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h"
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Mgmt/IR/MgmtDialect.h"
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Transforms/SecretInsertMgmt/Pipeline.h"
+#include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/Attributes.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"                 // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                    // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"            // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"           // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define DEBUG_TYPE "ilp-bootstrap-placement"
+#define GEN_PASS_DEF_ILPBOOTSTRAPPLACEMENT
+#include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h.inc"
+
+struct ILPBootstrapPlacement
+    : impl::ILPBootstrapPlacementBase<ILPBootstrapPlacement> {
+  using ILPBootstrapPlacementBase::ILPBootstrapPlacementBase;
+
+  LogicalResult processSecretGenericOp(
+      secret::GenericOp genericOp, DataFlowSolver* solver,
+      SmallVector<Value, 32>* valuesToBootstrap) {
+    genericOp->walk([&](mgmt::BootstrapOp op) {
+      op.getResult().replaceAllUsesWith(op.getOperand());
+      op.erase();
+    });
+
+    ILPBootstrapPlacementAnalysis analysis(genericOp, solver,
+                                           bootstrapWaterline);
+    if (failed(analysis.solve())) {
+      genericOp->emitError(
+          "Failed to solve the bootstrap placement optimization problem");
+      return failure();
+    }
+    LLVM_DEBUG(analysis.printSolution(llvm::dbgs()));
+    for (Value v : analysis.getValuesToBootstrap())
+      valuesToBootstrap->push_back(v);
+    return success();
+  }
+
+  void insertBootstrapsForValues(ArrayRef<Value> valuesToBootstrap) {
+    OpBuilder b(&getContext());
+    for (Value v : valuesToBootstrap) {
+      // After modreduce/relinearize we have mul -> relinearize -> modreduce.
+      // Follow the chain so we bootstrap the modreduce result (correct level
+      // refresh) and insert after it.
+      Value toBootstrap = v;
+      Operation* insertAfter = v.getDefiningOp();
+      while (toBootstrap.hasOneUse()) {
+        Operation* user = *toBootstrap.getUsers().begin();
+        if (isa<mgmt::RelinearizeOp>(user) || isa<mgmt::ModReduceOp>(user)) {
+          toBootstrap = user->getResult(0);
+          insertAfter = user;
+        } else {
+          break;
+        }
+      }
+      b.setInsertionPointAfter(insertAfter);
+      auto bootstrapOp =
+          mgmt::BootstrapOp::create(b, insertAfter->getLoc(), toBootstrap);
+      toBootstrap.replaceAllUsesExcept(bootstrapOp.getResult(), {bootstrapOp});
+    }
+  }
+
+  void runOnOperation() override {
+    Operation* module = getOperation();
+
+    DataFlowSolver solver;
+    dataflow::loadBaselineAnalyses(solver);
+    solver.load<SecretnessAnalysis>();
+
+    if (failed(solver.initializeAndRun(getOperation()))) {
+      getOperation()->emitOpError() << "Failed to run the analysis.\n";
+      signalPassFailure();
+      return;
+    }
+
+    SmallVector<Value, 32> valuesToBootstrap;
+    auto result = module->walk([&](secret::GenericOp genericOp) {
+      if (failed(
+              processSecretGenericOp(genericOp, &solver, &valuesToBootstrap)))
+        return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+    if (result.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
+    // Modreduce after every mul.
+    insertModReduceBeforeOrAfterMult(getOperation(), /*afterMul=*/true,
+                                     /*beforeMulIncludeFirstMul=*/false,
+                                     /*includeFloats=*/true);
+
+    // Relinearize after every mul.
+    insertRelinearizeAfterMult(getOperation(), /*includeFloats=*/true);
+
+    // Insert bootstraps at the Values the ILP chose. Values remain valid.
+    insertBootstrapsForValues(valuesToBootstrap);
+
+    OpPassManager nested("builtin.module");
+    nested.addPass(createCanonicalizerPass());
+    nested.addPass(createCSEPass());
+    nested.addPass(mgmt::createAnnotateMgmt());
+    if (failed(runPipeline(nested, getOperation()))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h
+++ b/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_ILP_BOOTSTRAP_PLACEMENT_H_
+#define LIB_TRANSFORMS_ILP_BOOTSTRAP_PLACEMENT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_ILP_BOOTSTRAP_PLACEMENT_H_

--- a/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.td
+++ b/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.td
@@ -1,0 +1,38 @@
+#ifndef LIB_TRANSFORMS_ILP_BOOTSTRAP_PLACEMENT_TD_
+#define LIB_TRANSFORMS_ILP_BOOTSTRAP_PLACEMENT_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def ILPBootstrapPlacement : Pass <"ilp-bootstrap-placement"> {
+    let summary = "Optimize placement of bootstrap ops using ILP";
+    let description = [{
+        This pass uses an integer linear program to determine the optimal level
+        of each term in the MLIR, and thus the placement of bootstrap and
+        modreduce operations.
+
+        The pass runs on [ciphertext-semantic](https://heir.dev/docs/design/layout/#data-semantic-and-ciphertext-semantic-tensors)
+        IR (secret.generic with arith ops operating on pre-packed tensors). It
+        1) Inserts mgmt.modreduce after each level-consuming op (e.g. mul in
+           CKKS, where level drops only at multiplications).
+        2) Inserts mgmt.bootstrap at the positions chosen by the ILP.
+        3) Inserts mgmt.relinearize after each mul. Resulting order is mul ->
+           relinearize -> modreduce, with bootstrap after modreduce or after
+           the op where the ILP chose.
+
+        Note: The ILP formulation does not account for a freshly encrypted
+        ciphertext starting at a higher level than the bootstrap waterline.
+        This will be implemented as future work.
+    }];
+
+    let dependentDialects = ["mlir::heir::mgmt::MgmtDialect"];
+
+  let options = [
+    Option<"bootstrapWaterline",
+           "bootstrap-waterline",
+           "int",
+           /*default=*/"3",
+           "Bootstrap waterline (max level). Levels are 0..bootstrap-waterline (inclusive); inputs start at bootstrap-waterline.">,
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_ILP_BOOTSTRAP_PLACEMENT_TD_

--- a/tests/Transforms/ilp_bootstrap_placement/BUILD
+++ b/tests/Transforms/ilp_bootstrap_placement/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/ilp_bootstrap_placement/bootstrap_placement_comparison.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/bootstrap_placement_comparison.mlir
@@ -1,0 +1,75 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s --check-prefix=CHECK-ILP
+// RUN: heir-opt --secret-insert-mgmt-ckks=bootstrap-waterline=3 %s | FileCheck %s --check-prefix=CHECK-GREEDY
+
+// Compare the greedy bootstrap placement against the ILP bootstrap placement
+// with bootstrap-waterline=3. Greedy gives 3 bootstraps after L5, L6, L7 (each
+// bootstrap immediately after the modreduce that brings that branch to level
+// 0). ILP places 2 bootstraps (optimal for this DAG with levels 0..3):
+//
+// Computation:
+// L1 = I1 * I2   (level 2)
+// L2 = I2 * I3   (level 2)
+// L3 = I4 * I5   (level 2)
+// L4 = L1 * L2   (level 1)
+// L5 = I1 * L4   (would be level 0, needs bootstrap)
+// L6 = L4 * I4   (would be level 0, needs bootstrap)
+// L7 = L3 * L4   (would be level 0, needs bootstrap)
+// L8 = L5 * L6   (would be level -1, needs bootstrap)
+// L9 = L6 * L7   (would be level -1, needs bootstrap)
+// L10 = L8 * L9  (would be level -2, needs bootstrap)
+
+// CHECK-ILP-COUNT-2: mgmt.bootstrap
+// CHECK-ILP-NOT: mgmt.bootstrap
+// CHECK-GREEDY-COUNT-3: mgmt.bootstrap
+
+func.func @bootstrap_placement_test(
+    %arg0: !secret.secret<tensor<8xf32>>,
+    %arg1: !secret.secret<tensor<8xf32>>,
+    %arg2: !secret.secret<tensor<8xf32>>,
+    %arg3: !secret.secret<tensor<8xf32>>,
+    %arg4: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+  %0 = secret.generic(
+      %arg0: !secret.secret<tensor<8xf32>>,
+      %arg1: !secret.secret<tensor<8xf32>>,
+      %arg2: !secret.secret<tensor<8xf32>>,
+      %arg3: !secret.secret<tensor<8xf32>>,
+      %arg4: !secret.secret<tensor<8xf32>>) {
+  ^body(%input0: tensor<8xf32>,
+        %input1: tensor<8xf32>,
+        %input2: tensor<8xf32>,
+        %input3: tensor<8xf32>,
+        %input4: tensor<8xf32>):
+    // L1 = I1 * I2
+    %l1 = arith.mulf %input0, %input1 : tensor<8xf32>
+
+    // L2 = I2 * I3
+    %l2 = arith.mulf %input1, %input2 : tensor<8xf32>
+
+    // L3 = I4 * I5
+    %l3 = arith.mulf %input3, %input4 : tensor<8xf32>
+
+    // L4 = L1 * L2
+    %l4 = arith.mulf %l1, %l2 : tensor<8xf32>
+
+    // L5 = I1 * L4
+    %l5 = arith.mulf %input0, %l4 : tensor<8xf32>
+
+    // L6 = L4 * I4
+    %l6 = arith.mulf %l4, %input3 : tensor<8xf32>
+
+    // L7 = L3 * L4
+    %l7 = arith.mulf %l3, %l4 : tensor<8xf32>
+
+    // L8 = L5 * L6
+    %l8 = arith.mulf %l5, %l6 : tensor<8xf32>
+
+    // L9 = L6 * L7
+    %l9 = arith.mulf %l6, %l7 : tensor<8xf32>
+
+    // L10 = L8 * L9
+    %l10 = arith.mulf %l8, %l9 : tensor<8xf32>
+
+    secret.yield %l10 : tensor<8xf32>
+  } -> !secret.secret<tensor<8xf32>>
+  return %0 : !secret.secret<tensor<8xf32>>
+}

--- a/tests/Transforms/ilp_bootstrap_placement/ilp_relin_modreduce_placement.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/ilp_relin_modreduce_placement.mlir
@@ -1,0 +1,52 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s
+
+// Test relinearize and modreduce operations are inserted correctly after the
+// ILP bootstrap placement pass, i.e., each multiplication should be followed by
+// a `mgmt.relinearize` and a `mgmt.modreduce`. This test samples 3 mul ops and
+// checks that these mgmt operations are inserted.
+
+// CHECK: func.func @bootstrap_placement_test
+// CHECK: secret.generic
+// CHECK: arith.mulf %input3, %input4
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK: arith.mulf %3, %6
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK: arith.mulf %10, %14
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.modreduce
+// CHECK: secret.yield
+
+
+func.func @bootstrap_placement_test(
+    %arg0: !secret.secret<tensor<8xf32>>,
+    %arg1: !secret.secret<tensor<8xf32>>,
+    %arg2: !secret.secret<tensor<8xf32>>,
+    %arg3: !secret.secret<tensor<8xf32>>,
+    %arg4: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+  %0 = secret.generic(
+      %arg0: !secret.secret<tensor<8xf32>>,
+      %arg1: !secret.secret<tensor<8xf32>>,
+      %arg2: !secret.secret<tensor<8xf32>>,
+      %arg3: !secret.secret<tensor<8xf32>>,
+      %arg4: !secret.secret<tensor<8xf32>>) {
+  ^body(%input0: tensor<8xf32>,
+        %input1: tensor<8xf32>,
+        %input2: tensor<8xf32>,
+        %input3: tensor<8xf32>,
+        %input4: tensor<8xf32>):
+    %l1 = arith.mulf %input0, %input1 : tensor<8xf32>
+    %l2 = arith.mulf %input1, %input2 : tensor<8xf32>
+    %l3 = arith.mulf %input3, %input4 : tensor<8xf32>
+    %l4 = arith.mulf %l1, %l2 : tensor<8xf32>
+    %l5 = arith.mulf %input0, %l4 : tensor<8xf32>
+    %l6 = arith.mulf %l4, %input3 : tensor<8xf32>
+    %l7 = arith.mulf %l3, %l4 : tensor<8xf32>
+    %l8 = arith.mulf %l5, %l6 : tensor<8xf32>
+    %l9 = arith.mulf %l6, %l7 : tensor<8xf32>
+    %l10 = arith.mulf %l8, %l9 : tensor<8xf32>
+    secret.yield %l10 : tensor<8xf32>
+  } -> !secret.secret<tensor<8xf32>>
+  return %0 : !secret.secret<tensor<8xf32>>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -129,6 +129,7 @@ cc_binary(
         "@heir//lib/Transforms/FullLoopUnroll",
         "@heir//lib/Transforms/GenerateParam",
         "@heir//lib/Transforms/Halo:Transforms",
+        "@heir//lib/Transforms/ILPBootstrapPlacement",
         "@heir//lib/Transforms/InlineActivations",
         "@heir//lib/Transforms/LayoutOptimization",
         "@heir//lib/Transforms/LayoutOptimization:InterfaceImpl",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -83,6 +83,7 @@
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
 #include "lib/Transforms/GenerateParam/GenerateParam.h"
 #include "lib/Transforms/Halo/Passes.h"
+#include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h"
 #include "lib/Transforms/InlineActivations/InlineActivations.h"
 #include "lib/Transforms/LayoutOptimization/InterfaceImpl.h"
 #include "lib/Transforms/LayoutOptimization/LayoutOptimization.h"
@@ -310,6 +311,7 @@ int main(int argc, char** argv) {
   registerStraightLineVectorizerPasses();
   registerUnusedMemRefPasses();
   registerValidateNoisePasses();
+  registerILPBootstrapPlacementPasses();
   registerOptimizeRelinearizationPasses();
   registerRemoveUnusedPureCallPasses();
   registerRotationAnalysisPasses();


### PR DESCRIPTION
This PR is an initial attempt at implementing a naive ILP-based bootstrap placement pass for more efficient bootstrap and secret-mgmt operation placement. The pass does not rely on the current secret-mgmt-insert-pass, as the pass initially solves for the level of each op, thereby determining the bootstrap and other secret-mgmt operation placement. 

- New pass --ilp-bootstrap-placement with option bootstrap-waterline
- LIT tests: bootstrap_placement_comparison.mlir, ilp_relin_modreduce_placement.mlir.

At a high-level, the formulation is as follows:
- Variables
  - the input level of each op, the output level of each op, and whether a bootstrap is placed on an op. 
- Constraints 
  - Level bounds: 0 <= op.level <= bootstrapWaterline 
  - Operand matching: operand levels must be equal
  - Multiplication: assumes multiplications consume 1 level 
  - Non-mult: all other operations forward the operand level 
  - Bootstrap (big-M): if bootstrap, then the output level is the bootstrapWaterline, otherwise the input level is forwarded to the output level. 
- Objective: minimize number of bootstrap operations


Note: This is still a naive ILP implementation and there are concerns yet to be addressed. 
- This ILP formulation relies on the assumption that every multiplication consumes a level.  This can be relaxed with more fine-grain scale analysis, (e.g., that delays multiple multiplications before a rescale instruction). 
- The ILP formulation only considers the input and output level of each vertex. However, this misses potential level changes along edges (e.g., when two independent data paths converge at an op with a level mismatch). The assumption assumes a modReduce operation after every multiplication, and all operands levels are equal without additional modReduce operations. 

These limitations will be addressed in the future.