### PR TITLE
[utils] Add SCC and condense calls to Graph utils

### DIFF
--- a/lib/Utils/Graph/Graph.h
+++ b/lib/Utils/Graph/Graph.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/ADT/SetVector.h"          // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 
 namespace mlir {
@@ -152,6 +153,100 @@ class Graph {
     inEdges.erase(target);
 
     return true;
+  }
+
+  // Returns all strongly connected components using Tarjan's algorithm.
+  // Each SCC is returned as a std::set<V> (consistent with getVertices()).
+  // Reference implementation:
+  // https://cp-algorithms.com/graph/strongly-connected-components.html#implementation_1
+  //
+  // Returns a vector of set of vertices, where each set represents a strong
+  // connected component. The order of the components and the order of vertices
+  // within each component are not preserved.
+  //
+  // TODO(#2736): This implementation does not apply Nuutila's modification.
+  // Performance can be bad for larger SCCs. Consider implementing Nuutila's
+  // modification if this becomes a bottleneck.
+  // https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.strongly_connected_components.html
+  std::vector<std::set<V>> getStronglyConnectedComponents() {
+    std::vector<std::set<V>> result;
+    std::map<V, int> index, lowlink;
+    llvm::SetVector<V> stack;
+    int currentIndex = 0;
+
+    std::function<void(V)> dfs = [&](V v) {
+      index[v] = lowlink[v] = currentIndex++;
+      stack.insert(v);
+
+      for (const V& w : edgesOutOf(v)) {
+        if (!index.contains(w)) {
+          dfs(w);
+          lowlink[v] = std::min(lowlink[v], lowlink[w]);
+        } else if (stack.contains(w)) {
+          lowlink[v] = std::min(lowlink[v], index[w]);
+        }
+      }
+
+      if (lowlink[v] == index[v]) {
+        std::set<V> scc;
+        V w;
+        do {
+          w = stack.back();
+          stack.pop_back();
+          scc.insert(w);
+        } while (w != v);
+        result.push_back(std::move(scc));
+      }
+    };
+
+    for (const V& v : vertices)
+      if (!index.contains(v)) dfs(v);
+
+    return result;
+  }
+
+  // Condense each strongly connected component into a single vertex, thus
+  // making the graph acyclic. The optional mergeFn is a functor that takes the
+  // source and target vertex and is expected to perform custom logic on the
+  // vertices that need to be updated as a result of the condensation,
+  // internally it is consumed by contractEdge when contracting edges between
+  // vertices in the same SCC.
+  //
+  // V = struct { string name; }
+  // mergeFn = [](V& source, const V& target) { source.name += target.name; }
+  //
+  // and we contract edge (v1, v2) where v1.name = "foo" and v2.name = "bar",
+  // then the mergeFn could update v1.name to "foobar" to preserve some
+  // information from both vertices before v2 is removed from the graph.
+  //
+  // TODO(#2736): Evaluate if it is more efficient to construct a new graph
+  // instead of modifying the existing graph in-place by contracting edges. The
+  // current implementation is straightforward but can be inefficient for larger
+  // SCCs.
+  void condenseGraph(std::function<void(V&, const V&)> mergeFn = nullptr) {
+    auto sccs = getStronglyConnectedComponents();
+
+    for (auto& scc : sccs) {
+      if (scc.size() <= 1) continue;
+
+      // needs multiples passes as contractEdge can create new edges between
+      // vertices in the same SCC that need to be contracted.
+      std::set<V> alive(scc.begin(), scc.end());
+      while (alive.size() > 1) {
+        // needs a snapshot as we modify the alive set while iterating through
+        // it.
+        std::vector<V> aliveSnapShot(alive.begin(), alive.end());
+        for (const V& u : aliveSnapShot) {
+          if (!alive.count(u)) continue;
+          for (V v : edgesOutOf(u)) {
+            if (alive.count(v)) {
+              contractEdge(u, v, mergeFn);
+              alive.erase(v);
+            }
+          }
+        }
+      }
+    }
   }
 
   FailureOr<std::vector<V>> getLongestSourceToSinkPath() {

--- a/lib/Utils/Graph/GraphTest.cpp
+++ b/lib/Utils/Graph/GraphTest.cpp
@@ -260,6 +260,171 @@ TEST(ContractEdgeTest, ReturnsFalseIfEdgeAbsent) {
   EXPECT_TRUE(graph.hasEdge(0, 1));
 }
 
+// getStronglyConnectedComponents tests
+TEST(SCCTest, DAGEachNodeIsOwnSCC) {
+  // 0 → 1 → 2 → 3  (no cycles)
+  // Every node is its own SCC.
+  Graph<int> g;
+  for (int i = 0; i < 4; i++) g.addVertex(i);
+  g.addEdge(0, 1);
+  g.addEdge(1, 2);
+  g.addEdge(2, 3);
+
+  auto sccs = g.getStronglyConnectedComponents();
+  EXPECT_EQ(sccs.size(), 4);
+  EXPECT_THAT(sccs, UnorderedElementsAre(std::set<int>{0}, std::set<int>{1},
+                                         std::set<int>{2}, std::set<int>{3}));
+}
+
+TEST(SCCTest, SingleCycleIsOneSCC) {
+  // 0 → 1 → 2 → 0  (one big cycle)
+  Graph<int> g;
+  for (int i = 0; i < 3; i++) g.addVertex(i);
+  g.addEdge(0, 1);
+  g.addEdge(1, 2);
+  g.addEdge(2, 0);
+
+  auto sccs = g.getStronglyConnectedComponents();
+  ASSERT_EQ(sccs.size(), 1);
+  EXPECT_EQ(sccs[0], (std::set<int>{0, 1, 2}));
+}
+
+TEST(SCCTest, SingleVertex) {
+  Graph<int> g;
+  g.addVertex(42);
+
+  auto sccs = g.getStronglyConnectedComponents();
+  ASSERT_EQ(sccs.size(), 1);
+  EXPECT_EQ(sccs[0], (std::set<int>{42}));
+}
+
+TEST(SCCTest, TwoCyclesConnectedByBridge) {
+  // Example graph:
+  //
+  // 0 → 1 → 2 → 3 → 4
+  // ↑       ↓     ↖ ↓
+  // └────── 0       5
+  //
+  Graph<int> g;
+  for (int i = 0; i < 6; i++) g.addVertex(i);
+  g.addEdge(0, 1);
+  g.addEdge(1, 2);
+  g.addEdge(2, 0);
+  g.addEdge(2, 3);
+  g.addEdge(3, 4);
+  g.addEdge(4, 5);
+  g.addEdge(5, 3);
+
+  auto sccs = g.getStronglyConnectedComponents();
+  ASSERT_EQ(sccs.size(), 2);
+  EXPECT_THAT(sccs, UnorderedElementsAre(std::set<int>{0, 1, 2},
+                                         std::set<int>{3, 4, 5}));
+}
+
+TEST(SCCTest, MixedSCCSizes) {
+  // Example graph:
+  //
+  // 0 → 1 → 2 → 3 → 4
+  // ↑   │       ↑   │
+  // └───┘       └───┘
+  //
+  Graph<int> g;
+  for (int i = 0; i < 5; i++) g.addVertex(i);
+  g.addEdge(0, 1);
+  g.addEdge(1, 0);
+  g.addEdge(1, 2);
+  g.addEdge(2, 3);
+  g.addEdge(3, 4);
+  g.addEdge(4, 3);
+
+  auto sccs = g.getStronglyConnectedComponents();
+  ASSERT_EQ(sccs.size(), 3);
+  EXPECT_THAT(sccs, UnorderedElementsAre(std::set<int>{0, 1}, std::set<int>{2},
+                                         std::set<int>{3, 4}));
+}
+
+TEST(SCCTest, DisconnectedGraph) {
+  // Three isolated vertices — each its own SCC.
+  Graph<int> g;
+  g.addVertex(10);
+  g.addVertex(20);
+  g.addVertex(30);
+
+  auto sccs = g.getStronglyConnectedComponents();
+  ASSERT_EQ(sccs.size(), 3);
+  EXPECT_THAT(sccs, UnorderedElementsAre(std::set<int>{10}, std::set<int>{20},
+                                         std::set<int>{30}));
+}
+
+// condenseGraph tests
+TEST(CondenseTest, DAGCondenseIsIdentity) {
+  Graph<int> g;
+  for (int i = 0; i < 4; i++) g.addVertex(i);
+  g.addEdge(0, 1);
+  g.addEdge(1, 2);
+  g.addEdge(2, 3);
+
+  g.condenseGraph();
+
+  EXPECT_EQ(g.getVertices().size(), 4);
+  EXPECT_TRUE(g.hasEdge(0, 1));
+  EXPECT_TRUE(g.hasEdge(1, 2));
+  EXPECT_TRUE(g.hasEdge(2, 3));
+  EXPECT_FALSE(g.hasEdge(0, 2));
+}
+
+TEST(CondenseTest, CycleCollapsedToOneNode) {
+  // 3
+  // ↑
+  // 0 → 1 → 2
+  //  ↖ ___ ↙
+
+  Graph<int> g;
+  g.addVertex(0);
+  g.addVertex(1);
+  g.addVertex(2);
+  g.addVertex(10);
+  g.addEdge(0, 1);
+  g.addEdge(1, 2);
+  g.addEdge(2, 0);
+  g.addEdge(0, 10);
+
+  MergeRecorder recorder;
+
+  // Map each SCC to the sum of its members (unique within this graph).
+  g.condenseGraph(std::ref(recorder));
+
+  ASSERT_EQ(recorder.calls.size(), 2);
+  ASSERT_EQ(g.getVertices().size(), 2);
+  EXPECT_TRUE(g.hasEdge(2, 10));
+  EXPECT_FALSE(g.hasEdge(2, 2));
+  EXPECT_THAT(recorder.calls,
+              UnorderedElementsAre(std::make_pair(0, 1), std::make_pair(2, 0)));
+}
+
+TEST(CondenseTest, NoSelfLoopsAfterCondense) {
+  // After condensing, the result must be a DAG (no cycles, no self-loops).
+  Graph<int> g;
+  for (int i = 0; i < 6; i++) g.addVertex(i);
+  g.addEdge(0, 1);
+  g.addEdge(1, 2);
+  g.addEdge(2, 0);
+  g.addEdge(2, 3);
+  g.addEdge(3, 4);
+  g.addEdge(4, 5);
+  g.addEdge(5, 3);
+
+  g.condenseGraph();
+
+  // Result must be acyclic.
+  EXPECT_TRUE(succeeded(g.topologicalSort()));
+
+  ASSERT_EQ(g.getVertices().size(), 2);
+  EXPECT_FALSE(g.hasEdge(2, 2));
+  EXPECT_FALSE(g.hasEdge(5, 5));
+  EXPECT_TRUE(g.hasEdge(2, 5));
+}
+
 TEST(LevelSortTest, SimpleGraphLevelSort) {
   // Example graph:
   //       ↗ 2 ↘


### PR DESCRIPTION
This patch adds the following API calls to the Graph class:

1) getStronglyConnectedComponents: Implement function to find strongly connected components using Tarjan's algorithm. It returns a vector of sets, each set represents one SCC.

2) condenseGraph: Condenses each strongly connected component into a single vertex, thus making the graph acyclic.