### PR TITLE
[NFC] ArithmeticDag visitor returns vector

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/ImplementRotateAndReduce.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementRotateAndReduce.cpp
@@ -58,7 +58,7 @@ LogicalResult convertRotateAndReduceOp(RotateAndReduceOp op) {
   rewriter.setInsertionPointAfter(op);
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
   IRMaterializingVisitor visitor(b, input.getType());
-  Value finalOutput = implementedKernel->visit(visitor);
+  Value finalOutput = implementedKernel->visit(visitor)[0];
   rewriter.replaceOp(op, finalOutput);
   return success();
 }

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
@@ -264,7 +264,12 @@ LogicalResult convertRemapOp(RemapOp op,
       implementShiftNetwork(ciphertexts, mapping, scheme, ciphertextSize);
 
   kernel::IRMaterializingVisitor visitor(b, singleCiphertextType);
-  std::vector<Value> result = visitor.process(resultNodes);
+  auto resultVectors = visitor.process(resultNodes);
+  std::vector<Value> result;
+  result.reserve(resultVectors.size());
+  for (const auto& vec : resultVectors) {
+    result.push_back(vec[0]);
+  }
 
   // Finally, recombine with an empty tensor + tensor.insert_slice
   Value combinedResult = tensor::EmptyOp::create(

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetworkTest.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetworkTest.cpp
@@ -68,7 +68,12 @@ std::vector<std::vector<int>> manuallyApplyMapping(
   auto expected = manuallyApplyMapping(mapping, input, ciphertextSize);
   auto dag =
       implementShiftNetwork(inputLeaves, mapping, scheme, ciphertextSize);
-  std::vector<LiteralValue> actual = multiEvalKernel(dag);
+  auto evalResults = multiEvalKernel(dag);
+  std::vector<LiteralValue> actual;
+  actual.reserve(evalResults.size());
+  for (const auto& result : evalResults) {
+    actual.push_back(result[0]);
+  }
 
   std::vector<std::vector<int>> combinedActual;
   combinedActual.reserve(numCiphertexts);

--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -29,7 +29,7 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvec) {
 
   auto dag =
       implementMatvec(KernelName::MatvecDiagonal, matrixInput, vectorInput);
-  LiteralValue actual = evalKernel(dag);
+  LiteralValue actual = evalKernel(dag)[0];
   EXPECT_EQ(std::get<std::vector<int>>(actual.getTensor()), expected);
 }
 
@@ -58,7 +58,7 @@ TEST(KernelImplementationTest, HaleviShoup3x5) {
   LiteralValue vectorInput = vector;
 
   auto dag = implementHaleviShoup(vectorInput, matrixInput, {3, 5});
-  LiteralValue result = evalKernel(dag);
+  LiteralValue result = evalKernel(dag)[0];
   auto actual = std::get<std::vector<int>>(result.getTensor());
 
   // The result is of size 8, but we only care about the first 3 elements.
@@ -73,7 +73,7 @@ TEST(KernelImplementationTest, TestExtract) {
 
   auto dag = ArithmeticDagNode<LiteralValue>::extract(
       ArithmeticDagNode<LiteralValue>::leaf(matrixInput), 1);
-  LiteralValue actual = evalKernel(dag);
+  LiteralValue actual = evalKernel(dag)[0];
   EXPECT_EQ(std::get<std::vector<int>>(actual.getTensor()), expected);
 }
 
@@ -94,7 +94,7 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvecWithLayout) {
 
   auto dag =
       implementMatvec(KernelName::MatvecDiagonal, matrixInput, vectorInput);
-  LiteralValue actual = evalKernel(dag);
+  LiteralValue actual = evalKernel(dag)[0];
   EXPECT_EQ(std::get<std::vector<int>>(actual.getTensor()), expected);
 }
 
@@ -131,7 +131,7 @@ TEST(KernelImplementationTest, Test2DConvWithLayout) {
 
   auto dag = implementHaleviShoup(vectorInput, matrixInput,
                                   expandedMatrixType.getShape());
-  LiteralValue actual = evalKernel(dag);
+  LiteralValue actual = evalKernel(dag)[0];
   // Result is a 2x2 tensor repeated row-major in a tensor of size 16.
   std::vector<int> actualVector =
       std::get<std::vector<int>>(actual.getTensor());
@@ -163,7 +163,7 @@ TEST(KernelImplementationTest, BicyclicMatmul) {
   LiteralValue packedBValue = packedB[0];
 
   auto dag = implementBicyclicMatmul(packedAValue, packedBValue, m, n, p);
-  LiteralValue result = evalKernel(dag);
+  LiteralValue result = evalKernel(dag)[0];
   auto resultVec = std::get<std::vector<int>>(result.getTensor());
 
   auto resultLayout = getBicyclicLayoutRelation(
@@ -239,7 +239,7 @@ TEST(KernelImplementationTest, TricyclicBatchMatmul) {
   // Generate kernel DAG and evaluate
   auto dag =
       implementTricyclicBatchMatmul(packedAValue, packedBValue, h, m, n, p);
-  LiteralValue result = evalKernel(dag);
+  LiteralValue result = evalKernel(dag)[0];
   auto resultVec = std::get<std::vector<int>>(result.getTensor());
 
   // Compute expected packed φ(Z) via evaluateLayoutOnTensor for the cleartext

--- a/lib/Kernel/RotateAndReduceFuzzTest.cpp
+++ b/lib/Kernel/RotateAndReduceFuzzTest.cpp
@@ -64,7 +64,7 @@ std::pair<std::vector<int>, int> runImpl(
   result = implementRotateAndReduce(vectorInput, plaintextsInput, period, n,
                                     zeroDiagonals, reduceOp);
   std::vector<int> resultTensor =
-      std::get<std::vector<int>>(evalKernel(result).getTensor());
+      std::get<std::vector<int>>(evalKernel(result)[0].getTensor());
   int depth = evalMultiplicativeDepth(result);
   return std::make_pair(resultTensor, depth);
 }

--- a/lib/Kernel/RotateAndReduceImplTest.cpp
+++ b/lib/Kernel/RotateAndReduceImplTest.cpp
@@ -61,7 +61,7 @@ std::vector<int> runImpl(const std::vector<int>& vec,
   }
   result = implementRotateAndReduce(vectorInput, plaintextsInput, period, n);
   std::cerr << "Rotate and reduce dag: " << printKernel(result) << "\n";
-  return std::get<std::vector<int>>(evalKernel(result).getTensor());
+  return std::get<std::vector<int>>(evalKernel(result)[0].getTensor());
 }
 
 TEST(RotateAndReduceImplTest, TestUnitPeriodWithPlaintextsSimpleValues) {

--- a/lib/Kernel/TestingUtils.h
+++ b/lib/Kernel/TestingUtils.h
@@ -16,25 +16,27 @@ namespace kernel {
 // A visitor that evaluates an arithmetic DAG of ciphertext semantic tensors.
 // The evaluation is done by replacing the leaves with their literal values and
 // then computing the operations.
-class EvalVisitor : public CachingVisitor<LiteralValue, LiteralValue> {
+using EvalResults = std::vector<LiteralValue>;
+
+class EvalVisitor : public CachingVisitor<LiteralValue, EvalResults> {
  public:
-  using CachingVisitor<LiteralValue, LiteralValue>::operator();
+  using CachingVisitor<LiteralValue, EvalResults>::operator();
 
-  EvalVisitor() : CachingVisitor<LiteralValue, LiteralValue>() {}
+  EvalVisitor() : CachingVisitor<LiteralValue, EvalResults>() {}
 
-  LiteralValue operator()(const ConstantTensorNode& node) override;
-  LiteralValue operator()(const LeafNode<LiteralValue>& node) override;
-  LiteralValue operator()(const AddNode<LiteralValue>& node) override;
-  LiteralValue operator()(const SubtractNode<LiteralValue>& node) override;
-  LiteralValue operator()(const MultiplyNode<LiteralValue>& node) override;
-  LiteralValue operator()(const LeftRotateNode<LiteralValue>& node) override;
-  LiteralValue operator()(const ExtractNode<LiteralValue>& node) override;
+  EvalResults operator()(const ConstantTensorNode& node) override;
+  EvalResults operator()(const LeafNode<LiteralValue>& node) override;
+  EvalResults operator()(const AddNode<LiteralValue>& node) override;
+  EvalResults operator()(const SubtractNode<LiteralValue>& node) override;
+  EvalResults operator()(const MultiplyNode<LiteralValue>& node) override;
+  EvalResults operator()(const LeftRotateNode<LiteralValue>& node) override;
+  EvalResults operator()(const ExtractNode<LiteralValue>& node) override;
 };
 
-LiteralValue evalKernel(
+EvalResults evalKernel(
     const std::shared_ptr<ArithmeticDagNode<LiteralValue>>& dag);
 
-std::vector<LiteralValue> multiEvalKernel(
+std::vector<EvalResults> multiEvalKernel(
     ArrayRef<std::shared_ptr<ArithmeticDagNode<LiteralValue>>> dags);
 
 // A visitor that prints the dag in textual form

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -668,7 +668,7 @@ struct ConvertLinalgMatvecLayout
     IRMaterializingVisitor visitor(
         b, input.getType(),
         [&](Operation* createdOp) { setMaterializedAttr(createdOp); });
-    Value finalOutput = implementedKernel->visit(visitor);
+    Value finalOutput = implementedKernel->visit(visitor)[0];
 
     auto layoutAttr = cast<LayoutAttr>(op->getAttr(kLayoutAttrName));
     auto* finalOutputOp = finalOutput.getDefiningOp();
@@ -797,7 +797,7 @@ struct ConvertLinalgConv2D
     IRMaterializingVisitor visitor(
         b, data.getType(),
         [&](Operation* createdOp) { setMaterializedAttr(createdOp); });
-    Value finalOutput = implementedKernel->visit(visitor);
+    Value finalOutput = implementedKernel->visit(visitor)[0];
 
     auto layoutAttr = cast<LayoutAttr>(op->getAttr(kLayoutAttrName));
     auto finalOutputOp = finalOutput.getDefiningOp();
@@ -1966,7 +1966,7 @@ struct ConvertLinalgMatmul
     IRMaterializingVisitor visitor(b, lhs.getType(), [&](Operation* createdOp) {
       setMaterializedAttr(op);
     });
-    Value finalOutput = implementedKernel->visit(visitor);
+    Value finalOutput = implementedKernel->visit(visitor)[0];
 
     auto layoutAttr = cast<LayoutAttr>(op->getAttr(kLayoutAttrName));
     auto* finalOutputOp = finalOutput.getDefiningOp();

--- a/lib/Transforms/LowerPolynomialEval/Patterns.cpp
+++ b/lib/Transforms/LowerPolynomialEval/Patterns.cpp
@@ -69,7 +69,7 @@ LogicalResult LowerViaHorner::matchAndRewrite(EvalOp op,
   // Use IRMaterializingVisitor to convert to MLIR
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
   kernel::IRMaterializingVisitor visitor(b, op.getValue().getType());
-  Value finalOutput = resultNode->visit(visitor);
+  Value finalOutput = resultNode->visit(visitor)[0];
 
   rewriter.replaceOp(op, finalOutput);
   return success();
@@ -104,7 +104,7 @@ LogicalResult LowerViaPatersonStockmeyerMonomial::matchAndRewrite(
   // Use IRMaterializingVisitor to convert to MLIR
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
   kernel::IRMaterializingVisitor visitor(b, op.getValue().getType());
-  Value finalOutput = resultNode->visit(visitor);
+  Value finalOutput = resultNode->visit(visitor)[0];
 
   rewriter.replaceOp(op, finalOutput);
   return success();
@@ -161,7 +161,7 @@ LogicalResult LowerViaPatersonStockmeyerChebyshev::matchAndRewrite(
       xNode, chebCoeffs, getMinCoefficientThreshold());
 
   IRMaterializingVisitor visitor(b, op.getValue().getType());
-  Value finalOutput = resultNode->visit(visitor);
+  Value finalOutput = resultNode->visit(visitor)[0];
 
   rewriter.replaceOp(op, finalOutput);
   return success();

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerFuzzTest.cpp
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerFuzzTest.cpp
@@ -28,7 +28,7 @@ double psEvalChebyshevPolynomial(const std::vector<double>& coefficients,
   if (!resultNode) return 0.0;
 
   test::EvalVisitor visitor;
-  return resultNode->visit(visitor);
+  return resultNode->visit(visitor)[0];
 }
 
 void patersonStockmeyerMatchesNaive(const std::vector<double>& coefficients,

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerTest.cpp
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerTest.cpp
@@ -18,7 +18,7 @@ double evalChebyshevPolynomial(double x,
       patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
 
   test::EvalVisitor visitor;
-  return resultNode->visit(visitor);
+  return resultNode->visit(visitor)[0];
 }
 
 int evalMultiplicativeDepth(double x, const std::vector<double>& coefficients) {

--- a/lib/Utils/Polynomial/HornerTest.cpp
+++ b/lib/Utils/Polynomial/HornerTest.cpp
@@ -22,7 +22,7 @@ double evalHornerPolynomial(double x,
   auto result_node = hornerMonomialPolynomialEvaluation(x_node, coefficients);
 
   test::EvalVisitor visitor;
-  return result_node->visit(visitor);
+  return result_node->visit(visitor)[0];
 }
 
 TEST(HornerEvaluationTest, ConstantPolynomial) {

--- a/lib/Utils/Polynomial/PatersonStockmeyerTest.cpp
+++ b/lib/Utils/Polynomial/PatersonStockmeyerTest.cpp
@@ -23,7 +23,7 @@ double evalPatersonStockmeyerPolynomial(
       patersonStockmeyerMonomialPolynomialEvaluation(x_node, coefficients);
 
   test::EvalVisitor visitor;
-  return result_node->visit(visitor);
+  return result_node->visit(visitor)[0];
 }
 
 // Helper function to compute multiplicative depth


### PR DESCRIPTION
This commit changes the return type of all ArithmeticDag visitor operator() methods to `std::vector<T>` from T. This is in preparation for supporting ForLoop DAG nodes that have multiple iter args, toward keeping our FHE kernels rolled.

- Updated EvalVisitor, IRMaterializingVisitor to return vectors
- Updated all call sites to extract [0] from the returned vectors

Extracted from https://github.com/google/heir/pull/2655