### PR TITLE
Make PolyMulToNTT more robust

### DIFF
--- a/lib/Dialect/Polynomial/Transforms/NTTSolver.cpp
+++ b/lib/Dialect/Polynomial/Transforms/NTTSolver.cpp
@@ -1,5 +1,6 @@
 #include "lib/Dialect/Polynomial/Transforms/NTTSolver.h"
 
+#include "lib/Dialect/ModArith/IR/ModArithTypeInterfaces.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTypes.h"
 #include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
@@ -42,13 +43,22 @@ bool CPSATSolution::isValid() const {
 
 int getConversionCost(const Value& v) {
   Type t = v.getType();
-  if (auto p = dyn_cast<PolynomialType>(t)) {
-    return 1;
+  int multiplicity = 1;
+
+  if (auto shaped = dyn_cast<ShapedType>(t)) {
+    multiplicity = shaped.getNumElements();
+    t = shaped.getElementType();
   }
-  if (auto rt = dyn_cast<RankedTensorType>(t)) {
-    return rt.getNumElements();
-  }
-  return 0;
+
+  auto polyTy = dyn_cast<PolynomialType>(t);
+  if (!polyTy) return 0;
+
+  auto coeffTy = dyn_cast<mod_arith::ModQTypeInterface>(
+      polyTy.getRing().getCoefficientType());
+  assert(coeffTy &&
+         "polynomial coefficient type must implement ModQTypeInterface");
+
+  return coeffTy.getNumResidues() * multiplicity;
 }
 
 NTTSolver::RepVars& NTTSolver::getOrCreateVars(const Value& v) {

--- a/lib/Dialect/Polynomial/Transforms/Passes.td
+++ b/lib/Dialect/Polynomial/Transforms/Passes.td
@@ -15,6 +15,9 @@ def PolyMulToNTT : Pass <"convert-polynomial-mul-to-ntt", "func::FuncOp"> {
   let dependentDialects = ["mlir::heir::polynomial::PolynomialDialect"];
 
   let statistics = [
+    // Note that these statistics count the number of ops inserted, *not* the number
+    // of Zq NTTs/INTTs. These may be different, e.g., if an NTT op takes an RNS
+    // polynomial.
     Statistic<"numNttsInserted", "num-ntts-inserted", "Number of NTT ops inserted">,
     Statistic<"numInttsInserted", "num-intts-inserted", "Number of INTT ops inserted">
   ];

--- a/tests/Dialect/Polynomial/Transforms/poly_mul_to_ntt_optimal_placement.mlir
+++ b/tests/Dialect/Polynomial/Transforms/poly_mul_to_ntt_optimal_placement.mlir
@@ -2,11 +2,20 @@
 
 !Zq0 = !mod_arith.int<1095233372161 : i64>
 !Zq1 = !mod_arith.int<1032955396097 : i64>
+!Zq2 = !mod_arith.int<1002198353921 : i64>
 #ring_1 = #polynomial.ring<coefficientType = !rns.rns<!Zq0>, polynomialModulus = <1 + x**1024>>
 !poly_ty_1 = !polynomial.polynomial<ring=#ring_1, form=coeff>
+!ntt_poly_ty_1 = !polynomial.polynomial<ring=#ring_1, form=eval>
 
 #ring_2 = #polynomial.ring<coefficientType = !rns.rns<!Zq0, !Zq1>, polynomialModulus = <1 + x**1024>>
 !poly_ty_2 = !polynomial.polynomial<ring=#ring_2, form=coeff>
+
+#ring_3 = #polynomial.ring<coefficientType = !rns.rns<!Zq0, !Zq1, !Zq2>, polynomialModulus = <1 + x**1024>>
+!poly_ty_3 = !polynomial.polynomial<ring=#ring_3, form=coeff>
+
+#ring_4 = #polynomial.ring<coefficientType = !rns.rns<!Zq1>, polynomialModulus = <1 + x**1024>>
+!poly_ty_4 = !polynomial.polynomial<ring=#ring_4, form=coeff>
+!ntt_poly_ty_4 = !polynomial.polynomial<ring=#ring_4, form=eval>
 
 module {
   // Covers: a shared-dataflow circuit where optimal placement must avoid
@@ -41,5 +50,29 @@ module {
     // coeff-only consumer of %prod
     %out = polynomial.convert_basis %prod {targetBasis = !rns.rns<!Zq0>} : !poly_ty_2 -> !poly_ty_1
     return %out, %x_t, %shift_t : !poly_ty_1, tensor<1024x!rns.rns<!Zq0, !Zq1>>, tensor<1024x!rns.rns<!Zq0, !Zq1>>
+  }
+
+  // Covers: limb-aware conversion costs can move NTTs past extract_slice.
+  // Old unweighted costs would hoist one NTT on %x; the weighted model keeps
+  // %x in coeff form and inserts two cheaper one-limb NTTs on the slices.
+  // CHECK: func.func @weighted_extract_slice_ntt_placement([[x:%.+]]: [[poly_ty_3:![^ ]+]]) -> ([[ntt_poly_ty_1:![^ ]+]], [[ntt_poly_ty_4:![^ ]+]], tensor<1024x[[RNS3:![^ ]+]]>) {
+  // CHECK-NOT: polynomial.ntt
+  // CHECK: [[a:%.+]] = polynomial.extract_slice [[x]] {size = 1 : index, start = 0 : index} : [[poly_ty_3]] -> [[poly_ty_1:![^ ]+]]
+  // CHECK: [[a_ntt:%.+]] = polynomial.ntt [[a]] : [[poly_ty_1]]
+  // CHECK: [[b:%.+]] = polynomial.extract_slice [[x]] {size = 1 : index, start = 1 : index} : [[poly_ty_3]] -> [[poly_ty_4:![^ ]+]]
+  // CHECK: [[b_ntt:%.+]] = polynomial.ntt [[b]] : [[poly_ty_4]]
+  // CHECK: [[ma:%.+]] = polynomial.mul [[a_ntt]], [[a_ntt]] : [[ntt_poly_ty_1]]
+  // CHECK: [[mb:%.+]] = polynomial.mul [[b_ntt]], [[b_ntt]] : [[ntt_poly_ty_4]]
+  // CHECK: [[x_t:%.+]] = polynomial.to_tensor [[x]] : [[poly_ty_3]] -> tensor<1024x[[RNS3]]>
+  // CHECK: return [[ma]], [[mb]], [[x_t]] : [[ntt_poly_ty_1]], [[ntt_poly_ty_4]], tensor<1024x[[RNS3]]>
+  func.func @weighted_extract_slice_ntt_placement(%x: !poly_ty_3) -> (!poly_ty_1, !poly_ty_4, tensor<1024x!rns.rns<!Zq0, !Zq1, !Zq2>>) {
+    %a = polynomial.extract_slice %x {start = 0 : index, size = 1 : index}
+        : !poly_ty_3 -> !poly_ty_1
+    %b = polynomial.extract_slice %x {start = 1 : index, size = 1 : index}
+        : !poly_ty_3 -> !poly_ty_4
+    %ma = polynomial.mul %a, %a : !poly_ty_1
+    %mb = polynomial.mul %b, %b : !poly_ty_4
+    %x_t = polynomial.to_tensor %x : !poly_ty_3 -> tensor<1024x!rns.rns<!Zq0, !Zq1, !Zq2>>
+    return %ma, %mb, %x_t : !poly_ty_1, !poly_ty_4, tensor<1024x!rns.rns<!Zq0, !Zq1, !Zq2>>
   }
 }


### PR DESCRIPTION
The PolyMulToNTT transform considered all polynomials to have the same NTT cost, but that's not accurate. In reality, the NTT cost should depend on the number of RNS limbs in the polynomial.

I added a contrived regression test. It's not clear if or when this change would impact NTT placement in the wild, but this change certainly can't hurt.