### PR TITLE
update contributing.md with ai tools policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ This project follows
 
 ## Contribution process
 
+### AI Tool Use Policy
+
+Please see our
+[AI Tool Use Policy](https://heir.dev/docs/development/ai_policy/) for our
+guidelines on using AI tools to generate contributions to the project. Please
+note especially that we do not accept AI-based solutions from new contributors
+on ["good first issues"](https://github.com/google/heir/contribute).
+
 ### Code reviews
 
 All submissions, including submissions by project members, require review. We
@@ -33,6 +41,6 @@ use GitHub pull requests for this purpose. Consult
 information on using pull requests.
 
 Before contributing, please read
-[Contributing to HEIR](https://heir.dev/docs/contributing/).
+[Contributing code to HEIR](https://heir.dev/docs/development/#contributing-code-to-heir).
 
 <!-- mdformat global-off -->

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ There are many ways to contribute to HEIR:
 - Ask questions or discuss feature ideas in the `#heir` channel on
   [the FHE.org discord](https://discord.fhe.org/).
 - Work on an issue marked
-  ["good first issue"](https://github.com/google/heir/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-  or browse issues [labeled by topic](https://github.com/google/heir/labels).
+  ["good first issue"](https://github.com/google/heir/contribute) or browse
+  issues [labeled by topic](https://github.com/google/heir/labels).
 - Help us understand new FHE research: either
   - Read a paper tagged under
     [research synthesis](https://github.com/google/heir/labels/research%20synthesis)

--- a/docs/content/en/docs/Development/ai_policy.md
+++ b/docs/content/en/docs/Development/ai_policy.md
@@ -3,8 +3,6 @@ title: AI Tool Use Policy
 weight: 20
 ---
 
-# AI Tool Use Policy
-
 _Nb., this policy was adapted from the
 [LLVM AI Tool Use Policy](https://github.com/llvm/llvm-project/pull/154441)._
 
@@ -66,7 +64,7 @@ and are intended to be learning opportunities for new contributors to get
 familiar with the codebase. Fully automating the process of fixing this issue
 squanders the learning opportunity and doesn't add much value to the project.
 **New contributors using AI tools to fix issues labelled as "good first issues"
-is forbidden**..
+is forbidden**.
 
 ## Extractive Contributions
 


### PR DESCRIPTION
I noticed that we did not yet link to our AI tool policy from CONTRIBUTING.md so this PR aims to fix that (unless there's some google policy that says the file must always be the blessed-by-legal default).

It also fixes a few other smaller things (duplicated page title, broken link, etc) and replaces links to "good first issues" searches with https://github.com/google/heir/contribute which not only looks nicer in the markdown but also includes a link to contributing.md)