### PR TITLE
[NFC]: add integer type as an option in LiteralValue

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetworkTest.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetworkTest.cpp
@@ -78,7 +78,7 @@ std::vector<std::vector<int>> manuallyApplyMapping(
   std::vector<std::vector<int>> combinedActual;
   combinedActual.reserve(numCiphertexts);
   for (const LiteralValue& val : actual) {
-    combinedActual.push_back(std::get<std::vector<int>>(val.getTensor()));
+    combinedActual.push_back(std::get<std::vector<int>>(val.get()));
   }
 
   ::testing::StringMatchResultListener listener;

--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -30,7 +30,7 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvec) {
   auto dag =
       implementMatvec(KernelName::MatvecDiagonal, matrixInput, vectorInput);
   LiteralValue actual = evalKernel(dag)[0];
-  EXPECT_EQ(std::get<std::vector<int>>(actual.getTensor()), expected);
+  EXPECT_EQ(std::get<std::vector<int>>(actual.get()), expected);
 }
 
 TEST(KernelImplementationTest, HaleviShoup3x5) {
@@ -59,7 +59,7 @@ TEST(KernelImplementationTest, HaleviShoup3x5) {
 
   auto dag = implementHaleviShoup(vectorInput, matrixInput, {3, 5});
   LiteralValue result = evalKernel(dag)[0];
-  auto actual = std::get<std::vector<int>>(result.getTensor());
+  auto actual = std::get<std::vector<int>>(result.get());
 
   // The result is of size 8, but we only care about the first 3 elements.
   EXPECT_EQ(std::vector<int>(actual.begin(), actual.begin() + 3), expected);
@@ -74,7 +74,7 @@ TEST(KernelImplementationTest, TestExtract) {
   auto dag = ArithmeticDagNode<LiteralValue>::extract(
       ArithmeticDagNode<LiteralValue>::leaf(matrixInput), 1);
   LiteralValue actual = evalKernel(dag)[0];
-  EXPECT_EQ(std::get<std::vector<int>>(actual.getTensor()), expected);
+  EXPECT_EQ(std::get<std::vector<int>>(actual.get()), expected);
 }
 
 TEST(KernelImplementationTest, TestHaleviShoupMatvecWithLayout) {
@@ -95,7 +95,7 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvecWithLayout) {
   auto dag =
       implementMatvec(KernelName::MatvecDiagonal, matrixInput, vectorInput);
   LiteralValue actual = evalKernel(dag)[0];
-  EXPECT_EQ(std::get<std::vector<int>>(actual.getTensor()), expected);
+  EXPECT_EQ(std::get<std::vector<int>>(actual.get()), expected);
 }
 
 TEST(KernelImplementationTest, Test2DConvWithLayout) {
@@ -133,8 +133,7 @@ TEST(KernelImplementationTest, Test2DConvWithLayout) {
                                   expandedMatrixType.getShape());
   LiteralValue actual = evalKernel(dag)[0];
   // Result is a 2x2 tensor repeated row-major in a tensor of size 16.
-  std::vector<int> actualVector =
-      std::get<std::vector<int>>(actual.getTensor());
+  std::vector<int> actualVector = std::get<std::vector<int>>(actual.get());
   std::vector<int> extractedResult = {actualVector.begin(),
                                       actualVector.begin() + 4};
   EXPECT_EQ(extractedResult, expected);
@@ -164,7 +163,7 @@ TEST(KernelImplementationTest, BicyclicMatmul) {
 
   auto dag = implementBicyclicMatmul(packedAValue, packedBValue, m, n, p);
   LiteralValue result = evalKernel(dag)[0];
-  auto resultVec = std::get<std::vector<int>>(result.getTensor());
+  auto resultVec = std::get<std::vector<int>>(result.get());
 
   auto resultLayout = getBicyclicLayoutRelation(
       RankedTensorType::get({m, p}, mlir::IndexType::get(&context)), numSlots);
@@ -240,7 +239,7 @@ TEST(KernelImplementationTest, TricyclicBatchMatmul) {
   auto dag =
       implementTricyclicBatchMatmul(packedAValue, packedBValue, h, m, n, p);
   LiteralValue result = evalKernel(dag)[0];
-  auto resultVec = std::get<std::vector<int>>(result.getTensor());
+  auto resultVec = std::get<std::vector<int>>(result.get());
 
   // Compute expected packed φ(Z) via evaluateLayoutOnTensor for the cleartext
   // result. First compute plain CPU batched matmul result (h x m x p).

--- a/lib/Kernel/RotateAndReduceFuzzTest.cpp
+++ b/lib/Kernel/RotateAndReduceFuzzTest.cpp
@@ -64,7 +64,7 @@ std::pair<std::vector<int>, int> runImpl(
   result = implementRotateAndReduce(vectorInput, plaintextsInput, period, n,
                                     zeroDiagonals, reduceOp);
   std::vector<int> resultTensor =
-      std::get<std::vector<int>>(evalKernel(result)[0].getTensor());
+      std::get<std::vector<int>>(evalKernel(result)[0].get());
   int depth = evalMultiplicativeDepth(result);
   return std::make_pair(resultTensor, depth);
 }

--- a/lib/Kernel/RotateAndReduceImplTest.cpp
+++ b/lib/Kernel/RotateAndReduceImplTest.cpp
@@ -61,7 +61,7 @@ std::vector<int> runImpl(const std::vector<int>& vec,
   }
   result = implementRotateAndReduce(vectorInput, plaintextsInput, period, n);
   std::cerr << "Rotate and reduce dag: " << printKernel(result) << "\n";
-  return std::get<std::vector<int>>(evalKernel(result)[0].getTensor());
+  return std::get<std::vector<int>>(evalKernel(result)[0].get());
 }
 
 TEST(RotateAndReduceImplTest, TestUnitPeriodWithPlaintextsSimpleValues) {

--- a/lib/Kernel/TestingUtils.cpp
+++ b/lib/Kernel/TestingUtils.cpp
@@ -2,10 +2,8 @@
 
 #include <cassert>
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -17,19 +15,8 @@ namespace mlir {
 namespace heir {
 namespace kernel {
 
-void printVec(const std::vector<int>& vec) {
-  std::cout << "[";
-  for (size_t i = 0; i < vec.size(); ++i) {
-    std::cout << vec[i];
-    if (i != vec.size() - 1) {
-      std::cout << ", ";
-    }
-  }
-  std::cout << "]";
-}
-
 EvalResults EvalVisitor::operator()(const LeafNode<LiteralValue>& node) {
-  const auto& nodeVal = node.value.getTensor();
+  const auto& nodeVal = node.value.get();
   const auto* vecVal = std::get_if<std::vector<int>>(&nodeVal);
   const auto* matVal = std::get_if<std::vector<std::vector<int>>>(&nodeVal);
   if (vecVal) {
@@ -39,13 +26,7 @@ EvalResults EvalVisitor::operator()(const LeafNode<LiteralValue>& node) {
     assert(matVal->size() == node.value.getShape()[0]);
   }
 
-  // std::cout << "Leaf node with shape: ";
-  // for (auto dim : node.value.getShape()) {
-  //   std::cout << dim << " ";
-  // }
-  // std::cout << "\n";
-
-  return {node.value.getTensor()};
+  return {node.value.get()};
 }
 
 EvalResults EvalVisitor::operator()(const AddNode<LiteralValue>& node) {
@@ -53,9 +34,18 @@ EvalResults EvalVisitor::operator()(const AddNode<LiteralValue>& node) {
   // to ensure caching is applied at every step.
   auto left = this->process(node.left)[0];
   auto right = this->process(node.right)[0];
+  const auto& lVal = left.get();
+  const auto& rVal = right.get();
+
+  // Handle scalar addition
+  const auto* lScalar = std::get_if<int>(&lVal);
+  const auto* rScalar = std::get_if<int>(&rVal);
+  if (lScalar && rScalar) {
+    return {LiteralValue(*lScalar + *rScalar)};
+  }
+
+  // Handle vector addition
   auto dim = left.getShape()[0];
-  const auto& lVal = left.getTensor();
-  const auto& rVal = right.getTensor();
   const auto* lVec = std::get_if<std::vector<int>>(&lVal);
   const auto* rVec = std::get_if<std::vector<int>>(&rVal);
   assert(lVec && rVec && "unsupported add operands");
@@ -64,24 +54,24 @@ EvalResults EvalVisitor::operator()(const AddNode<LiteralValue>& node) {
   for (size_t i = 0; i < dim; ++i) {
     result[i] = (*lVec)[i] + (*rVec)[i];
   }
-
-  // std::cout << "Add lhs=";
-  // printVec(*lVec);
-  // std::cout << " rhs=";
-  // printVec(*rVec);
-  // std::cout << " result=";
-  // printVec(result);
-  // std::cout << "\n";
-
   return {result};
 }
 
 EvalResults EvalVisitor::operator()(const SubtractNode<LiteralValue>& node) {
   auto left = this->process(node.left)[0];
   auto right = this->process(node.right)[0];
+  const auto& lVal = left.get();
+  const auto& rVal = right.get();
+
+  // Handle scalar subtraction
+  const auto* lScalar = std::get_if<int>(&lVal);
+  const auto* rScalar = std::get_if<int>(&rVal);
+  if (lScalar && rScalar) {
+    return {LiteralValue(*lScalar - *rScalar)};
+  }
+
+  // Handle vector subtraction
   auto dim = left.getShape()[0];
-  const auto& lVal = left.getTensor();
-  const auto& rVal = right.getTensor();
   const auto* lVec = std::get_if<std::vector<int>>(&lVal);
   const auto* rVec = std::get_if<std::vector<int>>(&rVal);
   assert(lVec && rVec && "unsupported sub operands");
@@ -91,22 +81,24 @@ EvalResults EvalVisitor::operator()(const SubtractNode<LiteralValue>& node) {
     result[i] = (*lVec)[i] - (*rVec)[i];
   }
 
-  // std::cout << "Sub lhs=";
-  // printVec(*lVec);
-  // std::cout << " rhs=";
-  // printVec(*rVec);
-  // std::cout << " result=";
-  // printVec(result);
-  // std::cout << "\n";
   return {result};
 }
 
 EvalResults EvalVisitor::operator()(const MultiplyNode<LiteralValue>& node) {
   auto left = this->process(node.left)[0];
   auto right = this->process(node.right)[0];
+  const auto& lVal = left.get();
+  const auto& rVal = right.get();
+
+  // Handle scalar multiplication
+  const auto* lScalar = std::get_if<int>(&lVal);
+  const auto* rScalar = std::get_if<int>(&rVal);
+  if (lScalar && rScalar) {
+    return {LiteralValue(*lScalar * *rScalar)};
+  }
+
+  // Handle vector multiplication
   auto dim = left.getShape()[0];
-  const auto& lVal = left.getTensor();
-  const auto& rVal = right.getTensor();
   const auto* lVec = std::get_if<std::vector<int>>(&lVal);
   const auto* rVec = std::get_if<std::vector<int>>(&rVal);
   assert(lVec && rVec && "unsupported mul operands");
@@ -115,13 +107,6 @@ EvalResults EvalVisitor::operator()(const MultiplyNode<LiteralValue>& node) {
   for (size_t i = 0; i < dim; ++i) {
     result[i] = (*lVec)[i] * (*rVec)[i];
   }
-  // std::cout << "Mul lhs=";
-  // printVec(*lVec);
-  // std::cout << " rhs=";
-  // printVec(*rVec);
-  // std::cout << " result=";
-  // printVec(result);
-  // std::cout << "\n";
   return {result};
 }
 
@@ -129,41 +114,37 @@ EvalResults EvalVisitor::operator()(const MultiplyNode<LiteralValue>& node) {
 EvalResults EvalVisitor::operator()(const LeftRotateNode<LiteralValue>& node) {
   auto operand = this->process(node.operand)[0];
   auto dim = operand.getShape()[0];
-  int amount = node.shift;
+  auto amount = node.shift;
   // Normalize amount to be in [0, dim)
   amount = ((amount % dim) + dim) % dim;
 
-  const auto& oVal = operand.getTensor();
+  const auto& oVal = operand.get();
   const auto* oVec = std::get_if<std::vector<int>>(&oVal);
   assert(oVec && "unsupported rotate operand");
   std::vector<int> result(dim);
   for (size_t i = 0; i < dim; ++i) {
     result[i] = (*oVec)[(i + amount) % oVec->size()];
   }
-
-  // std::cout << "Rot vec=";
-  // printVec(*oVec);
-  // std::cout << " shift=" << amount;
-  // std::cout << " result=";
-  // printVec(result);
-  // std::cout << "\n";
   return {result};
 }
 
 EvalResults EvalVisitor::operator()(const ExtractNode<LiteralValue>& node) {
   auto tensor = this->process(node.operand)[0];
-  unsigned index = node.index;
-  return {std::visit(
-      [&](auto&& t) -> LiteralValue {
-        // We can only extract from a 2D vector.
+  int index = node.index;
+
+  return std::visit(
+      [&](auto&& t) -> EvalResults {
         if constexpr (std::is_same_v<std::decay_t<decltype(t)>,
                                      std::vector<std::vector<int>>>) {
-          return t[index];
+          return {LiteralValue(t[index])};
+        } else if constexpr (std::is_same_v<std::decay_t<decltype(t)>,
+                                            std::vector<int>>) {
+          return {LiteralValue(t[index])};
         }
         assert(false && "Unsupported type for extraction");
-        return LiteralValue(std::vector<int>({}));
+        return {};
       },
-      tensor.getTensor())};
+      tensor.get());
 }
 
 EvalResults EvalVisitor::operator()(const ConstantTensorNode& node) {
@@ -173,10 +154,44 @@ EvalResults EvalVisitor::operator()(const ConstantTensorNode& node) {
   for (double v : node.value) {
     vec.push_back(static_cast<int>(v));
   }
-  // std::cout << "Const vec=";
-  // printVec(vec);
-  // std::cout << "\n";
   return {LiteralValue(vec)};
+}
+
+EvalResults EvalVisitor::operator()(const ConstantScalarNode& node) {
+  // A bit of a hack, casting the double to an int
+  return {LiteralValue(static_cast<int>(node.value))};
+}
+
+EvalResults EvalVisitor::operator()(const SplatNode& node) {
+  // A bit of a hack, casting the double to an int
+  int splatValue = static_cast<int>(node.value);
+
+  // Check if this is a tensor type
+  if (std::holds_alternative<kernel::IntTensorType>(node.type.type_variant)) {
+    const auto& tensorType =
+        std::get<kernel::IntTensorType>(node.type.type_variant);
+    // Compute total size as product of all dimensions
+    int64_t totalSize = 1;
+    for (int64_t dim : tensorType.shape) {
+      totalSize *= dim;
+    }
+    std::vector<int> result(totalSize, splatValue);
+    return {LiteralValue(result)};
+  } else if (std::holds_alternative<kernel::FloatTensorType>(
+                 node.type.type_variant)) {
+    const auto& tensorType =
+        std::get<kernel::FloatTensorType>(node.type.type_variant);
+    // Compute total size as product of all dimensions
+    int64_t totalSize = 1;
+    for (int64_t dim : tensorType.shape) {
+      totalSize *= dim;
+    }
+    std::vector<int> result(totalSize, splatValue);
+    return {LiteralValue(result)};
+  }
+
+  // Scalar type
+  return {LiteralValue(splatValue)};
 }
 
 EvalResults evalKernel(
@@ -192,7 +207,7 @@ std::vector<EvalResults> multiEvalKernel(
 }
 
 std::string PrintVisitor::operator()(const LeafNode<LiteralValue>& node) {
-  const auto& nodeVal = node.value.getTensor();
+  const auto& nodeVal = node.value.get();
   const auto* vecVal = std::get_if<std::vector<int>>(&nodeVal);
   const auto* matVal = std::get_if<std::vector<std::vector<int>>>(&nodeVal);
   if (vecVal) {
@@ -212,6 +227,14 @@ std::string PrintVisitor::operator()(const LeafNode<LiteralValue>& node) {
   }
 
   return "UnknownLeaf";
+}
+
+std::string PrintVisitor::operator()(const ConstantScalarNode& node) {
+  return std::to_string(node.value);
+}
+
+std::string PrintVisitor::operator()(const SplatNode& node) {
+  return "splat(" + std::to_string(node.value) + ")";
 }
 
 std::string PrintVisitor::operator()(const AddNode<LiteralValue>& node) {
@@ -234,7 +257,8 @@ std::string PrintVisitor::operator()(const MultiplyNode<LiteralValue>& node) {
 
 std::string PrintVisitor::operator()(const LeftRotateNode<LiteralValue>& node) {
   std::string operand = this->process(node.operand);
-  return "Rot(" + operand + ", " + std::to_string(node.shift) + ")";
+  std::string shift = std::to_string(node.shift);
+  return "Rot(" + operand + ", " + shift + ")";
 }
 
 std::string PrintVisitor::operator()(const ExtractNode<LiteralValue>& node) {
@@ -242,7 +266,8 @@ std::string PrintVisitor::operator()(const ExtractNode<LiteralValue>& node) {
   // and the textual form of the entire matrix is too verbose. Could also
   // run a simplification on the generated kernel to inline the extracted
   // tensor instead of printing recursively.
-  return "pt(" + std::to_string(node.index) + ")";
+  std::string indexStr = std::to_string(node.index);
+  return "pt(" + indexStr + ")";
 }
 
 std::string printKernel(

--- a/lib/Kernel/TestingUtils.h
+++ b/lib/Kernel/TestingUtils.h
@@ -25,6 +25,8 @@ class EvalVisitor : public CachingVisitor<LiteralValue, EvalResults> {
   EvalVisitor() : CachingVisitor<LiteralValue, EvalResults>() {}
 
   EvalResults operator()(const ConstantTensorNode& node) override;
+  EvalResults operator()(const ConstantScalarNode& node) override;
+  EvalResults operator()(const SplatNode& node) override;
   EvalResults operator()(const LeafNode<LiteralValue>& node) override;
   EvalResults operator()(const AddNode<LiteralValue>& node) override;
   EvalResults operator()(const SubtractNode<LiteralValue>& node) override;
@@ -52,6 +54,8 @@ class PrintVisitor : public CachingVisitor<LiteralValue, std::string> {
   std::string operator()(const MultiplyNode<LiteralValue>& node) override;
   std::string operator()(const LeftRotateNode<LiteralValue>& node) override;
   std::string operator()(const ExtractNode<LiteralValue>& node) override;
+  std::string operator()(const ConstantScalarNode& node) override;
+  std::string operator()(const SplatNode& node) override;
 };
 
 std::string printKernel(
@@ -67,6 +71,7 @@ class MultiplicativeDepthVisitorImpl
   MultiplicativeDepthVisitorImpl() : CachingVisitor<LiteralValue, double>() {}
 
   double operator()(const ConstantScalarNode& node) override { return -1.0; }
+  double operator()(const SplatNode& node) override { return -1.0; }
 
   double operator()(const LeafNode<LiteralValue>& node) override { return 0.0; }
 


### PR DESCRIPTION
This is required to support loop induction variables (and computations of dynamic rotation indices) in the construction of a rolled linalg kernel. Extracted from #2655 and rebased over #2693 and #2692