### PR TITLE
Implement basis conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ tests/Examples/tfhe_rust_bool/fpga/tfhe-rs/
 # for python files
 __pycache__/
 
+# AI agent config
+.codex
+
 # lockfile is updated by automation
 MODULE.bazel.lock

--- a/lib/Dialect/CKKS/Transforms/BUILD
+++ b/lib/Dialect/CKKS/Transforms/BUILD
@@ -1,4 +1,4 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
@@ -72,19 +72,8 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = {
-        "Passes.h.inc": [
-            "-gen-pass-decls",
-            "-name=CKKS",
-        ],
-        "CKKSPasses.md": ["-gen-pass-doc"],
-    },
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+add_heir_transforms(
+    header_filename = "Passes.h.inc",
+    pass_name = "CKKS",
     td_file = "Passes.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
 )

--- a/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
@@ -12,12 +12,14 @@
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTypes.h"
+#include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/Random/IR/RandomEnums.h"
 #include "lib/Dialect/Random/IR/RandomOps.h"
 #include "lib/Dialect/Random/IR/RandomTypes.h"
 #include "lib/Utils/ConversionUtils.h"
 #include "lib/Utils/Polynomial/Polynomial.h"
 #include "llvm/include/llvm/ADT/ArrayRef.h"              // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMap.h"              // from @llvm-project
 #include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
 #include "llvm/include/llvm/Support/ErrorHandling.h"     // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
@@ -610,9 +612,26 @@ struct ConvertConvertBasis : public OpConversionPattern<ConvertBasisOp> {
       ConvertBasisOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op->getLoc(), rewriter);
-    rewriter.replaceOp(
-        op, polynomial::ConvertBasisOp::create(b, adaptor.getValue(),
-                                               adaptor.getTargetBasis()));
+    MLIRContext* context = op.getContext();
+
+    polynomial::PolynomialType inputPolyTy =
+        cast<polynomial::PolynomialType>(adaptor.getValue().getType());
+    polynomial::RingAttr ringAttr = inputPolyTy.getRing();
+    rns::RNSType targetBasisTy = dyn_cast<rns::RNSType>(op.getTargetBasis());
+    if (!targetBasisTy) return failure();
+    polynomial::RingAttr outputRingAttr = polynomial::RingAttr::get(
+        context, targetBasisTy, ringAttr.getPolynomialModulus());
+    polynomial::PolynomialType outputPolyTy =
+        polynomial::PolynomialType::get(context, outputRingAttr);
+
+    Value coeffLoop = polynomial::ApplyCoefficientwiseOp::create(
+        b, adaptor.getValue(), outputPolyTy,
+        [&](ImplicitLocOpBuilder& nestedBuilder, Value coeff,
+            Value _) -> Value {
+          return rns::ConvertBasisOp::create(nestedBuilder, coeff,
+                                             targetBasisTy);
+        });
+    rewriter.replaceOp(op, coeffLoop);
     return success();
   }
 };

--- a/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -8,6 +8,7 @@
 #include "lib/Dialect/ModArith/IR/ModArithDialect.h"
 #include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
+#include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Utils/APIntUtils.h"
 #include "lib/Utils/ConversionUtils.h"
