### PR TITLE
[utils] Add getEdges() and contractEdge() to Graph utils

### DIFF
--- a/lib/Utils/Graph/Graph.h
+++ b/lib/Utils/Graph/Graph.h
@@ -62,6 +62,15 @@ class Graph {
   bool empty() const { return vertices.empty(); }
 
   const std::set<V>& getVertices() { return vertices; }
+  std::set<std::pair<V, V>> getEdges() const {
+    std::set<std::pair<V, V>> result;
+    for (const auto& [source, targets] : outEdges) {
+      for (const auto& target : targets) {
+        result.insert({source, target});
+      }
+    }
+    return result;
+  }
 
   // Returns the edges that point out of the given vertex.
   std::vector<V> edgesOutOf(V vertex) {
@@ -83,6 +92,66 @@ class Graph {
       return result;
     }
     return {};
+  }
+
+  // Contract the edge from source to target, thus merging target into source
+  // and removing target from the graph. Returns false if the edge doesn't
+  // exist. The optional mergeFn is a functor that takes the source and target
+  // vertex and is expected to perform custom logic on the vertices that need to
+  // be updated as a result of the merge, and is called before the graph is
+  // modified. It is called exactly once for the contracted edge if provided.
+  //
+  // V = struct { string name; }
+  // mergeFn = [](V& source, const V& target) { source.name += target.name; }
+  //
+  // and we contract edge (v1, v2) where v1.name = "foo" and v2.name = "bar",
+  // then the mergeFn could update v1.name to "foobar" to preserve some
+  // information from both vertices before v2 is removed from the graph.
+  bool contractEdge(V source, V target,
+                    std::function<void(V&, const V&)> mergeFn = nullptr) {
+    if (!hasEdge(source, target)) return false;
+
+    // Merge target into source
+    if (mergeFn) mergeFn(source, target);
+
+    // Redirect all outgoing edges from target to source
+    for (V succ : edgesOutOf(target)) {
+      // Avoid creating a edge to self
+      if (succ != source) {
+        if (weights.contains({target, succ})) {
+          weights[{source, succ}] = weights.at({target, succ});
+          weights.erase({target, succ});
+        }
+        addEdge(source, succ);
+      }
+    }
+
+    // Redirect all incoming edges to target to source
+    for (V pred : edgesInto(target)) {
+      // Avoid creating a edge to self
+      if (pred != source) {
+        if (weights.contains({pred, target})) {
+          weights[{pred, source}] = weights.at({pred, target});
+          weights.erase({pred, target});
+        }
+        addEdge(pred, source);
+      }
+    }
+    // Remove the original source→target edge
+    outEdges[source].erase(target);
+    weights.erase({source, target});
+
+    // Remove stale target references from successors' inEdges
+    for (V succ : edgesOutOf(target)) inEdges[succ].erase(target);
+
+    // Remove stale target references from predecessors' outEdges
+    for (V pred : edgesInto(target)) outEdges[pred].erase(target);
+
+    vertices.erase(target);
+    outEdges.erase(target);
+    inEdges.erase(target);
+
+    return true;
   }
 
   FailureOr<std::vector<V>> getLongestSourceToSinkPath() {

--- a/lib/Utils/Graph/GraphTest.cpp
+++ b/lib/Utils/Graph/GraphTest.cpp
@@ -39,6 +39,11 @@ Graph<int> make_levels_graph() {
   return graph;
 }
 
+TEST(GraphUtilsTest, getEdges) {
+  auto graph = make_levels_graph();
+  ASSERT_EQ(graph.getEdges().size(), 10);
+}
+
 TEST(GraphUtilsTest, SourceAndSink) {
   auto graph = make_levels_graph();
   ASSERT_EQ(graph.getSources().size(), 5);
@@ -96,6 +101,163 @@ TEST(GraphUtilsTest, CriticalPath) {
   ASSERT_EQ((*resultpath)[3], 8);
   ASSERT_EQ((*resultpath)[4], 9);
   ASSERT_EQ((*resultpath)[5], 10);
+}
+
+TEST(ContractEdgeTest, SimpleContraction) {
+  // Before: 0 → 1 → 2
+  // Contract (0, 1) → merge 1 into 0
+  // After:  0 → 2   (0 now has 1's successor)
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addEdge(0, 1);
+  graph.addEdge(1, 2);
+
+  graph.contractEdge(0, 1);
+
+  EXPECT_FALSE(graph.contains(1));
+  EXPECT_TRUE(graph.contains(0));
+  EXPECT_TRUE(graph.contains(2));
+  EXPECT_TRUE(graph.hasEdge(0, 2));
+  EXPECT_FALSE(graph.hasEdge(0, 1));
+}
+
+TEST(ContractEdgeTest, PreservesOtherEdges) {
+  // Before: 0 → 1 → 3
+  //           ↘   ↗
+  //             2
+  // Contract (1, 3) → merge 3 into 1
+  // After:  0 → 1,  0 → 2 → 1
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addVertex(3);
+  graph.addEdge(0, 1);
+  graph.addEdge(0, 2);
+  graph.addEdge(1, 3);
+  graph.addEdge(2, 3);
+
+  graph.contractEdge(1, 3);
+
+  EXPECT_FALSE(graph.contains(3));
+  EXPECT_TRUE(graph.hasEdge(0, 1));
+  EXPECT_TRUE(graph.hasEdge(0, 2));
+  EXPECT_TRUE(graph.hasEdge(2, 1));
+  EXPECT_FALSE(graph.hasEdge(1, 3));
+  EXPECT_EQ(graph.getVertices().size(), 3);
+}
+
+TEST(ContractEdgeTest, NoSelfLoop) {
+  // Before: 0 → 1 → 2
+  //          ↘ → → ↗
+  // Contract (0, 1): 1's successor is 2, which 0 already points to.
+  // After:  0 → 2   (no self-loop, no duplicate edge)
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addEdge(0, 1);
+  graph.addEdge(1, 2);
+  graph.addEdge(0, 2);
+
+  graph.contractEdge(0, 1);
+
+  EXPECT_FALSE(graph.contains(1));
+  EXPECT_TRUE(graph.hasEdge(0, 2));
+  EXPECT_FALSE(graph.hasEdge(0, 0));    // no self-loop
+  EXPECT_EQ(graph.getOutDegree(0), 1);  // only one edge to 2
+}
+
+// Functor that records which pairs were merged and keeps the source vertex.
+struct MergeRecorder {
+  std::vector<std::pair<int, int>> calls;
+  void operator()(int &source, const int &target) {
+    calls.push_back({source, target});
+  }
+};
+
+TEST(ContractEdgeTest, LargerGraphWithFunctor) {
+  // Graph:
+  //
+  //  0 → 1 → 2 → 3 → 7
+  //      ↓       ↑
+  //      4 → 5 → 6
+  //
+  // Contract edge (2, 3):
+  //   - 3's successor  (3→7) redirected  → 2→7
+  //   - 3's predecessor (6→3) redirected → 6→2
+  //   - 3 removed
+  //
+  // After:
+  //  0 → 1 → → → 2 → 7
+  //      ↓       ↑
+  //      4 → 5 → 6
+
+  Graph<int> graph;
+  for (int i = 0; i <= 7; i++) graph.addVertex(i);
+  graph.addEdge(0, 1);
+  graph.addEdge(1, 2);
+  graph.addEdge(1, 4);
+  graph.addEdge(2, 3);
+  graph.addEdge(3, 7);
+  graph.addEdge(4, 5);
+  graph.addEdge(5, 6);
+  graph.addEdge(6, 3);
+
+  MergeRecorder recorder;
+  bool result = graph.contractEdge(2, 3, std::ref(recorder));
+
+  EXPECT_TRUE(result);
+
+  // Functor called exactly once with (source=2, target=3)
+  ASSERT_EQ(recorder.calls.size(), 1);
+  EXPECT_EQ(recorder.calls[0], std::make_pair(2, 3));
+
+  // 3 is gone
+  EXPECT_FALSE(graph.contains(3));
+  EXPECT_EQ(graph.getVertices().size(), 7);
+
+  // 3's outgoing edge (3→7) redirected to 2→7
+  EXPECT_TRUE(graph.hasEdge(2, 7));
+
+  // 3's incoming edge (6→3) redirected to 6→2
+  EXPECT_TRUE(graph.hasEdge(6, 2));
+
+  // Original edges preserved
+  EXPECT_TRUE(graph.hasEdge(0, 1));
+  EXPECT_TRUE(graph.hasEdge(1, 2));
+  EXPECT_TRUE(graph.hasEdge(1, 4));
+  EXPECT_TRUE(graph.hasEdge(4, 5));
+  EXPECT_TRUE(graph.hasEdge(5, 6));
+
+  // Contracted edge and all edges to 3 gone
+  EXPECT_FALSE(graph.hasEdge(2, 3));
+  EXPECT_FALSE(graph.hasEdge(6, 3));
+  EXPECT_FALSE(graph.hasEdge(3, 7));
+
+  // No self-loop on 2
+  EXPECT_FALSE(graph.hasEdge(2, 2));
+}
+
+TEST(ContractEdgeTest, ReturnsFalseIfEdgeAbsent) {
+  Graph<int> graph;
+  graph.addVertex(0);
+  graph.addVertex(1);
+  graph.addVertex(2);
+  graph.addEdge(0, 1);
+
+  MergeRecorder recorder;
+  // Edge (1, 0) doesn't exist (wrong direction)
+  EXPECT_FALSE(graph.contractEdge(1, 0, std::ref(recorder)));
+  // Edge (0, 2) doesn't exist
+  EXPECT_FALSE(graph.contractEdge(0, 2, std::ref(recorder)));
+
+  // Nothing was merged, graph unchanged
+  EXPECT_EQ(recorder.calls.size(), 0);
+  EXPECT_EQ(graph.getVertices().size(), 3);
+  EXPECT_TRUE(graph.hasEdge(0, 1));
 }
 
 TEST(LevelSortTest, SimpleGraphLevelSort) {


### PR DESCRIPTION
This patch adds two new functions to the Graph class.
1) getEdges() returns all edges as a set of pair of vertices as {source, target}.
2) contractEdge(u, v, fn) merges edge u into edge v and runs a functor fn on u and v to perform custom merge operation on u and v.