### PR TITLE
Make LWE ops more robust

### DIFF
--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -317,7 +317,7 @@ def LWE_ExtractSliceOp : LWE_Op<"extract_slice", [Pure, DeclareOpInterfaceMethod
   let results = (outs
     LWERingElt:$output
   );
-  let assemblyFormat = "$input attr-dict `:` type($input)";
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
   let hasVerifier = 1;
 }
 
@@ -335,7 +335,7 @@ def LWE_ConvertBasisOp : LWE_Op<"convert_basis", [Pure, DeclareOpInterfaceMethod
   let results = (outs
     LWERingElt:$output
   );
-  let assemblyFormat = "$value attr-dict `:` type($value)";
+  let assemblyFormat = "$value attr-dict `:` type($value) `->` type($output)";
 }
 
 #endif  // LIB_DIALECT_LWE_IR_LWEOPS_TD_

--- a/tests/Dialect/CKKS/Transforms/decompose_keyswitch.mlir
+++ b/tests/Dialect/CKKS/Transforms/decompose_keyswitch.mlir
@@ -36,15 +36,15 @@ module attributes {
   // CHECK-SAME: [[ksk:%.+]]: tensor<1x!ct_L1>) -> (!ringelt, !ringelt) {
   func.func @test_keyswitch(%x: !ringelt_L1, %arg0: tensor<1x!ct_L2>) -> (!ringelt_L1, !ringelt_L1) {
     // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
-    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 0 : index} : !ringelt
+    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 0 : index} : !ringelt -> !ringelt
     // !ringelt1 has the same LWERingElt type as the keyswitch key
-    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L1} : !ringelt
+    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L1} : !ringelt -> !ringelt1
     // CHECK-DAG: [[ksk0:%.+]] = tensor.extract [[ksk]][[[C0]]] : tensor<1x!ct_L1>
     // CHECK-DAG: [[dp:%.+]] = lwe.mul_ring_elt [[extPart0]], [[ksk0]] : (!ringelt1, !ct_L1) -> !ct_L1
     // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : !ct_L1
     // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : !ct_L1
-    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L0} : !ringelt1
-    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L0} : !ringelt1
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L0} : !ringelt1 -> !ringelt
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L0} : !ringelt1 -> !ringelt
     // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt, !ringelt
     %constTerm, %linearTerm = ckks.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<1x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
     return %constTerm, %linearTerm: !ringelt_L1, !ringelt_L1

--- a/tests/Dialect/CKKS/Transforms/decompose_keyswitch_multipart.mlir
+++ b/tests/Dialect/CKKS/Transforms/decompose_keyswitch_multipart.mlir
@@ -43,10 +43,10 @@ module attributes {
   func.func @test_keyswitch_2part(%x: !ringelt_L1, %arg0: tensor<2x!ct_L2>) -> (!ringelt_L1, !ringelt_L1) {
     // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
     // CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
-    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 0 : index} : !ringelt
-    // CHECK-DAG: [[part1:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 1 : index} : !ringelt
-    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L2} : !ringelt1
-    // CHECK-DAG: [[extPart1:%.+]] = lwe.convert_basis [[part1]] {targetBasis = !rns_L2} : !ringelt2
+    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 0 : index} : !ringelt -> !ringelt1
+    // CHECK-DAG: [[part1:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 1 : index} : !ringelt -> !ringelt2
+    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L2} : !ringelt1 -> !ringelt3
+    // CHECK-DAG: [[extPart1:%.+]] = lwe.convert_basis [[part1]] {targetBasis = !rns_L2} : !ringelt2 -> !ringelt3
     // CHECK-DAG: [[ksk0:%.+]] = tensor.extract [[ksk]][[[C0]]] : tensor<2x!ct_L2>
     // CHECK-DAG: [[ksk1:%.+]] = tensor.extract [[ksk]][[[C1]]] : tensor<2x!ct_L2>
     // CHECK-DAG: [[dp0:%.+]] = lwe.mul_ring_elt [[extPart0]], [[ksk0]] : (!ringelt3, !ct_L2) -> !ct_L2
@@ -54,8 +54,8 @@ module attributes {
     // CHECK-DAG: [[dp:%.+]] = lwe.radd [[dp0]], [[dp1]] : (!ct_L2, !ct_L2) -> !ct_L2
     // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : !ct_L2
     // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : !ct_L2
-    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L1} : !ringelt3
-    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L1} : !ringelt3
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L1} : !ringelt3 -> !ringelt
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L1} : !ringelt3 -> !ringelt
     // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt, !ringelt
     %constTerm, %linearTerm = ckks.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<2x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
     return %constTerm, %linearTerm: !ringelt_L1, !ringelt_L1