@@ -176,6 +177,55 @@ struct ConvertExtract : public OpConversionPattern<ExtractOp> {
       ExtractOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
     rewriter.replaceOp(op, adaptor.getOperands()[0]);
+    return success();
+  }
+};
+
+struct ConvertRNSExtractResidue
+    : public OpConversionPattern<rns::ExtractResidueOp> {
+  ConvertRNSExtractResidue(mlir::MLIRContext* context)
+      : OpConversionPattern<rns::ExtractResidueOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      rns::ExtractResidueOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    auto inputType = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+    if (!inputType || inputType.getRank() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "expected scalar RNS value lowered to a rank-1 tensor");
+    }
+
+    Value index =
+        arith::ConstantIndexOp::create(b, op.getIndex().getSExtValue());
+    Value residue =
+        tensor::ExtractOp::create(b, adaptor.getInput(), ValueRange{index});
+    rewriter.replaceOp(op, residue);
+    return success();
+  }
+};
+
+struct ConvertRNSPack : public OpConversionPattern<rns::PackOp> {
+  ConvertRNSPack(mlir::MLIRContext* context)
+      : OpConversionPattern<rns::PackOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      rns::PackOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getOutput().getType());
+    auto rankedTensorType = dyn_cast<RankedTensorType>(resultType);
+    if (!rankedTensorType || rankedTensorType.getRank() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "expected scalar RNS value lowered to a rank-1 tensor");
+    }
+
+    Value result = tensor::FromElementsOp::create(
+        rewriter, op.getLoc(), rankedTensorType, adaptor.getOperands());
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -513,16 +563,18 @@ void ModArithToArith::runOnOperation() {
 
   ConversionTarget target(*context);
   target.addIllegalDialect<ModArithDialect>();
+  target.addIllegalOp<rns::ExtractResidueOp, rns::PackOp>();
   target.addLegalDialect<arith::ArithDialect>();
 
   RewritePatternSet patterns(context);
   rewrites::populateWithGenerated(patterns);
-  patterns.add<
-      ConvertEncapsulate, ConvertExtract, ConvertReduce, ConvertAdd, ConvertSub,
-      ConvertMul, ConvertMac, ConvertModSwitch, ConvertBarrettReduce,
-      ConvertConstant, ConvertAny<>, ConvertAny<affine::AffineForOp>,
-      ConvertAny<affine::AffineYieldOp>, ConvertAny<linalg::GenericOp> >(
-      typeConverter, context);
+  patterns
+      .add<ConvertEncapsulate, ConvertExtract, ConvertReduce, ConvertAdd,
+           ConvertSub, ConvertMul, ConvertMac, ConvertModSwitch,
+           ConvertBarrettReduce, ConvertConstant, ConvertRNSExtractResidue,
+           ConvertRNSPack, ConvertAny<>, ConvertAny<affine::AffineForOp>,
+           ConvertAny<affine::AffineYieldOp>, ConvertAny<linalg::GenericOp> >(
+          typeConverter, context);
 
   addStructuralConversionPatterns(typeConverter, patterns, target);
   addTensorOfTensorConversionPatterns(typeConverter, patterns, target);

--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -24,14 +24,14 @@ cc_library(
         "ModArithTypes.h",
     ],
     deps = [
-        ":ModArithTypeInterfaces",
+        ":TypeInterfaces",
         ":attributes_inc_gen",
         ":canonicalization_inc_gen",
         ":dialect_inc_gen",
         ":ops_inc_gen",
         ":type_interfaces_inc_gen",
         ":types_inc_gen",
-        "@heir//lib/Dialect/RNS/IR:RNSTypeInterfaces",
+        "@heir//lib/Dialect/RNS/IR:TypeInterfaces",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
@@ -41,7 +41,7 @@ cc_library(
 )
 
 cc_library(
-    name = "ModArithTypeInterfaces",
+    name = "TypeInterfaces",
     hdrs = [
         "ModArithTypeInterfaces.h",
     ],

--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/BUILD
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/BUILD
@@ -15,7 +15,7 @@ cc_library(
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
-        "@heir//lib/Dialect/ModArith/IR:ModArithTypeInterfaces",
+        "@heir//lib/Dialect/ModArith/IR:TypeInterfaces",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Utils",

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 #include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
@@ -68,6 +69,30 @@ LogicalResult coefficientTypeMatchesScalarType(Type polynomialLikeType,
     return failure();
   }
   return success();
+}
+
+void ApplyCoefficientwiseOp::build(
+    OpBuilder& builder, OperationState& state, Value input,
+    PolynomialType outputPolyTy, ApplyCoefficientwiseBuilderFn transformCoeff) {
+  state.addOperands(input);
+  Region* body = state.addRegion();
+  state.addTypes(outputPolyTy);
+
+  PolynomialType inputPolyTy = dyn_cast<PolynomialType>(input.getType());
+  if (!inputPolyTy) {
+    return;
+  }
+
+  ImplicitLocOpBuilder b(state.location, builder);
+  OpBuilder::InsertionGuard guard(b);
+  Block* block = b.createBlock(body);
+  block->addArgument(inputPolyTy.getRing().getCoefficientType(), b.getLoc());
+  block->addArgument(b.getIndexType(), b.getLoc());
+  b.setInsertionPointToStart(block);
+
+  Value coeff = block->getArgument(0);
+  Value degree = block->getArgument(1);
+  YieldOp::create(b, transformCoeff(b, coeff, degree));
 }
 
 void FromTensorOp::build(OpBuilder& builder, OperationState& result,
@@ -499,37 +524,6 @@ LogicalResult INTTOp::inferReturnTypes(
   return inferNTTReturnType(ctx, operands.front().getType(), results);
 }
 
-LogicalResult ConvertBasisOp::inferReturnTypes(
-    MLIRContext* ctx, std::optional<Location> /*loc*/, ValueRange operands,
-    DictionaryAttr attrs, mlir::PropertyRef properties,
-    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
-  ConvertBasisOpAdaptor op(operands, attrs, properties, regions);
-  if (operands.empty()) return failure();
-  Type inputType = op.getValue().getType();
-  PolynomialType inputPolyType = dyn_cast<PolynomialType>(inputType);
-  RankedTensorType inputTensorType;
-  if (!inputPolyType) {
-    inputTensorType = dyn_cast<RankedTensorType>(inputType);
-    if (!inputTensorType) return failure();
-    inputPolyType = dyn_cast<PolynomialType>(inputTensorType.getElementType());
-    if (!inputPolyType) return failure();
-  }
-  polynomial::RingAttr ringAttr = inputPolyType.getRing();
-  rns::RNSType elementType = dyn_cast<rns::RNSType>(op.getTargetBasis());
-  if (!elementType) return failure();
-
-  polynomial::RingAttr outputRingAttr = polynomial::RingAttr::get(
-      ctx, elementType, ringAttr.getPolynomialModulus());
-  PolynomialType resultType = PolynomialType::get(ctx, outputRingAttr);
-  if (dyn_cast<PolynomialType>(inputType)) {
-    results.push_back(resultType);
-  } else {
-    results.push_back(RankedTensorType::get(
-        inputTensorType.getShape(), resultType, inputTensorType.getEncoding()));
-  }
-  return success();
-}
-
 LogicalResult ExtractSliceOp::inferReturnTypes(
     MLIRContext* context, std::optional<Location> /*loc*/, ValueRange operands,
     DictionaryAttr attrs, mlir::PropertyRef properties,
@@ -599,6 +593,11 @@ LogicalResult ApplyCoefficientwiseOp::verify() {
                          << block.getArgument(1).getType();
   }
 
+  if (!block.mightHaveTerminator()) {
+    // Do not emit an error here. This situation occurs when the op creation
+    // failed; that emits its own (meaningful) error.
+    return failure();
+  }
   auto yieldOp = cast<YieldOp>(block.getTerminator());
   auto outputPolyTy = getOutput().getType();
   auto outputCoeffTy = outputPolyTy.getRing().getCoefficientType();

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.h
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.h
@@ -4,12 +4,28 @@
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTraits.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTypes.h"
-#include "mlir/include/mlir/IR/BuiltinOps.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Dialect.h"       // from @llvm-project
+#include "llvm/include/llvm/ADT/STLFunctionalExtras.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
 
 #define GET_OP_CLASSES
 #include "lib/Dialect/Polynomial/IR/PolynomialOps.h.inc"
+
+namespace mlir {
+namespace heir {
+namespace polynomial {
+
+FailureOr<Value> buildApplyCoefficientwise(
+    ImplicitLocOpBuilder& b, Value input, PolynomialType outputPolyTy,
+    llvm::function_ref<FailureOr<Value>(ImplicitLocOpBuilder&, Value, Value)>
+        transformCoeff);
+
+}  // namespace polynomial
+}  // namespace heir
+}  // namespace mlir
 
 #endif  // LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALOPS_H_

--- a/lib/Dialect/Polynomial/IR/PolynomialOps.td
+++ b/lib/Dialect/Polynomial/IR/PolynomialOps.td
@@ -416,24 +416,6 @@ def Polynomial_ExtractSliceOp : Polynomial_Op<"extract_slice", [Pure, SameOperan
   let hasVerifier = 1;
 }
 
-def Polynomial_ConvertBasisOp : Polynomial_Op<"convert_basis", [Pure, ElementwiseMappable, FixedFormCoeff, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
-  let summary = "Change a polynomial's RNS basis";
-  let description = [{
-    Given a polynomial with RNS coefficients, output a polynomial where the coefficients
-    have the target output basis. The output value of each coefficient is equivalent to
-    lifting the coefficient to its centered representative over the integers, and reducing
-    by the output modulus.
-  }];
-  let arguments = (ins
-      PolynomialLike:$value,
-      TypeAttr:$targetBasis
-  );
-  let results = (outs
-    PolynomialLike:$output
-  );
-  let assemblyFormat = "$value attr-dict `:` type($value) `->` type($output)";
-}
-
 def Polynomial_YieldOp : Polynomial_Op<"yield", [Terminator, HasParent<"ApplyCoefficientwiseOp">]> {
   let summary = "Yield a value from a polynomial.apply_coefficientwise region.";
   let arguments = (ins AnyType:$operand);
@@ -471,8 +453,24 @@ def Polynomial_ApplyCoefficientwiseOp : Polynomial_Op<"apply_coefficientwise", [
   let arguments = (ins Polynomial_PolynomialType:$input);
   let results = (outs Polynomial_PolynomialType:$output);
   let regions = (region SizedRegion<1>:$body);
+  let builders = [
+    OpBuilder<(ins
+      CArg<"Value">:$input,
+      CArg<"PolynomialType">:$outputPolyTy,
+      CArg<"function_ref<Value(ImplicitLocOpBuilder&, Value, Value)>">:$transformCoeff
+    )>
+  ];
   let assemblyFormat = "`(` $input `:` type($input) `)` attr-dict-with-keyword $body `->` type($output)";
   let hasVerifier = 1;
+  let extraClassDeclaration = [{
+    /// Callback used by the custom builder to populate the body of
+    /// `polynomial.apply_coefficientwise`.
+    ///
+    /// The callback receives a builder positioned at the start of the body block,
+    /// the current coefficient, and the coefficient degree. It returns the value
+    /// to yield as the transformed output coefficient.
+    using ApplyCoefficientwiseBuilderFn = function_ref<Value(ImplicitLocOpBuilder&, Value, Value)>;
+  }];
 }
 
 #endif  // LIB_DIALECT_POLYNOMIAL_IR_POLYNOMIALOPS_TD_

--- a/lib/Dialect/Polynomial/Transforms/BUILD
+++ b/lib/Dialect/Polynomial/Transforms/BUILD
@@ -1,6 +1,4 @@
-# Polynomial pass tablegen and headers.
-
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
@@ -58,7 +56,7 @@ cc_library(
         ":pass_inc_gen",
         "@com_google_ortools//ortools/sat:cp_model",
         "@com_google_ortools//ortools/sat:cp_model_solver",
-        "@heir//lib/Dialect/ModArith/IR:ModArithTypeInterfaces",
+        "@heir//lib/Dialect/ModArith/IR:TypeInterfaces",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
@@ -70,19 +68,8 @@ cc_library(
     ],
 )
 
-gentbl_cc_library(
-    name = "pass_inc_gen",
-    tbl_outs = {
-        "Passes.h.inc": [
-            "-gen-pass-decls",
-            "-name=Polynomial",
-        ],
-        "PolynomialPasses.md": ["-gen-pass-doc"],
-    },
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
+add_heir_transforms(
+    header_filename = "Passes.h.inc",
+    pass_name = "Polynomial",
     td_file = "Passes.td",
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
 )

--- a/lib/Dialect/Polynomial/Transforms/PolyMulToNTT.cpp
+++ b/lib/Dialect/Polynomial/Transforms/PolyMulToNTT.cpp
@@ -59,9 +59,8 @@ enum class OpFormClass {
 OpFormClass opFormClass(Operation* op) {
   if (isa<func::ReturnOp>(op)) {
     return OpFormClass::RETURN;
-  } else if (isa<ToTensorOp, LeadingTermOp, EvalOp, ConvertBasisOp,
-                 MonicMonomialMulOp, FromTensorOp, ApplyCoefficientwiseOp>(
-                 op)) {
+  } else if (isa<ToTensorOp, LeadingTermOp, EvalOp, MonicMonomialMulOp,
+                 FromTensorOp, ApplyCoefficientwiseOp>(op)) {
     return OpFormClass::COEFF;
   } else if (isa<MulOp>(op)) {
     return OpFormClass::EVAL;

--- a/lib/Dialect/Polynomial/Transforms/PolyMulToNTT.h
+++ b/lib/Dialect/Polynomial/Transforms/PolyMulToNTT.h
@@ -1,8 +1,6 @@
 #ifndef LIB_DIALECT_POLYNOMIAL_TRANSFORMS_POLYMULTONTT_H_
 #define LIB_DIALECT_POLYNOMIAL_TRANSFORMS_POLYMULTONTT_H_
 
-#include <memory>
-
 #include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
 
 namespace mlir {
@@ -11,8 +9,6 @@ namespace polynomial {
 
 #define GEN_PASS_DECL_POLYMULTONTT
 #include "lib/Dialect/Polynomial/Transforms/Passes.h.inc"
-
-std::unique_ptr<Pass> createPolyMulToNTTPass();
 
 }  // namespace polynomial
 }  // namespace heir

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -30,7 +30,9 @@ cc_library(
         ":ops_inc_gen",
         ":type_interfaces_inc_gen",
         ":types_inc_gen",
-        "@heir//lib/Dialect/ModArith/IR:ModArithTypeInterfaces",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:TypeInterfaces",
+        "@heir//lib/Utils:APIntUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
@@ -39,7 +41,7 @@ cc_library(
 )
 
 cc_library(
-    name = "RNSTypeInterfaces",
+    name = "TypeInterfaces",
     hdrs = [
         "RNSDialect.h",
         "RNSTypeInterfaces.h",

--- a/lib/Dialect/RNS/IR/RNSOps.cpp
+++ b/lib/Dialect/RNS/IR/RNSOps.cpp
@@ -3,20 +3,152 @@
 #include <cstdint>
 #include <optional>
 
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
+#include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
+#include "lib/Utils/APIntUtils.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"              // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallString.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypeInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Location.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/OperationSupport.h"       // from @llvm-project
 #include "mlir/include/mlir/IR/Region.h"                 // from @llvm-project
 #include "mlir/include/mlir/IR/TypeUtilities.h"          // from @llvm-project
 #include "mlir/include/mlir/IR/ValueRange.h"             // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace rns {
+
+FailureOr<SmallVector<Value>> computeMixedRadixCoeffs(
+    ImplicitLocOpBuilder& b, Value input,
+    const ArrayRef<mod_arith::ModArithAttr>& qInvProds) {
+  auto rnsTy = dyn_cast<RNSType>(input.getType());
+  if (!rnsTy) {
+    emitError(b.getLoc()) << "expected an RNS value, got " << input.getType();
+    return failure();
+  }
+  int64_t numLimbs = rnsTy.getBasisTypes().size();
+  // qInvProds is the partial products of all moduli: q0, q0*q1, q0*q1*q2, ...,
+  // excluding the product of all the moduli, hence numLimbs-1.
+  if (qInvProds.size() != numLimbs - 1) {
+    emitError(b.getLoc()) << "expected " << numLimbs - 1
+                          << " qInvProds for an RNS basis with " << numLimbs
+                          << " limbs, got " << qInvProds.size();
+    return failure();
+  }
+
+  SmallVector<Value> mrcs;
+
+  // The first mixed-radix coefficient just the lift of the first limb to the
+  // integers
+  auto c0Reduced = ExtractResidueOp::create(b, input, b.getIndexAttr(0));
+  Type intType =
+      cast<mod_arith::ModArithType>(c0Reduced.getType()).getLoweringType();
+  Value c0Lifted = mod_arith::ExtractOp::create(b, intType, c0Reduced);
+  mrcs.push_back(c0Lifted);
+
+  // Subsequent coefficients depend on prior coefficients
+  // c_i = \parens*{x_i - \sum_{j=0}^{i-1} \bracks*{c_j}_{q_j}\cdot
+  // Q_{j-1}}\cdot Q_{i-1}^{-1} \in\Z_{q_i} Here the Q_i's represent partial
+  // products of the limb moduli. Rather than use these values directly, we
+  // evaluate the sum using Horner's method.
+  for (int i = 1; i < numLimbs; i++) {
+    Value xi = ExtractResidueOp::create(b, input, b.getIndexAttr(i));
+    auto limbTy = dyn_cast<mod_arith::ModArithType>(xi.getType());
+    if (!limbTy) {
+      emitError(b.getLoc())
+          << "expected limb type to be mod_arith attribute, got "
+          << xi.getType();
+      return failure();
+    }
+    // Using Horner's method, we compute (c_{i-1}*q_{i-2} + c_{i-2})*q_{i-3} +
+    // c_{i-3} ... We start by reducing c_{i-1} (the previous mixed-radix coeff)
+    // mod, and accumulate into temp.
+    Value temp = mod_arith::EncapsulateOp::create(b, limbTy, mrcs[i - 1]);
+    temp = mod_arith::ReduceOp::create(b, limbTy, temp);
+    for (int j = i - 2; j >= 0; j--) {
+      // reduce c_j mod q_i
+      Value reducedCj = mod_arith::EncapsulateOp::create(b, limbTy, mrcs[j]);
+      reducedCj = mod_arith::ReduceOp::create(b, limbTy, reducedCj);
+      Value qjConst =
+          mod_arith::ConstantOp::create(b, limbTy, limbTy.getModulus());
+      temp = mod_arith::MacOp::create(b, temp, qjConst, reducedCj);
+    }
+    Value ci = mod_arith::SubOp::create(b, xi, temp);
+    mod_arith::ModArithAttr maAttr = qInvProds[i - 1];
+    if (maAttr.getType() != limbTy) {
+      emitError(b.getLoc())
+          << "expected qInv attribute type to match limb type " << limbTy
+          << ", got " << maAttr.getType();
+      return failure();
+    }
+    Value qInvConst =
+        mod_arith::ConstantOp::create(b, limbTy, maAttr.getValue());
+    ci = mod_arith::MulOp::create(b, ci, qInvConst);
+    Value liftedCi = mod_arith::ExtractOp::create(b, intType, ci);
+    mrcs.push_back(liftedCi);
+  }
+  return mrcs;
+}
+
+FailureOr<SmallVector<mod_arith::ModArithAttr>> buildQInvProds(
+    mlir::MLIRContext* ctx, rns::RNSType basisTy) {
+  SmallVector<mod_arith::ModArithAttr> qInvProdAttrs;
+  ArrayRef<Type> basisTypes = basisTy.getBasisTypes();
+  if (basisTypes.empty()) {
+    return qInvProdAttrs;
+  }
+  qInvProdAttrs.reserve(basisTypes.size() - 1);
+
+  SmallVector<mod_arith::ModArithType> maBases;
+  for (size_t i = 0; i < basisTypes.size(); ++i) {
+    auto qiTy = dyn_cast<mod_arith::ModArithType>(basisTypes[i]);
+    if (!qiTy) {
+      return failure();
+    }
+    maBases.push_back(qiTy);
+  }
+
+  // If there are k basis elements, we compute
+  // (prod_{j=0..i} q_i)^{-1} mod q_{i+1} for i from 0 to k-2
+  APInt partialProduct(/*numBits=*/1, /*val=*/1);
+  for (size_t i = 0; i < basisTypes.size() - 1; ++i) {
+    mod_arith::ModArithType qiTy = maBases[i];
+    APInt qi = qiTy.getModulus().getValue();
+    unsigned productWidth = partialProduct.getBitWidth() + qi.getBitWidth();
+    partialProduct = partialProduct.zext(productWidth) * qi.zext(productWidth);
+
+    auto modTy = maBases[i + 1];
+    APInt modValue = modTy.getModulus().getValue();
+
+    // Reduce the partial product mod modValue before computing the inverse
+    // to reduce bitwidth
+    APInt reducedPartial =
+        partialProduct.urem(modValue.zext(partialProduct.getBitWidth()))
+            .trunc(modValue.getBitWidth());
+    APInt qInv = multiplicativeInverse(reducedPartial, modValue);
+    if (qInv.isZero()) {
+      return failure();
+    }
+
+    IntegerAttr qInvValue = IntegerAttr::get(
+        modTy.getModulus().getType(),
+        qInv.zextOrTrunc(modTy.getModulus().getValue().getBitWidth()));
+    qInvProdAttrs.push_back(
+        mod_arith::ModArithAttr::get(ctx, modTy, qInvValue));
+  }
+
+  return qInvProdAttrs;
+}
 
 LogicalResult ExtractSliceOp::inferReturnTypes(
     MLIRContext* context, std::optional<Location> loc, ValueRange operands,
@@ -45,6 +177,103 @@ LogicalResult ExtractSliceOp::verify() {
   int64_t size = getSize().getZExtValue();
 
   return verifyExtractSliceOp(this, rnsType, start, size);
+}
+
+// verification for ExtractResidue used in both verify and inferReturnType
+static LogicalResult verifyExtractResidueInput(std::optional<Location> loc,
+                                               Type coeffType, APInt index) {
+  RNSType rnsCoeffType = dyn_cast<RNSType>(getElementTypeOrSelf(coeffType));
+  if (!rnsCoeffType) return failure();
+  int64_t sliceIndex = index.getSExtValue();
+
+  int64_t numLimbs = rnsCoeffType.getBasisTypes().size();
+  if (sliceIndex < 0 || sliceIndex >= numLimbs) {
+    return emitOptionalError(loc, "'rns.extract_residue' index ", sliceIndex,
+                             " is out of bounds for an RNS type with ",
+                             numLimbs, " limbs");
+  }
+
+  auto limbCoeffType = dyn_cast<mod_arith::ModArithType>(
+      rnsCoeffType.getBasisTypes()[sliceIndex]);
+  if (!limbCoeffType) {
+    return emitOptionalError(loc,
+                             "'rns.extract_residue' requires the selected "
+                             "RNS limb to have ModArith type, but found ",
+                             rnsCoeffType.getBasisTypes()[sliceIndex]);
+  }
+
+  return success();
+}
+
+LogicalResult ExtractResidueOp::verify() {
+  return verifyExtractResidueInput(getLoc(), getInput().getType(), getIndex());
+}
+
+LogicalResult ExtractResidueOp::inferReturnTypes(
+    MLIRContext* context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::PropertyRef properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
+  ExtractResidueOpAdaptor op(operands, attrs, properties, regions);
+  Type ty = op.getInput().getType();
+  APInt index = op.getIndex();
+  if (failed(verifyExtractResidueInput(loc, ty, index))) {
+    return failure();
+  }
+  int64_t sliceIndex = index.getSExtValue();
+  RNSType rnsCoeffType = cast<RNSType>(getElementTypeOrSelf(ty));
+  auto truncatedType =
+      cast<mod_arith::ModArithType>(rnsCoeffType.getBasisTypes()[sliceIndex]);
+
+  Type resultType = truncatedType;
+  if (auto shapedType = dyn_cast<ShapedType>(ty)) {
+    resultType = shapedType.clone(truncatedType);
+  }
+  results.push_back(resultType);
+  return success();
+}
+
+LogicalResult PackOp::inferReturnTypes(
+    MLIRContext* context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::PropertyRef properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
+  PackOpAdaptor op(operands, attrs, properties, regions);
+  ValueRange input = op.getInput();
+  // There must be at least one item in the list to form an RNS component
+  if (input.empty()) {
+    return emitOptionalError(loc, "'rns.pack' requires at least one input");
+  }
+
+  SmallVector<Type> basisTypes;
+  basisTypes.reserve(input.size());
+  for (Value operand : input) {
+    auto maTy = dyn_cast<mod_arith::ModArithType>(operand.getType());
+    if (!maTy) {
+      return emitOptionalError(loc, "'rns.pack' got input with type ",
+                               operand.getType());
+    }
+    basisTypes.push_back(maTy);
+  }
+  results.push_back(rns::RNSType::get(context, basisTypes));
+  return success();
+}
+
+LogicalResult ConvertBasisOp::inferReturnTypes(
+    MLIRContext* context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::PropertyRef properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
+  ConvertBasisOpAdaptor op(operands, attrs, properties, regions);
+  auto inputType = dyn_cast<RNSType>(op.getValue().getType());
+  if (!inputType) {
+    return emitOptionalError(loc, "expected RNS input, got ",
+                             op.getValue().getType());
+  }
+  auto targetBasisTy = dyn_cast<RNSType>(op.getTargetBasis());
+  if (!targetBasisTy) {
+    return emitOptionalError(loc, "expected RNS targetBasis, got ",
+                             op.getTargetBasis());
+  }
+  results.push_back(targetBasisTy);
+  return success();
 }
 
 }  // namespace rns

--- a/lib/Dialect/RNS/IR/RNSOps.h
+++ b/lib/Dialect/RNS/IR/RNSOps.h
@@ -3,7 +3,10 @@
 
 #include <cstdint>
 
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
+#include "llvm/include/llvm/ADT/APInt.h"       // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMap.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"    // from @llvm-project
 
@@ -52,6 +55,35 @@ RNSType inferExtractSliceReturnTypes(MLIRContext* ctx, Op* op,
   return RNSType::get(
       ctx, elementType.getBasisTypes().drop_front(start).take_front(size));
 }
+
+// Given an RNS value x with limbs x_i = x mod q_i for pairwise-coprime moduli
+// q_0, ..., q_{k-1}, compute its mixed-radix digits c_0, ..., c_{k-1} such
+// that
+//
+//   x = c_0 + c_1 * q_0 + c_2 * (q_0 * q_1) + ... + c_{k-1} * (q_0 * ... *
+//   q_{k-2}).
+//
+// Equivalently, if Q_i = \prod_{j=0}^i q_j, then each coefficient satisfies
+//
+//   c_i = (x_i - \sum_{j=0}^{i-1} c_j * Q_{j-1}) * Q_{i-1}^{-1} mod q_i,
+//
+// where qInvProds[i - 1] stores Q_{i-1}^{-1} in Z / (q_i Z). The returned SSA
+// values are the c_i lifted from their limb-wise mod_arith types into the
+// corresponding integer lowering types.
+FailureOr<SmallVector<Value>> computeMixedRadixCoeffs(
+    ImplicitLocOpBuilder& b, Value input,
+    const ArrayRef<mod_arith::ModArithAttr>& qInvProds);
+
+// For an input basis q_0, ..., q_{k-1}, build the precomputed inverses used by
+// computeMixedRadixCoeffs and convertBasis. The returned array has length k - 1
+// and stores
+//
+//   qInvProds[i] = (q_0 * ... * q_i)^{-1} mod q_{i+1}.
+//
+// Each entry is encoded as a mod_arith attribute in the corresponding
+// q_{i+1}-limb type.
+FailureOr<SmallVector<mod_arith::ModArithAttr>> buildQInvProds(
+    mlir::MLIRContext* ctx, RNSType basisTy);
 
 }  // namespace rns
 }  // namespace heir

--- a/lib/Dialect/RNS/IR/RNSOps.td
+++ b/lib/Dialect/RNS/IR/RNSOps.td
@@ -29,5 +29,68 @@ def RNS_ExtractSliceOp : RNS_Op<"extract_slice", [Pure, ElementwiseMappable, Dec
   let hasVerifier = 1;
 }
 
+def RNS_ExtractResidueOp : RNS_Op<"extract_residue", [Pure, ElementwiseMappable, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
+  let summary = "Extract one RNS residue as the type of the limb";
+  let description = [{
+    Given an RNS-typed value, extract the basis limb at `index` and return it
+    as the corresponding type.
+
+    For shaped inputs, this operation is applied elementwise, preserving the
+    input container shape while replacing each RNS element with the selected
+    limb.
+  }];
+  let arguments = (ins RNSLike:$input, IndexAttr:$index);
+  let results = (outs RNSBasisTypeInterfaceLike:$output);
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
+  let hasVerifier = 1;
+}
+
+def RNS_PackOp : RNS_Op<"pack", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
+  let summary = "Pack multiple residues into one RNS value";
+  let description = [{
+    `rns.pack` converts a list of `mod_arith` values into a single value with
+    RNS type.
+
+    The output RNS basis is formed by the input operand types in operand order,
+    so operand `i` becomes limb `i` of the packed result.
+
+    Examples:
+    ```
+    !zp17 = !mod_arith.int<17 : i32>
+    !zp257 = !mod_arith.int<257 : i32>
+    !rns = !rns.rns<!zp17, !zp257>
+
+    %packed = rns.pack %x, %y : !zp17, !zp257
+    return %packed : !rns
+    ```
+  }];
+  let arguments = (ins Variadic<RNSBasisTypeInterface>:$input);
+  let results = (outs RNS:$output);
+  let assemblyFormat = "operands attr-dict `:` type($input)";
+}
+
+def RNS_ConvertBasisOp : RNS_Op<"convert_basis", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
+  let summary = "Change an RNS value's basis";
+  let description = [{
+    Given x \in Z_Q represented as {x_i mod q_i} where Q=\prod q_i,
+    convertBasis returns the target-basis representation obtained by:
+    1. Compute x's centered integer representative in [-Q/2, Q/2]
+    2. Reduce the integer representation mod p_i for each p_i in the target basis.
+
+    This performs the conversion directly from the RNS representation of x,
+    without first reconstructing x over the integers. Note that both bases must
+    be composed entirely of odd moduli; this algorithm does not work for bases
+    with even moduli.
+  }];
+  let arguments = (ins
+      RNS:$value,
+      TypeAttr:$targetBasis
+  );
+  let results = (outs
+    RNS:$output
+  );
+  let assemblyFormat = "$value attr-dict `:` type($value) `->` type($output)";
+}
+
 
 #endif  // LIB_DIALECT_RNS_IR_RNSOPS_TD_

--- a/lib/Dialect/RNS/IR/RNSTypeInterfaces.td
+++ b/lib/Dialect/RNS/IR/RNSTypeInterfaces.td
@@ -32,4 +32,6 @@ def RNSBasisTypeInterface : TypeInterface<"RNSBasisTypeInterface"> {
   ];
 }
 
+def RNSBasisTypeInterfaceLike: TypeOrValueSemanticsContainer<RNSBasisTypeInterface, "rns-basis-type-interface-like">;
+
 #endif  // LIB_DIALECT_RNS_IR_RNSTYPEINTERFACES_TD_

--- a/lib/Dialect/RNS/Transforms/BUILD
+++ b/lib/Dialect/RNS/Transforms/BUILD
@@ -7,33 +7,33 @@ package(
 )
 
 cc_library(
-    name = "LWEToPolynomial",
-    srcs = ["LWEToPolynomial.cpp"],
-    hdrs = [
-        "LWEToPolynomial.h",
+    name = "Transforms",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":LowerConvertBasis",
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
     ],
+)
+
+cc_library(
+    name = "LowerConvertBasis",
+    srcs = ["LowerConvertBasis.cpp"],
+    hdrs = ["LowerConvertBasis.h"],
     deps = [
         ":pass_inc_gen",
-        "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
-        "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
-        "@heir//lib/Dialect/Random/IR:Dialect",
-        "@heir//lib/Utils:ConversionUtils",
-        "@heir//lib/Utils/Polynomial",
         "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
     ],
-    alwayslink = 1,
 )
 
 add_heir_transforms(
-    header_filename = "LWEToPolynomial.h.inc",
-    pass_name = "LWEToPolynomial",
-    td_file = "LWEToPolynomial.td",
+    header_filename = "Passes.h.inc",
+    pass_name = "RNS",
+    td_file = "Passes.td",
 )

--- a/lib/Dialect/RNS/Transforms/LowerConvertBasis.cpp
+++ b/lib/Dialect/RNS/Transforms/LowerConvertBasis.cpp
@@ -1,0 +1,182 @@
+#include "lib/Dialect/RNS/Transforms/LowerConvertBasis.h"
+
+#include <cstddef>
+#include <utility>
+
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
+#include "lib/Dialect/ModArith/IR/ModArithOps.h"
+#include "lib/Dialect/ModArith/IR/ModArithTypes.h"
+#include "lib/Dialect/RNS/IR/RNSOps.h"
+#include "lib/Dialect/RNS/IR/RNSTypes.h"
+#include "llvm/include/llvm/ADT/APInt.h"                // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMap.h"             // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"            // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallString.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"    // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rns {
+
+#define GEN_PASS_DEF_LOWERCONVERTBASIS
+#include "lib/Dialect/RNS/Transforms/Passes.h.inc"
+
+// Implementation based on
+// https://userpages.cs.umbc.edu/lomonaco/s08/441/handouts/GarnerAlg.pdf
+//
+// NOTE: When lifting using standard representatives, Garner's algorithm (not
+// mod p) outputs the standard representative of the CRT reconstruction without
+// any explicit mods by the product of the input basis. When lifting using
+// canonical representatives, it outputs the canonical representative of the CRT
+// reconstruction *WHEN THE INPUT BASIS IS ODD*. The key here is that when the
+// cs are (perfectly) centered, the reconstruction will be as well. If some
+// modulus is even, however, the canonical representative for that component is
+// *not* perfectly centered. As a result, the reconstructed output is also not
+// perfectly centered, i.e., it is not the canonical representative! This breaks
+// everything because we rely on the fact that Garner's outputs lift(crt(xs,
+// qs)) so that when we compute it mod p, we actually are doing basis extension.
+// If Garner outputs y != lift(crt(xs, qs)), then we compute y mod p, which is
+// meaningless.
+struct LowerConvertBasisOp : public OpRewritePattern<ConvertBasisOp> {
+  using OpRewritePattern<ConvertBasisOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConvertBasisOp op,
+                                PatternRewriter& rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    MLIRContext* context = op.getContext();
+
+    Value x = op.getValue();
+    auto inputBasisTy = dyn_cast<RNSType>(x.getType());
+    if (!inputBasisTy) {
+      return op.emitError() << "expected input basis type to be RNS";
+    }
+    auto targetBasisTy = dyn_cast<RNSType>(op.getTargetBasis());
+    if (!targetBasisTy) {
+      return op.emitError() << "expected target basis type to be RNS";
+    }
+
+    FailureOr<SmallVector<mod_arith::ModArithAttr>> qInvProdsFailable =
+        buildQInvProds(context, inputBasisTy);
+    if (failed(qInvProdsFailable)) {
+      return op.emitError() << "failed to build mixed-radix inverse products";
+    }
+
+    // We need a map from modulus to index (on the input basis) for
+    // short-circuiting
+    llvm::DenseMap<APInt, size_t> inputBasisIndexByModulus;
+    for (auto [i, basisTy] : llvm::enumerate(inputBasisTy.getBasisTypes())) {
+      auto inputLimbTy = dyn_cast<mod_arith::ModArithType>(basisTy);
+      if (!inputLimbTy) {
+        return op.emitError() << "expected input basis limb to be ModArithType";
+      }
+      inputBasisIndexByModulus[inputLimbTy.getModulus().getValue()] = i;
+    }
+
+    ArrayRef<Type> targetBasisTypes = targetBasisTy.getBasisTypes();
+    FailureOr<SmallVector<Value>> maybeMrcs =
+        rns::computeMixedRadixCoeffs(b, x, *qInvProdsFailable);
+    if (failed(maybeMrcs)) {
+      return op.emitError()
+             << "failed to compute mixed radix coefficients for input";
+    }
+    if (maybeMrcs->empty()) {
+      return op.emitError() << "expected non-empty mixed-radix coefficients";
+    }
+
+    SmallVector<Value>& mrcs = *maybeMrcs;
+    SmallVector<mod_arith::ModArithType> maInputBasisTys;
+    for (auto [i, basisTy] : llvm::enumerate(inputBasisTy.getBasisTypes())) {
+      auto qi = dyn_cast<mod_arith::ModArithType>(basisTy);
+      if (!qi) {
+        return op.emitError()
+               << "expected source basis limb to be ModArithType";
+      }
+      APInt modulusValue = qi.getModulus().getValue();
+      if (!modulusValue[0]) {
+        SmallString<16> modulusStr;
+        modulusValue.toStringUnsigned(modulusStr);
+        return op.emitError()
+               << "basis conversion requires odd moduli, "
+               << "but input basis contains even modulus " << modulusStr;
+      }
+      maInputBasisTys.push_back(qi);
+    }
+    IntegerType storageTy =
+        cast<IntegerType>(cast<mod_arith::ModArithType>(targetBasisTypes[0])
+                              .getModulus()
+                              .getType());
+
+    SmallVector<Value> outputLimbs;
+    outputLimbs.reserve(targetBasisTypes.size());
+    for (int i = 0; i < targetBasisTypes.size(); i++) {
+      mod_arith::ModArithType targetLimbTy =
+          dyn_cast<mod_arith::ModArithType>(targetBasisTypes[i]);
+      if (!targetLimbTy) {
+        return op.emitError()
+               << "expected target basis limb to be ModArithType";
+      }
+      APInt targetModulusValue = targetLimbTy.getModulus().getValue();
+      if (!targetModulusValue[0]) {
+        SmallString<16> modulusStr;
+        targetModulusValue.toStringUnsigned(modulusStr);
+        return op.emitError()
+               << "basis conversion requires odd moduli, "
+               << "but target basis contains even modulus " << modulusStr;
+      }
+
+      // This short-circuit optimization may not be optimal on all backends;
+      // this block can be commented out while preserving correctness.
+      llvm::DenseMap<APInt, size_t>::const_iterator inputIndexIt =
+          inputBasisIndexByModulus.find(targetModulusValue);
+      if (inputIndexIt != inputBasisIndexByModulus.end()) {
+        outputLimbs.push_back(rns::ExtractResidueOp::create(
+            b, x, b.getIndexAttr(inputIndexIt->second)));
+        continue;
+      }
+
+      // If the output modulus isn't in the input basis, compute its
+      // representative Again, this uses Horner's method with `temp` as the
+      // accumulator
+      Value temp =
+          mod_arith::EncapsulateOp::create(b, targetLimbTy, mrcs.back());
+      temp = mod_arith::ReduceOp::create(b, targetLimbTy, temp);
+      for (int j = static_cast<int>(mrcs.size()) - 2; j >= 0; j--) {
+        // get q_j, extend it to q_i's width, and reduce it mod q_i.
+        mod_arith::ModArithType sourceLimbTy = maInputBasisTys[j];
+        IntegerAttr qjAttr = IntegerAttr::get(
+            storageTy, sourceLimbTy.getModulus().getValue().zextOrTrunc(
+                           storageTy.getWidth()));
+        Value qjConst = mod_arith::ConstantOp::create(b, targetLimbTy, qjAttr);
+        Value reducedCj =
+            mod_arith::EncapsulateOp::create(b, targetLimbTy, mrcs[j]);
+        reducedCj = mod_arith::ReduceOp::create(b, targetLimbTy, reducedCj);
+        temp = mod_arith::MacOp::create(b, temp, qjConst, reducedCj);
+      }
+      outputLimbs.push_back(temp);
+    }
+
+    Value result = rns::PackOp::create(b, targetBasisTy, outputLimbs);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct LowerConvertBasis : impl::LowerConvertBasisBase<LowerConvertBasis> {
+  using LowerConvertBasisBase::LowerConvertBasisBase;
+
+  void runOnOperation() override {
+    MLIRContext* context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<LowerConvertBasisOp>(context);
+    (void)walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace rns
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/RNS/Transforms/LowerConvertBasis.h
+++ b/lib/Dialect/RNS/Transforms/LowerConvertBasis.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_RNS_TRANSFORMS_LOWERCONVERTBASIS_H_
+#define LIB_DIALECT_RNS_TRANSFORMS_LOWERCONVERTBASIS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rns {
+
+#define GEN_PASS_DECL_LOWERCONVERTBASIS
+#include "lib/Dialect/RNS/Transforms/Passes.h.inc"
+
+}  // namespace rns
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_RNS_TRANSFORMS_LOWERCONVERTBASIS_H_

--- a/lib/Dialect/RNS/Transforms/Passes.h
+++ b/lib/Dialect/RNS/Transforms/Passes.h
@@ -1,0 +1,20 @@
+#ifndef LIB_DIALECT_RNS_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_RNS_TRANSFORMS_PASSES_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/RNS/Transforms/LowerConvertBasis.h"
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+namespace rns {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/RNS/Transforms/Passes.h.inc"
+
+}  // namespace rns
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_RNS_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/RNS/Transforms/Passes.td
+++ b/lib/Dialect/RNS/Transforms/Passes.td
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_RNS_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_RNS_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def LowerConvertBasis : Pass<"rns-lower-convert-basis"> {
+  let summary = "Lower rns.convert_basis to explicit RNS and ModArith ops";
+  let description = [{
+    This pass replaces `rns.convert_basis` with an implementation based on
+    mixed-radix representation over the target RNS basis.
+    (* example filepath=tests/Dialect/RNS/Transforms/lower_convert_basis.mlir *)
+  }];
+  let dependentDialects = [
+    "mlir::heir::mod_arith::ModArithDialect",
+    "mlir::heir::rns::RNSDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_RNS_TRANSFORMS_PASSES_TD_

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "@heir//lib/Dialect/LWE/Conversions/LWEToPolynomial",
         "@heir//lib/Dialect/ModArith/Conversions/ModArithToArith",
         "@heir//lib/Dialect/Polynomial/Conversions/PolynomialToModArith",
+        "@heir//lib/Dialect/RNS/Transforms",
         "@heir//lib/Dialect/Secret/Conversions/SecretToCGGI",
         "@heir//lib/Transforms/ConvertIfToSelect",
         "@heir//lib/Transforms/ConvertSecretExtractToStaticExtract",

--- a/lib/Pipelines/PipelineRegistration.cpp
+++ b/lib/Pipelines/PipelineRegistration.cpp
@@ -2,6 +2,7 @@
 
 #include "lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.h"
 #include "lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.h"
+#include "lib/Dialect/RNS/Transforms/LowerConvertBasis.h"
 #include "lib/Transforms/ConvertIfToSelect/ConvertIfToSelect.h"
 #include "lib/Transforms/ConvertSecretExtractToStaticExtract/ConvertSecretExtractToStaticExtract.h"
 #include "lib/Transforms/ConvertSecretForToStaticFor/ConvertSecretForToStaticFor.h"
@@ -67,6 +68,7 @@ void polynomialToLLVMPipelineBuilder(OpPassManager& manager) {
   elementwiseOptions.convertDialects = {"polynomial"};
   manager.addPass(createElementwiseToAffine(elementwiseOptions));
   manager.addPass(polynomial::createPolynomialToModArith());
+  manager.addPass(rns::createLowerConvertBasis());
   manager.addPass(::mlir::heir::mod_arith::createModArithToArith());
   manager.addPass(createCanonicalizerPass());
 

--- a/lib/Utils/TargetUtils.cpp
+++ b/lib/Utils/TargetUtils.cpp
@@ -198,7 +198,8 @@ void emitFlattenedExtractSlice(ShapedType resultType, ShapedType sourceType,
   DynamicLoopOpenerFn dynamicLoopOpener = [&](raw_indented_ostream& os,
                                               const std::string& iv,
                                               OpFoldResult size) {
-    loopOpener(os, iv, mlir::cast<IntegerAttr>(size.get<Attribute>()).getInt());
+    loopOpener(os, iv,
+               mlir::cast<IntegerAttr>(mlir::cast<Attribute>(size)).getInt());
   };
 
   emitFlattenedExtractSlice(resultType, sourceType, resultName, sourceName,

--- a/tests/Dialect/LWE/Conversions/lwe_to_polynomial/lower_relinearize_to_polynomial.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_polynomial/lower_relinearize_to_polynomial.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-decompose-relinearize --ckks-decompose-keyswitch --ckks-to-lwe --lwe-to-polynomial --convert-polynomial-mul-to-ntt --attach-ntt-roots %s
+// RUN: heir-opt --ckks-decompose-relinearize --ckks-decompose-keyswitch --ckks-to-lwe --lwe-to-polynomial --convert-polynomial-mul-to-ntt --attach-ntt-roots --rns-lower-convert-basis %s
 
 !Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
 !Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>

--- a/tests/Dialect/LWE/IR/rlwe_ops.mlir
+++ b/tests/Dialect/LWE/IR/rlwe_ops.mlir
@@ -88,3 +88,20 @@ func.func @test_rmul_plain(%0: !ct, %1: !pt) -> !ct {
   %3 = lwe.rmul_plain %1, %0 : (!pt, !ct) -> !ct
   return %2 : !ct
 }
+
+!Z4 = !mod_arith.int<4 : i32>
+!Z3 = !mod_arith.int<3 : i32>
+!Z5 = !mod_arith.int<5 : i32>
+!rns_src_even = !rns.rns<!Z4, !Z3>
+!rns_tgt_odd = !rns.rns<!Z5>
+#ring_src_even = #polynomial.ring<coefficientType = !rns_src_even, polynomialModulus = <1 + x**8>>
+#ring_tgt_odd = #polynomial.ring<coefficientType = !rns_tgt_odd, polynomialModulus = <1 + x**8>>
+!ringelt_src_even = !lwe.lwe_ring_elt<ring = #ring_src_even>
+!ringelt_tgt_odd = !lwe.lwe_ring_elt<ring = #ring_tgt_odd>
+
+// CHECK: test_convert_basis
+func.func @test_convert_basis(%arg0: !ringelt_src_even) -> !ringelt_tgt_odd {
+  // CHECK: lwe.convert_basis
+  %0 = "lwe.convert_basis"(%arg0) {targetBasis = !rns_tgt_odd} : (!ringelt_src_even) -> !ringelt_tgt_odd
+  return %0 : !ringelt_tgt_odd
+}

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/BUILD
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/BUILD
@@ -29,7 +29,6 @@ heir_benchmark_test(
 llvm_runner_test(
     name = "lower_add",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_add_test.cc",
@@ -39,7 +38,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_intt",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_intt_test.cc",
@@ -49,7 +47,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_leading_term",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_leading_term_test.cc",
@@ -59,7 +56,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_test.cc",
@@ -70,7 +66,6 @@ llvm_runner_test(
     name = "lower_mul_ntt_roundtrip",
     heir_opt_flags = [
         "--attach-ntt-roots",
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_ntt_roundtrip_test.cc",
@@ -80,7 +75,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_ntt",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_ntt_test.cc",
@@ -90,7 +84,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_ntt_rns",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_ntt_rns_test.cc",
@@ -100,7 +93,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_intt_rns",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_intt_rns_test.cc",
@@ -112,7 +104,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_0",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_0_test.cc",
@@ -122,7 +113,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_1",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_1_test.cc",
@@ -132,7 +122,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_2",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_2_test.cc",
@@ -142,7 +131,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_3",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_3_test.cc",
@@ -152,7 +140,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_4",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_4_test.cc",
@@ -162,7 +149,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_5",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_5_test.cc",
@@ -172,7 +158,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_6",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_6_test.cc",
@@ -182,7 +167,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_7",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_7_test.cc",
@@ -192,7 +176,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_8",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_8_test.cc",
@@ -202,7 +185,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_mul_9",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_mul_9_test.cc",
@@ -212,7 +194,6 @@ llvm_runner_test(
 llvm_runner_test(
     name = "lower_poly_eval",
     heir_opt_flags = [
-        "--emit-c-interface",
         "--heir-polynomial-to-llvm",
     ],
     main_c_src = "lower_poly_eval_test.cc",

--- a/tests/Dialect/Polynomial/Transforms/poly_mul_to_ntt.mlir
+++ b/tests/Dialect/Polynomial/Transforms/poly_mul_to_ntt.mlir
@@ -45,14 +45,18 @@ module {
     return %xsq: !poly_ty_1
   }
 
-  // Covers: eval->coeff path with INTT + ConvertBasis to satisfy narrower output basis.
+  // Covers: eval->coeff path with INTT + apply_coefficientwise to satisfy narrower output basis.
   // CHECK: func.func @test_ntt_insertion2([[x2:%.+]]: [[ntt_poly_ty_2]]) -> [[poly_ty_1]] {
   func.func @test_ntt_insertion2(%x: !poly_ty_2) -> !poly_ty_1 {
     // CHECK: [[xsq2:%.+]] = polynomial.mul [[x2]], [[x2]] : [[ntt_poly_ty_2]]
     %xsq = polynomial.mul %x, %x : !poly_ty_2
     // CHECK: [[coeff2:%.+]] = polynomial.intt [[xsq2]] : [[ntt_poly_ty_2]]
-    // CHECK: [[out2:%.+]] = polynomial.convert_basis [[coeff2]] {targetBasis = {{.*}}} : [[poly_ty_2]] -> [[poly_ty_1]]
-    %y = polynomial.convert_basis %xsq {targetBasis = !rns.rns<!Zq0>} : !poly_ty_2 -> !poly_ty_1
+    // CHECK: [[out2:%.+]] = polynomial.apply_coefficientwise{{ *}}([[coeff2]] : [[poly_ty_2]])
+    %y = polynomial.apply_coefficientwise (%xsq : !poly_ty_2) {
+    ^body(%coeff: !rns.rns<!Zq0, !Zq1>, %degree: index):
+      %reduced = rns.extract_slice %coeff {start = 0 : index, size = 1 : index} : !rns.rns<!Zq0, !Zq1> -> !rns.rns<!Zq0>
+      polynomial.yield %reduced : !rns.rns<!Zq0>
+    } -> !poly_ty_1
     // CHECK: return [[out2]] : [[poly_ty_1]]
     return %y: !poly_ty_1
   }
@@ -72,18 +76,6 @@ module {
     // NTT_PLACEMENT: return [[c3]] : [[ntt_poly_ty_1]]
     // ORDER: return [[c3]] : [[ntt_poly_ty_1]]
     return %c : !poly_ty_1
-  }
-
-  // Covers: another basis-conversion path to exercise solver consistency across functions.
-  // CHECK: func.func @test_ntt_insertion4([[x4:%.+]]: [[ntt_poly_ty_2]]) -> [[poly_ty_1]] {
-  func.func @test_ntt_insertion4(%x: !poly_ty_2) -> !poly_ty_1 {
-    // CHECK: [[xsq4:%.+]] = polynomial.mul [[x4]], [[x4]] : [[ntt_poly_ty_2]]
-    %xsq = polynomial.mul %x, %x : !poly_ty_2
-    // CHECK: [[coeff4:%.+]] = polynomial.intt [[xsq4]] : [[ntt_poly_ty_2]]
-    // CHECK: [[out4:%.+]] = polynomial.convert_basis [[coeff4]] {targetBasis = {{.*}}} : [[poly_ty_2]] -> [[poly_ty_1]]
-    %out = polynomial.convert_basis %xsq {targetBasis = !rns.rns<!Zq0>} : !poly_ty_2 -> !poly_ty_1
-    // CHECK: return [[out4]] : [[poly_ty_1]]
-    return %out : !poly_ty_1
   }
 
   // Covers: coeff-output op (monic_monomial_mul) feeding eval-only MulOp.
@@ -217,15 +209,33 @@ module {
     return %m : tensor<2x!poly_ty_1>
   }
 
-  // Covers: eval->coeff path for tensor<poly> via MulOp feeding ConvertBasis, which may require tensor INTT.
+  // Covers: eval->coeff path for tensor<poly> via MulOp feeding apply_coefficientwise, which may require tensor INTT.
   // CHECK: func.func @test_ntt_insertion16_tensor_convert_basis([[x16:%.+]]: tensor<2x[[ntt_poly_ty_2]]>) -> tensor<2x[[poly_ty_1]]> {
   // CHECK: [[xsq16:%.+]] = polynomial.mul [[x16]], [[x16]] : tensor<2x[[ntt_poly_ty_2]]>
   // CHECK: [[coeff16:%.+]] = polynomial.intt [[xsq16]] : tensor<2x[[ntt_poly_ty_2]]>
-  // CHECK: [[y16:%.+]] = polynomial.convert_basis [[coeff16]] {targetBasis = {{.*}}} : tensor<2x[[poly_ty_2]]> -> tensor<2x[[poly_ty_1]]>
+  // CHECK: [[coeff16_0:%.+]] = tensor.extract [[coeff16]][%{{.+}}] : tensor<2x[[poly_ty_2]]>
+  // CHECK: [[coeff16_1:%.+]] = tensor.extract [[coeff16]][%{{.+}}] : tensor<2x[[poly_ty_2]]>
+  // CHECK: [[y16_0:%.+]] = polynomial.apply_coefficientwise{{ *}}([[coeff16_0]] : [[poly_ty_2]])
+  // CHECK: [[y16_1:%.+]] = polynomial.apply_coefficientwise{{ *}}([[coeff16_1]] : [[poly_ty_2]])
+  // CHECK: [[y16:%.+]] = tensor.from_elements [[y16_0]], [[y16_1]] : tensor<2x[[poly_ty_1]]>
   // CHECK: return [[y16]] : tensor<2x[[poly_ty_1]]>
   func.func @test_ntt_insertion16_tensor_convert_basis(%x: tensor<2x!poly_ty_2>) -> tensor<2x!poly_ty_1> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
     %xsq = polynomial.mul %x, %x : tensor<2x!poly_ty_2>
-    %y = polynomial.convert_basis %xsq {targetBasis = !rns.rns<!Zq0>} : tensor<2x!poly_ty_2> -> tensor<2x!poly_ty_1>
+    %xsq0 = tensor.extract %xsq[%c0] : tensor<2x!poly_ty_2>
+    %xsq1 = tensor.extract %xsq[%c1] : tensor<2x!poly_ty_2>
+    %y0 = polynomial.apply_coefficientwise (%xsq0 : !poly_ty_2) {
+    ^body(%coeff: !rns.rns<!Zq0, !Zq1>, %degree: index):
+      %reduced = rns.extract_slice %coeff {start = 0 : index, size = 1 : index} : !rns.rns<!Zq0, !Zq1> -> !rns.rns<!Zq0>
+      polynomial.yield %reduced : !rns.rns<!Zq0>
+    } -> !poly_ty_1
+    %y1 = polynomial.apply_coefficientwise (%xsq1 : !poly_ty_2) {
+    ^body(%coeff: !rns.rns<!Zq0, !Zq1>, %degree: index):
+      %reduced = rns.extract_slice %coeff {start = 0 : index, size = 1 : index} : !rns.rns<!Zq0, !Zq1> -> !rns.rns<!Zq0>
+      polynomial.yield %reduced : !rns.rns<!Zq0>
+    } -> !poly_ty_1
+    %y = tensor.from_elements %y0, %y1 : tensor<2x!poly_ty_1>
     return %y : tensor<2x!poly_ty_1>
   }
 

--- a/tests/Dialect/Polynomial/Transforms/poly_mul_to_ntt_optimal_placement.mlir
+++ b/tests/Dialect/Polynomial/Transforms/poly_mul_to_ntt_optimal_placement.mlir
@@ -48,7 +48,11 @@ module {
 
     %prod = polynomial.mul %sum, %sum : !poly_ty_2
     // coeff-only consumer of %prod
-    %out = polynomial.convert_basis %prod {targetBasis = !rns.rns<!Zq0>} : !poly_ty_2 -> !poly_ty_1
+    %out = polynomial.apply_coefficientwise (%prod : !poly_ty_2) {
+    ^body(%coeff: !rns.rns<!Zq0, !Zq1>, %degree: index):
+      %reduced = rns.extract_slice %coeff {start = 0 : index, size = 1 : index} : !rns.rns<!Zq0, !Zq1> -> !rns.rns<!Zq0>
+      polynomial.yield %reduced : !rns.rns<!Zq0>
+    } -> !poly_ty_1
     return %out, %x_t, %shift_t : !poly_ty_1, tensor<1024x!rns.rns<!Zq0, !Zq1>>, tensor<1024x!rns.rns<!Zq0, !Zq1>>
   }
 

--- a/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/BUILD
+++ b/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/BUILD
@@ -1,0 +1,12 @@
+load("@heir//tests/llvm_runner:llvm_runner.bzl", "llvm_runner_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+llvm_runner_test(
+    name = "lower_convert_basis",
+    heir_opt_flags = [
+        "--heir-polynomial-to-llvm",
+    ],
+    main_c_src = "lower_convert_basis_test.cc",
+    mlir_src = "lower_convert_basis.mlir",
+)

--- a/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/lower_convert_basis.mlir
+++ b/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/lower_convert_basis.mlir
@@ -1,0 +1,81 @@
+!Z3 = !mod_arith.int<3 : i64>
+!Z5 = !mod_arith.int<5 : i64>
+!Z7 = !mod_arith.int<7 : i64>
+
+
+!rns3 = !rns.rns<!Z3>
+!rns5 = !rns.rns<!Z5>
+!rns7 = !rns.rns<!Z7>
+!rns35 = !rns.rns<!Z3, !Z5>
+!rns37 = !rns.rns<!Z3, !Z7>
+!rns57 = !rns.rns<!Z5, !Z7>
+!rns53 = !rns.rns<!Z5, !Z3>
+!rns73 = !rns.rns<!Z7, !Z3>
+!rns75 = !rns.rns<!Z7, !Z5>
+!rns357 = !rns.rns<!Z3, !Z5, !Z7>
+
+
+func.func public @test_convert_basis_5_35(%arg0: !rns5) -> !rns35 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns35} : !rns5 -> !rns35
+  return %0 : !rns35
+}
+
+func.func public @test_convert_basis_5_57(%arg0: !rns5) -> !rns57 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns57} : !rns5 -> !rns57
+  return %0 : !rns57
+}
+
+func.func public @test_convert_basis_7_37(%arg0: !rns7) -> !rns37 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns37} : !rns7 -> !rns37
+  return %0 : !rns37
+}
+
+func.func public @test_convert_basis_7_57(%arg0: !rns7) -> !rns57 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns57} : !rns7 -> !rns57
+  return %0 : !rns57
+}
+
+func.func public @test_convert_basis_3_357(%arg0: !rns3) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns3 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_5_357(%arg0: !rns5) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns5 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_7_357(%arg0: !rns7) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns7 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_35_357(%arg0: !rns35) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns35 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_37_357(%arg0: !rns37) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns37 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_57_357(%arg0: !rns57) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns57 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_53_357(%arg0: !rns53) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns53 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_73_357(%arg0: !rns73) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns73 -> !rns357
+  return %0 : !rns357
+}
+
+func.func public @test_convert_basis_75_357(%arg0: !rns75) -> !rns357 {
+  %0 = rns.convert_basis %arg0 {targetBasis = !rns357} : !rns75 -> !rns357
+  return %0 : !rns357
+}

--- a/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/lower_convert_basis_test.cc
+++ b/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/lower_convert_basis_test.cc
@@ -1,0 +1,96 @@
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "tests/llvm_runner/memref_types.h"
+
+using ConvertBasisTestFn = void (*)(StridedMemRefType<int64_t, 1>*,
+                                    StridedMemRefType<int64_t, 1>*);
+
+extern "C" {
+void _mlir_ciface_test_convert_basis_5_35(StridedMemRefType<int64_t, 1>* result,
+                                          StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_5_57(StridedMemRefType<int64_t, 1>* result,
+                                          StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_7_37(StridedMemRefType<int64_t, 1>* result,
+                                          StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_7_57(StridedMemRefType<int64_t, 1>* result,
+                                          StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_3_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_5_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_7_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_35_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_37_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_57_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_53_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_73_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+void _mlir_ciface_test_convert_basis_75_357(
+    StridedMemRefType<int64_t, 1>* result, StridedMemRefType<int64_t, 1>* arg0);
+}
+
+struct Case {
+  std::vector<int64_t> src_basis;
+  std::vector<int64_t> dst_basis;
+  ConvertBasisTestFn fn;
+};
+
+std::vector<Case> cases = {
+    {{5}, {3, 5}, _mlir_ciface_test_convert_basis_5_35},
+    {{5}, {5, 7}, _mlir_ciface_test_convert_basis_5_57},
+    {{7}, {3, 7}, _mlir_ciface_test_convert_basis_7_37},
+    {{7}, {5, 7}, _mlir_ciface_test_convert_basis_7_57},
+    {{3}, {3, 5, 7}, _mlir_ciface_test_convert_basis_3_357},
+    {{5}, {3, 5, 7}, _mlir_ciface_test_convert_basis_5_357},
+    {{7}, {3, 5, 7}, _mlir_ciface_test_convert_basis_7_357},
+    {{3, 5}, {3, 5, 7}, _mlir_ciface_test_convert_basis_35_357},
+    {{3, 7}, {3, 5, 7}, _mlir_ciface_test_convert_basis_37_357},
+    {{5, 7}, {3, 5, 7}, _mlir_ciface_test_convert_basis_57_357},
+    {{5, 3}, {3, 5, 7}, _mlir_ciface_test_convert_basis_53_357},
+    {{7, 3}, {3, 5, 7}, _mlir_ciface_test_convert_basis_73_357},
+    {{7, 5}, {3, 5, 7}, _mlir_ciface_test_convert_basis_75_357}};
+
+TEST(LowerConvertBasisTest, TestConvertBasis) {
+  StridedMemRefType<int64_t, 1> actualResult;
+  for (const Case& c : cases) {
+    // The product of the input basis moduli must fit into an int64_t
+    int64_t inputModulus = 1;
+    for (auto& q : c.src_basis) {
+      inputModulus *= q;
+    }
+    for (int64_t x = 0; x < inputModulus; x++) {
+      int64_t y = x;
+      // we choose to lift to the centered representative
+      // if (y > inputModulus / 2) {
+      //   y -= inputModulus;
+      // }
+      std::vector<int64_t> expectedResult;
+      for (auto& q : c.dst_basis) {
+        expectedResult.push_back(y % q);
+      }
+
+      // compute result via MLIR
+      std::vector<int64_t> residues;
+      residues.reserve(c.src_basis.size());
+      for (int64_t q : c.src_basis) {
+        residues.push_back(y % q);
+      }
+      StridedMemRefType<int64_t, 1> memref = StridedMemRefType<int64_t, 1>(
+          residues.data(), residues.data(), 0, residues.size(), 1);
+
+      c.fn(&actualResult, &memref);
+      std::vector<int64_t> actualValues(
+          actualResult.data, actualResult.data + actualResult.sizes[0]);
+      EXPECT_EQ(actualValues, expectedResult);
+    }
+  }
+  free(actualResult.basePtr);
+}

--- a/tests/Dialect/RNS/IR/syntax.mlir
+++ b/tests/Dialect/RNS/IR/syntax.mlir
@@ -17,6 +17,26 @@ func.func @elementwise_extract_slice(%arg0: tensor<10x!ty_modarith>) -> tensor<1
   return %0 : tensor<10x!ty_truncated>
 }
 
+func.func @test_extract_residue(%arg0: !ty_modarith) -> !Zp2 {
+  %0 = rns.extract_residue %arg0 {index = 1 : index} : !ty_modarith -> !Zp2
+  return %0 : !Zp2
+}
+
+func.func @elementwise_extract_residue(%arg0: tensor<10x!ty_modarith>) -> tensor<10x!Zp2> {
+  %0 = rns.extract_residue %arg0 {index = 1 : index} : tensor<10x!ty_modarith> -> tensor<10x!Zp2>
+  return %0 : tensor<10x!Zp2>
+}
+
+func.func @test_pack(%arg0: !Zp1, %arg1: !Zp2) -> !ty_truncated {
+  %0 = rns.pack %arg0, %arg1 : !Zp1, !Zp2
+  return %0 : !ty_truncated
+}
+
+func.func @test_convert_basis(%arg0: !ty_truncated) -> !ty_modarith {
+  %0 = rns.convert_basis %arg0 {targetBasis = !ty_modarith} : !ty_truncated -> !ty_modarith
+  return %0 : !ty_modarith
+}
+
 // expected-error@+1 {{RNS type has incompatible basis types}}
 !ty_modarith_bad = !rns.rns<!Zp1, !Zp2, !Zp1>
 
@@ -107,5 +127,18 @@ func.func @test_extract_slice_verifier_oob_size(%arg0: !ty_modarith_verify) {
 func.func @test_extract_slice_verifier_oob_start(%arg0: !ty_modarith_verify) {
   // expected-error@+1 {{slice of size 1 starting at 3 is out of bounds for RNS type with 3 limbs}}
   %0 = rns.extract_slice %arg0 {start = 3 : index, size = 1 : index} : !ty_modarith_verify -> !ty_truncated_verify
+  return
+}
+
+// -----
+
+!Zp1_verify = !mod_arith.int<3721063133 : i64>
+!Zp2_verify = !mod_arith.int<2737228591 : i64>
+!Zp3_verify = !mod_arith.int<3180146689 : i64>
+!ty_modarith_verify = !rns.rns<!Zp1_verify, !Zp2_verify, !Zp3_verify>
+
+func.func @test_extract_residue_verifier_oob_index(%arg0: !ty_modarith_verify) {
+  // expected-error@+1 {{'rns.extract_residue' index 3 is out of bounds for an RNS type with 3 limbs}}
+  %0 = rns.extract_residue %arg0 {index = 3 : index} : !ty_modarith_verify -> !Zp1_verify
   return
 }

--- a/tests/Dialect/RNS/Transforms/BUILD
+++ b/tests/Dialect/RNS/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/RNS/Transforms/convert_basis_even_modulus_error.mlir
+++ b/tests/Dialect/RNS/Transforms/convert_basis_even_modulus_error.mlir
@@ -1,0 +1,27 @@
+// RUN: heir-opt %s --rns-lower-convert-basis --verify-diagnostics --split-input-file 2>&1
+
+!Z4 = !mod_arith.int<4 : i32>
+!Z3 = !mod_arith.int<3 : i32>
+!Z5 = !mod_arith.int<5 : i32>
+!rns_src_even = !rns.rns<!Z4, !Z3>
+!rns_tgt_odd = !rns.rns<!Z5>
+
+func.func @input_basis_contains_even_modulus(%arg0: !rns_src_even) -> !rns_tgt_odd {
+  // expected-error@below {{basis conversion requires odd moduli, but input basis contains even modulus 4}}
+  %0 = "rns.convert_basis"(%arg0) {targetBasis = !rns_tgt_odd} : (!rns_src_even) -> !rns_tgt_odd
+  return %0 : !rns_tgt_odd
+}
+
+// -----
+
+!Z3 = !mod_arith.int<3 : i32>
+!Z5 = !mod_arith.int<5 : i32>
+!Z4 = !mod_arith.int<4 : i32>
+!rns_src_odd = !rns.rns<!Z3, !Z5>
+!rns_tgt_even = !rns.rns<!Z4>
+
+func.func @target_basis_contains_even_modulus(%arg0: !rns_src_odd) -> !rns_tgt_even {
+  // expected-error@below {{basis conversion requires odd moduli, but target basis contains even modulus 4}}
+  %0 = "rns.convert_basis"(%arg0) {targetBasis = !rns_tgt_even} : (!rns_src_odd) -> !rns_tgt_even
+  return %0 : !rns_tgt_even
+}

--- a/tests/Dialect/RNS/Transforms/lower_convert_basis.mlir
+++ b/tests/Dialect/RNS/Transforms/lower_convert_basis.mlir
@@ -1,0 +1,31 @@
+// RUN: heir-opt --rns-lower-convert-basis --mlir-print-local-scope %s | FileCheck %s
+
+!Z3 = !mod_arith.int<3 : i32>
+!Z5 = !mod_arith.int<5 : i32>
+!Z7 = !mod_arith.int<7 : i32>
+!src = !rns.rns<!Z3, !Z5>
+!target = !rns.rns<!Z5, !Z7>
+
+// CHECK: convert_basis
+func.func @convert_basis(%arg0: !src) -> !target {
+  // CHECK: rns.extract_residue
+  // CHECK-NEXT: mod_arith.extract
+  // CHECK-NEXT: rns.extract_residue
+  // CHECK-NEXT: mod_arith.encapsulate
+  // CHECK-NEXT: mod_arith.reduce
+  // CHECK-NEXT: mod_arith.sub
+  // CHECK-NEXT: mod_arith.constant 2
+  // CHECK-NEXT: mod_arith.mul
+  // CHECK-NEXT: mod_arith.extract
+  // CHECK-NEXT: rns.extract_residue
+  // CHECK-NEXT: mod_arith.encapsulate
+  // CHECK-NEXT: mod_arith.reduce
+  // CHECK-NEXT: mod_arith.constant 3
+  // CHECK-NEXT: mod_arith.encapsulate
+  // CHECK-NEXT: mod_arith.reduce
+  // CHECK-NEXT: mod_arith.mac
+  // CHECK-NEXT: rns.pack
+  // CHECK-NOT: rns.convert_basis
+  %0 = rns.convert_basis %arg0 {targetBasis = !target} : !src -> !target
+  return %0 : !target
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -89,6 +89,7 @@ cc_binary(
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/Transforms",
         "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@heir//lib/Dialect/RNS/Transforms",
         "@heir//lib/Dialect/Random/IR:Dialect",
         "@heir//lib/Dialect/Rotom/IR:Dialect",
         "@heir//lib/Dialect/Rotom/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -43,6 +43,7 @@
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "lib/Dialect/Polynomial/Transforms/Passes.h"
 #include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/RNS/Transforms/Passes.h"
 #include "lib/Dialect/Random/IR/RandomDialect.h"
 #include "lib/Dialect/Rotom/IR/RotomDialect.h"
 #include "lib/Dialect/Rotom/Transforms/Passes.h"
@@ -301,6 +302,7 @@ int main(int argc, char** argv) {
   mgmt::registerMgmtPasses();
   openfhe::registerOpenfhePasses();
   polynomial::registerPolynomialPasses();
+  rns::registerRNSPasses();
   rotom::registerRotomPasses();
   secret::registerSecretPasses();
   tensor_ext::registerTensorExtPasses();


### PR DESCRIPTION
This PR adds an implementation of basis extension. I made several choices which may not be right in the end, so input on architecture is welcome.

- I implemented basis conversion inside the LWEToPolynomial conversion. An alternate construction would be to lower LWE.convert_basis to polynomial.convert_basis and then replace polynomial.convert_basis with a polynomial.apply_coefficientwise, but that seemed unnecessary to me.
- This means there is no longer a need for Polynomial's ConvertBasisOp, so it has been removed. All of the NTT tests that used ConvertBasis have been converted to use ApplyCoefficientwise instead, since there were no tests for this op previously, and because it is coeff-only like ConvertBasis was.
- I added a helper function in PolynomialOps to properly apply polynomial.apply_coefficientwise, which involves a lot of boilerplate.
- I chose _not_ to add an rns.convert_basis op. My motivation for this and implementing the lowering in LWEToPolynomial is that my goal is to lower the implementation to the polynomial layer _without_ going to ModArith. I'm still not 100% sold on using polynomial.apply_coefficientwise for that reason, since it involves the use of ModArith, but I'm trying it for now. [The alternative would be to add some new ops to the Polynomial dialect, which is also not appealing.] Instead of an rns.convert_basis op, I implemented basis conversion as top-level C++ functions in RNSOps.cpp, which are used by the LWEToPolynomial lowering for LWE.ConvertBasis.
- There are new RNS ops for extracting a single slice (rather than an RNS subset of slices) and for packing individual limbs together into an RNS.

Miscellaneous changes:
1. When programming with GPT in VSCode, I get a .codex file, which should be ignored.
2. I renamed the TypeInterface build targets in RNS and ModArith to match the style of other build targets

The biggest piece missing from this PR is that there are no LLVM tests for basis conversion. This should be added, but I figured I should get an architecture review first, and also get input on where to put the tests. My feeling is that we should have some rns-to-llvm tests for basis conversion.

PR written with AI assistance.