### PR TITLE
Add types to some dag nodes

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/RotationGroupKernel.h
+++ b/lib/Dialect/TensorExt/Transforms/RotationGroupKernel.h
@@ -72,11 +72,14 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       auto [allZero, allOne] = allZeroAllOne(mask);
       if (allZero) {
         std::vector<double> zeros(ciphertextSize, 0.0);
-        masked.push_back(NodeTy::constantTensor(zeros));
+        masked.push_back(NodeTy::constantTensor(
+            zeros, kernel::DagType::floatTensor(64, {ciphertextSize})));
       } else if (allOne) {
         masked.push_back(ct);
       } else {
-        masked.push_back(NodeTy::mul(ct, NodeTy::constantTensor(mask)));
+        masked.push_back(NodeTy::mul(
+            ct, NodeTy::constantTensor(
+                    mask, kernel::DagType::floatTensor(64, {ciphertextSize}))));
       }
     }
 
@@ -141,12 +144,16 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       auto [allZero, allOne] = allZeroAllOne(mask);
       if (allZero) {
         std::vector<double> zeros(ciphertextSize, 0.0);
-        results[target1] = NodeTy::constantTensor(zeros);
+        results[target1] = NodeTy::constantTensor(
+            zeros, kernel::DagType::floatTensor(64, {ciphertextSize}));
       } else if (allOne) {
         results[target1] = NodeTy::leftRotate(ct, rotation);
       } else {
         results[target1] = NodeTy::leftRotate(
-            NodeTy::mul(ct, NodeTy::constantTensor(mask)), rotation);
+            NodeTy::mul(
+                ct, NodeTy::constantTensor(mask, kernel::DagType::floatTensor(
+                                                     64, {ciphertextSize}))),
+            rotation);
       }
       continue;
     }
@@ -181,7 +188,9 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       if (allZero) {
         rotated1 = std::nullopt;
       } else {
-        ValueTy masked1 = NodeTy::mul(ct, NodeTy::constantTensor(mask1));
+        ValueTy masked1 = NodeTy::mul(
+            ct, NodeTy::constantTensor(
+                    mask1, kernel::DagType::floatTensor(64, {ciphertextSize})));
         rotated1 = NodeTy::leftRotate(masked1, rotation);
       }
     }
@@ -192,7 +201,9 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       if (allZero) {
         rotated2 = std::nullopt;
       } else {
-        ValueTy masked2 = NodeTy::mul(ct, NodeTy::constantTensor(mask2));
+        ValueTy masked2 = NodeTy::mul(
+            ct, NodeTy::constantTensor(
+                    mask2, kernel::DagType::floatTensor(64, {ciphertextSize})));
         rotated2 = NodeTy::leftRotate(masked2, rotation);
       }
     }
@@ -279,7 +290,8 @@ rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
       } else if (allOne) {
         fixedCurrent.push_back(ct);
       } else {
-        ValueTy mask = NodeTy::constantTensor(fixedMask);
+        ValueTy mask = NodeTy::constantTensor(
+            fixedMask, kernel::DagType::floatTensor(64, {ciphertextSize}));
         fixedCurrent.push_back(NodeTy::mul(ct, mask));
       }
     }
@@ -336,7 +348,9 @@ rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
   for (int64_t i = 0; i < numCiphertexts; i++) {
     if (!finalTargetCiphertexts.contains(i)) {
       std::vector<double> zeroVec(ciphertextSize, 0);
-      current[i] = NodeTy::constantTensor(std::move(zeroVec));
+      current[i] = NodeTy::constantTensor(
+          std::move(zeroVec),
+          kernel::DagType::floatTensor(64, {ciphertextSize}));
     }
   }
 

