### PR TITLE
Add rolled rotate-and-reduce kernel

### DIFF
--- a/lib/Dialect/TensorExt/Transforms/BUILD
+++ b/lib/Dialect/TensorExt/Transforms/BUILD
@@ -162,6 +162,7 @@ cc_library(
         "@heir//lib/Kernel:ArithmeticDag",
         "@heir//lib/Kernel:IRMaterializingVisitor",
         "@heir//lib/Kernel:KernelImplementation",
+        "@heir//lib/Kernel:Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/lib/Dialect/TensorExt/Transforms/ImplementRotateAndReduce.cpp
+++ b/lib/Dialect/TensorExt/Transforms/ImplementRotateAndReduce.cpp
@@ -1,7 +1,5 @@
 #include "lib/Dialect/TensorExt/Transforms/ImplementRotateAndReduce.h"
 
-#include <cmath>
-#include <cstdint>
 #include <memory>
 #include <optional>
 
@@ -9,6 +7,7 @@
 #include "lib/Kernel/ArithmeticDag.h"
 #include "lib/Kernel/IRMaterializingVisitor.h"
 #include "lib/Kernel/KernelImplementation.h"
+#include "lib/Kernel/Utils.h"
 #include "llvm/include/llvm/Support/Debug.h"          // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
@@ -52,8 +51,9 @@ LogicalResult convertRotateAndReduceOp(RotateAndReduceOp op) {
   if (op.getReduceOp().has_value() && *op.getReduceOp() != nullptr) {
     reduceOp = op.getReduceOp()->getValue().str();
   }
-  implementedKernel = implementRotateAndReduce(vectorLeaf, plaintextsLeaf,
-                                               period, steps, {}, reduceOp);
+  kernel::DagType dagType = kernel::mlirTypeToDagType(input.getType());
+  implementedKernel = implementRotateAndReduce(
+      vectorLeaf, plaintextsLeaf, period, steps, dagType, {}, reduceOp);
   IRRewriter rewriter(op.getContext());
   rewriter.setInsertionPointAfter(op);
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);

--- a/lib/Kernel/BUILD
+++ b/lib/Kernel/BUILD
@@ -32,12 +32,14 @@ cc_library(
         ":AbstractValue",
         ":ArithmeticDag",
         ":KernelImplementation",
+        ":Utils",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
         "@heir//lib/Utils",
         "@heir//lib/Utils:MathUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
     ],
@@ -75,6 +77,17 @@ cc_library(
         ":Kernel",
         "@heir//lib/Utils:APIntUtils",
         "@heir//lib/Utils:MathUtils",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "Utils",
+    srcs = ["Utils.cpp"],
+    hdrs = ["Utils.h"],
+    deps = [
+        ":ArithmeticDag",
+        "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/lib/Kernel/IRMaterializingVisitor.cpp
+++ b/lib/Kernel/IRMaterializingVisitor.cpp
@@ -5,10 +5,12 @@
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "lib/Kernel/AbstractValue.h"
 #include "lib/Kernel/ArithmeticDag.h"
+#include "lib/Kernel/Utils.h"
 #include "lib/Utils/MathUtils.h"
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributeInterfaces.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
@@ -23,49 +25,7 @@ namespace mlir {
 namespace heir {
 namespace kernel {
 
-namespace {
-
-// Helper to convert DagType to MLIR Type
-Type dagTypeToMLIRType(const DagType& dagType, OpBuilder& builder) {
-  return std::visit(
-      [&](auto&& arg) -> Type {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, kernel::IntegerType>) {
-          return builder.getIntegerType(arg.bitWidth);
-        } else if constexpr (std::is_same_v<T, kernel::FloatType>) {
-          if (arg.bitWidth == 32) {
-            return builder.getF32Type();
-          } else if (arg.bitWidth == 64) {
-            return builder.getF64Type();
-          } else if (arg.bitWidth == 16) {
-            return builder.getF16Type();
-          } else {
-            llvm_unreachable("Unsupported float bit width");
-          }
-        } else if constexpr (std::is_same_v<T, kernel::IndexType>) {
-          return builder.getIndexType();
-        } else if constexpr (std::is_same_v<T, kernel::IntTensorType>) {
-          auto elementType = builder.getIntegerType(arg.bitWidth);
-          return RankedTensorType::get(arg.shape, elementType);
-        } else if constexpr (std::is_same_v<T, kernel::FloatTensorType>) {
-          mlir::Type elementType;
-          if (arg.bitWidth == 32) {
-            elementType = builder.getF32Type();
-          } else if (arg.bitWidth == 64) {
-            elementType = builder.getF64Type();
-          } else if (arg.bitWidth == 16) {
-            elementType = builder.getF16Type();
-          } else {
-            llvm_unreachable("Unsupported float bit width");
-          }
-          return RankedTensorType::get(arg.shape, elementType);
-        }
-        llvm_unreachable("Unknown DagType variant");
-      },
-      dagType.type_variant);
-}
-
-}  // namespace
+namespace {}  // namespace
 
 std::vector<Value> IRMaterializingVisitor::operator()(
     const LeafNode<SSAValue>& node) {
@@ -194,7 +154,7 @@ std::vector<Value> IRMaterializingVisitor::operator()(
   Value index = this->process(node.index)[0];
   // Ensure index has index type
   if (!index.getType().isIndex()) {
-    index = builder.create<arith::IndexCastOp>(builder.getIndexType(), index);
+    index = arith::IndexCastOp::create(builder, builder.getIndexType(), index);
   }
 
   RankedTensorType tensorType = cast<RankedTensorType>(operand.getType());
@@ -228,6 +188,70 @@ std::vector<Value> IRMaterializingVisitor::operator()(
       tensor::ExtractSliceOp::create(builder, operand, offsets, sizes, strides);
   createdOpCallback(extractOp);
   return {extractOp};
+}
+
+std::vector<Value> IRMaterializingVisitor::operator()(
+    const VariableNode<SSAValue>& node) {
+  assert(node.value.has_value() && "VariableNode value is not set");
+  return {node.value->getValue()};
+}
+
+std::vector<Value> IRMaterializingVisitor::operator()(
+    const ForLoopNode<SSAValue>& node) {
+  std::vector<Value> initValues;
+  initValues.reserve(node.inits.size());
+  for (const auto& init : node.inits) {
+    Value initProcessed = this->process(init)[0];
+    initValues.push_back(initProcessed);
+  }
+
+  Value lower = arith::ConstantIndexOp::create(builder, node.lower);
+  Value upper = arith::ConstantIndexOp::create(builder, node.upper);
+  Value step = arith::ConstantIndexOp::create(builder, node.step);
+  auto loop = scf::ForOp::create(
+      builder, lower, upper, step, initValues,
+      [&](OpBuilder& nestedBuilder, Location nestedLoc, Value iv,
+          ValueRange args) {
+        auto& inductionVarNode =
+            std::get<VariableNode<SSAValue>>(node.inductionVar->node_variant);
+        inductionVarNode.value = iv;
+
+        assert(node.iterArgs.size() == args.size());
+        for (size_t j = 0; j < args.size(); ++j) {
+          auto& iterArgNode =
+              std::get<VariableNode<SSAValue>>(node.iterArgs[j]->node_variant);
+          iterArgNode.value = args[j];
+        }
+
+        assert(node.body != nullptr);
+        assert(std::holds_alternative<YieldNode<SSAValue>>(
+                   node.body->node_variant) &&
+               "ForLoopNode body must be a YieldNode");
+        std::vector<Value> bodyResults = this->process(node.body);
+        scf::YieldOp::create(builder, bodyResults);
+      });
+
+  std::vector<Value> results(loop.getResults().begin(),
+                             loop.getResults().end());
+  return results;
+}
+
+std::vector<Value> IRMaterializingVisitor::operator()(
+    const YieldNode<SSAValue>& node) {
+  std::vector<Value> eltResults;
+  eltResults.reserve(node.elements.size());
+  for (const auto& elt : node.elements) {
+    std::vector<Value> values = this->process(elt);
+    assert(values.size() == 1 && "Yield operands must be single values");
+    eltResults.push_back(values[0]);
+  }
+  return eltResults;
+}
+
+std::vector<Value> IRMaterializingVisitor::operator()(
+    const ResultAtNode<SSAValue>& node) {
+  std::vector<Value> operands = this->process(node.operand);
+  return {operands[node.index]};
 }
 
 }  // namespace kernel

--- a/lib/Kernel/IRMaterializingVisitor.h
+++ b/lib/Kernel/IRMaterializingVisitor.h
@@ -64,6 +64,10 @@ class IRMaterializingVisitor
   std::vector<Value> operator()(const FloorDivNode<SSAValue>& node) override;
   std::vector<Value> operator()(const LeftRotateNode<SSAValue>& node) override;
   std::vector<Value> operator()(const ExtractNode<SSAValue>& node) override;
+  std::vector<Value> operator()(const VariableNode<SSAValue>& node) override;
+  std::vector<Value> operator()(const ForLoopNode<SSAValue>& node) override;
+  std::vector<Value> operator()(const YieldNode<SSAValue>& node) override;
+  std::vector<Value> operator()(const ResultAtNode<SSAValue>& node) override;
 
  private:
   ImplicitLocOpBuilder& builder;

--- a/lib/Kernel/KernelCostTest.cpp
+++ b/lib/Kernel/KernelCostTest.cpp
@@ -19,7 +19,8 @@ TEST(KernelCostTest, HaleviShoup_4x4_BabyStepGiantStep) {
   SymbolicValue matrix({4, 4}, false);  // Matrix is plaintext
   std::vector<int64_t> originalShape = {4, 4};
 
-  auto dag = implementHaleviShoup(vector, matrix, originalShape);
+  auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                  DagType::intTensor(32, {4}));
 
   RotationCountVisitor counter;
   int64_t rotations = counter.process(dag);
@@ -35,7 +36,8 @@ TEST(KernelCostTest, HaleviShoup_100x100_BabyStepGiantStep) {
   SymbolicValue matrix({100, 100}, false);  // Matrix is plaintext
   std::vector<int64_t> originalShape = {100, 100};
 
-  auto dag = implementHaleviShoup(vector, matrix, originalShape);
+  auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                  DagType::intTensor(32, {100}));
 
   RotationCountVisitor counter;
   int64_t rotations = counter.process(dag);
@@ -53,7 +55,8 @@ TEST(KernelCostTest, HaleviShoup_Rectangular_8x4) {
   SymbolicValue matrix({8, 8}, false);  // Matrix is plaintext
   std::vector<int64_t> originalShape = {8, 4};
 
-  auto dag = implementHaleviShoup(vector, matrix, originalShape);
+  auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                  DagType::intTensor(32, {8}));
 
   RotationCountVisitor counter;
   int64_t rotations = counter.process(dag);
@@ -69,7 +72,8 @@ TEST(KernelCostTest, HaleviShoup_Rectangular_4x8) {
   SymbolicValue matrix({4, 4}, false);  // Matrix is plaintext
   std::vector<int64_t> originalShape = {4, 8};
 
-  auto dag = implementHaleviShoup(vector, matrix, originalShape);
+  auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                  DagType::intTensor(32, {8}));
 
   RotationCountVisitor counter;
   int64_t rotations = counter.process(dag);
@@ -84,7 +88,8 @@ TEST(KernelCostTest, HaleviShoup_SmallMatrix_2x2) {
   SymbolicValue matrix({2, 2}, false);  // Matrix is plaintext
   std::vector<int64_t> originalShape = {2, 2};
 
-  auto dag = implementHaleviShoup(vector, matrix, originalShape);
+  auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                  DagType::intTensor(32, {2}));
 
   RotationCountVisitor counter;
   int64_t rotations = counter.process(dag);
@@ -99,7 +104,8 @@ TEST(KernelCostTest, HaleviShoup_LargeMatrix_512x512) {
   SymbolicValue matrix({512, 512}, false);  // Matrix is plaintext
   std::vector<int64_t> originalShape = {512, 512};
 
-  auto dag = implementHaleviShoup(vector, matrix, originalShape);
+  auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                  DagType::intTensor(32, {512}));
 
   RotationCountVisitor counter;
   int64_t rotations = counter.process(dag);
@@ -136,7 +142,8 @@ TEST(KernelCostTest, HaleviShoup_AsymptoticScaling_VerifiesSqrtN) {
                          false);  // Matrix is plaintext
     std::vector<int64_t> originalShape = {testCase.size, testCase.size};
 
-    auto dag = implementHaleviShoup(vector, matrix, originalShape);
+    auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                    DagType::intTensor(32, {testCase.size}));
     int64_t rotations = counter.process(dag);
 
     EXPECT_EQ(rotations, testCase.measuredRotations)
@@ -200,7 +207,8 @@ TEST(KernelCostTest, HaleviShoup_BeatsNaiveForLargeMatrices) {
                          false);  // Matrix is plaintext
     std::vector<int64_t> originalShape = {testCase.size, testCase.size};
 
-    auto dag = implementHaleviShoup(vector, matrix, originalShape);
+    auto dag = implementHaleviShoup(vector, matrix, originalShape,
+                                    DagType::intTensor(32, {testCase.size}));
     int64_t rotations = counter.process(dag);
 
     // Verify measured rotations are within bounds

--- a/lib/Kernel/KernelImplementation.h
+++ b/lib/Kernel/KernelImplementation.h
@@ -34,6 +34,12 @@ template <typename T>
 using DagExtractor = std::function<std::shared_ptr<ArithmeticDagNode<T>>(
     std::shared_ptr<ArithmeticDagNode<T>>, int64_t)>;
 
+// Dynamic extraction: takes tensor and DAG node representing runtime index
+template <typename T>
+using DagExtractorDynamic = std::function<std::shared_ptr<ArithmeticDagNode<T>>(
+    std::shared_ptr<ArithmeticDagNode<T>>,
+    std::shared_ptr<ArithmeticDagNode<T>>)>;
+
 // Returns an arithmetic DAG that implements a matvec kernel. Ensure this is
 // only generated for T a subclass of AbstractValue.
 template <typename T>
@@ -80,6 +86,41 @@ implementRotateAndReduceAccumulation(const T& vector, int64_t period,
   return vectorDag;
 }
 
+// Rolled version of implementRotateAndReduceAccumulation.
+template <typename T>
+std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
+                 std::shared_ptr<ArithmeticDagNode<T>>>
+implementRotateAndReduceAccumulationRolled(const T& vector, int64_t period,
+                                           int64_t steps,
+                                           DagReducer<T> reduceFunc,
+                                           const DagType& baseType) {
+  using NodeTy = ArithmeticDagNode<T>;
+  using NodePtr = std::shared_ptr<NodeTy>;
+
+  auto vectorDag = NodeTy::leaf(vector);
+  int64_t numIterations = static_cast<int64_t>(std::log2(steps));
+  if (numIterations <= 0) return vectorDag;
+
+  auto initialShift = NodeTy::constantScalar(steps / 2, DagType::integer(32));
+  auto loopNode = NodeTy::loop(
+      {vectorDag, initialShift}, /*lower=*/0, /*upper=*/numIterations,
+      /*step=*/1, [&](NodePtr i, const std::vector<NodePtr>& iterArgs) {
+        auto currentVector = iterArgs[0];
+        auto currentShift = iterArgs[1];
+
+        auto rotated = NodeTy::leftRotate(
+            currentVector,
+            NodeTy::mul(currentShift,
+                        NodeTy::constantScalar(period, DagType::integer(32))));
+        auto reduced = reduceFunc(currentVector, rotated);
+
+        auto nextShift = NodeTy::floorDiv(currentShift, 2);
+        return NodeTy::yield({reduced, nextShift});
+      });
+
+  return NodeTy::resultAt(loopNode, 0);
+}
+
 // A function that generalizes the choice of rotation for the "baby stepped
 // operand" of a baby-step giant-step algorithm. This is required because
 // the rotation used in Halevi-Shoup matvec differs from that of bicyclic
@@ -101,6 +142,35 @@ inline int64_t defaultDerivedRotationIndexFn(int64_t giantStepSize,
   return -giantStepSize * giantStepIndex * period;
 }
 
+// Dynamic version: builds DAG expression for rotation amount from DAG node
+// indices
+template <typename T>
+using DagDerivedRotationIndexFn =
+    std::function<std::shared_ptr<ArithmeticDagNode<T>>(
+        // giant step size (constant)
+        int64_t,
+        // current giant step index (DAG node)
+        std::shared_ptr<ArithmeticDagNode<T>>,
+        // current baby step index (DAG node)
+        std::shared_ptr<ArithmeticDagNode<T>>,
+        // period (constant)
+        int64_t)>;
+
+template <typename T>
+std::shared_ptr<ArithmeticDagNode<T>> defaultDagDerivedRotationIndexFn(
+    int64_t giantStepSize, std::shared_ptr<ArithmeticDagNode<T>> giantStepIndex,
+    std::shared_ptr<ArithmeticDagNode<T>> babyStepIndex, int64_t period) {
+  using NodeTy = ArithmeticDagNode<T>;
+  // Build: -(giantStepSize * giantStepIndex * period)
+  auto gsSize = NodeTy::constantScalar(giantStepSize, DagType::integer(32));
+  auto periodNode = NodeTy::constantScalar(period, DagType::integer(32));
+  auto negOne = NodeTy::constantScalar(-1, DagType::integer(32));
+
+  auto temp = NodeTy::mul(giantStepIndex, gsSize);
+  temp = NodeTy::mul(temp, periodNode);
+  return NodeTy::mul(temp, negOne);
+}
+
 // Returns an arithmetic DAG that implements a baby-step-giant-step
 // rotate-and-reduce accumulation between an input ciphertext
 // (giantSteppedOperand) and an abstraction over the other argument
@@ -117,8 +187,8 @@ std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
 implementBabyStepGiantStep(
     const T& giantSteppedOperand, const T& babySteppedOperand, int64_t period,
-    int64_t steps, DagExtractor<T> extractFunc,
-    std::map<int, bool> zeroDiagonals = {},
+    int64_t steps, DagType dagType, DagExtractor<T> extractFunc,
+    const std::map<int, bool>& zeroDiagonals = {},
     const DerivedRotationIndexFn& derivedRotationIndexFn =
         defaultDerivedRotationIndexFn) {
   using NodeTy = ArithmeticDagNode<T>;
@@ -174,10 +244,102 @@ implementBabyStepGiantStep(
     }
   }
 
-  // Hack to make 0 when there are no nonzero diagonals - only appears in
-  // fuzzing edge cases.
-  return result == nullptr ? NodeTy::sub(giantSteppedDag, giantSteppedDag)
-                           : result;
+  return result == nullptr ? NodeTy::splat(0, dagType) : result;
+}
+
+// Default dynamic extractor: simple extraction at runtime index
+template <typename T>
+std::shared_ptr<ArithmeticDagNode<T>> defaultDagExtractor(
+    std::shared_ptr<ArithmeticDagNode<T>> tensor,
+    std::shared_ptr<ArithmeticDagNode<T>> index) {
+  return ArithmeticDagNode<T>::extract(tensor, index);
+}
+
+// Rolled version of Baby-Step-Giant-Step algorithm.
+//
+// TODO(#2704): support skipping over zero diagonals
+//
+template <typename T>
+std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
+                 std::shared_ptr<ArithmeticDagNode<T>>>
+implementBabyStepGiantStepRolled(
+    const T& giantSteppedOperand, const T& babySteppedOperand, int64_t period,
+    int64_t steps, const DagType baseType,
+    DagExtractorDynamic<T> extractFunc = defaultDagExtractor<T>,
+    const DagDerivedRotationIndexFn<T>& dagRotationFn =
+        defaultDagDerivedRotationIndexFn<T>) {
+  using NodeTy = ArithmeticDagNode<T>;
+  using NodePtr = std::shared_ptr<NodeTy>;
+
+  auto giantSteppedDag = NodeTy::leaf(giantSteppedOperand);
+  auto babySteppedDag = NodeTy::leaf(babySteppedOperand);
+
+  int64_t numBabySteps = static_cast<int64_t>(std::ceil(std::sqrt(steps)));
+  int64_t giantStepSize = numBabySteps;
+  int64_t numGiantSteps = (steps + numBabySteps - 1) / numBabySteps;
+
+  // Initialize outer sum to zero
+  auto zero = NodeTy::splat(0, baseType);
+
+  // Outer loop over giant steps (j = 0 to numGiantSteps)
+  auto outerLoop = NodeTy::loop(
+      {zero}, /*lower=*/0, /*upper=*/numGiantSteps, /*step=*/1,
+      [&](NodePtr j, const std::vector<NodePtr>& outerIterArgs) {
+        auto outerSum = outerIterArgs[0];
+
+        // Inner loop over baby steps (i = 0 to numBabySteps)
+        // Initialize inner sum to zero
+        auto innerZero = NodeTy::splat(0, baseType);
+
+        auto innerLoop = NodeTy::loop(
+            {innerZero}, /*lower=*/0, /*upper=*/numBabySteps, /*step=*/1,
+            [&](NodePtr i, const std::vector<NodePtr>& innerIterArgs) {
+              auto innerSum = innerIterArgs[0];
+
+              // Compute extraction index: i + j * giantStepSize
+              auto gsSize =
+                  NodeTy::constantScalar(giantStepSize, DagType::integer(32));
+              auto jOffset = NodeTy::mul(j, gsSize);
+              auto extractIdx = NodeTy::add(i, jOffset);
+
+              auto plaintext = extractFunc(babySteppedDag, extractIdx);
+              auto innerRotAmount = dagRotationFn(giantStepSize, j, i, period);
+
+              auto rotatedPlaintext =
+                  NodeTy::leftRotate(plaintext, innerRotAmount);
+
+              // Compute baby-step rotation on-the-fly using loop variable i
+              // babyStepVal = rotate(giantSteppedOperand, i * period)
+              auto babyStepVal = NodeTy::leftRotate(
+                  giantSteppedDag,
+                  NodeTy::mul(
+                      i, NodeTy::constantScalar(period, DagType::integer(32))));
+
+              auto multiplied = NodeTy::mul(rotatedPlaintext, babyStepVal);
+              auto newInnerSum = NodeTy::add(innerSum, multiplied);
+
+              return NodeTy::yield({newInnerSum});
+            });
+
+        // Extract result from inner loop
+        auto innerResult = NodeTy::resultAt(innerLoop, 0);
+
+        // Rotate by j * giantStepSize * period
+        auto gsSize =
+            NodeTy::constantScalar(giantStepSize, DagType::integer(32));
+        auto periodNode = NodeTy::constantScalar(period, DagType::integer(32));
+        auto outerRotAmount = NodeTy::mul(j, gsSize);
+        outerRotAmount = NodeTy::mul(outerRotAmount, periodNode);
+
+        auto rotatedSum = NodeTy::leftRotate(innerResult, outerRotAmount);
+
+        // Accumulate into outer sum
+        auto newOuterSum = NodeTy::add(outerSum, rotatedSum);
+
+        return NodeTy::yield({newOuterSum});
+      });
+
+  return NodeTy::resultAt(outerLoop, 0);
 }
 
 // Returns an arithmetic DAG that implements a tensor_ext.rotate_and_reduce op.
@@ -203,9 +365,10 @@ template <typename T>
 std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
 implementRotateAndReduce(const T& vector, std::optional<T> plaintexts,
-                         int64_t period, int64_t steps,
-                         std::map<int, bool> zeroDiagonals = {},
-                         const std::string& reduceOp = "arith.addi") {
+                         int64_t period, int64_t steps, const DagType& dagType,
+                         const std::map<int, bool>& zeroDiagonals = {},
+                         const std::string& reduceOp = "arith.addi",
+                         bool unroll = true) {
   using NodeTy = ArithmeticDagNode<T>;
   auto performReduction = [&](std::shared_ptr<NodeTy> left,
                               std::shared_ptr<NodeTy> right) {
@@ -222,8 +385,12 @@ implementRotateAndReduce(const T& vector, std::optional<T> plaintexts,
   };
 
   if (!plaintexts.has_value()) {
-    return implementRotateAndReduceAccumulation<T>(vector, period, steps,
-                                                   performReduction);
+    if (unroll) {
+      return implementRotateAndReduceAccumulation<T>(vector, period, steps,
+                                                     performReduction);
+    }
+    return implementRotateAndReduceAccumulationRolled<T>(
+        vector, period, steps, performReduction, dagType);
   }
 
   assert(reduceOp == "arith.addi" ||
@@ -231,13 +398,27 @@ implementRotateAndReduce(const T& vector, std::optional<T> plaintexts,
              "Baby-step-giant-step rotate-and-reduce only supports addition "
              "as the reduction operation");
 
-  auto extractFunc = [](std::shared_ptr<NodeTy> babySteppedDag,
-                        int64_t extractionIndex) {
+  if (unroll) {
+    // Unrolled version: uses static extraction
+    auto extractFunc = [](std::shared_ptr<NodeTy> babySteppedDag,
+                          int64_t extractionIndex) {
+      return NodeTy::extract(babySteppedDag, extractionIndex);
+    };
+
+    return implementBabyStepGiantStep<T>(
+        vector, plaintexts.value(), period, steps, dagType, extractFunc,
+        zeroDiagonals, defaultDerivedRotationIndexFn);
+  }
+
+  // Rolled version: uses dynamic extraction and DAG rotation function
+  auto dynamicExtractFunc = [](std::shared_ptr<NodeTy> babySteppedDag,
+                               std::shared_ptr<NodeTy> extractionIndex) {
     return NodeTy::extract(babySteppedDag, extractionIndex);
   };
 
-  return implementBabyStepGiantStep<T>(vector, plaintexts.value(), period,
-                                       steps, extractFunc, zeroDiagonals);
+  return implementBabyStepGiantStepRolled<T>(
+      vector, plaintexts.value(), period, steps, dagType, dynamicExtractFunc,
+      defaultDagDerivedRotationIndexFn<T>);
 }
 
 // Returns an arithmetic DAG that implements a baby-step-giant-step between
@@ -259,7 +440,8 @@ std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
 implementCiphertextCiphertextBabyStepGiantStep(
     const T& giantSteppedOperand, const T& babySteppedOperand, int64_t period,
-    int64_t steps, DerivedRotationIndexFn derivedRotationIndexFn) {
+    int64_t steps, const DagType& dagType,
+    DerivedRotationIndexFn derivedRotationIndexFn) {
   using NodeTy = ArithmeticDagNode<T>;
 
   // Avoid replicating and re-extracting by simulating the extraction step by
@@ -268,7 +450,7 @@ implementCiphertextCiphertextBabyStepGiantStep(
                         int64_t extractionIndex) { return babySteppedDag; };
 
   return implementBabyStepGiantStep<T>(giantSteppedOperand, babySteppedOperand,
-                                       period, steps, extractFunc, {},
+                                       period, steps, dagType, extractFunc, {},
                                        derivedRotationIndexFn);
 }
 
@@ -281,13 +463,18 @@ std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
 implementHaleviShoup(const T& vector, const T& matrix,
                      std::vector<int64_t> originalMatrixShape,
-                     std::map<int, bool> zeroDiagonals = {}) {
+                     const DagType& dagType,
+                     std::map<int, bool> zeroDiagonals = {},
+                     bool unroll = true) {
   using NodeTy = ArithmeticDagNode<T>;
+  using NodePtr = std::shared_ptr<NodeTy>;
   int64_t numRotations = matrix.getShape()[0];
 
   auto rotateAndReduceResult = implementRotateAndReduce<T>(
       vector, std::optional<T>(matrix), /*period=*/1,
-      /*steps=*/numRotations, zeroDiagonals);
+      /*steps=*/numRotations, dagType, zeroDiagonals,
+      /*reduceOp=*/"arith.addi",
+      /*unroll=*/unroll);
 
   auto summedShifts = rotateAndReduceResult;
 
@@ -301,14 +488,31 @@ implementHaleviShoup(const T& vector, const T& matrix,
   // Post-processing partial-rotate-and-reduce step required for
   // squat-diagonal packing.
   int64_t numShifts = (int64_t)(log2(matrixNumCols) - log2(matrixNumRows));
-  int64_t shift = matrixNumCols / 2;
-  for (int64_t i = 0; i < numShifts; ++i) {
-    auto rotated = NodeTy::leftRotate(summedShifts, shift);
-    summedShifts = NodeTy::add(summedShifts, rotated);
-    shift /= 2;
+  if (unroll) {
+    int64_t shift = matrixNumCols / 2;
+    for (int64_t i = 0; i < numShifts; ++i) {
+      auto rotated = NodeTy::leftRotate(summedShifts, shift);
+      summedShifts = NodeTy::add(summedShifts, rotated);
+      shift /= 2;
+    }
+
+    return summedShifts;
   }
 
-  return summedShifts;
+  auto shift = NodeTy::constantScalar(matrixNumCols / 2, DagType::integer(32));
+  auto loopNode = NodeTy::loop(
+      {summedShifts, shift}, /*lower=*/0,
+      /*upper=*/numShifts, /*step=*/1,
+      [&](NodePtr iv, const std::vector<NodePtr>& iterArgs) {
+        auto currentSum = iterArgs[0];
+        auto currentShift = iterArgs[1];
+        auto rotated = NodeTy::leftRotate(currentSum, currentShift);
+        auto newSum = NodeTy::add(currentSum, rotated);
+        auto newShift = NodeTy::floorDiv(currentShift, 2);
+        return NodeTy::yield({newSum, newShift});
+      });
+
+  return NodeTy::resultAt(loopNode, 0);
 }
 
 // Returns an arithmetic DAG that implements the bicyclic matrix multiplication
@@ -344,7 +548,7 @@ template <typename T>
 std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
 implementBicyclicMatmul(const T& packedA, const T& packedB, int64_t m,
-                        int64_t n, int64_t p) {
+                        int64_t n, int64_t p, const DagType& dagType) {
   APInt mAPInt = APInt(64, m);
   APInt nAPInt = APInt(64, n);
   APInt pAPInt = APInt(64, p);
@@ -368,7 +572,8 @@ implementBicyclicMatmul(const T& packedA, const T& packedB, int64_t m,
   };
 
   return implementCiphertextCiphertextBabyStepGiantStep<T>(
-      packedA, packedB, /*period=*/m, /*steps=*/n, derivedRotationIndexFn);
+      packedA, packedB, /*period=*/m, /*steps=*/n, dagType,
+      derivedRotationIndexFn);
 }
 
 // Returns an arithmetic DAG that implements the tricyclic batch matrix
@@ -390,7 +595,8 @@ template <typename T>
 std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
 implementTricyclicBatchMatmul(const T& packedA, const T& packedB, int64_t h,
-                              int64_t m, int64_t n, int64_t p) {
+                              int64_t m, int64_t n, int64_t p,
+                              const DagType& dagType) {
   APInt hAPInt = APInt(64, h);
   APInt mAPInt = APInt(64, m);
   APInt nAPInt = APInt(64, n);
@@ -420,7 +626,8 @@ implementTricyclicBatchMatmul(const T& packedA, const T& packedB, int64_t h,
 
   int64_t period = h * m;
   return implementCiphertextCiphertextBabyStepGiantStep<T>(
-      packedA, packedB, /*period=*/period, /*steps=*/n, derivedRotationIndexFn);
+      packedA, packedB, /*period=*/period, /*steps=*/n, dagType,
+      derivedRotationIndexFn);
 }
 
 }  // namespace kernel

--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <vector>
 
 #include "gtest/gtest.h"  // from @googletest
@@ -18,7 +17,10 @@ namespace heir {
 namespace kernel {
 namespace {
 
-TEST(KernelImplementationTest, TestHaleviShoupMatvec) {
+// Parametrize over whether the kernel is rolled
+class KernelImplementationTest : public testing::TestWithParam<bool> {};
+
+TEST_P(KernelImplementationTest, TestHaleviShoupMatvec) {
   std::vector<int> vector = {0, 1, 2, 3};
   // Pre-packed diagonally
   std::vector<std::vector<int>> matrix = {
@@ -27,13 +29,14 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvec) {
   LiteralValue matrixInput = matrix;
   LiteralValue vectorInput = vector;
 
-  auto dag =
-      implementMatvec(KernelName::MatvecDiagonal, matrixInput, vectorInput);
+  auto dag = implementHaleviShoup(vectorInput, matrixInput, {4, 4},
+                                  DagType::intTensor(32, {4}),
+                                  /*zeroDiagonals=*/{}, /*unroll=*/GetParam());
   LiteralValue actual = evalKernel(dag)[0];
   EXPECT_EQ(std::get<std::vector<int>>(actual.get()), expected);
 }
 
-TEST(KernelImplementationTest, HaleviShoup3x5) {
+TEST_P(KernelImplementationTest, HaleviShoup3x5) {
   // Original matrix:
   // [ 0,  1,  2,  3,  4]
   // [ 5,  6,  7,  8,  9]
@@ -57,7 +60,9 @@ TEST(KernelImplementationTest, HaleviShoup3x5) {
   LiteralValue matrixInput = matrix;
   LiteralValue vectorInput = vector;
 
-  auto dag = implementHaleviShoup(vectorInput, matrixInput, {3, 5});
+  auto dag = implementHaleviShoup(vectorInput, matrixInput, {3, 5},
+                                  DagType::intTensor(32, {8}),
+                                  /*zeroDiagonals=*/{}, /*unroll=*/GetParam());
   LiteralValue result = evalKernel(dag)[0];
   auto actual = std::get<std::vector<int>>(result.get());
 
@@ -98,18 +103,19 @@ TEST(KernelImplementationTest, TestHaleviShoupMatvecWithLayout) {
   EXPECT_EQ(std::get<std::vector<int>>(actual.get()), expected);
 }
 
-TEST(KernelImplementationTest, Test2DConvWithLayout) {
+TEST_P(KernelImplementationTest, Test2DConvWithLayout) {
   MLIRContext context;
   RankedTensorType dataType =
       RankedTensorType::get({3, 3}, mlir::IndexType::get(&context));
   RankedTensorType filterType =
       RankedTensorType::get({2, 2}, mlir::IndexType::get(&context));
 
+  int numSlots = 16;
   // 3x3 input data, 2x2 filter
   std::vector<std::vector<int>> data = {{1, -1, 0}, {-3, 0, 2}, {8, 9, 1}};
   std::vector<std::vector<int>> matrix = {{1, -1}, {-1, 1}};
 
-  auto dataLayout = getRowMajorLayoutRelation(dataType, 16);
+  auto dataLayout = getRowMajorLayoutRelation(dataType, numSlots);
   std::vector<std::vector<int>> packedData =
       evaluateLayoutOnMatrix(dataLayout, data);
 
@@ -117,9 +123,10 @@ TEST(KernelImplementationTest, Test2DConvWithLayout) {
   std::vector<std::vector<int>> packedFilter =
       evaluateLayoutOnMatrix(filterLayout, matrix);
 
-  auto matrixLayout = get2dConvFilterDiagonalizedRelation(filterType, dataType,
-                                                          /*padding=*/0, 16)
-                          .value();
+  auto matrixLayout =
+      get2dConvFilterDiagonalizedRelation(filterType, dataType,
+                                          /*padding=*/0, numSlots)
+          .value();
   std::vector<std::vector<int>> packedMatrix =
       evaluateLayoutOnMatrix(matrixLayout, matrix);
   RankedTensorType expandedMatrixType =
@@ -130,7 +137,9 @@ TEST(KernelImplementationTest, Test2DConvWithLayout) {
   LiteralValue vectorInput = packedData[0];
 
   auto dag = implementHaleviShoup(vectorInput, matrixInput,
-                                  expandedMatrixType.getShape());
+                                  expandedMatrixType.getShape(),
+                                  DagType::intTensor(32, {numSlots}),
+                                  /*zeroDiagonals=*/{}, /*unroll=*/GetParam());
   LiteralValue actual = evalKernel(dag)[0];
   // Result is a 2x2 tensor repeated row-major in a tensor of size 16.
   std::vector<int> actualVector = std::get<std::vector<int>>(actual.get());
@@ -161,7 +170,8 @@ TEST(KernelImplementationTest, BicyclicMatmul) {
   LiteralValue packedAValue = packedA[0];
   LiteralValue packedBValue = packedB[0];
 
-  auto dag = implementBicyclicMatmul(packedAValue, packedBValue, m, n, p);
+  auto dag = implementBicyclicMatmul(packedAValue, packedBValue, m, n, p,
+                                     DagType::intTensor(32, {numSlots}));
   LiteralValue result = evalKernel(dag)[0];
   auto resultVec = std::get<std::vector<int>>(result.get());
 
@@ -181,10 +191,12 @@ TEST(KernelImplementationTest, BicyclicMatmulRotationCount) {
   int m = 123;
   int n = 124;
   int p = 125;
+  int numSlots = m * n * p;
 
   SymbolicValue packedAValue({m, n}, true);
   SymbolicValue packedBValue({n, p}, true);
-  auto dag = implementBicyclicMatmul(packedAValue, packedBValue, m, n, p);
+  auto dag = implementBicyclicMatmul(packedAValue, packedBValue, m, n, p,
+                                     DagType::intTensor(32, {numSlots}));
 
   RotationCountVisitor rotationCounter;
   int64_t rotationCount = rotationCounter.process(dag);
@@ -237,7 +249,8 @@ TEST(KernelImplementationTest, TricyclicBatchMatmul) {
 
   // Generate kernel DAG and evaluate
   auto dag =
-      implementTricyclicBatchMatmul(packedAValue, packedBValue, h, m, n, p);
+      implementTricyclicBatchMatmul(packedAValue, packedBValue, h, m, n, p,
+                                    DagType::intTensor(32, {numSlots}));
   LiteralValue result = evalKernel(dag)[0];
   auto resultVec = std::get<std::vector<int>>(result.get());
 
@@ -268,6 +281,10 @@ TEST(KernelImplementationTest, TricyclicBatchMatmul) {
   // Final check: compare expected packed φ(Z) vector with kernel output.
   EXPECT_EQ(expVec, resultVec);
 }
+
+INSTANTIATE_TEST_SUITE_P(WithAndWithoutRolledSuite, KernelImplementationTest,
+                         testing::Values(false, true));
+
 }  // namespace
 }  // namespace kernel
 }  // namespace heir

--- a/lib/Kernel/RotateAndReduceFuzzTest.cpp
+++ b/lib/Kernel/RotateAndReduceFuzzTest.cpp
@@ -34,7 +34,7 @@ std::vector<int> rotate(const std::vector<int>& vec, int64_t amount) {
 std::vector<int> runNaive(const std::vector<int>& vec,
                           const std::vector<std::vector<int>>& plaintexts,
                           int64_t period, int64_t n,
-                          std::map<int, bool> zeroDiagonals = {}) {
+                          const std::map<int, bool>& zeroDiagonals = {}) {
   if (vec.empty()) return vec;
   std::vector<int> result(vec.size(), 0);
   for (int64_t i = 0; i < n; ++i) {
@@ -51,7 +51,7 @@ std::vector<int> runNaive(const std::vector<int>& vec,
 std::pair<std::vector<int>, int> runImpl(
     const std::vector<int>& vec,
     const std::vector<std::vector<int>>& plaintexts, int64_t period, int64_t n,
-    std::map<int, bool> zeroDiagonals = {},
+    bool unroll = true, const std::map<int, bool>& zeroDiagonals = {},
     const std::string& reduceOp = "arith.addi") {
   if (vec.empty()) return std::make_pair(vec, 0.0);
   LiteralValue vectorInput(vec);
@@ -61,8 +61,10 @@ std::pair<std::vector<int>, int> runImpl(
   if (!plaintexts.empty()) {
     plaintextsInput = std::optional<LiteralValue>(LiteralValue(plaintexts));
   }
-  result = implementRotateAndReduce(vectorInput, plaintextsInput, period, n,
-                                    zeroDiagonals, reduceOp);
+  result = implementRotateAndReduce(
+      vectorInput, plaintextsInput, period, n,
+      DagType::intTensor(32, {static_cast<int64_t>(vec.size())}), zeroDiagonals,
+      reduceOp, unroll);
   std::vector<int> resultTensor =
       std::get<std::vector<int>>(evalKernel(result)[0].get());
   int depth = evalMultiplicativeDepth(result);
@@ -72,7 +74,7 @@ std::pair<std::vector<int>, int> runImpl(
 // Property: Implementation should match naive algorithm with plaintexts
 void rotateAndReduceWithPlaintextsMatchesNaive(
     const std::vector<int>& vector, int64_t period, int64_t steps,
-    const std::vector<std::vector<int>>& plaintexts) {
+    const std::vector<std::vector<int>>& plaintexts, bool unroll) {
   if (vector.empty() || steps <= 0 || period <= 0) return;
   if (plaintexts.size() != static_cast<size_t>(steps)) return;
   for (const auto& plaintext : plaintexts) {
@@ -81,7 +83,7 @@ void rotateAndReduceWithPlaintextsMatchesNaive(
 
   std::vector<int> expected = runNaive(vector, plaintexts, period, steps);
   std::pair<std::vector<int>, int> actualAndDepth =
-      runImpl(vector, plaintexts, period, steps);
+      runImpl(vector, plaintexts, period, steps, unroll);
 
   EXPECT_EQ(expected, actualAndDepth.first);
 }
@@ -102,21 +104,22 @@ std::vector<int> runNaiveNoPlaintexts(const std::vector<int>& vec,
 
 // Property: Implementation without plaintexts should sum rotations
 void rotateAndReduceWithoutPlaintexts(const std::vector<int>& vector,
-                                      int64_t period, int64_t steps) {
+                                      int64_t period, int64_t steps,
+                                      bool unroll) {
   if (vector.empty() || steps <= 0 || period <= 0) return;
 
   std::vector<int> expected = runNaiveNoPlaintexts(vector, period, steps);
   std::pair<std::vector<int>, int> actualAndDepth =
-      runImpl(vector, {}, period, steps);
+      runImpl(vector, {}, period, steps, unroll);
   EXPECT_EQ(expected, actualAndDepth.first);
 }
 
 // Property: Implementation should match naive algorithm with plaintexts with
 // zero diagonals
 void rotateAndReduceWithZeroDiagonalsPlaintexts(
-    std::tuple<std::vector<int>, int64_t, int64_t,
-               std::vector<std::vector<int>>, std::vector<int>>
-        args) {
+    const std::tuple<std::vector<int>, int64_t, int64_t,
+                     std::vector<std::vector<int>>, std::vector<int>>& args,
+    bool unroll) {
   const auto& [vector, period, steps, plaintexts, zeroDiagonals] = args;
   std::map<int, bool> zeroDiagonalsMap;
   for (int diagonal : zeroDiagonals) {
@@ -137,18 +140,17 @@ void rotateAndReduceWithZeroDiagonalsPlaintexts(
       runNaive(vector, zeroedPlaintexts, period, steps, zeroDiagonalsMap);
   std::pair<std::vector<int>, int> actualAndDepthWithNoMap =
       runImpl(vector, zeroedPlaintexts, period, steps);
-  std::pair<std::vector<int>, int> actualAndDepth =
-      runImpl(vector, zeroedPlaintexts, period, steps, zeroDiagonalsMap);
+  std::pair<std::vector<int>, int> actualAndDepth = runImpl(
+      vector, zeroedPlaintexts, period, steps, unroll, zeroDiagonalsMap);
 
   EXPECT_EQ(expected, actualAndDepth.first);
   EXPECT_EQ(expected, actualAndDepthWithNoMap.first);
+}
 
-  if (actualAndDepth.second != 0) {
-    EXPECT_EQ(actualAndDepth.second, actualAndDepthWithNoMap.second);
-  } else {
-    // With no filter-list for the zero diagonals, the depth will still be one.
-    EXPECT_EQ(actualAndDepthWithNoMap.second, 1);
-  }
+TEST(RotateAndReduceFuzzTest,
+     rotateAndReduceWithPlaintextsMatchesNaiveRegression) {
+  rotateAndReduceWithPlaintextsMatchesNaive({-100, -100}, 1, 1, {{2, 1}},
+                                            false);
 }
 
 // Fuzz test for rotate and reduce with plaintexts
@@ -158,13 +160,14 @@ FUZZ_TEST(RotateAndReduceFuzzTest, rotateAndReduceWithPlaintextsMatchesNaive)
             .WithMinSize(1)
             .WithMaxSize(32),
         /*period=*/fuzztest::InRange(1L, 4L),
-        /*steps=*/fuzztest::InRange(1L, 16L),
+        /*steps=*/fuzztest::ElementOf({1L, 4L, 9L, 16L}),
         /*plaintexts=*/
         fuzztest::VectorOf(fuzztest::VectorOf(fuzztest::InRange(-100, 100))
                                .WithMinSize(1)
                                .WithMaxSize(32))
             .WithMinSize(1)
-            .WithMaxSize(16));
+            .WithMaxSize(16),
+        fuzztest::Arbitrary<bool>());
 
 // Fuzz test for rotate and reduce without plaintexts
 FUZZ_TEST(RotateAndReduceFuzzTest, rotateAndReduceWithoutPlaintexts)
@@ -173,30 +176,33 @@ FUZZ_TEST(RotateAndReduceFuzzTest, rotateAndReduceWithoutPlaintexts)
             .WithMinSize(1)
             .WithMaxSize(32),
         /*period=*/fuzztest::InRange(1L, 4L),
-        /*steps=*/fuzztest::ElementOf({1L, 2L, 4L, 8L, 16L}));
+        /*steps=*/fuzztest::ElementOf({1L, 2L, 4L, 8L, 16L}),
+        fuzztest::Arbitrary<bool>());
 
 // Fuzz test for rotate and reduce with plaintexts and zero diagonals
 FUZZ_TEST(RotateAndReduceFuzzTest, rotateAndReduceWithZeroDiagonalsPlaintexts)
-    .WithDomains(fuzztest::FlatMap(
-        [](size_t vectorSize, int64_t period, int64_t steps) {
-          return fuzztest::TupleOf(
-              /*vector=*/fuzztest::VectorOf(fuzztest::InRange(-100, 100))
-                  .WithSize(vectorSize),
-              /*period=*/fuzztest::Just(period),
-              /*steps=*/fuzztest::Just(steps),
-              /*plaintexts=*/
-              fuzztest::VectorOf(
-                  fuzztest::VectorOf(fuzztest::InRange(-100, 100))
-                      .WithSize(vectorSize))
-                  .WithSize(steps),
-              /*zeroDiagonals=*/
-              fuzztest::VectorOf(fuzztest::InRange<int>(0, steps - 1))
-                  .WithMinSize(1)
-                  .WithMaxSize(steps));
-        },
-        /*vectorSize=*/fuzztest::InRange<size_t>(1, 32),
-        /*period=*/fuzztest::InRange(1L, 4L),
-        /*steps=*/fuzztest::InRange(1L, 16L)));
+    .WithDomains(
+        fuzztest::FlatMap(
+            [](size_t vectorSize, int64_t period, int64_t steps) {
+              return fuzztest::TupleOf(
+                  /*vector=*/fuzztest::VectorOf(fuzztest::InRange(-100, 100))
+                      .WithSize(vectorSize),
+                  /*period=*/fuzztest::Just(period),
+                  /*steps=*/fuzztest::Just(steps),
+                  /*plaintexts=*/
+                  fuzztest::VectorOf(
+                      fuzztest::VectorOf(fuzztest::InRange(-100, 100))
+                          .WithSize(vectorSize))
+                      .WithSize(steps),
+                  /*zeroDiagonals=*/
+                  fuzztest::VectorOf(fuzztest::InRange<int>(0, steps - 1))
+                      .WithMinSize(1)
+                      .WithMaxSize(steps));
+            },
+            /*vectorSize=*/fuzztest::InRange<size_t>(1, 32),
+            /*period=*/fuzztest::InRange(1L, 4L),
+            /*steps=*/fuzztest::ElementOf({1L, 4L, 9L, 16L})),
+        fuzztest::Arbitrary<bool>());
 
 }  // namespace
 }  // namespace kernel

--- a/lib/Kernel/RotateAndReduceImplTest.cpp
+++ b/lib/Kernel/RotateAndReduceImplTest.cpp
@@ -51,7 +51,7 @@ std::vector<int> runNaive(const std::vector<int>& vec,
 
 std::vector<int> runImpl(const std::vector<int>& vec,
                          const std::vector<std::vector<int>>& plaintexts,
-                         int64_t period, int64_t n) {
+                         int64_t period, int64_t n, bool unroll = true) {
   LiteralValue vectorInput(vec);
 
   std::shared_ptr<ArithmeticDagNode<LiteralValue>> result;
@@ -59,8 +59,10 @@ std::vector<int> runImpl(const std::vector<int>& vec,
   if (!plaintexts.empty()) {
     plaintextsInput = std::optional<LiteralValue>(LiteralValue(plaintexts));
   }
-  result = implementRotateAndReduce(vectorInput, plaintextsInput, period, n);
-  std::cerr << "Rotate and reduce dag: " << printKernel(result) << "\n";
+  result = implementRotateAndReduce(
+      vectorInput, plaintextsInput, period, n,
+      DagType::intTensor(32, {static_cast<int64_t>(vec.size())}), {},
+      "arith.addi", unroll);
   return std::get<std::vector<int>>(evalKernel(result)[0].get());
 }
 
@@ -78,6 +80,23 @@ TEST(RotateAndReduceImplTest, TestUnitPeriodWithPlaintextsSimpleValues) {
 
   std::vector<int> expected = runNaive(vector, plaintexts, period, n);
   std::vector<int> actual = runImpl(vector, plaintexts, period, n);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(RotateAndReduceImplTest, TestUnitPeriodWithPlaintextsSimpleValuesRolled) {
+  int64_t n = 4;
+  int64_t period = 1;
+
+  std::vector<int> vector = {0, 1, 2, 3};
+  std::vector<std::vector<int>> plaintexts = {
+      {1, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+  };
+
+  std::vector<int> expected = runNaive(vector, plaintexts, period, n);
+  std::vector<int> actual = runImpl(vector, plaintexts, period, n, false);
   EXPECT_EQ(expected, actual);
 }
 
@@ -138,6 +157,15 @@ TEST(RotateAndReduceImplTest, TestPeriod1WithNoPlaintext) {
   std::vector<int> vector = {0, 1, 2, 3, 4, 5, 6, 7};
   std::vector<int> expected(8, 28);
   std::vector<int> actual = runImpl(vector, {}, period, n);
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(RotateAndReduceImplTest, TestPeriod1WithNoPlaintextRolled) {
+  int64_t n = 8;
+  int64_t period = 1;
+  std::vector<int> vector = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<int> expected(8, 28);
+  std::vector<int> actual = runImpl(vector, {}, period, n, false);
   EXPECT_EQ(expected, actual);
 }
 

--- a/lib/Kernel/TestingUtils.cpp
+++ b/lib/Kernel/TestingUtils.cpp
@@ -219,6 +219,72 @@ EvalResults EvalVisitor::operator()(const SplatNode& node) {
   return {LiteralValue(splatValue)};
 }
 
+EvalResults EvalVisitor::operator()(const VariableNode<LiteralValue>& node) {
+  assert(node.value.has_value() && "VariableNode value is not set");
+  return {node.value.value()};
+}
+
+EvalResults EvalVisitor::operator()(const ForLoopNode<LiteralValue>& node) {
+  // Process initial values
+  std::vector<LiteralValue> iterValues;
+  iterValues.reserve(node.inits.size());
+  for (const auto& init : node.inits) {
+    EvalResults initResult = this->process(init);
+    assert(initResult.size() == 1 && "Init must produce single value");
+    iterValues.push_back(initResult[0]);
+  }
+
+  // Execute loop iterations
+  for (int32_t i = node.lower; i < node.upper; i += node.step) {
+    // Clear cache for the loop body since variables change each iteration
+    this->clearSubtreeCache(node.body);
+
+    // Set induction variable
+    auto& inductionVarNode =
+        std::get<VariableNode<LiteralValue>>(node.inductionVar->node_variant);
+    inductionVarNode.value = LiteralValue(static_cast<int>(i));
+
+    // Set iter args
+    assert(node.iterArgs.size() == iterValues.size());
+    for (size_t j = 0; j < node.iterArgs.size(); ++j) {
+      auto& iterArgNode =
+          std::get<VariableNode<LiteralValue>>(node.iterArgs[j]->node_variant);
+      iterArgNode.value = iterValues[j];
+    }
+
+    // Execute body (should be a YieldNode)
+    assert(node.body != nullptr);
+    assert(std::holds_alternative<YieldNode<LiteralValue>>(
+               node.body->node_variant) &&
+           "ForLoopNode body must be a YieldNode");
+    EvalResults bodyResults = this->process(node.body);
+
+    // Update iter values for next iteration
+    assert(bodyResults.size() == iterValues.size());
+    iterValues = bodyResults;
+  }
+
+  return iterValues;
+}
+
+EvalResults EvalVisitor::operator()(const YieldNode<LiteralValue>& node) {
+  EvalResults results;
+  results.reserve(node.elements.size());
+  for (const auto& element : node.elements) {
+    EvalResults elementResults = this->process(element);
+    assert(elementResults.size() == 1 &&
+           "Yield operands must be single values");
+    results.push_back(elementResults[0]);
+  }
+  return results;
+}
+
+EvalResults EvalVisitor::operator()(const ResultAtNode<LiteralValue>& node) {
+  EvalResults operandResults = this->process(node.operand);
+  assert(node.index < operandResults.size() && "Index out of bounds");
+  return {operandResults[node.index]};
+}
+
 EvalResults evalKernel(
     const std::shared_ptr<ArithmeticDagNode<LiteralValue>>& dag) {
   EvalVisitor visitor;
@@ -298,6 +364,43 @@ std::string PrintVisitor::operator()(const ExtractNode<LiteralValue>& node) {
   // tensor instead of printing recursively.
   std::string indexStr = this->process(node.index);
   return "pt(" + indexStr + ")";
+}
+
+std::string PrintVisitor::operator()(const VariableNode<LiteralValue>& node) {
+  if (node.value.has_value()) {
+    // If the variable has a value, print it
+    const auto& val = node.value.value().get();
+    if (const auto* intVal = std::get_if<int>(&val)) {
+      return std::to_string(*intVal);
+    }
+    return "var(?)";
+  }
+  return "var";
+}
+
+std::string PrintVisitor::operator()(const ForLoopNode<LiteralValue>& node) {
+  std::string result = "for(";
+  result += std::to_string(node.lower) + ".." + std::to_string(node.upper);
+  result += " step " + std::to_string(node.step) + ")";
+  return result;
+}
+
+std::string PrintVisitor::operator()(const YieldNode<LiteralValue>& node) {
+  if (node.elements.size() == 1) {
+    return this->process(node.elements[0]);
+  }
+  std::string result = "yield(";
+  for (size_t i = 0; i < node.elements.size(); ++i) {
+    if (i > 0) result += ", ";
+    result += this->process(node.elements[i]);
+  }
+  result += ")";
+  return result;
+}
+
+std::string PrintVisitor::operator()(const ResultAtNode<LiteralValue>& node) {
+  std::string operand = this->process(node.operand);
+  return operand + "[" + std::to_string(node.index) + "]";
 }
 
 std::string printKernel(

--- a/lib/Kernel/TestingUtils.h
+++ b/lib/Kernel/TestingUtils.h
@@ -34,6 +34,10 @@ class EvalVisitor : public CachingVisitor<LiteralValue, EvalResults> {
   EvalResults operator()(const FloorDivNode<LiteralValue>& node) override;
   EvalResults operator()(const LeftRotateNode<LiteralValue>& node) override;
   EvalResults operator()(const ExtractNode<LiteralValue>& node) override;
+  EvalResults operator()(const VariableNode<LiteralValue>& node) override;
+  EvalResults operator()(const ForLoopNode<LiteralValue>& node) override;
+  EvalResults operator()(const YieldNode<LiteralValue>& node) override;
+  EvalResults operator()(const ResultAtNode<LiteralValue>& node) override;
 };
 
 EvalResults evalKernel(
@@ -58,6 +62,10 @@ class PrintVisitor : public CachingVisitor<LiteralValue, std::string> {
   std::string operator()(const ExtractNode<LiteralValue>& node) override;
   std::string operator()(const ConstantScalarNode& node) override;
   std::string operator()(const SplatNode& node) override;
+  std::string operator()(const VariableNode<LiteralValue>& node) override;
+  std::string operator()(const ForLoopNode<LiteralValue>& node) override;
+  std::string operator()(const YieldNode<LiteralValue>& node) override;
+  std::string operator()(const ResultAtNode<LiteralValue>& node) override;
 };
 
 std::string printKernel(
@@ -139,6 +147,32 @@ class MultiplicativeDepthVisitorImpl
 
   double operator()(const ExtractNode<LiteralValue>& node) override {
     // Extraction doesn't increase multiplicative depth
+    return this->process(node.operand);
+  }
+
+  double operator()(const VariableNode<LiteralValue>& node) override {
+    // Variables have depth 0 (they are inputs)
+    return 0.0;
+  }
+
+  double operator()(const ForLoopNode<LiteralValue>& node) override {
+    if (node.body) {
+      return this->process(node.body);
+    }
+    return 0.0;
+  }
+
+  double operator()(const YieldNode<LiteralValue>& node) override {
+    // Return the maximum depth of all yielded elements
+    double maxDepth = -1.0;
+    for (const auto& element : node.elements) {
+      maxDepth = std::max(maxDepth, this->process(element));
+    }
+    return maxDepth;
+  }
+
+  double operator()(const ResultAtNode<LiteralValue>& node) override {
+    // Extracting a result doesn't increase multiplicative depth
     return this->process(node.operand);
   }
 };

--- a/lib/Kernel/Utils.cpp
+++ b/lib/Kernel/Utils.cpp
@@ -1,0 +1,75 @@
+#include "lib/Kernel/Utils.h"
+
+#include "lib/Kernel/ArithmeticDag.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace kernel {
+
+Type dagTypeToMLIRType(const DagType& dagType, OpBuilder& builder) {
+  return std::visit(
+      [&](auto&& arg) -> Type {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, kernel::IntegerType>) {
+          return builder.getIntegerType(arg.bitWidth);
+        } else if constexpr (std::is_same_v<T, kernel::FloatType>) {
+          if (arg.bitWidth == 32) {
+            return builder.getF32Type();
+          } else if (arg.bitWidth == 64) {
+            return builder.getF64Type();
+          } else if (arg.bitWidth == 16) {
+            return builder.getF16Type();
+          } else {
+            llvm_unreachable("Unsupported float bit width");
+          }
+        } else if constexpr (std::is_same_v<T, kernel::IndexType>) {
+          return builder.getIndexType();
+        } else if constexpr (std::is_same_v<T, kernel::IntTensorType>) {
+          auto elementType = builder.getIntegerType(arg.bitWidth);
+          return RankedTensorType::get(arg.shape, elementType);
+        } else if constexpr (std::is_same_v<T, kernel::FloatTensorType>) {
+          mlir::Type elementType;
+          if (arg.bitWidth == 32) {
+            elementType = builder.getF32Type();
+          } else if (arg.bitWidth == 64) {
+            elementType = builder.getF64Type();
+          } else if (arg.bitWidth == 16) {
+            elementType = builder.getF16Type();
+          } else {
+            llvm_unreachable("Unsupported float bit width");
+          }
+          return RankedTensorType::get(arg.shape, elementType);
+        }
+        llvm_unreachable("Unknown DagType variant");
+      },
+      dagType.type_variant);
+}
+
+DagType mlirTypeToDagType(Type type) {
+  return llvm::TypeSwitch<Type, DagType>(type)
+      .Case<mlir::IntegerType>(
+          [&](auto type) { return DagType::integer(type.getWidth()); })
+      .Case<mlir::IndexType>([&](auto type) { return DagType::index(); })
+      .Case<mlir::FloatType>(
+          [&](auto type) { return DagType::floatTy(type.getWidth()); })
+      .Case<mlir::RankedTensorType>([&](auto type) {
+        std::vector<int64_t> shape(type.getShape());
+        int width = type.getElementType().getIntOrFloatBitWidth();
+        return llvm::TypeSwitch<Type, DagType>(type.getElementType())
+            .template Case<mlir::IntegerType>(
+                [&](auto _) { return DagType::intTensor(width, shape); })
+            .template Case<mlir::FloatType>(
+                [&](auto _) { return DagType::floatTensor(width, shape); })
+            .Default([&](auto _) {
+              llvm_unreachable("Unsupported element type");
+              return DagType();
+            });
+      });
+}
+
+}  // namespace kernel
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Kernel/Utils.h
+++ b/lib/Kernel/Utils.h
@@ -1,0 +1,19 @@
+#ifndef LIB_KERNEL_UTILS_H_
+#define LIB_KERNEL_UTILS_H_
+
+#include "lib/Kernel/ArithmeticDag.h"
+#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace kernel {
+
+Type dagTypeToMLIRType(const DagType& dagType, OpBuilder& builder);
+
+DagType mlirTypeToDagType(Type type);
+
+}  // namespace kernel
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_KERNEL_UTILS_H_

--- a/lib/Transforms/ConvertToCiphertextSemantics/BUILD
+++ b/lib/Transforms/ConvertToCiphertextSemantics/BUILD
@@ -23,6 +23,7 @@ cc_library(
         "@heir//lib/Kernel:ArithmeticDag",
         "@heir//lib/Kernel:IRMaterializingVisitor",
         "@heir//lib/Kernel:KernelImplementation",
+        "@heir//lib/Kernel:Utils",
         "@heir//lib/Transforms/DropUnitDims",
         "@heir//lib/Utils",
         "@heir//lib/Utils:AttributeUtils",

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -24,6 +24,7 @@
 #include "lib/Kernel/IRMaterializingVisitor.h"
 #include "lib/Kernel/KernelImplementation.h"
 #include "lib/Kernel/KernelName.h"
+#include "lib/Kernel/Utils.h"
 #include "lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.h"
 #include "lib/Transforms/ConvertToCiphertextSemantics/TypeConversion.h"
 #include "lib/Transforms/DropUnitDims/DropUnitDims.h"
@@ -658,10 +659,13 @@ struct ConvertLinalgMatvecLayout
         cast<TypedValue<RankedTensorType>>(adaptor.getInputs()[0]);
     SSAValue matrixLeaf(matrix);
 
+    auto dagType = kernel::mlirTypeToDagType(input.getType().getElementType());
     std::shared_ptr<ArithmeticDagNode<SSAValue>> implementedKernel =
-        implementHaleviShoup(
-            vectorLeaf, matrixLeaf,
-            cast<RankedTensorType>(op.getInputs()[0].getType()).getShape());
+        implementHaleviShoup(vectorLeaf, matrixLeaf,
+                             cast<RankedTensorType>(op.getInputs()[0].getType())
+                                 .getShape()
+                                 .vec(),
+                             dagType);
 
     rewriter.setInsertionPointAfter(op);
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -788,9 +792,11 @@ struct ConvertLinalgConv2D
       zeroDiagonals[point[0]] = true;
     }
 
+    auto dagType = kernel::mlirTypeToDagType(data.getType().getElementType());
     std::shared_ptr<ArithmeticDagNode<SSAValue>> implementedKernel =
         implementHaleviShoup(vectorLeaf, matrixLeaf,
-                             expandedMatrixType.getShape(), zeroDiagonals);
+                             expandedMatrixType.getShape().vec(), dagType,
+                             zeroDiagonals);
 
     rewriter.setInsertionPointAfter(op);
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -1955,11 +1961,12 @@ struct ConvertLinalgMatmul
     auto lhsType = cast<RankedTensorType>(op.getInputs()[0].getType());
     auto rhsType = cast<RankedTensorType>(op.getInputs()[1].getType());
 
+    auto dagType = kernel::mlirTypeToDagType(lhsType.getElementType());
     // TODO(#2368): zero-pad inputs to ensure coprime dimensions
     std::shared_ptr<ArithmeticDagNode<SSAValue>> implementedKernel =
         kernel::implementBicyclicMatmul(lhsLeaf, rhsLeaf, lhsType.getShape()[0],
                                         lhsType.getShape()[1],
-                                        rhsType.getShape()[1]);
+                                        rhsType.getShape()[1], dagType);
 
     rewriter.setInsertionPointAfter(op);
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);

--- a/lib/Transforms/LayoutOptimization/BUILD
+++ b/lib/Transforms/LayoutOptimization/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "@heir//lib/Kernel:AbstractValue",
         "@heir//lib/Kernel:KernelImplementation",
         "@heir//lib/Kernel:RotationCountVisitor",
+        "@heir//lib/Kernel:Utils",
         "@heir//lib/Utils:AttributeUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
@@ -22,6 +22,7 @@
 #include "lib/Kernel/KernelImplementation.h"
 #include "lib/Kernel/KernelName.h"
 #include "lib/Kernel/RotationCountVisitor.h"
+#include "lib/Kernel/Utils.h"
 #include "lib/Transforms/LayoutOptimization/Hoisting.h"
 #include "lib/Transforms/LayoutOptimization/LayoutConversionCost.h"
 #include "lib/Transforms/LayoutOptimization/Patterns.h"
@@ -408,13 +409,14 @@ static FailureOr<Cost> computeKernelCostFromDAG(KernelName kernel,
       auto matrixType = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
       if (!matrixType) return failure();
       auto shape = matrixType.getShape();
+      auto dagType = kernel::mlirTypeToDagType(matrixType.getElementType());
 
       SymbolicValue symbolicVector({shape[1]},
                                    /*isSecret=*/true);
       SymbolicValue symbolicMatrix({shape[0], shape[1]},
                                    /*isSecret=*/false);
-      auto kernelDag =
-          kernel::implementHaleviShoup(symbolicVector, symbolicMatrix, shape);
+      auto kernelDag = kernel::implementHaleviShoup(
+          symbolicVector, symbolicMatrix, shape.vec(), dagType);
 
       if (!kernelDag) return failure();
       return costModel.process(kernelDag);
@@ -428,12 +430,13 @@ static FailureOr<Cost> computeKernelCostFromDAG(KernelName kernel,
       auto matrixType = dyn_cast<RankedTensorType>(op->getOperand(1).getType());
       if (!matrixType) return failure();
       auto shape = matrixType.getShape();
+      auto dagType = kernel::mlirTypeToDagType(matrixType.getElementType());
 
       SymbolicValue symbolicVector({shape[0]}, /*isSecret=*/true);
       SymbolicValue symbolicMatrix({shape[0], shape[1]},
                                    /*isSecret=*/false);
-      auto kernelDag =
-          kernel::implementHaleviShoup(symbolicVector, symbolicMatrix, shape);
+      auto kernelDag = kernel::implementHaleviShoup(
+          symbolicVector, symbolicMatrix, shape.vec(), dagType);
 
       if (!kernelDag) return failure();
       return costModel.process(kernelDag);
@@ -447,11 +450,12 @@ static FailureOr<Cost> computeKernelCostFromDAG(KernelName kernel,
       auto rhsType = dyn_cast<RankedTensorType>(op->getOperand(1).getType());
       if (!rhsType) return failure();
       auto rhsShape = rhsType.getShape();
+      auto dagType = kernel::mlirTypeToDagType(lhsType.getElementType());
 
       SymbolicValue lhsLeaf(lhsShape, /*isSecret=*/true);
       SymbolicValue rhsLeaf(rhsShape, /*isSecret=*/true);
       auto implementedKernel = kernel::implementBicyclicMatmul(
-          lhsLeaf, rhsLeaf, lhsShape[0], lhsShape[1], rhsShape[1]);
+          lhsLeaf, rhsLeaf, lhsShape[0], lhsShape[1], rhsShape[1], dagType);
 
       if (!implementedKernel) return failure();
       return costModel.process(implementedKernel);


### PR DESCRIPTION
This PR adds a new `unroll` API option to the KernelImplementation.h rotate and reduce kernels. Doesn't yet add a pass option to enable it due to the lack of rotation key analysis.

As per discussion with @asraa, I'm leaving out the zeroDiagonals support until a followup PR