### PR TITLE
ArithmeticDag: Add floorDiv node

### DIFF
--- a/lib/Kernel/ArithmeticDag.h
+++ b/lib/Kernel/ArithmeticDag.h
@@ -118,6 +118,12 @@ struct MultiplyNode {
 };
 
 template <typename T>
+struct FloorDivNode {
+  std::shared_ptr<ArithmeticDagNode<T>> left;
+  int divisor;
+};
+
+template <typename T>
 struct PowerNode {
   std::shared_ptr<ArithmeticDagNode<T>> base;
   size_t exponent;
@@ -137,9 +143,11 @@ struct ExtractNode {
 
 template <typename T>
 struct ArithmeticDagNode {
+  using NodePtr = std::shared_ptr<ArithmeticDagNode<T>>;
+
  public:
   std::variant<ConstantScalarNode, ConstantTensorNode, LeafNode<T>, AddNode<T>,
-               SubtractNode<T>, MultiplyNode<T>, PowerNode<T>,
+               SubtractNode<T>, MultiplyNode<T>, FloorDivNode<T>, PowerNode<T>,
                LeftRotateNode<T>, ExtractNode<T>, SplatNode>
       node_variant;
 
@@ -153,19 +161,16 @@ struct ArithmeticDagNode {
 
  public:
   // Static factory methods
-  static std::shared_ptr<ArithmeticDagNode<T>> leaf(const T& value) {
+  static NodePtr leaf(const T& value) {
     // This factory method differs from the others because T may not have a
     // default constructor to use with emplace. In that case, we need to rely
     // on the move or copy constructors, which corresponds to the two
     // ArithmeticDagNode constructors above.
-    return std::shared_ptr<ArithmeticDagNode<T>>(
-        new ArithmeticDagNode<T>(value));
+    return NodePtr(new ArithmeticDagNode<T>(value));
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> constantScalar(double constant,
-                                                              DagType type) {
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+  static NodePtr constantScalar(double constant, DagType type) {
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     // Note, to satisfy variant we need to use aggregate initialization inside
     // emplace
     node->node_variant.template emplace<ConstantScalarNode>(
@@ -173,10 +178,8 @@ struct ArithmeticDagNode {
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> constantTensor(
-      std::vector<double> constant, DagType type) {
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+  static NodePtr constantTensor(std::vector<double> constant, DagType type) {
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     // Note, to satisfy variant we need to use aggregate initialization inside
     // emplace
     node->node_variant.template emplace<ConstantTensorNode>(
@@ -184,73 +187,64 @@ struct ArithmeticDagNode {
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> splat(double constant,
-                                                     DagType type) {
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+  static NodePtr splat(double constant, DagType type) {
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<SplatNode>(
         SplatNode{constant, std::move(type)});
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> add(
-      std::shared_ptr<ArithmeticDagNode<T>> lhs,
-      std::shared_ptr<ArithmeticDagNode<T>> rhs) {
+  static NodePtr add(NodePtr lhs, NodePtr rhs) {
     assert(lhs && rhs && "invalid add");
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<AddNode<T>>(
         AddNode<T>{std::move(lhs), std::move(rhs)});
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> sub(
-      std::shared_ptr<ArithmeticDagNode<T>> lhs,
-      std::shared_ptr<ArithmeticDagNode<T>> rhs) {
+  static NodePtr sub(NodePtr lhs, NodePtr rhs) {
     assert(lhs && rhs && "invalid sub");
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<SubtractNode<T>>(
         SubtractNode<T>{std::move(lhs), std::move(rhs)});
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> mul(
-      std::shared_ptr<ArithmeticDagNode<T>> lhs,
-      std::shared_ptr<ArithmeticDagNode<T>> rhs) {
+  static NodePtr mul(NodePtr lhs, NodePtr rhs) {
     assert(lhs && rhs && "invalid mul");
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<MultiplyNode<T>>(
         MultiplyNode<T>{std::move(lhs), std::move(rhs)});
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> power(
-      std::shared_ptr<ArithmeticDagNode<T>> base, size_t exponent) {
+  static NodePtr floorDiv(NodePtr lhs, int rhs) {
+    assert(lhs && "invalid div");
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<FloorDivNode<T>>(
+        FloorDivNode<T>{std::move(lhs), rhs});
+    return node;
+  }
+
+  static NodePtr power(NodePtr base, size_t exponent) {
     assert(base && "invalid base for power");
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<PowerNode<T>>(
         PowerNode<T>{std::move(base), exponent});
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> leftRotate(
-      std::shared_ptr<ArithmeticDagNode<T>> tensor, int64_t shift) {
+  static NodePtr leftRotate(NodePtr tensor, int64_t shift) {
     assert(tensor && "invalid tensor for leftRotate");
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<LeftRotateNode<T>>(
         LeftRotateNode<T>{std::move(tensor), shift});
     return node;
   }
 
-  static std::shared_ptr<ArithmeticDagNode<T>> extract(
-      std::shared_ptr<ArithmeticDagNode<T>> tensor, size_t index) {
+  static NodePtr extract(NodePtr tensor, size_t index) {
     assert(tensor && "invalid tensor for extract");
-    auto node =
-        std::shared_ptr<ArithmeticDagNode<T>>(new ArithmeticDagNode<T>());
+    auto node = NodePtr(new ArithmeticDagNode<T>());
     node->node_variant.template emplace<ExtractNode<T>>(
         ExtractNode<T>{std::move(tensor), index});
     return node;
@@ -280,11 +274,13 @@ struct ArithmeticDagNode {
 ///   ResultType: The type of the result of the visit.
 template <typename T, typename ResultType>
 class CachingVisitor {
+  using NodePtr = std::shared_ptr<ArithmeticDagNode<T>>;
+
  public:
   virtual ~CachingVisitor() = default;
 
   /// The main entry point that contains the caching logic.
-  ResultType process(const std::shared_ptr<ArithmeticDagNode<T>>& node) {
+  ResultType process(const NodePtr& node) {
     assert(node != nullptr && "invalid null node!");
 
     const auto* nodePtr = node.get();
@@ -298,8 +294,7 @@ class CachingVisitor {
   }
 
   /// An alternate entry point that handles multiple roots.
-  std::vector<ResultType> process(
-      llvm::ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> nodes) {
+  std::vector<ResultType> process(llvm::ArrayRef<NodePtr> nodes) {
     std::vector<ResultType> results;
     results.reserve(nodes.size());
     for (const auto& node : nodes) {
@@ -345,6 +340,11 @@ class CachingVisitor {
 
   virtual ResultType operator()(const MultiplyNode<T>& node) {
     assert(false && "Visit logic for MultiplyNode is not implemented.");
+    return ResultType();
+  }
+
+  virtual ResultType operator()(const FloorDivNode<T>& node) {
+    assert(false && "Visit logic for FloorDivNode is not implemented.");
     return ResultType();
   }
 

--- a/lib/Kernel/ArithmeticDagTest.cpp
+++ b/lib/Kernel/ArithmeticDagTest.cpp
@@ -61,6 +61,13 @@ struct FlattenedStringVisitor {
     return ss.str();
   }
 
+  std::string operator()(const FloorDivNode<std::string>& node) const {
+    std::stringstream ss;
+    ss << "(" << node.left->visit(*this) << " / "
+       << std::to_string(node.divisor) << ")";
+    return ss.str();
+  }
+
   std::string operator()(const PowerNode<std::string>& node) const {
     std::stringstream ss;
     ss << "(" << node.base->visit(*this) << " ^ " << node.exponent << ")";
@@ -146,6 +153,18 @@ TEST(ArithmeticDagTest, TestPrint) {
   FlattenedStringVisitor visitor;
   std::string result = root->visit(visitor);
   EXPECT_EQ(result, "(((x + 3.00) * (y ^ 2)) << 7)");
+}
+
+TEST(ArithmeticDagTest, TestDiv) {
+  auto root = StringLeavedDag::leftRotate(
+      StringLeavedDag::mul(
+          StringLeavedDag::floorDiv(StringLeavedDag::leaf("x"), 3),
+          StringLeavedDag::power(StringLeavedDag::leaf("y"), 2)),
+      7);
+
+  FlattenedStringVisitor visitor;
+  std::string result = root->visit(visitor);
+  EXPECT_EQ(result, "(((x / 3) * (y ^ 2)) << 7)");
 }
 
 TEST(ArithmeticDagTest, TestProperDag) {

--- a/lib/Kernel/IRMaterializingVisitor.cpp
+++ b/lib/Kernel/IRMaterializingVisitor.cpp
@@ -98,6 +98,16 @@ std::vector<Value> IRMaterializingVisitor::operator()(
 }
 
 std::vector<Value> IRMaterializingVisitor::operator()(
+    const FloorDivNode<SSAValue>& node) {
+  Value lhs = this->process(node.left)[0];
+  Value rhs =
+      arith::ConstantIntOp::create(builder, lhs.getType(), node.divisor);
+  auto op = arith::DivSIOp::create(builder, lhs, rhs);
+  createdOpCallback(op);
+  return {op->getResult(0)};
+}
+
+std::vector<Value> IRMaterializingVisitor::operator()(
     const LeftRotateNode<SSAValue>& node) {
   Value operand = this->process(node.operand)[0];
   Value shift = arith::ConstantIndexOp::create(builder, node.shift);

--- a/lib/Kernel/IRMaterializingVisitor.h
+++ b/lib/Kernel/IRMaterializingVisitor.h
@@ -60,6 +60,7 @@ class IRMaterializingVisitor
   std::vector<Value> operator()(const AddNode<SSAValue>& node) override;
   std::vector<Value> operator()(const SubtractNode<SSAValue>& node) override;
   std::vector<Value> operator()(const MultiplyNode<SSAValue>& node) override;
+  std::vector<Value> operator()(const FloorDivNode<SSAValue>& node) override;
   std::vector<Value> operator()(const LeftRotateNode<SSAValue>& node) override;
   std::vector<Value> operator()(const ExtractNode<SSAValue>& node) override;
 

--- a/lib/Kernel/RotationCountVisitor.cpp
+++ b/lib/Kernel/RotationCountVisitor.cpp
@@ -98,6 +98,15 @@ int64_t RotationCountVisitor::operator()(
   return leftCount + rightCount;
 }
 
+int64_t RotationCountVisitor::operator()(
+    const FloorDivNode<SymbolicValue>& node) {
+  const auto* thisNode = currentNode;  // Save before recursion
+  int64_t leftCount = processInternal(node.left);
+  bool leftIsSecret = nodeSecretStatus[node.left.get()];
+  nodeSecretStatus[thisNode] = leftIsSecret;
+  return leftCount;
+}
+
 int64_t RotationCountVisitor::operator()(const PowerNode<SymbolicValue>& node) {
   const auto* thisNode = currentNode;  // Save before recursion
 

--- a/lib/Kernel/RotationCountVisitor.h
+++ b/lib/Kernel/RotationCountVisitor.h
@@ -33,6 +33,7 @@ class RotationCountVisitor {
   int64_t operator()(const AddNode<SymbolicValue>& node);
   int64_t operator()(const SubtractNode<SymbolicValue>& node);
   int64_t operator()(const MultiplyNode<SymbolicValue>& node);
+  int64_t operator()(const FloorDivNode<SymbolicValue>& node);
   int64_t operator()(const PowerNode<SymbolicValue>& node);
   int64_t operator()(const LeftRotateNode<SymbolicValue>& node);
   int64_t operator()(const ExtractNode<SymbolicValue>& node);

--- a/lib/Kernel/TestingUtils.cpp
+++ b/lib/Kernel/TestingUtils.cpp
@@ -110,6 +110,27 @@ EvalResults EvalVisitor::operator()(const MultiplyNode<LiteralValue>& node) {
   return {result};
 }
 
+EvalResults EvalVisitor::operator()(const FloorDivNode<LiteralValue>& node) {
+  auto left = this->process(node.left)[0];
+  const auto& lVal = left.get();
+
+  // Scalar case
+  const auto* lScalar = std::get_if<int>(&lVal);
+  if (*lScalar) {
+    return {LiteralValue(*lScalar / node.divisor)};
+  }
+
+  // Vector case
+  auto dim = left.getShape()[0];
+  const auto* lVec = std::get_if<std::vector<int>>(&lVal);
+  assert(lVec && "unsupported floorDiv operands");
+  std::vector<int> result(dim);
+  for (size_t i = 0; i < dim; ++i) {
+    result[i] = (*lVec)[i] / node.divisor;
+  }
+  return {result};
+}
+
 // Cyclic left-rotation by a given index
 EvalResults EvalVisitor::operator()(const LeftRotateNode<LiteralValue>& node) {
   auto operand = this->process(node.operand)[0];
@@ -253,6 +274,11 @@ std::string PrintVisitor::operator()(const MultiplyNode<LiteralValue>& node) {
   std::string left = this->process(node.left);
   std::string right = this->process(node.right);
   return "(" + left + " * " + right + ")";
+}
+
+std::string PrintVisitor::operator()(const FloorDivNode<LiteralValue>& node) {
+  std::string left = this->process(node.left);
+  return "(" + left + " / " + std::to_string(node.divisor) + ")";
 }
 
 std::string PrintVisitor::operator()(const LeftRotateNode<LiteralValue>& node) {

--- a/lib/Kernel/TestingUtils.h
+++ b/lib/Kernel/TestingUtils.h
@@ -31,6 +31,7 @@ class EvalVisitor : public CachingVisitor<LiteralValue, EvalResults> {
   EvalResults operator()(const AddNode<LiteralValue>& node) override;
   EvalResults operator()(const SubtractNode<LiteralValue>& node) override;
   EvalResults operator()(const MultiplyNode<LiteralValue>& node) override;
+  EvalResults operator()(const FloorDivNode<LiteralValue>& node) override;
   EvalResults operator()(const LeftRotateNode<LiteralValue>& node) override;
   EvalResults operator()(const ExtractNode<LiteralValue>& node) override;
 };
@@ -52,6 +53,7 @@ class PrintVisitor : public CachingVisitor<LiteralValue, std::string> {
   std::string operator()(const AddNode<LiteralValue>& node) override;
   std::string operator()(const SubtractNode<LiteralValue>& node) override;
   std::string operator()(const MultiplyNode<LiteralValue>& node) override;
+  std::string operator()(const FloorDivNode<LiteralValue>& node) override;
   std::string operator()(const LeftRotateNode<LiteralValue>& node) override;
   std::string operator()(const ExtractNode<LiteralValue>& node) override;
   std::string operator()(const ConstantScalarNode& node) override;
@@ -95,6 +97,11 @@ class MultiplicativeDepthVisitorImpl
       return left;
     }
     return std::max(left, right) + 1.0;
+  }
+
+  double operator()(const FloorDivNode<LiteralValue>& node) override {
+    // Division by plaintext doesn't increase multiplicative depth
+    return this->process(node.left);
   }
 
   double operator()(const ConstantTensorNode& node) override {


### PR DESCRIPTION
This is primarily needed for division operations used in index calculations for dynamic rotations (e.g., updating the iter_arg `shift //= 2` in a rotate-and-reduce loop). 