### PR TITLE
Add new ModQTypeInterface API

### DIFF
--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -79,17 +79,9 @@ std::optional<ModQTypeInterface> getModQTypeInterface(Type type) {
   return std::nullopt;
 }
 
-unsigned getNumResidues(ModQTypeInterface type) {
-  Type loweringType = type.getLoweringType();
-  if (auto shapedType = dyn_cast<ShapedType>(loweringType)) {
-    return shapedType.getShape()[0];
-  }
-  return 1;
-}
-
 std::optional<ModArithType> getResidueModArithType(ModQTypeInterface type,
                                                    unsigned index) {
-  if (index >= getNumResidues(type)) {
+  if (index >= type.getNumResidues()) {
     return std::nullopt;
   }
   if (auto residueType = dyn_cast<ModArithType>(type.getResidueType(index))) {
@@ -108,7 +100,7 @@ LogicalResult verifyTypeLowering(OpType op, Type modularType,
   }
 
   int64_t rnsLength = isa<ShapedType>(modQType->getLoweringType())
-                          ? getNumResidues(*modQType)
+                          ? modQType->getNumResidues()
                           : 0;
   auto innerIntegerType = cast<IntegerType>(getElementTypeOrSelf(integerType));
   auto modularShape = getShapeOrEmpty(modularType);
@@ -138,7 +130,7 @@ LogicalResult verifySingleToMultiModSwitch(OpType op,
            << "expected single-residue modular type to have a ModArith residue";
   }
 
-  if (getNumResidues(multiTy) < 2) {
+  if (multiTy.getNumResidues() < 2) {
     return op.emitOpError() << "expected multi-residue modular type";
   }
 
@@ -156,7 +148,7 @@ LogicalResult verifySingleToMultiModSwitch(OpType op,
   }
 
   APInt product(width, 1);
-  for (unsigned i = 0; i < getNumResidues(multiTy); ++i) {
+  for (unsigned i = 0; i < multiTy.getNumResidues(); ++i) {
     auto residueType = getResidueModArithType(multiTy, i);
     if (!residueType) {
       return op.emitOpError()
@@ -184,8 +176,8 @@ LogicalResult ModSwitchOp::verify() {
     llvm_unreachable("Verifier should make sure this doesn't happen.");
   }
 
-  unsigned inputResidues = getNumResidues(*inputType);
-  unsigned outputResidues = getNumResidues(*outputType);
+  unsigned inputResidues = inputType->getNumResidues();
+  unsigned outputResidues = outputType->getNumResidues();
   if (inputResidues == 1 && outputResidues == 1) {
     return success();
   }

--- a/lib/Dialect/ModArith/IR/ModArithTypeInterfaces.h
+++ b/lib/Dialect/ModArith/IR/ModArithTypeInterfaces.h
@@ -2,7 +2,8 @@
 #define LIB_DIALECT_MODARITH_IR_MODARITHTYPEINTERFACES_H_
 
 // IWYU pragma: begin_keep
-#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
 // IWYU pragma: end_keep
 
 #define GET_TYPEDEF_CLASSES

--- a/lib/Dialect/ModArith/IR/ModArithTypeInterfaces.td
+++ b/lib/Dialect/ModArith/IR/ModArithTypeInterfaces.td
@@ -13,6 +13,17 @@ def ModQTypeInterface : TypeInterface<"ModQTypeInterface"> {
         "Returns the lowered storage type for this modular type. Plain ModArith types lower to an integer type; RNS types lower to a rank-1 tensor whose extent is the residue count and whose element type is the residue storage type.",
         "::mlir::Type", "getLoweringType", (ins)>,
     InterfaceMethod<
+        "Returns the number of residue limbs represented by this modular type. Types need not implement this function as a default is provided.",
+        "unsigned", "getNumResidues", (ins),
+        [{}],
+        [{
+          if (auto shapedType = ::mlir::dyn_cast<::mlir::ShapedType>(
+                  $_type.getLoweringType())) {
+            return shapedType.getShape()[0];
+          }
+          return 1;
+        }]>,
+    InterfaceMethod<
         "Returns the residue type at the given index.",
         "::mlir::Type", "getResidueType", (ins "unsigned":$index)>
   ];

--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
@@ -98,17 +98,9 @@ struct CommonConversionInfo {
   RankedTensorType tensorType;
 };
 
-unsigned getNumResidues(ModQTypeInterface type) {
-  Type loweringType = type.getLoweringType();
-  if (auto shapedType = dyn_cast<ShapedType>(loweringType)) {
-    return shapedType.getShape()[0];
-  }
-  return 1;
-}
-
 std::optional<ModArithType> getSingleResidueModArithType(Type type) {
   auto modType = dyn_cast<ModQTypeInterface>(type);
-  if (!modType || getNumResidues(modType) != 1) {
+  if (!modType || modType.getNumResidues() != 1) {
     return std::nullopt;
   }
   if (auto residueType = dyn_cast<ModArithType>(modType.getResidueType(0))) {


### PR DESCRIPTION
In several places, we had to write helpers to compute the number of limbs of a polynomial (1 for ModArith, k for RNS). This PR adds `getNumLimbs` to the ModQTypeInterface API, with a default implementation since it can be derived from `getLoweringType`.

[Also useful for an upcoming PR that would needs this helper in yet another file.]