### PR TITLE
ArithmeticDag: use dynamic index for LeftRotateNode [NFC]

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetwork.cpp
@@ -216,6 +216,18 @@ LogicalResult convertRemapOp(RemapOp op,
   int64_t ciphertextSize = tensorTy.getDimSize(1);
   auto singleCiphertextType =
       RankedTensorType::get({1, ciphertextSize}, tensorTy.getElementType());
+
+  // Extract element type and convert to DagType
+  kernel::DagType dagElemType;
+  if (auto floatTy = dyn_cast<FloatType>(tensorTy.getElementType())) {
+    dagElemType = kernel::DagType::floatTy(floatTy.getWidth());
+  } else if (auto intTy = dyn_cast<IntegerType>(tensorTy.getElementType())) {
+    dagElemType = kernel::DagType::integer(intTy.getWidth());
+  } else {
+    return op.emitOpError()
+           << "expected tensor with float or integer element type";
+  }
+
   // Populate the mapping with (source, target) pairs
   // This require enumerating over the relation for the op
   Mapping mapping(ciphertextSize, numCiphertexts);
@@ -260,8 +272,8 @@ LogicalResult convertRemapOp(RemapOp op,
     ciphertexts.push_back(kernel::SSAValue(slice.getResult()));
   }
 
-  auto resultNodes =
-      implementShiftNetwork(ciphertexts, mapping, scheme, ciphertextSize);
+  auto resultNodes = implementShiftNetwork(ciphertexts, mapping, scheme,
+                                           ciphertextSize, dagElemType);
 
   kernel::IRMaterializingVisitor visitor(b, singleCiphertextType);
   auto resultVectors = visitor.process(resultNodes);

--- a/lib/Dialect/TensorExt/Transforms/ImplementShiftNetworkTest.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementShiftNetworkTest.cpp
@@ -66,8 +66,9 @@ std::vector<std::vector<int>> manuallyApplyMapping(
   }
 
   auto expected = manuallyApplyMapping(mapping, input, ciphertextSize);
-  auto dag =
-      implementShiftNetwork(inputLeaves, mapping, scheme, ciphertextSize);
+  kernel::DagType defaultType = kernel::DagType::integer(32);
+  auto dag = implementShiftNetwork(inputLeaves, mapping, scheme, ciphertextSize,
+                                   defaultType);
   auto evalResults = multiEvalKernel(dag);
   std::vector<LiteralValue> actual;
   actual.reserve(evalResults.size());

--- a/lib/Dialect/TensorExt/Transforms/RotationGroupKernel.h
+++ b/lib/Dialect/TensorExt/Transforms/RotationGroupKernel.h
@@ -23,6 +23,24 @@ namespace tensor_ext {
 using kernel::AbstractValue;
 using kernel::ArithmeticDagNode;
 
+namespace {
+// Helper to create a tensor DagType from an element type and shape
+inline kernel::DagType makeTensorType(const kernel::DagType& elemType,
+                                      const std::vector<int64_t>& shape) {
+  if (std::holds_alternative<kernel::FloatType>(elemType.type_variant)) {
+    unsigned bitWidth =
+        std::get<kernel::FloatType>(elemType.type_variant).bitWidth;
+    return kernel::DagType::floatTensor(bitWidth, shape);
+  } else if (std::holds_alternative<kernel::IntegerType>(
+                 elemType.type_variant)) {
+    unsigned bitWidth =
+        std::get<kernel::IntegerType>(elemType.type_variant).bitWidth;
+    return kernel::DagType::intTensor(bitWidth, shape);
+  }
+  llvm_unreachable("Expected scalar DagType");
+}
+}  // namespace
+
 //  Apply a virtual rotation to a real list of ciphertexts.
 //
 //  A virtual ciphertext is a flattening of a list of ciphertexts. When this
@@ -53,10 +71,12 @@ std::enable_if_t<
 applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
                      int64_t rotation,
                      const std::vector<std::vector<double>>& rotateMasks,
-                     int64_t ciphertextSize) {
+                     int64_t ciphertextSize, kernel::DagType elementType) {
   using NodeTy = ArithmeticDagNode<T>;
   using ValueTy = std::shared_ptr<NodeTy>;
   int64_t numCiphertexts = input.size();
+  auto tensorType =
+      makeTensorType(elementType, {1, static_cast<int64_t>(ciphertextSize)});
 
   // We need to identify the (possibly two) target ciphertexts for each input
   // ciphertext that was rotated.
@@ -71,15 +91,12 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       // Eagerly skip masking if possible
       auto [allZero, allOne] = allZeroAllOne(mask);
       if (allZero) {
-        std::vector<double> zeros(ciphertextSize, 0.0);
-        masked.push_back(NodeTy::constantTensor(
-            zeros, kernel::DagType::floatTensor(64, {ciphertextSize})));
+        masked.push_back(NodeTy::splat(0.0, tensorType));
       } else if (allOne) {
         masked.push_back(ct);
       } else {
-        masked.push_back(NodeTy::mul(
-            ct, NodeTy::constantTensor(
-                    mask, kernel::DagType::floatTensor(64, {ciphertextSize}))));
+        masked.push_back(
+            NodeTy::mul(ct, NodeTy::constantTensor(mask, tensorType)));
       }
     }
 
@@ -143,16 +160,12 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       // Eagerly skip masking if possible
       auto [allZero, allOne] = allZeroAllOne(mask);
       if (allZero) {
-        std::vector<double> zeros(ciphertextSize, 0.0);
-        results[target1] = NodeTy::constantTensor(
-            zeros, kernel::DagType::floatTensor(64, {ciphertextSize}));
+        results[target1] = NodeTy::splat(0.0, tensorType);
       } else if (allOne) {
         results[target1] = NodeTy::leftRotate(ct, rotation);
       } else {
         results[target1] = NodeTy::leftRotate(
-            NodeTy::mul(
-                ct, NodeTy::constantTensor(mask, kernel::DagType::floatTensor(
-                                                     64, {ciphertextSize}))),
+            NodeTy::mul(ct, NodeTy::constantTensor(mask, tensorType)),
             rotation);
       }
       continue;
@@ -188,9 +201,8 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       if (allZero) {
         rotated1 = std::nullopt;
       } else {
-        ValueTy masked1 = NodeTy::mul(
-            ct, NodeTy::constantTensor(
-                    mask1, kernel::DagType::floatTensor(64, {ciphertextSize})));
+        ValueTy masked1 =
+            NodeTy::mul(ct, NodeTy::constantTensor(mask1, tensorType));
         rotated1 = NodeTy::leftRotate(masked1, rotation);
       }
     }
