### PR TITLE
1D Convolution relation

### DIFF
--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -136,10 +136,9 @@ TEST_P(KernelImplementationTest, Test2DConvWithLayout) {
   std::vector<std::vector<int>> packedFilter =
       evaluateLayoutOnMatrix(filterLayout, matrix);
 
-  auto matrixLayout =
-      get2dConvFilterDiagonalizedRelation(filterType, dataType,
-                                          /*padding=*/0, numSlots)
-          .value();
+  auto matrixLayout = getConvFilterDiagonalizedRelation(filterType, dataType,
+                                                        /*padding=*/0, numSlots)
+                          .value();
   std::vector<std::vector<int>> packedMatrix =
       evaluateLayoutOnMatrix(matrixLayout, matrix);
   RankedTensorType expandedMatrixType =

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
@@ -625,14 +625,14 @@ LogicalResult LayoutPropagation::visitOperation(Conv2DOp op) {
   // The kernel for this operation requires expanding the conv filter matrix
   // into a larger matrix and then diagonalizing.
   LayoutAttr filterLayout = assignedLayouts.at(filter);
-  if (!isRelation2dConvFilterDiagonalized(filterType, dataType, /*padding=*/0,
-                                          ciphertextSize,
-                                          filterLayout.getIntegerRelation())) {
+  if (!isRelationConvFilterDiagonalized(filterType, dataType, /*padding=*/0,
+                                        ciphertextSize,
+                                        filterLayout.getIntegerRelation())) {
     LLVM_DEBUG(llvm::dbgs() << "conv_2d filter input is not diagonalized, "
                                "inserting layout conversion.\n");
     // Insert a layout conversion op to make the matrix layout expanded and
     // squat diagonal
-    auto convRelation = get2dConvFilterDiagonalizedRelation(
+    auto convRelation = getConvFilterDiagonalizedRelation(
         filterType, dataType, /*padding=*/0, ciphertextSize);
     if (failed(convRelation)) {
       return failure();

--- a/lib/Utils/Layout/Convolution.cpp
+++ b/lib/Utils/Layout/Convolution.cpp
@@ -131,6 +131,107 @@ presburger::IntegerRelation get2dConvFilterRelation(RankedTensorType filterType,
   return result;
 }
 
+presburger::IntegerRelation matrixRowStridingRelation(int64_t rowSize,
+                                                      int64_t colSize,
+                                                      int64_t stride) {
+  IntegerRelation result(PresburgerSpace::getRelationSpace(
+      2, /*numRange=*/2, /*numSymbol=*/0, /*numLocals=*/1));
+
+  // Initial row and column indices
+  auto matRow = result.getVarKindOffset(VarKind::Domain);
+  auto matCol = result.getVarKindOffset(VarKind::Domain) + 1;
+
+  auto resultRow = result.getVarKindOffset(VarKind::Range);
+  auto resultCol = result.getVarKindOffset(VarKind::Range) + 1;
+
+  addBounds(result, matRow, 0, rowSize);
+  addBounds(result, matCol, 0, colSize);
+
+  // Only pick rows whose index is divisible by stride:
+  // matRow = stride *resultRow
+  addConstraint(result, {{matRow, 1}, {resultRow, -stride}}, true);
+  // Keep all the columns
+  addConstraint(result, {{matCol, 1}, {resultCol, -1}}, true);
+  return result;
+}
+
+// We iterate over i the position of the start of the filter over the data
+// (starting from -padding and with 0 indexing over the data)
+//
+// -padding <= i <= dataSize - filterSize + padding
+//
+// matRow = padding + i (hence matRow <=  dataSize - kernelSize + 2*padding)
+//
+// matCol = i + filterIndex
+presburger::IntegerRelation get1dConvFilterRelation(RankedTensorType filterType,
+                                                    RankedTensorType dataType,
+                                                    int64_t stride,
+                                                    int64_t padding) {
+  auto domainSize = filterType.getRank();
+  assert(domainSize == 1 && "expected 1-D filter matrix");
+
+  IntegerRelation result(PresburgerSpace::getRelationSpace(
+      domainSize, /*numRange=*/2, /*numSymbol=*/0, /*numLocals=*/1));
+
+  auto filterIndex = result.getVarKindOffset(VarKind::Domain);
+
+  // Matrix row and column indices
+  auto matRow = result.getVarKindOffset(VarKind::Range);
+  auto matCol = result.getVarKindOffset(VarKind::Range) + 1;
+
+  auto i = result.getVarKindOffset(VarKind::Local);
+
+  // Constant coefficient
+  auto constCoeff = result.getNumCols() - 1;
+
+  // Filter, datasize
+  auto filterSize = filterType.getDimSize(0);
+  auto dataSize = dataType.getDimSize(0);
+
+  // The maximum values for the sliding window indices.
+  auto slidingSize = dataSize + padding - filterSize;
+
+  // Add bounds for the filter matrix dimensions.
+  addBounds(result, filterIndex, 0, filterSize - 1);
+
+  // Add bounds for the sliding window indices.
+  addBounds(result, i, -padding, slidingSize);
+
+  // Add bound for the column index
+  addBounds(result, matCol, 0, dataSize - 1);
+
+  addBounds(result, matRow, 0, slidingSize + padding);
+
+  // Note that i starts at -padding
+  // matRow = i + padding
+  addConstraint(result, {{matRow, 1}, {i, -1}, {constCoeff, -padding}}, true);
+  // matCol = i + filterIndex
+  addConstraint(
+      result, {{matCol, 1}, {i, -1}, {filterIndex, -1}, {constCoeff, 0}}, true);
+
+  if (stride > 1) {
+    auto rowSelector =
+        matrixRowStridingRelation(slidingSize + padding, dataSize - 1, stride);
+    result.applyRange(rowSelector);
+  }
+
+  return result;
+}
+
+RankedTensorType get1dConvFilterExpandedType(RankedTensorType filterType,
+                                             RankedTensorType dataType,
+                                             int64_t stride, int64_t padding) {
+  auto filterSize = filterType.getDimSize(0);
+  auto dataSize = dataType.getDimSize(0);
+
+  int64_t rows = (dataSize + 2 * padding - filterSize) / stride + 1;
+
+  // Number of columns will be the number of data elements.
+  int64_t cols = dataSize;
+
+  return RankedTensorType::get({rows, cols}, filterType.getElementType());
+}
+
 RankedTensorType get2dConvFilterExpandedType(RankedTensorType filterType,
                                              RankedTensorType dataType,
                                              int64_t padding,
@@ -244,14 +345,20 @@ presburger::IntegerRelation get2dConvChwFchwFilterRelation(
   return singleFilterRelation;
 }
 
-FailureOr<presburger::IntegerRelation> get2dConvFilterDiagonalizedRelation(
+FailureOr<presburger::IntegerRelation> getConvFilterDiagonalizedRelation(
     RankedTensorType filterType, RankedTensorType dataType, int64_t padding,
     int64_t ciphertextSize) {
+  if (filterType.getRank() == 1) {
+    int64_t stride = 1;
+    auto filterRelation =
+        get1dConvFilterRelation(filterType, dataType, stride, padding);
+    return diagonalize2dMatrix(filterRelation, filterType, ciphertextSize);
+  }
+  if (filterType.getRank() != 2) return failure();
   SmallVector<int64_t> strides = {1, 1};
-  auto expandedFilterRelation =
+  auto filterRelation =
       get2dConvFilterRelation(filterType, dataType, strides, padding);
-  return diagonalize2dMatrix(expandedFilterRelation, filterType,
-                             ciphertextSize);
+  return diagonalize2dMatrix(filterRelation, filterType, ciphertextSize);
 }
 
 FailureOr<presburger::IntegerRelation>
@@ -286,10 +393,10 @@ get2dConvChwFchwFilterDiagonalizedRelation(RankedTensorType filterType,
                              ciphertextSize);
 }
 
-bool isRelation2dConvFilterDiagonalized(
+bool isRelationConvFilterDiagonalized(
     RankedTensorType filterType, RankedTensorType dataType, int64_t padding,
     int64_t ciphertextSize, const presburger::IntegerRelation& relation) {
-  auto diagonalizedRelation = get2dConvFilterDiagonalizedRelation(
+  auto diagonalizedRelation = getConvFilterDiagonalizedRelation(
       filterType, dataType, padding, ciphertextSize);
   if (failed(diagonalizedRelation)) {
     return false;

--- a/lib/Utils/Layout/Convolution.h
+++ b/lib/Utils/Layout/Convolution.h
@@ -14,21 +14,35 @@ namespace heir {
 // convolution into a 2-D matrix such that the convolution is
 // equivalent a matrix product with the flattened input vector. Each row
 // corresponds to one filter multiplication. This does not include diagonalizing
-// the matrix, this simply returns the expanded data matrix.
+// the matrix, the returned relation only expands the filter to the data matrix.
 presburger::IntegerRelation get2dConvFilterRelation(RankedTensorType filterType,
                                                     RankedTensorType dataType,
                                                     ArrayRef<int64_t> strides,
+                                                    int64_t padding);
+
+// Returns an IntegerRelation that expands a 1-D filter used in a
+// convolution into a 2-D matrix such that the convolution is
+// equivalent a matrix product with the input vector. Each row
+// corresponds to one filter multiplication. This does not include diagonalizing
+// the matrix, the returned relation only expands the filter to the data matrix.
+presburger::IntegerRelation get1dConvFilterRelation(RankedTensorType filterType,
+                                                    RankedTensorType dataType,
+                                                    int64_t stride,
                                                     int64_t padding);
 
 RankedTensorType get2dConvFilterExpandedType(
     RankedTensorType filterType, RankedTensorType dataType, int64_t padding,
     ArrayRef<int64_t> strides = {1, 1});
 
-// Returns an IntegerRelation that expands a 2-D filter matrix used in a
+RankedTensorType get1dConvFilterExpandedType(RankedTensorType filterType,
+                                             RankedTensorType dataType,
+                                             int64_t stride, int64_t padding);
+
+// Returns an IntegerRelation that expands a filter matrix used in a
 // convolution into a 2-D matrix such that the convolution is
 // equivalent a matrix product with the flattened input vector. Each row
 // corresponds to one filter multiplication.
-FailureOr<presburger::IntegerRelation> get2dConvFilterDiagonalizedRelation(
+FailureOr<presburger::IntegerRelation> getConvFilterDiagonalizedRelation(
     RankedTensorType filterType, RankedTensorType dataType, int64_t padding,
     int64_t ciphertextSize);
 
@@ -77,7 +91,7 @@ get2dConvChwFchwFilterDiagonalizedRelation(RankedTensorType filterType,
 presburger::IntegerRelation getRowInterchangeRelation(int64_t c, int64_t h,
                                                       int64_t w, int64_t g);
 
-bool isRelation2dConvFilterDiagonalized(
+bool isRelationConvFilterDiagonalized(
     RankedTensorType filterType, RankedTensorType dataType, int64_t padding,
     int64_t ciphertextSize, const presburger::IntegerRelation& relation);
 

--- a/lib/Utils/Layout/ConvolutionTest.cpp
+++ b/lib/Utils/Layout/ConvolutionTest.cpp
@@ -128,6 +128,157 @@ TEST(ConvolutionTest, ConvFilterRelationEvaluate) {
   EXPECT_EQ(packedFilter, expected);
 }
 
+TEST(ConvolutionTest, Conv1dFilterRelationEvaluate) {
+  MLIRContext context;
+  RankedTensorType filterType =
+      RankedTensorType::get({3}, IndexType::get(&context));
+  RankedTensorType dataType =
+      RankedTensorType::get({5}, IndexType::get(&context));
+  int64_t stride = 1;
+  int64_t padding = 1;
+  IntegerRelation convFilterRelation =
+      get1dConvFilterRelation(filterType, dataType, stride, padding);
+
+  std::vector<int> filter = {1, 2, 3};
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayoutOnVector(convFilterRelation, filter);
+
+  std::vector<std::vector<int>> expected = {
+      {2, 3, 0, 0, 0}, {1, 2, 3, 0, 0}, {0, 1, 2, 3, 0},
+      {0, 0, 1, 2, 3}, {0, 0, 0, 1, 2},
+  };
+  EXPECT_EQ(packedFilter, expected);
+}
+
+TEST(ConvolutionTest, Conv1dFilterRelationEvaluateWithPadding) {
+  MLIRContext context;
+  RankedTensorType filterType =
+      RankedTensorType::get({3}, IndexType::get(&context));
+  RankedTensorType dataType =
+      RankedTensorType::get({3}, IndexType::get(&context));
+  int64_t stride = 1;
+  int64_t padding = 2;
+  IntegerRelation convFilterRelation =
+      get1dConvFilterRelation(filterType, dataType, stride, padding);
+
+  std::vector<int> filter = {1, 2, 3};
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayoutOnVector(convFilterRelation, filter);
+
+  std::vector<std::vector<int>> expected = {
+      {3, 0, 0}, {2, 3, 0}, {1, 2, 3}, {0, 1, 2}, {0, 0, 1},
+  };
+  EXPECT_EQ(packedFilter, expected);
+}
+
+TEST(ConvolutionTest, Conv1dFilterRelationEvaluateEvenSizedKernel) {
+  MLIRContext context;
+  RankedTensorType filterType =
+      RankedTensorType::get({4}, IndexType::get(&context));
+  RankedTensorType dataType =
+      RankedTensorType::get({5}, IndexType::get(&context));
+  int64_t stride = 1;
+  int64_t padding = 1;
+  IntegerRelation convFilterRelation =
+      get1dConvFilterRelation(filterType, dataType, stride, padding);
+
+  std::vector<int> filter = {1, 2, 3, 4};
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayoutOnVector(convFilterRelation, filter);
+
+  std::vector<std::vector<int>> expected = {
+      {2, 3, 4, 0, 0},
+      {1, 2, 3, 4, 0},
+      {0, 1, 2, 3, 4},
+      {0, 0, 1, 2, 3},
+  };
+  EXPECT_EQ(packedFilter, expected);
+}
+
+TEST(ConvolutionTest, Conv1dFilterRelationEvaluateStridedEvenSizedKernel) {
+  MLIRContext context;
+  RankedTensorType filterType =
+      RankedTensorType::get({2}, IndexType::get(&context));
+  RankedTensorType dataType =
+      RankedTensorType::get({6}, IndexType::get(&context));
+  int64_t stride = 3;
+  int64_t padding = 0;
+  IntegerRelation convFilterRelation =
+      get1dConvFilterRelation(filterType, dataType, stride, padding);
+
+  std::vector<int> filter = {1, 2};
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayoutOnVector(convFilterRelation, filter);
+
+  std::vector<std::vector<int>> expected = {
+      {1, 2, 0, 0, 0, 0},
+      {0, 0, 0, 1, 2, 0},
+  };
+  EXPECT_EQ(packedFilter, expected);
+}
+
+TEST(ConvolutionTest, Conv1dFilterRelationEvaluateWithStride) {
+  MLIRContext context;
+  RankedTensorType filterType =
+      RankedTensorType::get({3}, IndexType::get(&context));
+  RankedTensorType dataType =
+      RankedTensorType::get({6}, IndexType::get(&context));
+  int64_t stride = 2;
+  int64_t padding = 1;
+  IntegerRelation convFilterRelation =
+      get1dConvFilterRelation(filterType, dataType, stride, padding);
+
+  std::vector<int> filter = {1, 2, 3};
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayoutOnVector(convFilterRelation, filter);
+
+  std::vector<std::vector<int>> expected = {
+      {2, 3, 0, 0, 0, 0},
+      {0, 1, 2, 3, 0, 0},
+      {0, 0, 0, 1, 2, 3},
+  };
+  EXPECT_EQ(packedFilter, expected);
+}
+
+TEST(ConvolutionTest, Conv1dFilterRelationEvaluateExpanded) {
+  MLIRContext context;
+  RankedTensorType filterType =
+      RankedTensorType::get({3}, IndexType::get(&context));
+  RankedTensorType dataType =
+      RankedTensorType::get({6}, IndexType::get(&context));
+  int64_t stride = 1;
+  int64_t padding = 1;
+  IntegerRelation convFilterRelation =
+      get1dConvFilterRelation(filterType, dataType, stride, padding);
+
+  std::vector<int> filter = {1, 2, 3};
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayoutOnVector(convFilterRelation, filter);
+
+  std::vector<std::vector<int>> expected = {
+      {2, 3, 0, 0, 0, 0},
+      {1, 2, 3, 0, 0, 0},
+      {0, 1, 2, 3, 0, 0},
+      {0, 0, 1, 2, 3, 0},
+      {0, 0, 0, 1, 2, 3},
+      {
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+      },
+  };
+
+  RankedTensorType expanded =
+      get1dConvFilterExpandedType(filterType, dataType, stride, padding);
+
+  EXPECT_EQ(packedFilter, expected);
+  EXPECT_EQ(expanded.getDimSize(0), expected.size());
+  EXPECT_EQ(expanded.getDimSize(1), expected[0].size());
+}
+
 TEST(ConvolutionTest, ConvFilterRelationEvaluateStrided) {
   MLIRContext context;
   RankedTensorType filterType =

--- a/lib/Utils/Layout/EvaluateTest.cpp
+++ b/lib/Utils/Layout/EvaluateTest.cpp
@@ -155,7 +155,7 @@ TEST(EvaluateTest, EvaluateLayoutFor2DConvDiagonalized) {
       RankedTensorType::get({3, 3}, IndexType::get(&context));
   RankedTensorType dataType =
       RankedTensorType::get({3, 3}, IndexType::get(&context));
-  auto relation = get2dConvFilterDiagonalizedRelation(
+  auto relation = getConvFilterDiagonalizedRelation(
       filterType, dataType, /*padding=*/1, /*ciphertextSize=*/16);
 
   std::vector<std::vector<int>> filter = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};


### PR DESCRIPTION
Add support for 1D convolution.

Right now this only adds the relation. This is a standalone PR, and I will build off this to finish #2900

For the moment, I keep the `padding` argument until we have a clearer picture of how we want to handle it.