### PR TITLE
improve error messages for failed approximations

### DIFF
--- a/lib/Transforms/LowerPolynomialEval/Patterns.cpp
+++ b/lib/Transforms/LowerPolynomialEval/Patterns.cpp
@@ -1,5 +1,6 @@
 #include "lib/Transforms/LowerPolynomialEval/Patterns.h"
 
+#include <cmath>
 #include <cstdint>
 #include <map>
 
@@ -43,6 +44,20 @@ using polynomial::TypedFloatPolynomialAttr;
 
 namespace {
 
+// Helper to check if coefficients are all finite
+template <typename CoeffRange>
+LogicalResult checkCoefficientsFinite(polynomial::EvalOp op,
+                                      CoeffRange&& coeffs) {
+  for (auto c : coeffs) {
+    if (!std::isfinite(c)) {
+      return op.emitError()
+             << "Cannot evaluate a polynomial with non-finite (NaN or "
+                "infinity) coefficient(s).";
+    }
+  }
+  return success();
+}
+
 // Helper to convert mlir::Type to kernel::DagType
 DagType floatTypeToDagType(Type type) {
   return llvm::TypeSwitch<Type, DagType>(type)
@@ -82,6 +97,11 @@ LogicalResult LowerViaHorner::matchAndRewrite(EvalOp op,
   for (auto& [key, monomial] : monomialMap) {
     double coeffValue = monomial.getCoefficient().convertToDouble();
     coefficients[key] = coeffValue;
+  }
+
+  if (failed(
+          checkCoefficientsFinite(op, llvm::make_second_range(coefficients)))) {
+    return failure();
   }
 
   // Create ArithmeticDag nodes
@@ -125,6 +145,11 @@ LogicalResult LowerViaPatersonStockmeyerMonomial::matchAndRewrite(
     coefficients[key] = coeffValue;
   }
 
+  if (failed(
+          checkCoefficientsFinite(op, llvm::make_second_range(coefficients)))) {
+    return failure();
+  }
+
   // Create ArithmeticDag nodes
   auto xNode =
       kernel::ArithmeticDagNode<kernel::SSAValue>::leaf(op.getOperand());
@@ -150,6 +175,10 @@ LogicalResult LowerViaPatersonStockmeyerChebyshev::matchAndRewrite(
       llvm::map_to_vector(chebCoeffsAttr, [](Attribute attr) {
         return llvm::cast<FloatAttr>(attr).getValue().convertToDouble();
       });
+
+  if (failed(checkCoefficientsFinite(op, chebCoeffs))) {
+    return failure();
+  }
 
   // Expect domain attributes to be set.
   auto lowerAttr = op->getAttr("domain_lower");

--- a/lib/Transforms/PolynomialApproximation/PolynomialApproximation.cpp
+++ b/lib/Transforms/PolynomialApproximation/PolynomialApproximation.cpp
@@ -47,6 +47,23 @@ using polynomial::PolynomialType;
 using polynomial::RingAttr;
 using polynomial::TypedChebyshevPolynomialAttr;
 
+// Emit an error on `op` and return failure
+// if any coefficient in `poly` is non-finite (NaN or infinity).
+LogicalResult checkApproximationFinite(Operation* op,
+                                       const ChebyshevPolynomial& poly) {
+  for (const APFloat& c : poly.getTerms()) {
+    if (!c.isFinite()) {
+      return op->emitError()
+             << "polynomial approximation produced a non-finite coefficient "
+                "(NaN or infinity); this might mean the function is not "
+                "defined on the requested domain. Set `domain_lower`/"
+                "`domain_upper` on the op to a domain where the function is "
+                "defined.";
+    }
+  }
+  return success();
+}
+
 inline APFloat absf(const APFloat& x) {
   return APFloat(std::abs(x.convertToDouble()));
 }
@@ -218,6 +235,7 @@ struct ConvertUnaryOp : public OpRewritePattern<OpTy> {
             cppFunc, degreeAttr.getInt(),
             domainLowerAttr.getValue().convertToDouble(),
             domainUpperAttr.getValue().convertToDouble());
+    if (failed(checkApproximationFinite(op, poly))) return failure();
     PolynomialType polyType =
         PolynomialType::get(ctx, RingAttr::get(Float64Type::get(ctx)));
     TypedChebyshevPolynomialAttr polyAttr =
@@ -331,6 +349,7 @@ struct ConvertBinaryConstOp : public OpRewritePattern<OpTy> {
         unaryFunc, degreeAttr.getInt(),
         domainLowerAttr.getValue().convertToDouble(),
         domainUpperAttr.getValue().convertToDouble());
+    if (failed(checkApproximationFinite(op, poly))) return failure();
     PolynomialType polyType =
         PolynomialType::get(ctx, RingAttr::get(Float64Type::get(ctx)));
     TypedChebyshevPolynomialAttr polyAttr =

--- a/tests/Regression/issue_2888.mlir
+++ b/tests/Regression/issue_2888.mlir
@@ -1,0 +1,47 @@
+// Regression test for issue #2888.
+//
+// If polynomial-approximation is asked to approximate a function outside its
+// domain of definition (e.g. sqrt on [-1, 1]), the Remez/CF routine samples
+// the function where it is undefined and all Chebyshev coefficients come out
+// as NaN. Lowering these NaN coefficients via Paterson-Stockmeyer used to
+// trip `assert(node != nullptr)` in CachingVisitor::process.
+
+// RUN: heir-opt %s --polynomial-approximation --lower-polynomial-eval --verify-diagnostics --split-input-file
+
+!poly_ty = !polynomial.polynomial<ring=<coefficientType=f64>>
+func.func @monomial_nan_direct(%x: f64) -> f64 {
+  // expected-error@+1 {{non-finite}}
+  %0 = polynomial.eval #polynomial.typed_float_polynomial<
+      0x7FF8000000000000
+      + 0x7FF8000000000000 x
+      + 0x7FF8000000000000 x**2
+  > : !poly_ty, %x : f64
+  return %0 : f64
+}
+
+// -----
+
+!poly_ty = !polynomial.polynomial<ring=<coefficientType=f64>>
+func.func @chebyshev_nan_direct(%x: f64) -> f64 {
+  // expected-error@+1 {{non-finite}}
+  %0 = polynomial.eval #polynomial.typed_chebyshev_polynomial<[
+      0x7FF8000000000000 : f64, 0x7FF8000000000000 : f64,
+      0x7FF8000000000000 : f64, 0x7FF8000000000000 : f64,
+      0x7FF8000000000000 : f64, 0x7FF8000000000000 : f64
+  ]> : !poly_ty, %x {domain_lower = -1.0 : f64, domain_upper = 1.0 : f64} : f64
+  return %0 : f64
+}
+
+// -----
+func.func @sqrt_on_negative_domain(%x: f32) -> f32 {
+  // expected-error@+1 {{non-finite}}
+  %0 = math.sqrt %x {domain_lower = -1.0 : f64, domain_upper = 1.0 : f64} : f32
+  return %0 : f32
+}
+
+// -----
+func.func @sqrt_on_positive_domain(%x: f32) -> f32 {
+  // CHECK-NOT: math.sqrt
+  %0 = math.sqrt %x {domain_lower = 0.25 : f64, domain_upper = 4.0 : f64} : f32
+  return %0 : f32
+}


### PR DESCRIPTION
Closes #2888

When an approximation fails (e.g., because the domain wasn't valid) and we get a bunch of NaN coefficients, this (a) fails early during polynomial approximation but anyway still (b) emits an error in the polynomial.eval lowering rather than crashing with an `assert(node != nullptr)`