### PR TITLE
Add torch cleanup to plaintext pipeline

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -205,12 +205,12 @@ void mlirToSecretArithmeticPipelineBuilder(
 
 void mlirToPlaintextPipelineBuilder(OpPassManager& pm,
                                     const PlaintextBackendOptions& options) {
+  linalgPreprocessingBuilder(pm);
+
   // Convert to secret arithmetic
   MlirToRLWEPipelineOptions mlirToRLWEPipelineOptions;
   mlirToRLWEPipelineOptions.ciphertextDegree = options.plaintextSize;
   mlirToSecretArithmeticPipelineBuilder(pm, mlirToRLWEPipelineOptions);
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
 
   if (options.debug) {
     // Insert debug handler calls

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -176,6 +176,7 @@ cc_binary(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:IndexToLLVM",
         "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:LLVMIRTransforms",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MathDialect",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -132,8 +132,9 @@
 #include "mlir/include/mlir/Dialect/Func/Extensions/AllExtensions.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"    // from @llvm-project
-#include "mlir/include/mlir/Dialect/Linalg/Passes.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/Passes.h"     // from @llvm-project
 #include "mlir/include/mlir/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Math/IR/Math.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
@@ -260,6 +261,7 @@ int main(int argc, char** argv) {
   scf::registerBufferizableOpInterfaceExternalModels(registry);
   tensor::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::arith::registerConvertArithToLLVMInterface(registry);
+  mlir::LLVM::registerInlinerInterface(registry);
 
   // Custom passes in HEIR
   registerEmitCInterfacePass();


### PR DESCRIPTION
This fixes the command

```
bazel run //tools:heir-opt -- --mlir-to-plaintext-backend="plaintext-size=1024" $PWD/tests/Examples/common/mnist.mlir
```

but I haven't had the chance to actually run the generated LLVM IR.

Fixes https://github.com/google/heir/issues/2669