### PR TITLE
Issue1485_OpenFHE-Emitter_e2e_testing

### DIFF
--- a/lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.h
+++ b/lib/Dialect/SCIFRBool/Transforms/CGGIEstimator.h
@@ -28,7 +28,7 @@ struct LWEParameters {
 struct CGGIOpsData : LWEParameters {
   explicit CGGIOpsData(uint64_t polynomial_degree, uint64_t levels,
                        uint64_t glwe_param, uint64_t lwe_dim)
-      : LWEParameters(polynomial_degree, levels, glwe_param, lwe_dim) {}
+      : LWEParameters(polynomial_degree, levels, glwe_param, lwe_dim){};
 
   enum CGGIOpsEnum {
     AND,

--- a/tests/Examples/openfhe/bfv/dot_product_8_debug/BUILD
+++ b/tests/Examples/openfhe/bfv/dot_product_8_debug/BUILD
@@ -17,3 +17,16 @@ openfhe_end_to_end_test(
     test_src = "dot_product_8_debug_test.cpp",
     deps = ["@heir//tests/Examples/openfhe/bfv:debug_helper"],
 )
+
+openfhe_end_to_end_test(
+    name = "dot_product_8_default_debug_test",
+    generate_debug_helper = True,
+    generated_lib_header = "dot_product_8_default_debug_lib.h",
+    heir_opt_flags = [
+        "--annotate-module=backend=openfhe scheme=bfv",
+        "--mlir-to-bfv=ciphertext-degree=8192 annotate-noise-bound=true",
+        "--scheme-to-openfhe=insert-debug-handler-calls=true",
+    ],
+    mlir_src = "@heir//tests/Examples/common:dot_product_8.mlir",
+    test_src = "dot_product_8_default_debug_test.cpp",
+)

--- a/tests/Examples/openfhe/bfv/dot_product_8_debug/dot_product_8_default_debug_test.cpp
+++ b/tests/Examples/openfhe/bfv/dot_product_8_debug/dot_product_8_default_debug_test.cpp
@@ -1,0 +1,40 @@
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"  // from @googletest
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/bfv/dot_product_8_debug/dot_product_8_default_debug_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(DotProduct8Test, RunTest) {
+  auto cryptoContext = dot_product__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      dot_product__configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<int16_t> arg0 = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<int16_t> arg1 = {2, 3, 4, 5, 6, 7, 8, 9};
+  int64_t expected = 240;
+
+  auto arg0Encrypted =
+      dot_product__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg1Encrypted =
+      dot_product__encrypt__arg1(cryptoContext, arg1, publicKey);
+  auto outputEncrypted =
+      dot_product(cryptoContext, secretKey, arg0Encrypted, arg1Encrypted);
+  auto actual =
+      dot_product__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/Examples/openfhe/bgv/dot_product_8_debug/BUILD
+++ b/tests/Examples/openfhe/bgv/dot_product_8_debug/BUILD
@@ -17,3 +17,16 @@ openfhe_end_to_end_test(
     test_src = "dot_product_8_debug_test.cpp",
     deps = ["@heir//tests/Examples/openfhe/bgv:debug_helper"],
 )
+
+openfhe_end_to_end_test(
+    name = "dot_product_8_default_debug_test",
+    generate_debug_helper = True,
+    generated_lib_header = "dot_product_8_default_debug_lib.h",
+    heir_opt_flags = [
+        "--annotate-module=backend=openfhe scheme=bgv",
+        "--mlir-to-bfv=ciphertext-degree=8192 annotate-noise-bound=true",
+        "--scheme-to-openfhe=insert-debug-handler-calls=true",
+    ],
+    mlir_src = "@heir//tests/Examples/common:dot_product_8.mlir",
+    test_src = "dot_product_8_default_debug_test.cpp",
+)

--- a/tests/Examples/openfhe/bgv/dot_product_8_debug/dot_product_8_default_debug_test.cpp
+++ b/tests/Examples/openfhe/bgv/dot_product_8_debug/dot_product_8_default_debug_test.cpp
@@ -1,0 +1,39 @@
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"  // from @googletest
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/bgv/dot_product_8_debug/dot_product_8_default_debug_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(DotProduct8Test, RunTest) {
+  auto cryptoContext = dot_product__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      dot_product__configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<int16_t> arg0 = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<int16_t> arg1 = {2, 3, 4, 5, 6, 7, 8, 9};
+  int64_t expected = 240;
+
+  auto arg0Encrypted =
+      dot_product__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg1Encrypted =
+      dot_product__encrypt__arg1(cryptoContext, arg1, publicKey);
+  auto outputEncrypted =
+      dot_product(cryptoContext, secretKey, arg0Encrypted, arg1Encrypted);
+  auto actual =
+      dot_product__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_EQ(expected, actual);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/Examples/openfhe/ckks/dot_product_8f_debug/BUILD
+++ b/tests/Examples/openfhe/ckks/dot_product_8f_debug/BUILD
@@ -21,3 +21,20 @@ openfhe_end_to_end_test(
     test_src = "dot_product_8f_debug_test.cpp",
     deps = ["@heir//tests/Examples/openfhe/ckks:debug_helper"],
 )
+
+openfhe_end_to_end_test(
+    name = "dot_product_8f_default_debug_test",
+    data = [
+        "@heir//tests/Examples/plaintext/dot_product_f_debug:dot_product_8f_debug.log",
+    ],
+    generate_debug_helper = True,
+    generated_lib_header = "dot_product_8f_default_debug_lib.h",
+    heir_opt_flags = [
+        "--annotate-module=backend=openfhe scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=8 \
+          plaintext-execution-result-file-name=$(location @heir//tests/Examples/plaintext/dot_product_f_debug:dot_product_8f_debug.log)",
+        "--scheme-to-openfhe=insert-debug-handler-calls=true",
+    ],
+    mlir_src = "@heir//tests/Examples/common:dot_product_8f.mlir",
+    test_src = "dot_product_8f_default_debug_test.cpp",
+)

--- a/tests/Examples/openfhe/ckks/dot_product_8f_debug/dot_product_8f_default_debug_test.cpp
+++ b/tests/Examples/openfhe/ckks/dot_product_8f_debug/dot_product_8f_default_debug_test.cpp
@@ -1,0 +1,38 @@
+#include <vector>
+
+#include "gtest/gtest.h"  // from @googletest
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/ckks/dot_product_8f_debug/dot_product_8f_default_debug_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(DotProduct8FTest, RunTest) {
+  auto cryptoContext = dot_product__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      dot_product__configure_crypto_context(cryptoContext, secretKey);
+
+  std::vector<float> arg0 = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8};
+  std::vector<float> arg1 = {0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
+  float expected = 2.4 + 0.1;
+
+  auto arg0Encrypted =
+      dot_product__encrypt__arg0(cryptoContext, arg0, publicKey);
+  auto arg1Encrypted =
+      dot_product__encrypt__arg0(cryptoContext, arg1, publicKey);
+  auto outputEncrypted =
+      dot_product(cryptoContext, secretKey, arg0Encrypted, arg1Encrypted);
+  auto actual =
+      dot_product__decrypt__result0(cryptoContext, outputEncrypted, secretKey);
+
+  EXPECT_NEAR(expected, actual, 1e-3);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir

--- a/tests/Examples/openfhe/test.bzl
+++ b/tests/Examples/openfhe/test.bzl
@@ -5,7 +5,7 @@ load("@heir//tools:heir-openfhe.bzl", "openfhe_lib")
 load("@heir//tools:heir-opt.bzl", "heir_opt")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-def openfhe_end_to_end_test(name, mlir_src, test_src, generated_lib_header, heir_opt_flags = [], heir_translate_flags = [], data = [], size = "small", tags = [], deps = [], **kwargs):
+def openfhe_end_to_end_test(name, mlir_src, test_src, generated_lib_header, heir_opt_flags = [], heir_translate_flags = [], data = [], size = "small", tags = [], deps = [], generate_debug_helper = False, **kwargs):
     """A rule for running generating OpenFHE and running a test on it.
 
     Args:
@@ -20,10 +20,11 @@ def openfhe_end_to_end_test(name, mlir_src, test_src, generated_lib_header, heir
       size: Size to pass to cc_test
       tags: Tags to pass to cc_test
       deps: Deps to pass to cc_test and cc_library
+      generate_debug_helper: Flag for generating default debug helper code,
       **kwargs: Keyword arguments to pass to cc_library and cc_test.
     """
     cc_lib_target_name = "%s_cc_lib" % name
-    openfhe_lib(name = name, mlir_src = mlir_src, generated_lib_header = generated_lib_header, cc_lib_target_name = cc_lib_target_name, heir_opt_flags = heir_opt_flags, heir_translate_flags = heir_translate_flags, data = data, tags = tags, deps = deps, **kwargs)
+    openfhe_lib(name = name, mlir_src = mlir_src, generated_lib_header = generated_lib_header, cc_lib_target_name = cc_lib_target_name, heir_opt_flags = heir_opt_flags, heir_translate_flags = heir_translate_flags, data = data, tags = tags, deps = deps, generate_debug_helper = generate_debug_helper, **kwargs)
     cc_test(
         name = name,
         srcs = [test_src],

--- a/tools/heir-openfhe.bzl
+++ b/tools/heir-openfhe.bzl
@@ -17,6 +17,7 @@ def openfhe_lib(
         data = [],
         tags = [],
         deps = [],
+        generate_debug_helper = False,
         **kwargs):
     """A rule for running generating OpenFHE C++ code and running a test on it.
 
@@ -32,6 +33,7 @@ def openfhe_lib(
       data: Data dependencies to be passed to heir_opt
       tags: Tags to pass to cc_test and cc_library
       deps: Deps to pass to cc_test and cc_library
+      generate_debug_helper: Flag for generating default debug helper code,
       **kwargs: Keyword arguments to pass to cc_library and cc_test.
     """
     cc_codegen_target = name + ".heir_translate_cc"
@@ -40,8 +42,8 @@ def openfhe_lib(
     generated_cc_filename = "%s_lib.inc.cc" % name
     heir_opt_name = "%s_heir_opt" % name
     generated_heir_opt_name = "%s_heir_opt.mlir" % name
-    heir_translate_cc_flags = heir_translate_flags + ["--emit-openfhe-pke", "--openfhe-include-type=source-relative"]
-    heir_translate_h_flags = heir_translate_flags + ["--emit-openfhe-pke-header", "--openfhe-include-type=source-relative"]
+
+    heir_translate_source_relative_flags = heir_translate_flags + ["--openfhe-include-type=source-relative"]
 
     cc_lib_target = cc_lib_target_name
     if not cc_lib_target:
@@ -61,6 +63,55 @@ def openfhe_lib(
         )
     else:
         generated_heir_opt_name = mlir_src
+
+    if generate_debug_helper:
+        generated_debug_h_filename = "%s_debug_helper.h" % name
+        generated_debug_cc_filename = "%s_debug_helper.cc" % name
+        heir_translate_debug_header_flags = heir_translate_source_relative_flags + [
+            "--emit-openfhe-pke-debug-header",
+        ]
+
+        debug_header_codegen_target = name + ".heir_debug_h"
+        heir_translate(
+            name = debug_header_codegen_target,
+            src = generated_heir_opt_name,
+            pass_flags = heir_translate_debug_header_flags,
+            generated_filename = generated_debug_h_filename,
+        )
+
+        heir_translate_source_relative_flags = heir_translate_source_relative_flags + [
+            "--openfhe-debug-helper-include-path=%s" % generated_debug_h_filename,
+        ]
+
+        heir_translate_debug_flags = heir_translate_source_relative_flags + [
+            "--emit-openfhe-pke-debug",
+        ]
+
+        cc_debug_codegen_target = name + ".heir_debug_cc"
+        heir_translate(
+            name = cc_debug_codegen_target,
+            src = generated_heir_opt_name,
+            pass_flags = heir_translate_debug_flags,
+            generated_filename = generated_debug_cc_filename,
+        )
+
+        debug_lib_target = "%s_debug_helper_lib" % name
+        cc_library(
+            name = debug_lib_target,
+            srcs = [generated_debug_cc_filename],
+            hdrs = [generated_debug_h_filename],
+            deps = deps + ["@openfhe//:pke"],
+            tags = tags,
+            data = data,
+            copts = OPENMP_COPTS,
+            linkopts = OPENMP_LINKOPTS,
+            **kwargs
+        )
+
+        deps = deps + [debug_lib_target]
+
+    heir_translate_cc_flags = heir_translate_source_relative_flags + ["--emit-openfhe-pke"]
+    heir_translate_h_flags = heir_translate_source_relative_flags + ["--emit-openfhe-pke-header"]
 
     heir_translate(
         name = cc_codegen_target,


### PR DESCRIPTION
This PR adds a new boolean generate_debug_helper option to openfhe_lib.  if it's true, it makes an extra call  to heir_translate and cc_library for the debug code, and  includes that new cc_library as a dependency of the cc_library target. This new option is passed through openfhe_end_to_end_test and a new test added that sets it.

followup to openfhe default debug helper  emitter in https://github.com/google/heir/pull/2679, related to https://github.com/google/heir/issues/1485 