### PR TITLE
ArithmeticDag: add ForLoopNode and related

### DIFF
--- a/lib/Kernel/ArithmeticDag.h
+++ b/lib/Kernel/ArithmeticDag.h
@@ -84,6 +84,15 @@ struct LeafNode {
   T value;
 };
 
+// VariableNode represents a variable that can be bound to a value. Used in
+// ForLoopNode to represent the induction variable and iter_arg. These nodes
+// are not meant to be leaves, but are rather meant to have a value filled in
+// by a visitor at evaluation time.
+template <typename T>
+struct VariableNode {
+  std::optional<T> value;
+};
+
 struct ConstantScalarNode {
   double value;
   DagType type;
@@ -142,13 +151,38 @@ struct ExtractNode {
 };
 
 template <typename T>
+struct YieldNode {
+  std::vector<std::shared_ptr<ArithmeticDagNode<T>>> elements;
+};
+
+template <typename T>
+struct ResultAtNode {
+  std::shared_ptr<ArithmeticDagNode<T>> operand;
+  size_t index;
+};
+
+// A For loop with static bounds
+template <typename T>
+struct ForLoopNode {
+  using NodePtr = std::shared_ptr<ArithmeticDagNode<T>>;
+  NodePtr inductionVar;
+  std::vector<NodePtr> inits;
+  std::vector<NodePtr> iterArgs;
+  NodePtr body;
+  int32_t lower;
+  int32_t upper;
+  int32_t step;
+};
+
+template <typename T>
 struct ArithmeticDagNode {
   using NodePtr = std::shared_ptr<ArithmeticDagNode<T>>;
 
  public:
   std::variant<ConstantScalarNode, ConstantTensorNode, LeafNode<T>, AddNode<T>,
                SubtractNode<T>, MultiplyNode<T>, FloorDivNode<T>, PowerNode<T>,
-               LeftRotateNode<T>, ExtractNode<T>, SplatNode>
+               LeftRotateNode<T>, ExtractNode<T>, VariableNode<T>,
+               ForLoopNode<T>, YieldNode<T>, ResultAtNode<T>, SplatNode>
       node_variant;
 
   explicit ArithmeticDagNode(const T& value)
@@ -264,6 +298,72 @@ struct ArithmeticDagNode {
         tensor, constantScalar(static_cast<double>(index), DagType::index()));
   }
 
+  static NodePtr variable() {
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<VariableNode<T>>(
+        VariableNode<T>{std::nullopt});
+    return node;
+  }
+
+  using BodyBuilderFunc =
+      std::function<NodePtr(NodePtr inductionVar, const NodePtr& iterArg)>;
+
+  // Construct a loop with a single iter arg. Note that the body builder must
+  // have as its root node a YieldNode.
+  static NodePtr loop(NodePtr init, int32_t lower, int32_t upper, int32_t step,
+                      const BodyBuilderFunc& bodyBuilder = nullptr) {
+    assert(init && "invalid init");
+    auto inductionVar = variable();
+    auto iterArg = variable();
+    auto body = bodyBuilder ? bodyBuilder(inductionVar, iterArg) : nullptr;
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<ForLoopNode<T>>(
+        ForLoopNode<T>{std::move(inductionVar),
+                       {std::move(init)},
+                       {std::move(iterArg)},
+                       body,
+                       lower,
+                       upper,
+                       step});
+    return node;
+  }
+
+  using BodyBuilderFuncManyIterArgs = std::function<NodePtr(
+      NodePtr inductionVar, const std::vector<NodePtr>& iterArgs)>;
+
+  // Construct a loop with multiple iter args. Note that the body builder must
+  // have as its root node a YieldNode.
+  static NodePtr loop(
+      std::vector<NodePtr> inits, int32_t lower, int32_t upper, int32_t step,
+      const BodyBuilderFuncManyIterArgs& bodyBuilder = nullptr) {
+    auto inductionVar = variable();
+    std::vector<NodePtr> iterArgs(inits.size());
+    for (size_t i = 0; i < inits.size(); ++i) {
+      iterArgs[i] = variable();
+    }
+
+    auto body = bodyBuilder ? bodyBuilder(inductionVar, iterArgs) : nullptr;
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<ForLoopNode<T>>(
+        ForLoopNode<T>{std::move(inductionVar), std::move(inits),
+                       std::move(iterArgs), body, lower, upper, step});
+    return node;
+  }
+
+  static NodePtr yield(std::vector<NodePtr> values) {
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<YieldNode<T>>(
+        YieldNode<T>{std::move(values)});
+    return node;
+  }
+
+  static NodePtr resultAt(NodePtr value, size_t index) {
+    auto node = NodePtr(new ArithmeticDagNode<T>());
+    node->node_variant.template emplace<ResultAtNode<T>>(
+        ResultAtNode<T>{std::move(value), index});
+    return node;
+  }
+
   ArithmeticDagNode(const ArithmeticDagNode&) = default;
   ArithmeticDagNode& operator=(const ArithmeticDagNode&) = default;
   ArithmeticDagNode(ArithmeticDagNode&&) noexcept = default;
@@ -377,9 +477,78 @@ class CachingVisitor {
     return ResultType();
   }
 
+  virtual ResultType operator()(const VariableNode<T>& node) {
+    assert(false && "Visit logic for VariableNode is not implemented.");
+    return ResultType();
+  }
+
+  virtual ResultType operator()(const YieldNode<T>& node) {
+    assert(false && "Visit logic for YieldNode is not implemented.");
+    return ResultType();
+  }
+
+  virtual ResultType operator()(const ResultAtNode<T>& node) {
+    assert(false && "Visit logic for ResultAtNode is not implemented.");
+    return ResultType();
+  }
+
+  virtual ResultType operator()(const ForLoopNode<T>& node) {
+    assert(false && "Visit logic for ForLoopNode is not implemented.");
+    return ResultType();
+  }
+
   virtual ResultType operator()(const SplatNode& node) {
     assert(false && "Visit logic for SplatNode is not implemented.");
     return ResultType();
+  }
+
+ protected:
+  void clearCache() { cache.clear(); }
+
+  void clearCacheEntry(const ArithmeticDagNode<T>* node) { cache.erase(node); }
+
+  void clearSubtreeCache(const std::shared_ptr<ArithmeticDagNode<T>>& node) {
+    if (!node) return;
+
+    clearCacheEntry(node.get());
+
+    // Recursively clear cache for child nodes
+    std::visit(
+        [this](auto&& n) {
+          using NodeType = std::decay_t<decltype(n)>;
+          if constexpr (std::is_same_v<NodeType, AddNode<T>> ||
+                        std::is_same_v<NodeType, SubtractNode<T>> ||
+                        std::is_same_v<NodeType, MultiplyNode<T>>) {
+            clearSubtreeCache(n.left);
+            clearSubtreeCache(n.right);
+          } else if constexpr (std::is_same_v<NodeType, FloorDivNode<T>>) {
+            clearSubtreeCache(n.left);
+          } else if constexpr (std::is_same_v<NodeType, PowerNode<T>>) {
+            clearSubtreeCache(n.base);
+          } else if constexpr (std::is_same_v<NodeType, LeftRotateNode<T>>) {
+            clearSubtreeCache(n.operand);
+            clearSubtreeCache(n.shift);
+          } else if constexpr (std::is_same_v<NodeType, ExtractNode<T>>) {
+            clearSubtreeCache(n.operand);
+            clearSubtreeCache(n.index);
+          } else if constexpr (std::is_same_v<NodeType, ResultAtNode<T>>) {
+            clearSubtreeCache(n.operand);
+          } else if constexpr (std::is_same_v<NodeType, ForLoopNode<T>>) {
+            clearSubtreeCache(n.inductionVar);
+            for (const auto& init : n.inits) {
+              clearSubtreeCache(init);
+            }
+            for (const auto& iterArg : n.iterArgs) {
+              clearSubtreeCache(iterArg);
+            }
+            clearSubtreeCache(n.body);
+          } else if constexpr (std::is_same_v<NodeType, YieldNode<T>>) {
+            for (const auto& element : n.elements) {
+              clearSubtreeCache(element);
+            }
+          }
+        },
+        node->node_variant);
   }
 
  private:

--- a/lib/Kernel/ArithmeticDagTest.cpp
+++ b/lib/Kernel/ArithmeticDagTest.cpp
@@ -5,6 +5,7 @@
 #include <ios>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #include "gtest/gtest.h"  // from @googletest
 #include "lib/Kernel/ArithmeticDag.h"
@@ -18,6 +19,9 @@ using StringLeavedDag = ArithmeticDagNode<std::string>;
 using DoubleLeavedDag = ArithmeticDagNode<double>;
 
 struct FlattenedStringVisitor {
+  mutable std::unordered_map<const VariableNode<std::string>*, std::string>
+      varNames;
+  mutable int varCounter = 0;
   std::string operator()(const ConstantScalarNode& node) const {
     std::stringstream ss;
     ss << std::fixed << std::setprecision(2) << node.value;
@@ -93,6 +97,58 @@ struct FlattenedStringVisitor {
     ss << "splat(" << node.value << ")";
     return ss.str();
   }
+
+  std::string operator()(const VariableNode<std::string>& node) const {
+    if (varNames.find(&node) == varNames.end()) {
+      varNames[&node] = "i" + std::to_string(varCounter++);
+    }
+    return varNames[&node];
+  }
+
+  std::string operator()(const YieldNode<std::string>& node) const {
+    // For a single element, don't wrap in parentheses
+    if (node.elements.size() == 1) {
+      return node.elements[0]->visit(*this);
+    }
+    std::stringstream ss;
+    ss << "(";
+    for (size_t i = 0; i < node.elements.size(); ++i) {
+      ss << node.elements[i]->visit(*this);
+      if (i != node.elements.size() - 1) {
+        ss << ", ";
+      }
+    }
+    ss << ")";
+    return ss.str();
+  }
+
+  std::string operator()(const ResultAtNode<std::string>& node) const {
+    std::stringstream ss;
+    ss << node.operand->visit(*this) << "#" << node.index;
+    return ss.str();
+  }
+
+  std::string operator()(const ForLoopNode<std::string>& node) const {
+    std::stringstream ss;
+    std::string inductionVarName = node.inductionVar->visit(*this);
+    std::vector<std::string> visitedIterArgs;
+    std::vector<std::string> visitedInits;
+    for (size_t i = 0; i < node.inits.size(); ++i) {
+      visitedIterArgs.push_back(node.iterArgs[i]->visit(*this));
+      visitedInits.push_back(node.inits[i]->visit(*this));
+    }
+    std::string initsString;
+    for (size_t i = 0; i < visitedIterArgs.size(); ++i) {
+      initsString += visitedIterArgs[i] + "=" + visitedInits[i];
+      if (i != visitedIterArgs.size() - 1) {
+        initsString += ", ";
+      }
+    }
+    ss << "for(" << inductionVarName << "=" << node.lower << " to "
+       << node.upper << " step " << node.step << "; " << initsString << ") { "
+       << (node.body ? node.body->visit(*this) : "") << " }";
+    return ss.str();
+  }
 };
 
 class EvalVisitor : public CachingVisitor<double, std::vector<double>> {
@@ -139,6 +195,60 @@ class EvalVisitor : public CachingVisitor<double, std::vector<double>> {
   std::vector<double> operator()(const SplatNode& node) override {
     callCount += 1;
     return {node.value};
+  }
+
+  std::vector<double> operator()(const VariableNode<double>& node) override {
+    callCount += 1;
+    assert(node.value.has_value() &&
+           "VariableNode must have a value during evaluation");
+    return {node.value.value()};
+  }
+
+  std::vector<double> operator()(const YieldNode<double>& node) override {
+    callCount += 1;
+    std::vector<double> results;
+    for (const auto& value : node.elements) {
+      results.push_back(this->process(value)[0]);
+    }
+    return results;
+  }
+
+  std::vector<double> operator()(const ResultAtNode<double>& node) override {
+    callCount += 1;
+    std::vector<double> results = this->process(node.operand);
+    return {results[node.index]};
+  }
+
+  std::vector<double> operator()(const ForLoopNode<double>& node) override {
+    callCount += 1;
+    std::vector<double> results;
+    for (const auto& init : node.inits) {
+      results.push_back(this->process(init)[0]);
+    }
+    for (size_t i = node.lower; i < node.upper; i += node.step) {
+      // Set the induction variable value
+      auto& inductionVarNode =
+          std::get<VariableNode<double>>(node.inductionVar->node_variant);
+      inductionVarNode.value = static_cast<double>(i);
+
+      // Set the iter arg values
+      for (size_t j = 0; j < node.iterArgs.size(); ++j) {
+        auto& iterArgNode =
+            std::get<VariableNode<double>>(node.iterArgs[j]->node_variant);
+        iterArgNode.value = results[j];
+      }
+
+      // Clear the cache for the body and its dependencies before each iteration
+      // since the body depends on variables that change each iteration
+      if (node.body) {
+        this->clearSubtreeCache(node.body);
+        std::vector<double> bodyResults = this->process(node.body);
+        for (size_t j = 0; j < results.size(); ++j) {
+          results[j] = bodyResults[j];
+        }
+      }
+    }
+    return results;
   }
 };
 
@@ -202,6 +312,33 @@ TEST(ArithmeticDagTest, TestEvaluationVisitorSubstract) {
   double result = root->visit(visitor)[0];
   EXPECT_EQ(result, -1);
   EXPECT_EQ(visitor.callCount, 3);
+}
+
+TEST(ArithmeticDagTest, TestLoop) {
+  auto x = DoubleLeavedDag::leaf(1.0);
+  auto loop = DoubleLeavedDag::loop(x, 0, 10, 1);
+  auto& loopNode = std::get<ForLoopNode<double>>(loop->node_variant);
+  loopNode.body =
+      DoubleLeavedDag::yield({DoubleLeavedDag::add(x, loopNode.iterArgs[0])});
+  EvalVisitor visitor;
+  double result = loop->visit(visitor)[0];
+  EXPECT_EQ(result, 11);
+}
+
+TEST(ArithmeticDagTest, TestLoopStringVisitor) {
+  auto x = StringLeavedDag::leaf("x");
+  auto loop = StringLeavedDag::loop(
+      x, 0, 10, 1,
+      [](const std::shared_ptr<StringLeavedDag>& inductionVar,
+         const std::shared_ptr<StringLeavedDag>& iterArg) {
+        return StringLeavedDag::yield({StringLeavedDag::add(
+            StringLeavedDag::mul(inductionVar, StringLeavedDag::leaf("y")),
+            iterArg)});
+      });
+
+  FlattenedStringVisitor visitor;
+  std::string result = loop->visit(visitor);
+  EXPECT_EQ(result, "for(i0=0 to 10 step 1; i1=x) { ((i0 * y) + i1) }");
 }
 
 }  // namespace

--- a/lib/Kernel/RotationCountVisitor.cpp
+++ b/lib/Kernel/RotationCountVisitor.cpp
@@ -151,6 +151,60 @@ int64_t RotationCountVisitor::operator()(
   return operandCount + indexCount;
 }
 
+int64_t RotationCountVisitor::operator()(
+    const VariableNode<SymbolicValue>& node) {
+  // Variables are typically placeholders - treat as plaintext by default
+  nodeSecretStatus[currentNode] = false;
+  return 0;
+}
+
+int64_t RotationCountVisitor::operator()(const YieldNode<SymbolicValue>& node) {
+  const auto* thisNode = currentNode;  // Save before recursion
+  bool isSecret = false;
+  int64_t totalCount = 0;
+  for (const auto& element : node.elements) {
+    totalCount += processInternal(element);
+    isSecret = isSecret || nodeSecretStatus[element.get()];
+  }
+  nodeSecretStatus[thisNode] = isSecret;
+  return totalCount;
+}
+
+int64_t RotationCountVisitor::operator()(
+    const ResultAtNode<SymbolicValue>& node) {
+  const auto* thisNode = currentNode;  // Save before recursion
+  int64_t operandCount = processInternal(node.operand);
+  bool operandIsSecret = nodeSecretStatus[node.operand.get()];
+  nodeSecretStatus[thisNode] = operandIsSecret;
+  return operandCount;
+}
+
+int64_t RotationCountVisitor::operator()(
+    const ForLoopNode<SymbolicValue>& node) {
+  const auto* thisNode = currentNode;  // Save before recursion
+
+  // Process the init value
+  int64_t initCount = 0;
+  bool initIsSecret = false;
+  for (const auto& init : node.inits) {
+    initCount += processInternal(init);
+    initIsSecret = initIsSecret || nodeSecretStatus[init.get()];
+  }
+
+  // Process the body if it exists
+  int64_t bodyCount = 0;
+  if (node.body) {
+    bodyCount = processInternal(node.body);
+  }
+
+  // A loop's secret status is determined by its init and body
+  bool bodyIsSecret = node.body ? nodeSecretStatus[node.body.get()] : false;
+  nodeSecretStatus[thisNode] = initIsSecret || bodyIsSecret;
+
+  // Total rotations = init + body rotations * number of iterations
+  return initCount + bodyCount * ((node.upper - node.lower) / node.step);
+}
+
 int64_t RotationCountVisitor::operator()(const SplatNode& node) {
   // Splat constants are always plaintext
   nodeSecretStatus[currentNode] = false;

--- a/lib/Kernel/RotationCountVisitor.h
+++ b/lib/Kernel/RotationCountVisitor.h
@@ -37,6 +37,10 @@ class RotationCountVisitor {
   int64_t operator()(const PowerNode<SymbolicValue>& node);
   int64_t operator()(const LeftRotateNode<SymbolicValue>& node);
   int64_t operator()(const ExtractNode<SymbolicValue>& node);
+  int64_t operator()(const VariableNode<SymbolicValue>& node);
+  int64_t operator()(const YieldNode<SymbolicValue>& node);
+  int64_t operator()(const ResultAtNode<SymbolicValue>& node);
+  int64_t operator()(const ForLoopNode<SymbolicValue>& node);
   int64_t operator()(const SplatNode& node);
 
  private:


### PR DESCRIPTION
This adds the ForLoopNode to ArithmeticDag, along with related constructs for the induction variable (VariableNode) the loop yield (YieldNode) and multiple iter args (ResultAtNode).

This PR modifies the CachingVisitor to support clearing the cache, which is necessary for the EvaluationVisitor for a loop, to ensure that one can re-run the loop body without hitting the cache for variables defined in the loop.

This is tested with the EvaluationVisitor, and support in the IRMaterializingVisitor and the actual kernel implementation is coming next.

Rebased over #2697 