--- a/lib/Kernel/ArithmeticDag.h
+++ b/lib/Kernel/ArithmeticDag.h
@@ -16,6 +16,63 @@ namespace mlir {
 namespace heir {
 namespace kernel {
 
+// Type system for ArithmeticDag nodes
+struct IntegerType {
+  unsigned bitWidth;
+};
+
+struct FloatType {
+  unsigned bitWidth;
+};
+
+struct IndexType {};
+
+struct IntTensorType {
+  unsigned bitWidth;
+  std::vector<int64_t> shape;
+};
+
+struct FloatTensorType {
+  unsigned bitWidth;
+  std::vector<int64_t> shape;
+};
+
+struct DagType {
+  std::variant<IntegerType, FloatType, IndexType, IntTensorType,
+               FloatTensorType>
+      type_variant;
+
+  static DagType integer(unsigned bitWidth) {
+    DagType t;
+    t.type_variant = IntegerType{bitWidth};
+    return t;
+  }
+
+  static DagType floatTy(unsigned bitWidth) {
+    DagType t;
+    t.type_variant = FloatType{bitWidth};
+    return t;
+  }
+
+  static DagType index() {
+    DagType t;
+    t.type_variant = IndexType{};
+    return t;
+  }
+
+  static DagType intTensor(unsigned bitWidth, std::vector<int64_t> shape) {
+    DagType t;
+    t.type_variant = IntTensorType{bitWidth, std::move(shape)};
+    return t;
+  }
+
+  static DagType floatTensor(unsigned bitWidth, std::vector<int64_t> shape) {
+    DagType t;
+    t.type_variant = FloatTensorType{bitWidth, std::move(shape)};
+    return t;
+  }
+};
+
 // This file contains a generic DAG structure that can be used for representing
 // arithmetic DAGs with leaf nodes of various types.
 template <typename T>
@@ -29,10 +86,17 @@ struct LeafNode {
 
 struct ConstantScalarNode {
   double value;
+  DagType type;
 };
 
 struct ConstantTensorNode {
   std::vector<double> value;
+  DagType type;
+};
+
+struct SplatNode {
+  double value;
+  DagType type;
 };
 
 template <typename T>
@@ -76,7 +140,7 @@ struct ArithmeticDagNode {
  public:
   std::variant<ConstantScalarNode, ConstantTensorNode, LeafNode<T>, AddNode<T>,
                SubtractNode<T>, MultiplyNode<T>, PowerNode<T>,
-               LeftRotateNode<T>, ExtractNode<T>>
+               LeftRotateNode<T>, ExtractNode<T>, SplatNode>
       node_variant;
 
   explicit ArithmeticDagNode(const T& value)
@@ -98,24 +162,34 @@ struct ArithmeticDagNode {
         new ArithmeticDagNode<T>(value));
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> constantScalar(double constant) {
+  static std::shared_ptr<ArithmeticDagNode<T>> constantScalar(double constant,
+                                                              DagType type) {
     auto node =
         std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
     // Note, to satisfy variant we need to use aggregate initialization inside
     // emplace
     node->node_variant.template emplace<ConstantScalarNode>(
-        ConstantScalarNode{constant});
+        ConstantScalarNode{constant, std::move(type)});
     return node;
   }
 
   static std::shared_ptr<ArithmeticDagNode<T>> constantTensor(
-      std::vector<double> constant) {
+      std::vector<double> constant, DagType type) {
     auto node =
         std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
     // Note, to satisfy variant we need to use aggregate initialization inside
     // emplace
     node->node_variant.template emplace<ConstantTensorNode>(
-        ConstantTensorNode{std::move(constant)});
+        ConstantTensorNode{std::move(constant), std::move(type)});
+    return node;
+  }
+
+  static std::shared_ptr<ArithmeticDagNode<T>> splat(double constant,
+                                                     DagType type) {
+    auto node =
+        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<SplatNode>(
+        SplatNode{constant, std::move(type)});
     return node;
   }
 
@@ -286,6 +360,11 @@ class CachingVisitor {
 
   virtual ResultType operator()(const ExtractNode<T>& node) {
     assert(false && "Visit logic for ExtractNode is not implemented.");
+    return ResultType();
+  }
+
+  virtual ResultType operator()(const SplatNode& node) {
+    assert(false && "Visit logic for SplatNode is not implemented.");
     return ResultType();
   }
 

--- a/lib/Kernel/ArithmeticDagTest.cpp
+++ b/lib/Kernel/ArithmeticDagTest.cpp
@@ -78,6 +78,13 @@ struct FlattenedStringVisitor {
     ss << node.operand->visit(*this) << "[" << node.index << "]";
     return ss.str();
   }
+
+  std::string operator()(const SplatNode& node) const {
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "splat(" << node.value << ")";
+    return ss.str();
+  }
 };
 
 class EvalVisitor : public CachingVisitor<double, std::vector<double>> {
@@ -120,13 +127,19 @@ class EvalVisitor : public CachingVisitor<double, std::vector<double>> {
     callCount += 1;
     return {std::pow(this->process(node.base)[0], node.exponent)};
   }
+
+  std::vector<double> operator()(const SplatNode& node) override {
+    callCount += 1;
+    return {node.value};
+  }
 };
 
 TEST(ArithmeticDagTest, TestPrint) {
   auto root = StringLeavedDag::leftRotate(
       StringLeavedDag::mul(
-          StringLeavedDag::add(StringLeavedDag::leaf("x"),
-                               StringLeavedDag::constantScalar(3.0)),
+          StringLeavedDag::add(
+              StringLeavedDag::leaf("x"),
+              StringLeavedDag::constantScalar(3.0, DagType::floatTy(64))),
           StringLeavedDag::power(StringLeavedDag::leaf("y"), 2)),
       7);
 
@@ -147,8 +160,9 @@ TEST(ArithmeticDagTest, TestProperDag) {
 
 TEST(ArithmeticDagTest, TestEvaluationVisitor) {
   auto shared = DoubleLeavedDag::power(DoubleLeavedDag::leaf(2.0), 2);
-  auto root = DoubleLeavedDag::mul(DoubleLeavedDag::add(shared, shared),
-                                   DoubleLeavedDag::constantScalar(3.0));
+  auto root = DoubleLeavedDag::mul(
+      DoubleLeavedDag::add(shared, shared),
+      DoubleLeavedDag::constantScalar(3.0, DagType::floatTy(64)));
 
   EvalVisitor visitor;
   double result = root->visit(visitor)[0];

--- a/lib/Kernel/IRMaterializingVisitor.cpp
+++ b/lib/Kernel/IRMaterializingVisitor.cpp
@@ -35,13 +35,14 @@ std::vector<Value> IRMaterializingVisitor::operator()(
   // DAGs that can be evaluated elementwise for ElementwiseMappable ops like
   // arith ops.
   TypedAttr attr;
-  if (auto floatTy = dyn_cast<FloatType>(getElementTypeOrSelf(evaluatedType))) {
+  if (auto floatTy =
+          dyn_cast<mlir::FloatType>(getElementTypeOrSelf(evaluatedType))) {
     APFloat apVal(node.value);
     APFloat converted =
         convertFloatToSemantics(apVal, floatTy.getFloatSemantics());
     attr = getScalarOrDenseAttr(evaluatedType, converted);
-  } else if (auto intTy =
-                 dyn_cast<IntegerType>(getElementTypeOrSelf(evaluatedType))) {
+  } else if (auto intTy = dyn_cast<mlir::IntegerType>(
+                 getElementTypeOrSelf(evaluatedType))) {
     // Node values are doubles and we may have to properly support integers.
     APInt apVal(intTy.getWidth(), std::floor(node.value));
     attr = getScalarOrDenseAttr(evaluatedType, apVal);
@@ -56,7 +57,7 @@ std::vector<Value> IRMaterializingVisitor::operator()(
     const ConstantTensorNode& node) {
   RankedTensorType tensorTy = cast<RankedTensorType>(evaluatedType);
   TypedAttr attr;
-  if (auto floatTy = dyn_cast<FloatType>(tensorTy.getElementType())) {
+  if (auto floatTy = dyn_cast<mlir::FloatType>(tensorTy.getElementType())) {
     SmallVector<APFloat> values;
     for (double v : node.value) {
       APFloat apVal(v);
@@ -67,7 +68,7 @@ std::vector<Value> IRMaterializingVisitor::operator()(
     attr = DenseElementsAttr::get(tensorTy, values);
   } else {
     // Node values are doubles and we must convert them to integers
-    auto intTy = cast<IntegerType>(tensorTy.getElementType());
+    auto intTy = cast<mlir::IntegerType>(tensorTy.getElementType());
     SmallVector<APInt> values;
     for (double v : node.value) {
       APInt apVal(intTy.getWidth(), std::floor(v));

--- a/lib/Kernel/IRMaterializingVisitor.h
+++ b/lib/Kernel/IRMaterializingVisitor.h
@@ -41,10 +41,10 @@ class IRMaterializingVisitor
     Value lhs = this->process(node.left)[0];
     Value rhs = this->process(node.right)[0];
     auto op = TypeSwitch<Type, Operation*>(getElementTypeOrSelf(evaluatedType))
-                  .template Case<FloatType>([&](auto ty) {
+                  .template Case<mlir::FloatType>([&](auto ty) {
                     return FloatOp::create(builder, lhs, rhs);
                   })
-                  .template Case<IntegerType>(
+                  .template Case<mlir::IntegerType>(
                       [&](auto ty) { return IntOp::create(builder, lhs, rhs); })
                   .Default([&](Type) {
                     llvm_unreachable("Unsupported type for binary operation");

--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -84,7 +84,7 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvecWithLayout) {
   std::vector<std::vector<int>> matrix = {
       {0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}, {12, 13, 14, 15}};
   auto diagonalLayout = getDiagonalLayoutRelation(
-      RankedTensorType::get({4, 4}, IndexType::get(&context)), 4);
+      RankedTensorType::get({4, 4}, mlir::IndexType::get(&context)), 4);
   std::vector<std::vector<int>> diagonalMatrix =
       evaluateLayoutOnMatrix(diagonalLayout, matrix);
 
@@ -101,9 +101,9 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvecWithLayout) {
 TEST(KernelImplementationTest, Test2DConvWithLayout) {
   MLIRContext context;
   RankedTensorType dataType =
-      RankedTensorType::get({3, 3}, IndexType::get(&context));
+      RankedTensorType::get({3, 3}, mlir::IndexType::get(&context));
   RankedTensorType filterType =
-      RankedTensorType::get({2, 2}, IndexType::get(&context));
+      RankedTensorType::get({2, 2}, mlir::IndexType::get(&context));
 
   // 3x3 input data, 2x2 filter
   std::vector<std::vector<int>> data = {{1, -1, 0}, {-3, 0, 2}, {8, 9, 1}};
@@ -152,11 +152,11 @@ TEST(KernelImplementationTest, BicyclicMatmul) {
   int numSlots = m * n * p;
 
   auto layoutA = getBicyclicLayoutRelation(
-      RankedTensorType::get({m, n}, IndexType::get(&context)), numSlots);
+      RankedTensorType::get({m, n}, mlir::IndexType::get(&context)), numSlots);
   auto packedA = evaluateLayoutOnMatrix(layoutA, matrixA);
 
   auto layoutB = getBicyclicLayoutRelation(
-      RankedTensorType::get({n, p}, IndexType::get(&context)), numSlots);
+      RankedTensorType::get({n, p}, mlir::IndexType::get(&context)), numSlots);
   auto packedB = evaluateLayoutOnMatrix(layoutB, matrixB);
 
   LiteralValue packedAValue = packedA[0];
@@ -167,7 +167,7 @@ TEST(KernelImplementationTest, BicyclicMatmul) {
   auto resultVec = std::get<std::vector<int>>(result.getTensor());
 
   auto resultLayout = getBicyclicLayoutRelation(
-      RankedTensorType::get({m, p}, IndexType::get(&context)), numSlots);
+      RankedTensorType::get({m, p}, mlir::IndexType::get(&context)), numSlots);
   auto unpackedResult =
       unpackLayoutToMatrix<int>(resultLayout, {resultVec}, {m, p});
 
@@ -222,9 +222,9 @@ TEST(KernelImplementationTest, TricyclicBatchMatmul) {
 
   // Pack using the tricyclic layout relation.
   RankedTensorType typeA =
-      RankedTensorType::get({h, m, n}, IndexType::get(&context));
+      RankedTensorType::get({h, m, n}, mlir::IndexType::get(&context));
   RankedTensorType typeB =
-      RankedTensorType::get({h, n, p}, IndexType::get(&context));
+      RankedTensorType::get({h, n, p}, mlir::IndexType::get(&context));
 
   auto layoutA = getTricyclicLayoutRelation(typeA, numSlots);
   auto packedA = evaluateLayoutOnTensor(layoutA, A);
@@ -259,7 +259,7 @@ TEST(KernelImplementationTest, TricyclicBatchMatmul) {
   }
 
   RankedTensorType resultType =
-      RankedTensorType::get({h, m, p}, IndexType::get(&context));
+      RankedTensorType::get({h, m, p}, mlir::IndexType::get(&context));
   auto resultLayout = getTricyclicLayoutRelation(resultType, numSlots);
   auto expectedPacked = evaluateLayoutOnTensor(resultLayout, expectedTensor);
 

--- a/lib/Kernel/RotationCountVisitor.cpp
+++ b/lib/Kernel/RotationCountVisitor.cpp
@@ -141,6 +141,12 @@ int64_t RotationCountVisitor::operator()(
   return operandCount;
 }
 
+int64_t RotationCountVisitor::operator()(const SplatNode& node) {
+  // Splat constants are always plaintext
+  nodeSecretStatus[currentNode] = false;
+  return 0;
+}
+
 }  // namespace kernel
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Kernel/RotationCountVisitor.h
+++ b/lib/Kernel/RotationCountVisitor.h
@@ -36,6 +36,7 @@ class RotationCountVisitor {
   int64_t operator()(const PowerNode<SymbolicValue>& node);
   int64_t operator()(const LeftRotateNode<SymbolicValue>& node);
   int64_t operator()(const ExtractNode<SymbolicValue>& node);
+  int64_t operator()(const SplatNode& node);
 
  private:
   std::unordered_set<const NodeTy*> visitedNodes;

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h
@@ -102,7 +102,7 @@ std::vector<std::shared_ptr<kernel::ArithmeticDagNode<T>>> computePowers(
   using NodeTy = kernel::ArithmeticDagNode<T>;
   std::vector<std::shared_ptr<NodeTy>> result;
   result.reserve(k + 1);
-  result.push_back(NodeTy::constantScalar(1));
+  result.push_back(NodeTy::constantScalar(1, kernel::DagType::floatTy(64)));
   if (k >= 1) {
     result.push_back(x);
   }
@@ -145,7 +145,7 @@ std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
 
   if (n == 0) {
     // T_0(x) = 1
-    cache[0] = NodeTy::constantScalar(1);
+    cache[0] = NodeTy::constantScalar(1, kernel::DagType::floatTy(64));
     return cache[0];
   }
 
@@ -166,13 +166,14 @@ std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
   // Apply Chebyshev recurrence: T_n = 2*T_a*T_b - T_c
   // where c = |a - b|
   int64_t c = std::abs(a - b);
-  auto two = NodeTy::constantScalar(2);
+  auto two = NodeTy::constantScalar(2, kernel::DagType::floatTy(64));
   tN = NodeTy::mul(two, tN);
 
   // Compute T_n = 2*T_a*T_b - T_c
   if (c == 0) {
     // T_0 = 1, so subtract 1
-    tN = NodeTy::sub(tN, NodeTy::constantScalar(1));
+    tN = NodeTy::sub(tN,
+                     NodeTy::constantScalar(1, kernel::DagType::floatTy(64)));
   } else {
     auto tC = genChebyshevPowerRecursive(x, c, cache);
     tN = NodeTy::sub(tN, tC);
@@ -202,7 +203,8 @@ genChebyshevPowersRecursive(std::shared_ptr<kernel::ArithmeticDagNode<T>> x,
     genChebyshevPowerRecursive(x, i, cache);
   }
 
-  cache[0] = kernel::ArithmeticDagNode<T>::constantScalar(1);
+  cache[0] = kernel::ArithmeticDagNode<T>::constantScalar(
+      1, kernel::DagType::floatTy(64));
   return cache;
 }
 
@@ -216,8 +218,8 @@ computeChebyshevPolynomialValues(const T& x, int64_t k) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
   std::vector<std::shared_ptr<NodeTy>> result;
   result.reserve(k + 1);
-  auto number1 = NodeTy::constantScalar(1);
-  auto number2 = NodeTy::constantScalar(2);
+  auto number1 = NodeTy::constantScalar(1, kernel::DagType::floatTy(64));
+  auto number2 = NodeTy::constantScalar(2, kernel::DagType::floatTy(64));
   auto xNode = NodeTy::leaf(x);
   result.push_back(number1);
   if (k >= 1) {
@@ -266,7 +268,8 @@ patersonStockmeyerChebyshevPolynomialEvaluation(
     if (std::abs(coefficients[0]) < minCoeffThreshold) {
       return nullptr;
     }
-    return NodeTy::constantScalar(coefficients[0]);
+    return NodeTy::constantScalar(coefficients[0],
+                                  kernel::DagType::floatTy(64));
   }
 
   // Choose k optimally using Lattigo's optimal split
@@ -297,8 +300,9 @@ patersonStockmeyerChebyshevPolynomialEvaluation(
         continue;
       }
 
-      auto termNode = NodeTy::mul(NodeTy::constantScalar(coeffs[j]),
-                                  chebPolynomialValuesMap[j]);
+      auto termNode = NodeTy::mul(
+          NodeTy::constantScalar(coeffs[j], kernel::DagType::floatTy(64)),
+          chebPolynomialValuesMap[j]);
 
       if (pol) {
         pol = NodeTy::add(pol, termNode);

--- a/lib/Utils/Polynomial/Horner.h
+++ b/lib/Utils/Polynomial/Horner.h
@@ -21,7 +21,7 @@ hornerMonomialPolynomialEvaluation(
   using NodeTy = kernel::ArithmeticDagNode<T>;
 
   if (coefficients.empty()) {
-    return NodeTy::constantScalar(0.0);
+    return NodeTy::constantScalar(0.0, kernel::DagType::floatTy(64));
   }
 
   // Filter coefficients and find the highest degree
@@ -32,14 +32,16 @@ hornerMonomialPolynomialEvaluation(
 
   // Start with the coefficient of the highest degree term
   int64_t maxDegree = coeffMap.rbegin()->first;
-  auto result = NodeTy::constantScalar(coeffMap[maxDegree]);
+  auto result =
+      NodeTy::constantScalar(coeffMap[maxDegree], kernel::DagType::floatTy(64));
 
   // Apply Horner's method
   for (int64_t i = maxDegree - 1; i >= 0; i--) {
     result = NodeTy::mul(result, x);
 
     if (coeffMap.count(i)) {
-      auto coeffNode = NodeTy::constantScalar(coeffMap.at(i));
+      auto coeffNode =
+          NodeTy::constantScalar(coeffMap.at(i), kernel::DagType::floatTy(64));
       result = NodeTy::add(result, coeffNode);
     }
   }

--- a/lib/Utils/Polynomial/PatersonStockmeyer.h
+++ b/lib/Utils/Polynomial/PatersonStockmeyer.h
@@ -25,7 +25,7 @@ patersonStockmeyerMonomialPolynomialEvaluation(
   using NodeTy = kernel::ArithmeticDagNode<T>;
 
   if (coefficients.empty()) {
-    return NodeTy::constantScalar(0.0);
+    return NodeTy::constantScalar(0.0, kernel::DagType::floatTy(64));
   }
 
   // Filter coefficients
@@ -57,7 +57,8 @@ patersonStockmeyerMonomialPolynomialEvaluation(
     for (int64_t j = lowestDegreeInChunk; j <= highestDegreeInChunk; j++) {
       if (coeffMap.count(j)) {
         int64_t powerIndex = j - lowestDegreeInChunk;
-        auto coeff = NodeTy::constantScalar(coeffMap[j]);
+        auto coeff =
+            NodeTy::constantScalar(coeffMap[j], kernel::DagType::floatTy(64));
 
         std::shared_ptr<NodeTy> term;
         if (powerIndex == 0) {
@@ -75,7 +76,7 @@ patersonStockmeyerMonomialPolynomialEvaluation(
     }
 
     if (!chunkValue) {
-      chunkValue = NodeTy::constantScalar(0.0);
+      chunkValue = NodeTy::constantScalar(0.0, kernel::DagType::floatTy(64));
     }
     chunkValues.push_back(chunkValue);
   }


### PR DESCRIPTION
Rebased over #2692

This commit adds types to ArithmeticDag nodes, allowing constant nodes to carry type information needed for proper MLIR materialization. This came from https://github.com/google/heir/pull/2655 where the IRMaterializer now needs to know the appropriate types of certain dag nodes (such as a tensor splat)

Primarily this PR updates ConstantScalarNode and ConstantTensorNode to include a DagType field.

To demonstrate the need for this, this PR also adds a SplatNode dag node.