@@ -201,9 +213,8 @@ applyVirtualRotation(ArrayRef<std::shared_ptr<ArithmeticDagNode<T>>> input,
       if (allZero) {
         rotated2 = std::nullopt;
       } else {
-        ValueTy masked2 = NodeTy::mul(
-            ct, NodeTy::constantTensor(
-                    mask2, kernel::DagType::floatTensor(64, {ciphertextSize})));
+        ValueTy masked2 =
+            NodeTy::mul(ct, NodeTy::constantTensor(mask2, tensorType));
         rotated2 = NodeTy::leftRotate(masked2, rotation);
       }
     }
@@ -233,7 +244,8 @@ std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  SmallVector<std::shared_ptr<ArithmeticDagNode<T>>>>
 rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
                ArrayRef<SourceShift> sourceShifts, ArrayRef<ShiftRound> rounds,
-               const RotationGroup& group, int64_t ciphertextSize) {
+               const RotationGroup& group, int64_t ciphertextSize,
+               kernel::DagType elementType) {
   using NodeTy = ArithmeticDagNode<T>;
   using ValueTy = std::shared_ptr<NodeTy>;
 
@@ -283,6 +295,8 @@ rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
     // skip masking if possible
     SmallVector<std::optional<ValueTy>> fixedCurrent;
     fixedCurrent.reserve(numCiphertexts);
+    auto tensorType =
+        makeTensorType(elementType, {1, static_cast<int64_t>(ciphertextSize)});
     for (const auto& [ct, fixedMask] : llvm::zip(current, fixedMasks)) {
       auto [allZero, allOne] = allZeroAllOne(fixedMask);
       if (allZero) {
@@ -290,8 +304,7 @@ rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
       } else if (allOne) {
         fixedCurrent.push_back(ct);
       } else {
-        ValueTy mask = NodeTy::constantTensor(
-            fixedMask, kernel::DagType::floatTensor(64, {ciphertextSize}));
+        ValueTy mask = NodeTy::constantTensor(fixedMask, tensorType);
         fixedCurrent.push_back(NodeTy::mul(ct, mask));
       }
     }
@@ -314,7 +327,7 @@ rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
       // }
       rotatedCurrent =
           applyVirtualRotation(ArrayRef<ValueTy>(current), round.rotationAmount,
-                               rotateMasks, ciphertextSize);
+                               rotateMasks, ciphertextSize, elementType);
     }
 
     // Combine the rotated and fixed parts to form the new current.