@@ -94,12 +94,12 @@ module attributes {
     // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
     // CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
     // CHECK-DAG: [[C2:%.+]] = arith.constant 2 : index
-    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 0 : index} : !ringelt4
-    // CHECK-DAG: [[part1:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 2 : index} : !ringelt4
-    // CHECK-DAG: [[part2:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 4 : index} : !ringelt4
-    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L6} : !ringelt
-    // CHECK-DAG: [[extPart1:%.+]] = lwe.convert_basis [[part1]] {targetBasis = !rns_L6} : !ringelt5
-    // CHECK-DAG: [[extPart2:%.+]] = lwe.convert_basis [[part2]] {targetBasis = !rns_L6} : !ringelt6
+    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 0 : index} : !ringelt4 -> !ringelt
+    // CHECK-DAG: [[part1:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 2 : index} : !ringelt4 -> !ringelt5
+    // CHECK-DAG: [[part2:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 4 : index} : !ringelt4 -> !ringelt6
+    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L6} : !ringelt -> !ringelt7
+    // CHECK-DAG: [[extPart1:%.+]] = lwe.convert_basis [[part1]] {targetBasis = !rns_L6} : !ringelt5 -> !ringelt7
+    // CHECK-DAG: [[extPart2:%.+]] = lwe.convert_basis [[part2]] {targetBasis = !rns_L6} : !ringelt6 -> !ringelt7
     // CHECK-DAG: [[ksk0:%.+]] = tensor.extract [[ksk]][[[C0]]] : tensor<3x!ct_L6>
     // CHECK-DAG: [[ksk1:%.+]] = tensor.extract [[ksk]][[[C1]]] : tensor<3x!ct_L6>
     // CHECK-DAG: [[ksk2:%.+]] = tensor.extract [[ksk]][[[C2]]] : tensor<3x!ct_L6>
@@ -110,8 +110,8 @@ module attributes {
     // CHECK-DAG: [[dp:%.+]] = lwe.radd [[dpsum0]], [[dp2]] : (!ct_L6, !ct_L6) -> !ct_L6
     // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : !ct_L6
     // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : !ct_L6
-    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L4} : !ringelt7
-    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L4} : !ringelt7
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L4} : !ringelt7 -> !ringelt4
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L4} : !ringelt7 -> !ringelt4
     // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt4, !ringelt4
     %constTerm, %linearTerm = ckks.key_switch_inner %x, %arg0 : (!ringelt_L5, tensor<3x!ct_L7>) -> (!ringelt_L5, !ringelt_L5)
     return %constTerm, %linearTerm: !ringelt_L5, !ringelt_L5

--- a/tests/Dialect/LWE/IR/extract_slice_shape_inference.mlir
+++ b/tests/Dialect/LWE/IR/extract_slice_shape_inference.mlir
@@ -1,0 +1,25 @@
+// RUN: heir-opt %s
+
+// This test exists to prevent regressions of
+// https://github.com/google/heir/pull/2671#issuecomment-3975431340.
+// At one point, the issue was fixed in Polynomial (because tests were failing),
+// but no tests were covering the corresponding LWE op. This test exercises the
+// shape-inference path for `lwe.extract_slice`.
+
+#poly_mod = #polynomial.int_polynomial<1 + x**4>
+!coeff0 = !mod_arith.int<17 : i32>
+!coeff1 = !mod_arith.int<97 : i32>
+!rns2 = !rns.rns<!coeff0, !coeff1>
+!rns1 = !rns.rns<!coeff0>
+#ring = #polynomial.ring<coefficientType=!rns2, polynomialModulus=#poly_mod>
+#slice_ring = #polynomial.ring<coefficientType=!rns1, polynomialModulus=#poly_mod>
+!input_ringelt = !lwe.lwe_ring_elt<ring=#ring>
+!slice_ringelt = !lwe.lwe_ring_elt<ring=#slice_ring>
+
+module {
+  func.func @preserve_extract_slice_shape(%x: !input_ringelt) {
+    %0 = lwe.extract_slice %x {start = 0 : index, size = 1 : index}
+        : !input_ringelt -> !slice_ringelt
+    return
+  }
+}


### PR DESCRIPTION
While doing other work, I realized that the issue identified [here](https://github.com/google/heir/pull/2671#issuecomment-3975431340) was still present in the LWE dialect. Why wasn't this causing a segfault like it did in Polynomial?

After some investigation, the reason was random chance: there is a real "bug" here, and LWE segfaults were just waiting to happen. I added a test that triggered the segfault, then fixed the issue (by adding explicit return types to ops with attributes and type inference that uses the attributes). There do not appear to be any other occurrences of the "bad" combination of factors in the repo.

I opened issue an with MLIR [here](https://github.com/llvm/llvm-project/issues/193284).