@@ -345,12 +358,11 @@ rotateOneGroup(const Mapping& mapping, ArrayRef<T> initialCiphertexts,
   // Add up the results, zeroing out any ciphertexts that are not the final
   // target of some rotation, as they contain partially-shifted and fixed
   // values from middle rounds of this group.
+  auto tensorType =
+      makeTensorType(elementType, {1, static_cast<int64_t>(ciphertextSize)});
   for (int64_t i = 0; i < numCiphertexts; i++) {
     if (!finalTargetCiphertexts.contains(i)) {
-      std::vector<double> zeroVec(ciphertextSize, 0);
-      current[i] = NodeTy::constantTensor(
-          std::move(zeroVec),
-          kernel::DagType::floatTensor(64, {ciphertextSize}));
+      current[i] = NodeTy::splat(0.0, tensorType);
     }
   }
 
@@ -362,7 +374,8 @@ std::enable_if_t<
     std::is_base_of<AbstractValue, T>::value,
     SmallVector<SmallVector<std::shared_ptr<ArithmeticDagNode<T>>>>>
 implementRotationGroups(SmallVector<T>& ciphertexts, const Mapping& mapping,
-                        const ShiftScheme& scheme, int64_t ciphertextSize) {
+                        const ShiftScheme& scheme, int64_t ciphertextSize,
+                        kernel::DagType elementType) {
   using NodeTy = ArithmeticDagNode<T>;
   using ValueTy = std::shared_ptr<NodeTy>;
 
@@ -387,9 +400,9 @@ implementRotationGroups(SmallVector<T>& ciphertexts, const Mapping& mapping,
     //             << ss.shift << "\n";
     // }
 
-    SmallVector<ValueTy> perGroupResult =
-        rotateOneGroup(mapping, ArrayRef<T>(ciphertexts), sourceShifts,
-                       scheme.strategy.getRounds(), group, ciphertextSize);
+    SmallVector<ValueTy> perGroupResult = rotateOneGroup(
+        mapping, ArrayRef<T>(ciphertexts), sourceShifts,
+        scheme.strategy.getRounds(), group, ciphertextSize, elementType);
     groupResults.push_back(perGroupResult);
   }
 
@@ -400,11 +413,12 @@ template <typename T>
 std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  SmallVector<std::shared_ptr<ArithmeticDagNode<T>>>>
 implementShiftNetwork(SmallVector<T>& ciphertexts, const Mapping& mapping,
-                      const ShiftScheme& scheme, int64_t ciphertextSize) {
+                      const ShiftScheme& scheme, int64_t ciphertextSize,
+                      kernel::DagType elementType) {
   using NodeTy = ArithmeticDagNode<T>;
   using ValueTy = std::shared_ptr<NodeTy>;
-  SmallVector<SmallVector<ValueTy>> groupResults =
-      implementRotationGroups(ciphertexts, mapping, scheme, ciphertextSize);
+  SmallVector<SmallVector<ValueTy>> groupResults = implementRotationGroups(
+      ciphertexts, mapping, scheme, ciphertextSize, elementType);
 
   // Add all the per-group results together
   SmallVector<ValueTy> summedResults = groupResults[0];

--- a/lib/Kernel/ArithmeticDag.h
+++ b/lib/Kernel/ArithmeticDag.h
@@ -132,7 +132,7 @@ struct PowerNode {
 template <typename T>
 struct LeftRotateNode {
   std::shared_ptr<ArithmeticDagNode<T>> operand;
-  int64_t shift;
+  std::shared_ptr<ArithmeticDagNode<T>> shift;
 };
 
 template <typename T>
@@ -237,8 +237,17 @@ struct ArithmeticDagNode {
   static NodePtr leftRotate(NodePtr tensor, int64_t shift) {
     assert(tensor && "invalid tensor for leftRotate");
     auto node = NodePtr(new ArithmeticDagNode<T>());
+    auto constantShift = constantScalar(shift, DagType::index());
     node->node_variant.template emplace<LeftRotateNode<T>>(
-        LeftRotateNode<T>{std::move(tensor), shift});
+        LeftRotateNode<T>{std::move(tensor), std::move(constantShift)});
+    return node;
+  }
+
+  static NodePtr leftRotate(NodePtr tensor, NodePtr shift) {
+    assert(tensor && "invalid tensor for leftRotate");
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<LeftRotateNode<T>>(
+        LeftRotateNode<T>{std::move(tensor), std::move(shift)});
     return node;
   }
 

--- a/lib/Kernel/ArithmeticDagTest.cpp
+++ b/lib/Kernel/ArithmeticDagTest.cpp
@@ -76,7 +76,8 @@ struct FlattenedStringVisitor {
 
   std::string operator()(const LeftRotateNode<std::string>& node) const {
     std::stringstream ss;
-    ss << "(" << node.operand->visit(*this) << " << " << node.shift << ")";
+    ss << "(" << node.operand->visit(*this) << " << "
+       << node.shift->visit(*this) << ")";
     return ss.str();
   }
 
@@ -152,7 +153,10 @@ TEST(ArithmeticDagTest, TestPrint) {
 
   FlattenedStringVisitor visitor;
   std::string result = root->visit(visitor);
-  EXPECT_EQ(result, "(((x + 3.00) * (y ^ 2)) << 7)");
+  // Use a double print style for the left shift index because, while you could
+  // type switch in FlattenedStringVisitor, there is no point in doing that for
+  // this test.
+  EXPECT_EQ(result, "(((x + 3.00) * (y ^ 2)) << 7.00)");
 }
 
 TEST(ArithmeticDagTest, TestDiv) {
@@ -164,7 +168,7 @@ TEST(ArithmeticDagTest, TestDiv) {
 
   FlattenedStringVisitor visitor;
   std::string result = root->visit(visitor);
-  EXPECT_EQ(result, "(((x / 3) * (y ^ 2)) << 7)");
+  EXPECT_EQ(result, "(((x / 3) * (y ^ 2)) << 7.00)");
 }
 
 TEST(ArithmeticDagTest, TestProperDag) {

--- a/lib/Kernel/IRMaterializingVisitor.cpp
+++ b/lib/Kernel/IRMaterializingVisitor.cpp
@@ -23,6 +23,50 @@ namespace mlir {
 namespace heir {
 namespace kernel {
 
+namespace {
+
+// Helper to convert DagType to MLIR Type
+Type dagTypeToMLIRType(const DagType& dagType, OpBuilder& builder) {
+  return std::visit(
+      [&](auto&& arg) -> Type {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, kernel::IntegerType>) {
+          return builder.getIntegerType(arg.bitWidth);
+        } else if constexpr (std::is_same_v<T, kernel::FloatType>) {
+          if (arg.bitWidth == 32) {
+            return builder.getF32Type();
+          } else if (arg.bitWidth == 64) {
+            return builder.getF64Type();
+          } else if (arg.bitWidth == 16) {
+            return builder.getF16Type();
+          } else {
+            llvm_unreachable("Unsupported float bit width");
+          }
+        } else if constexpr (std::is_same_v<T, kernel::IndexType>) {
+          return builder.getIndexType();
+        } else if constexpr (std::is_same_v<T, kernel::IntTensorType>) {
+          auto elementType = builder.getIntegerType(arg.bitWidth);
+          return RankedTensorType::get(arg.shape, elementType);
+        } else if constexpr (std::is_same_v<T, kernel::FloatTensorType>) {
+          mlir::Type elementType;
+          if (arg.bitWidth == 32) {
+            elementType = builder.getF32Type();
+          } else if (arg.bitWidth == 64) {
+            elementType = builder.getF64Type();
+          } else if (arg.bitWidth == 16) {
+            elementType = builder.getF16Type();
+          } else {
+            llvm_unreachable("Unsupported float bit width");
+          }
+          return RankedTensorType::get(arg.shape, elementType);
+        }
+        llvm_unreachable("Unknown DagType variant");
+      },
+      dagType.type_variant);
+}
+
+}  // namespace
+
 std::vector<Value> IRMaterializingVisitor::operator()(
     const LeafNode<SSAValue>& node) {
   return {node.value.getValue()};
@@ -30,32 +74,59 @@ std::vector<Value> IRMaterializingVisitor::operator()(
 
 std::vector<Value> IRMaterializingVisitor::operator()(
     const ConstantScalarNode& node) {
-  // A "ConstantScalarNode" can still have a shaped type, and in that case the
-  // value is treated as a splat. This is preferred in some cases to support
-  // DAGs that can be evaluated elementwise for ElementwiseMappable ops like
-  // arith ops.
+  Type targetType = dagTypeToMLIRType(node.type, builder);
   TypedAttr attr;
-  if (auto floatTy =
-          dyn_cast<mlir::FloatType>(getElementTypeOrSelf(evaluatedType))) {
+  if (auto indexTy = dyn_cast<mlir::IndexType>(targetType)) {
+    // Handle index type specially - convert double to index integer
+    APInt apVal = APInt(64, static_cast<int64_t>(std::floor(node.value)));
+    attr = builder.getIntegerAttr(indexTy, apVal);
+  } else if (auto floatTy = dyn_cast<mlir::FloatType>(targetType)) {
     APFloat apVal(node.value);
     APFloat converted =
         convertFloatToSemantics(apVal, floatTy.getFloatSemantics());
-    attr = getScalarOrDenseAttr(evaluatedType, converted);
-  } else if (auto intTy = dyn_cast<mlir::IntegerType>(
-                 getElementTypeOrSelf(evaluatedType))) {
-    // Node values are doubles and we may have to properly support integers.
-    APInt apVal(intTy.getWidth(), std::floor(node.value));
-    attr = getScalarOrDenseAttr(evaluatedType, apVal);
+    attr = builder.getFloatAttr(floatTy, converted);
+  } else if (auto intTy = dyn_cast<mlir::IntegerType>(targetType)) {
+    int64_t intValue = static_cast<int64_t>(std::floor(node.value));
+    APInt apVal(intTy.getWidth(), intValue, /*isSigned=*/true);
+    attr = builder.getIntegerAttr(intTy, apVal);
   }
 
-  auto constantOp = arith::ConstantOp::create(builder, evaluatedType, attr);
+  auto constantOp = arith::ConstantOp::create(builder, targetType, attr);
+  createdOpCallback(constantOp);
+  return {constantOp};
+}
+
+std::vector<Value> IRMaterializingVisitor::operator()(const SplatNode& node) {
+  Type targetType = dagTypeToMLIRType(node.type, builder);
+
+  // SplatNode should always produce a tensor type
+  RankedTensorType tensorTy = cast<RankedTensorType>(targetType);
+  Type elementType = tensorTy.getElementType();
+
+  TypedAttr attr;
+  if (auto floatTy = dyn_cast<mlir::FloatType>(elementType)) {
+    APFloat apVal(node.value);
+    APFloat converted =
+        convertFloatToSemantics(apVal, floatTy.getFloatSemantics());
+    attr = DenseElementsAttr::get(tensorTy, converted);
+  } else if (auto intTy = dyn_cast<mlir::IntegerType>(elementType)) {
+    int64_t intValue = static_cast<int64_t>(std::floor(node.value));
+    APInt apVal(intTy.getWidth(), intValue, /*isSigned=*/true);
+    attr = DenseElementsAttr::get(tensorTy, apVal);
+  } else {
+    llvm_unreachable("Unsupported element type for SplatNode");
+  }
+
+  auto constantOp = arith::ConstantOp::create(builder, targetType, attr);
   createdOpCallback(constantOp);
   return {constantOp};
 }
 
 std::vector<Value> IRMaterializingVisitor::operator()(
     const ConstantTensorNode& node) {
-  RankedTensorType tensorTy = cast<RankedTensorType>(evaluatedType);
+  Type targetType = dagTypeToMLIRType(node.type, builder);
+  RankedTensorType tensorTy = cast<RankedTensorType>(targetType);
+
   TypedAttr attr;
   if (auto floatTy = dyn_cast<mlir::FloatType>(tensorTy.getElementType())) {
     SmallVector<APFloat> values;
@@ -77,7 +148,7 @@ std::vector<Value> IRMaterializingVisitor::operator()(
     attr = DenseElementsAttr::get(tensorTy, values);
   }
 
-  auto constantOp = arith::ConstantOp::create(builder, evaluatedType, attr);
+  auto constantOp = arith::ConstantOp::create(builder, targetType, attr);
   createdOpCallback(constantOp);
   return {constantOp};
 }
@@ -110,9 +181,9 @@ std::vector<Value> IRMaterializingVisitor::operator()(
 std::vector<Value> IRMaterializingVisitor::operator()(
     const LeftRotateNode<SSAValue>& node) {
   Value operand = this->process(node.operand)[0];
-  Value shift = arith::ConstantIndexOp::create(builder, node.shift);
+  Value shift = this->process(node.shift)[0];
   auto rotateOp =
-      tensor_ext::RotateOp::create(builder, evaluatedType, operand, shift);
+      tensor_ext::RotateOp::create(builder, operand.getType(), operand, shift);
   createdOpCallback(rotateOp);
   return {rotateOp};
 }

--- a/lib/Kernel/IRMaterializingVisitor.h
+++ b/lib/Kernel/IRMaterializingVisitor.h
@@ -55,6 +55,7 @@ class IRMaterializingVisitor
   }
 
   std::vector<Value> operator()(const ConstantScalarNode& node) override;
+  std::vector<Value> operator()(const SplatNode& node) override;
   std::vector<Value> operator()(const ConstantTensorNode& node) override;
   std::vector<Value> operator()(const LeafNode<SSAValue>& node) override;
   std::vector<Value> operator()(const AddNode<SSAValue>& node) override;

--- a/lib/Kernel/TestingUtils.cpp
+++ b/lib/Kernel/TestingUtils.cpp
@@ -135,7 +135,8 @@ EvalResults EvalVisitor::operator()(const FloorDivNode<LiteralValue>& node) {
 EvalResults EvalVisitor::operator()(const LeftRotateNode<LiteralValue>& node) {
   auto operand = this->process(node.operand)[0];
   auto dim = operand.getShape()[0];
-  auto amount = node.shift;
+  auto evaluatedShift = this->process(node.shift)[0];
+  int amount = std::get<int>(evaluatedShift.get());
   // Normalize amount to be in [0, dim)
   amount = ((amount % dim) + dim) % dim;
 
@@ -283,7 +284,7 @@ std::string PrintVisitor::operator()(const FloorDivNode<LiteralValue>& node) {
 
 std::string PrintVisitor::operator()(const LeftRotateNode<LiteralValue>& node) {
   std::string operand = this->process(node.operand);
-  std::string shift = std::to_string(node.shift);
+  std::string shift = this->process(node.shift);
   return "Rot(" + operand + ", " + shift + ")";
 }
 

--- a/lib/Transforms/LayoutOptimization/LayoutConversionCost.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutConversionCost.cpp
@@ -107,8 +107,9 @@ Cost computeCostOfLayoutConversion(int64_t numCiphertexts,
   using ValueTy = std::shared_ptr<NodeTy>;
   SmallVector<SymbolicValue> inputLeaves(numCiphertexts,
                                          SymbolicValue({ciphertextSize}));
-  SmallVector<SmallVector<ValueTy>> groupResults =
-      implementRotationGroups(inputLeaves, mapping, scheme, ciphertextSize);
+  kernel::DagType defaultType = kernel::DagType::integer(32);
+  SmallVector<SmallVector<ValueTy>> groupResults = implementRotationGroups(
+      inputLeaves, mapping, scheme, ciphertextSize, defaultType);
 
   // The cost is the maximum number of rotations in any group
   Cost maxRotations = 0;

--- a/lib/Transforms/LowerPolynomialEval/Patterns.cpp
+++ b/lib/Transforms/LowerPolynomialEval/Patterns.cpp
@@ -34,11 +34,29 @@ namespace mlir {
 namespace heir {
 
 using kernel::ArithmeticDagNode;
+using kernel::DagType;
 using kernel::IRMaterializingVisitor;
 using kernel::SSAValue;
 using polynomial::EvalOp;
 using polynomial::FloatPolynomial;
 using polynomial::TypedFloatPolynomialAttr;
+
+namespace {
+
+// Helper to convert mlir::Type to kernel::DagType
+DagType floatTypeToDagType(Type type) {
+  return llvm::TypeSwitch<Type, DagType>(type)
+      .Case<FloatType>([](auto ty) { return DagType::floatTy(ty.getWidth()); })
+      .Case<RankedTensorType>([](auto ty) {
+        return DagType::floatTensor(ty.getElementType().getIntOrFloatBitWidth(),
+                                    ty.getShape().vec());
+      })
+      .Default([](Type) {
+        llvm_unreachable("Unsupported type for polynomial coefficients");
+        return DagType();
+      });
+}
+}  // namespace
 
 LogicalResult LowerViaHorner::matchAndRewrite(EvalOp op,
                                               PatternRewriter& rewriter) const {
@@ -52,6 +70,12 @@ LogicalResult LowerViaHorner::matchAndRewrite(EvalOp op,
   const int degreeThreshold = 5;
   if (!shouldForce() && maxDegree > degreeThreshold) return failure();
 
+  // Only support floating point element types
+  auto floatTy =
+      dyn_cast<FloatType>(getElementTypeOrSelf(op.getResult().getType()));
+  if (!floatTy) return failure();
+  DagType dagType = floatTypeToDagType(op.getResult().getType());
+
   // Convert coefficient map to std::map<int64_t, double>
   auto monomialMap = attr.getValue().getPolynomial().getCoeffMap();
   std::map<int64_t, double> coefficients;
@@ -63,8 +87,8 @@ LogicalResult LowerViaHorner::matchAndRewrite(EvalOp op,
   // Create ArithmeticDag nodes
   auto xNode =
       kernel::ArithmeticDagNode<kernel::SSAValue>::leaf(op.getOperand());
-  auto resultNode =
-      polynomial::hornerMonomialPolynomialEvaluation(xNode, coefficients);
+  auto resultNode = polynomial::hornerMonomialPolynomialEvaluation(
+      xNode, coefficients, dagType);
 
   // Use IRMaterializingVisitor to convert to MLIR
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -87,6 +111,12 @@ LogicalResult LowerViaPatersonStockmeyerMonomial::matchAndRewrite(
   const int degreeThreshold = 5;
   if (!shouldForce() && maxDegree > degreeThreshold) return failure();
 
+  // Only support floating point element types
+  auto floatTy =
+      dyn_cast<FloatType>(getElementTypeOrSelf(op.getResult().getType()));
+  if (!floatTy) return failure();
+  DagType dagType = floatTypeToDagType(op.getResult().getType());
+
   // Convert coefficient map to std::map<int64_t, double>
   auto monomialMap = attr.getValue().getPolynomial().getCoeffMap();
   std::map<int64_t, double> coefficients;
@@ -99,7 +129,7 @@ LogicalResult LowerViaPatersonStockmeyerMonomial::matchAndRewrite(
   auto xNode =
       kernel::ArithmeticDagNode<kernel::SSAValue>::leaf(op.getOperand());
   auto resultNode = polynomial::patersonStockmeyerMonomialPolynomialEvaluation(
-      xNode, coefficients);
+      xNode, coefficients, dagType);
 
   // Use IRMaterializingVisitor to convert to MLIR
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -136,6 +166,7 @@ LogicalResult LowerViaPatersonStockmeyerChebyshev::matchAndRewrite(
 
   auto floatTy = dyn_cast<FloatType>(getElementTypeOrSelf(op));
   if (!floatTy) return failure();
+  DagType dagType = floatTypeToDagType(op.getResult().getType());
 
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
   Value xInput = op.getValue();
@@ -158,8 +189,7 @@ LogicalResult LowerViaPatersonStockmeyerChebyshev::matchAndRewrite(
   SSAValue xNode(xInput);
 
   auto resultNode = polynomial::patersonStockmeyerChebyshevPolynomialEvaluation(
-      xNode, chebCoeffs, getMinCoefficientThreshold());
-
+      xNode, chebCoeffs, getMinCoefficientThreshold(), dagType);
   IRMaterializingVisitor visitor(b, op.getValue().getType());
   Value finalOutput = resultNode->visit(visitor)[0];
 

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyer.h
@@ -98,11 +98,14 @@ inline std::pair<int64_t, int64_t> splitDegree(int64_t n) {
 // The multiplicative depth is ceil(log2(k)).
 template <typename T>
 std::vector<std::shared_ptr<kernel::ArithmeticDagNode<T>>> computePowers(
-    std::shared_ptr<kernel::ArithmeticDagNode<T>> x, int64_t k) {
+    std::shared_ptr<kernel::ArithmeticDagNode<T>> x, int64_t k,
+    kernel::DagType coeffType) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
+  bool isTensorType = coeffType.type_variant.index() >= 2;
   std::vector<std::shared_ptr<NodeTy>> result;
   result.reserve(k + 1);
-  result.push_back(NodeTy::constantScalar(1, kernel::DagType::floatTy(64)));
+  result.push_back(isTensorType ? NodeTy::splat(1, coeffType)
+                                : NodeTy::constantScalar(1, coeffType));
   if (k >= 1) {
     result.push_back(x);
   }
@@ -128,14 +131,17 @@ std::vector<std::shared_ptr<kernel::ArithmeticDagNode<T>>> computePowers(
 //   x: The input node representing the variable
 //   n: The degree of the Chebyshev polynomial to compute
 //   cache: Map caching already computed powers
+//   coeffType: The type for coefficient constants
 //
 // Returns:
 //   Node representing T_n(x)
 template <typename T>
 std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
     std::shared_ptr<kernel::ArithmeticDagNode<T>> x, int64_t n,
-    std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>>& cache) {
+    std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>>& cache,
+    kernel::DagType coeffType) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
+  bool isTensorType = coeffType.type_variant.index() >= 2;
 
   // Check cache
   auto it = cache.find(n);
@@ -145,7 +151,8 @@ std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
 
   if (n == 0) {
     // T_0(x) = 1
-    cache[0] = NodeTy::constantScalar(1, kernel::DagType::floatTy(64));
+    cache[0] = isTensorType ? NodeTy::splat(1, coeffType)
+                            : NodeTy::constantScalar(1, coeffType);
     return cache[0];
   }
 
@@ -159,23 +166,25 @@ std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
   auto [a, b] = splitDegree(n);
 
   // Compute T_n(x) = T_a(x) * T_b(x)
-  auto tA = genChebyshevPowerRecursive(x, a, cache);
-  auto tB = genChebyshevPowerRecursive(x, b, cache);
+  auto tA = genChebyshevPowerRecursive(x, a, cache, coeffType);
+  auto tB = genChebyshevPowerRecursive(x, b, cache, coeffType);
   auto tN = NodeTy::mul(tA, tB);
 
   // Apply Chebyshev recurrence: T_n = 2*T_a*T_b - T_c
   // where c = |a - b|
   int64_t c = std::abs(a - b);
-  auto two = NodeTy::constantScalar(2, kernel::DagType::floatTy(64));
+  auto two = isTensorType ? NodeTy::splat(2, coeffType)
+                          : NodeTy::constantScalar(2, coeffType);
   tN = NodeTy::mul(two, tN);
 
   // Compute T_n = 2*T_a*T_b - T_c
   if (c == 0) {
     // T_0 = 1, so subtract 1
-    tN = NodeTy::sub(tN,
-                     NodeTy::constantScalar(1, kernel::DagType::floatTy(64)));
+    auto one = isTensorType ? NodeTy::splat(1, coeffType)
+                            : NodeTy::constantScalar(1, coeffType);
+    tN = NodeTy::sub(tN, one);
   } else {
-    auto tC = genChebyshevPowerRecursive(x, c, cache);
+    auto tC = genChebyshevPowerRecursive(x, c, cache, coeffType);
     tN = NodeTy::sub(tN, tC);
   }
 
@@ -189,22 +198,25 @@ std::shared_ptr<kernel::ArithmeticDagNode<T>> genChebyshevPowerRecursive(
 // Args:
 //   x: The input node
 //   maxDegree: Maximum degree to compute
+//   coeffType: The type for coefficient constants
 //
 // Returns:
 //   Map from degree to Node representing T_degree(x)
 template <typename T>
 std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>>
 genChebyshevPowersRecursive(std::shared_ptr<kernel::ArithmeticDagNode<T>> x,
-                            int64_t maxDegree) {
+                            int64_t maxDegree, kernel::DagType coeffType) {
   std::map<int64_t, std::shared_ptr<kernel::ArithmeticDagNode<T>>> cache;
+  bool isTensorType = coeffType.type_variant.index() >= 2;
 
   // Generate all powers up to maxDegree
   for (int64_t i = 1; i <= maxDegree; i++) {
-    genChebyshevPowerRecursive(x, i, cache);
+    genChebyshevPowerRecursive(x, i, cache, coeffType);
   }
 
-  cache[0] = kernel::ArithmeticDagNode<T>::constantScalar(
-      1, kernel::DagType::floatTy(64));
+  cache[0] = isTensorType
+                 ? kernel::ArithmeticDagNode<T>::splat(1, coeffType)
+                 : kernel::ArithmeticDagNode<T>::constantScalar(1, coeffType);
   return cache;
 }
 
@@ -214,12 +226,16 @@ genChebyshevPowersRecursive(std::shared_ptr<kernel::ArithmeticDagNode<T>> x,
 template <typename T>
 std::enable_if_t<std::is_base_of<kernel::AbstractValue, T>::value,
                  std::vector<std::shared_ptr<kernel::ArithmeticDagNode<T>>>>
-computeChebyshevPolynomialValues(const T& x, int64_t k) {
+computeChebyshevPolynomialValues(const T& x, int64_t k,
+                                 kernel::DagType coeffType) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
+  bool isTensorType = coeffType.type_variant.index() >= 2;
   std::vector<std::shared_ptr<NodeTy>> result;
   result.reserve(k + 1);
-  auto number1 = NodeTy::constantScalar(1, kernel::DagType::floatTy(64));
-  auto number2 = NodeTy::constantScalar(2, kernel::DagType::floatTy(64));
+  auto number1 = isTensorType ? NodeTy::splat(1, coeffType)
+                              : NodeTy::constantScalar(1, coeffType);
+  auto number2 = isTensorType ? NodeTy::splat(2, coeffType)
+                              : NodeTy::constantScalar(2, coeffType);
   auto xNode = NodeTy::leaf(x);
   result.push_back(number1);
   if (k >= 1) {
@@ -256,9 +272,10 @@ template <typename T>
 std::enable_if_t<std::is_base_of<kernel::AbstractValue, T>::value,
                  std::shared_ptr<kernel::ArithmeticDagNode<T>>>
 patersonStockmeyerChebyshevPolynomialEvaluation(
-    const T& x, ::llvm::ArrayRef<double> coefficients,
-    double minCoeffThreshold = kMinCoeffs) {
+    const T& x, ::llvm::ArrayRef<double> coefficients, double minCoeffThreshold,
+    kernel::DagType coeffType) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
+  bool isTensorType = coeffType.type_variant.index() >= 2;
   int64_t polynomialDegree = coefficients.size() - 1;
   if (polynomialDegree < 0) {
     return nullptr;
@@ -268,8 +285,8 @@ patersonStockmeyerChebyshevPolynomialEvaluation(
     if (std::abs(coefficients[0]) < minCoeffThreshold) {
       return nullptr;
     }
-    return NodeTy::constantScalar(coefficients[0],
-                                  kernel::DagType::floatTy(64));
+    return isTensorType ? NodeTy::splat(coefficients[0], coeffType)
+                        : NodeTy::constantScalar(coefficients[0], coeffType);
   }
 
   // Choose k optimally using Lattigo's optimal split
@@ -284,7 +301,8 @@ patersonStockmeyerChebyshevPolynomialEvaluation(
 
   // Precompute T_0(x), T_1(x), ..., T_k(x) using recursive approach.
   auto xNode = NodeTy::leaf(x);
-  auto chebPolynomialValuesMap = genChebyshevPowersRecursive(xNode, k);
+  auto chebPolynomialValuesMap =
+      genChebyshevPowersRecursive(xNode, k, coeffType);
 
   // Evaluate the baby steps and save them in a list.
   std::vector<std::shared_ptr<NodeTy>> babySteps;
@@ -300,9 +318,10 @@ patersonStockmeyerChebyshevPolynomialEvaluation(
         continue;
       }
 
-      auto termNode = NodeTy::mul(
-          NodeTy::constantScalar(coeffs[j], kernel::DagType::floatTy(64)),
-          chebPolynomialValuesMap[j]);
+      auto coeffNode = isTensorType
+                           ? NodeTy::splat(coeffs[j], coeffType)
+                           : NodeTy::constantScalar(coeffs[j], coeffType);
+      auto termNode = NodeTy::mul(coeffNode, chebPolynomialValuesMap[j]);
 
       if (pol) {
         pol = NodeTy::add(pol, termNode);

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerFuzzTest.cpp
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerFuzzTest.cpp
@@ -22,8 +22,8 @@ double psEvalChebyshevPolynomial(const std::vector<double>& coefficients,
   if (coefficients.empty()) return 0.0;
 
   kernel::LiteralDouble xNode = x;
-  auto resultNode =
-      patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
+  auto resultNode = patersonStockmeyerChebyshevPolynomialEvaluation(
+      xNode, coefficients, kMinCoeffs, kernel::DagType::floatTy(64));
 
   if (!resultNode) return 0.0;
 

--- a/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerTest.cpp
+++ b/lib/Utils/Polynomial/ChebyshevPatersonStockmeyerTest.cpp
@@ -14,8 +14,8 @@ namespace {
 double evalChebyshevPolynomial(double x,
                                const std::vector<double>& coefficients) {
   kernel::LiteralDouble xNode = x;
-  auto resultNode =
-      patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
+  auto resultNode = patersonStockmeyerChebyshevPolynomialEvaluation(
+      xNode, coefficients, kMinCoeffs, kernel::DagType::floatTy(64));
 
   test::EvalVisitor visitor;
   return resultNode->visit(visitor)[0];
@@ -23,8 +23,8 @@ double evalChebyshevPolynomial(double x,
 
 int evalMultiplicativeDepth(double x, const std::vector<double>& coefficients) {
   kernel::LiteralDouble xNode = x;
-  auto resultNode =
-      patersonStockmeyerChebyshevPolynomialEvaluation(xNode, coefficients);
+  auto resultNode = patersonStockmeyerChebyshevPolynomialEvaluation(
+      xNode, coefficients, kMinCoeffs, kernel::DagType::floatTy(64));
 
   test::MultiplicativeDepthVisitor visitor;
   return static_cast<int>(resultNode->visit(visitor));

--- a/lib/Utils/Polynomial/Horner.h
+++ b/lib/Utils/Polynomial/Horner.h
@@ -17,11 +17,16 @@ template <typename T>
 std::shared_ptr<kernel::ArithmeticDagNode<T>>
 hornerMonomialPolynomialEvaluation(
     std::shared_ptr<kernel::ArithmeticDagNode<T>> x,
-    const std::map<int64_t, double>& coefficients) {
+    const std::map<int64_t, double>& coefficients, kernel::DagType dagType) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
 
+  bool isTensorType = dagType.type_variant.index() >= 2;
+
   if (coefficients.empty()) {
-    return NodeTy::constantScalar(0.0, kernel::DagType::floatTy(64));
+    if (isTensorType) {
+      return NodeTy::splat(0.0, dagType);
+    }
+    return NodeTy::constantScalar(0.0, dagType);
   }
 
   // Filter coefficients and find the highest degree
@@ -32,16 +37,18 @@ hornerMonomialPolynomialEvaluation(
 
   // Start with the coefficient of the highest degree term
   int64_t maxDegree = coeffMap.rbegin()->first;
-  auto result =
-      NodeTy::constantScalar(coeffMap[maxDegree], kernel::DagType::floatTy(64));
+  auto result = isTensorType
+                    ? NodeTy::splat(coeffMap[maxDegree], dagType)
+                    : NodeTy::constantScalar(coeffMap[maxDegree], dagType);
 
   // Apply Horner's method
   for (int64_t i = maxDegree - 1; i >= 0; i--) {
     result = NodeTy::mul(result, x);
 
     if (coeffMap.count(i)) {
-      auto coeffNode =
-          NodeTy::constantScalar(coeffMap.at(i), kernel::DagType::floatTy(64));
+      auto coeffNode = isTensorType
+                           ? NodeTy::splat(coeffMap.at(i), dagType)
+                           : NodeTy::constantScalar(coeffMap.at(i), dagType);
       result = NodeTy::add(result, coeffNode);
     }
   }

--- a/lib/Utils/Polynomial/HornerTest.cpp
+++ b/lib/Utils/Polynomial/HornerTest.cpp
@@ -19,7 +19,8 @@ using kernel::LiteralDouble;
 double evalHornerPolynomial(double x,
                             const std::map<int64_t, double>& coefficients) {
   auto x_node = ArithmeticDagNode<LiteralDouble>::leaf(LiteralDouble(x));
-  auto result_node = hornerMonomialPolynomialEvaluation(x_node, coefficients);
+  auto result_node = hornerMonomialPolynomialEvaluation(
+      x_node, coefficients, kernel::DagType::floatTy(64));
 
   test::EvalVisitor visitor;
   return result_node->visit(visitor)[0];

--- a/lib/Utils/Polynomial/PatersonStockmeyer.h
+++ b/lib/Utils/Polynomial/PatersonStockmeyer.h
@@ -21,11 +21,16 @@ template <typename T>
 std::shared_ptr<kernel::ArithmeticDagNode<T>>
 patersonStockmeyerMonomialPolynomialEvaluation(
     std::shared_ptr<kernel::ArithmeticDagNode<T>> x,
-    const std::map<int64_t, double>& coefficients) {
+    const std::map<int64_t, double>& coefficients, kernel::DagType coeffType) {
   using NodeTy = kernel::ArithmeticDagNode<T>;
 
+  bool isTensorType = coeffType.type_variant.index() >= 2;
+
   if (coefficients.empty()) {
-    return NodeTy::constantScalar(0.0, kernel::DagType::floatTy(64));
+    if (isTensorType) {
+      return NodeTy::splat(0.0, coeffType);
+    }
+    return NodeTy::constantScalar(0.0, coeffType);
   }
 
   // Filter coefficients
@@ -41,7 +46,7 @@ patersonStockmeyerMonomialPolynomialEvaluation(
                        static_cast<int64_t>(1));
 
   // Precompute x^1, x^2, ..., x^k
-  std::vector<std::shared_ptr<NodeTy>> xPowers = computePowers(x, k);
+  std::vector<std::shared_ptr<NodeTy>> xPowers = computePowers(x, k, coeffType);
 
   // Number of chunks we'll need
   int64_t m =
@@ -57,8 +62,9 @@ patersonStockmeyerMonomialPolynomialEvaluation(
     for (int64_t j = lowestDegreeInChunk; j <= highestDegreeInChunk; j++) {
       if (coeffMap.count(j)) {
         int64_t powerIndex = j - lowestDegreeInChunk;
-        auto coeff =
-            NodeTy::constantScalar(coeffMap[j], kernel::DagType::floatTy(64));
+        auto coeff = isTensorType
+                         ? NodeTy::splat(coeffMap[j], coeffType)
+                         : NodeTy::constantScalar(coeffMap[j], coeffType);
 
         std::shared_ptr<NodeTy> term;
         if (powerIndex == 0) {
@@ -76,7 +82,8 @@ patersonStockmeyerMonomialPolynomialEvaluation(
     }
 
     if (!chunkValue) {
-      chunkValue = NodeTy::constantScalar(0.0, kernel::DagType::floatTy(64));
+      chunkValue = isTensorType ? NodeTy::splat(0.0, coeffType)
+                                : NodeTy::constantScalar(0.0, coeffType);
     }
     chunkValues.push_back(chunkValue);
   }

--- a/lib/Utils/Polynomial/PatersonStockmeyerTest.cpp
+++ b/lib/Utils/Polynomial/PatersonStockmeyerTest.cpp
@@ -19,8 +19,8 @@ using kernel::LiteralDouble;
 double evalPatersonStockmeyerPolynomial(
     double x, const std::map<int64_t, double>& coefficients) {
   auto x_node = ArithmeticDagNode<LiteralDouble>::leaf(LiteralDouble(x));
-  auto result_node =
-      patersonStockmeyerMonomialPolynomialEvaluation(x_node, coefficients);
+  auto result_node = patersonStockmeyerMonomialPolynomialEvaluation(
+      x_node, coefficients, kernel::DagType::floatTy(64));
 
   test::EvalVisitor visitor;
   return result_node->visit(visitor)[0];
@@ -30,8 +30,8 @@ double evalPatersonStockmeyerPolynomial(
 int computeMultiplicativeDepth(double x,
                                const std::map<int64_t, double>& coefficients) {
   auto x_node = ArithmeticDagNode<LiteralDouble>::leaf(LiteralDouble(x));
-  auto result_node =
-      patersonStockmeyerMonomialPolynomialEvaluation(x_node, coefficients);
+  auto result_node = patersonStockmeyerMonomialPolynomialEvaluation(
+      x_node, coefficients, kernel::DagType::floatTy(64));
 
   test::MultiplicativeDepthVisitor visitor;
   return static_cast<int>(result_node->visit(visitor));


### PR DESCRIPTION
This commit went a bit down a rabbit hole. The reason is that, by making the index of LeftRotateNode itself a DagNode (required for dynamic rotation indices for rolled kernels), the current deficiencies of the IRMaterializingVisitor started to show through. In particular, when materializing a constant scalar node, the IRMaterializingVisitor decided on the type by using a globally provided "evaluated type," which most users of IRMaterializingVisitor set to a tensor type (e.g., the tensor type of the underlying tensor used in a layout conversion shift network).

To fix this, I had to make the IRMaterializingVisitor use the DagType from a ConstantScalarNode or ConstantTensorNode instead of the evaluatedType.

Fixing this required making a lot more invasive changes across the codebase, including migrating polynomial lowering uses of ArithmeticDag and the shift network.

Along the way, I made some additional opportunistic migrations of code from #2655 to use SplatNodes where more verbose constant tensors were used, and to add SplatNode to IRMaterializingVisitor.

Rebased over #2695 and all its ancestors.