### PR TITLE
Implementing secrecy aware operation rebalancing

### DIFF
--- a/lib/Transforms/OperationBalancer/BUILD
+++ b/lib/Transforms/OperationBalancer/BUILD
@@ -14,6 +14,7 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect/Secret/IR:SecretOps",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Transforms/OperationBalancer/OperationBalancer.cpp
+++ b/lib/Transforms/OperationBalancer/OperationBalancer.cpp
@@ -1,19 +1,23 @@
 #include "lib/Transforms/OperationBalancer/OperationBalancer.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <set>
 #include <stack>
 #include <vector>
 
+#include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
-#include "llvm/include/llvm/ADT/STLExtras.h"           // from @llvm-project
-#include "llvm/include/llvm/Support/Debug.h"           // from @llvm-project
-#include "mlir/include/mlir/Analysis/SliceAnalysis.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Dialect.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/Location.h"             // from @llvm-project
-#include "mlir/include/mlir/IR/Visitors.h"             // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"            // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"               // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
+#include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/SliceAnalysis.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Location.h"                 // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"                // from @llvm-project
 
 #define DEBUG_TYPE "operation-balancer"
 
@@ -70,8 +74,19 @@ OpType recursiveProduceBalancedTree(OpBuilder& builder, Location& loc,
   }
 }
 
+namespace {
+// If a lattice is unknown treat it as secret
+bool isKnownPublic(Value value, DataFlowSolver* solver) {
+  auto* lattice = solver->lookupState<SecretnessLattice>(value);
+  if (lattice == nullptr) return false;
+  if (!lattice->getValue().isInitialized()) return false;
+  return !lattice->getValue().getSecretness();
+}
+
+}  // namespace
+
 template <typename OpType>
-void tryBalanceBlock(Block* block) {
+void tryBalanceBlock(Block* block, DataFlowSolver& secretnessSolver) {
   // visited set checks whether we've already handled an operation
   std::set<Operation*> visited;
 
@@ -170,6 +185,11 @@ void tryBalanceBlock(Block* block) {
       continue;
     }
 
+    // Group known public values
+    std::stable_partition(operands.begin(), operands.end(), [&](Value v) {
+      return isKnownPublic(v, &secretnessSolver);
+    });
+
     // Now that we have the flattened operands, we can create the balanced tree
     // of operations.
     Location loc = root->getLoc();
@@ -189,16 +209,24 @@ struct OperationBalancer : impl::OperationBalancerBase<OperationBalancer> {
   using OperationBalancerBase::OperationBalancerBase;
 
   void runOnOperation() override {
+    // Call the SecretnessAnalysis to identify operand Secretness values
+    DataFlowSolver solver;
+    dataflow::loadBaselineAnalyses(solver);
+    solver.load<SecretnessAnalysis>();
+
+    auto result = solver.initializeAndRun(getOperation());
+
+    if (failed(result)) {
+      getOperation()->emitOpError() << "Failed to run SecretnessAnalysis.\n";
+      signalPassFailure();
+      return;
+    }
+
     getOperation()->walk<WalkOrder::PreOrder>([&](secret::GenericOp genericOp) {
-      // TODO (#836): analyze the block to see which operations should be done
-      // secretly (i.e. under homomorphic encryption) to determine which
-      // operations are done plaintext and others over ciphertext. This is
-      // useful because we can then sort the operations in a way that minimizes
-      // the number of encodings.
-      tryBalanceBlock<arith::AddIOp>(genericOp.getBody());
-      tryBalanceBlock<arith::MulIOp>(genericOp.getBody());
-      tryBalanceBlock<arith::AddFOp>(genericOp.getBody());
-      tryBalanceBlock<arith::MulFOp>(genericOp.getBody());
+      tryBalanceBlock<arith::AddIOp>(genericOp.getBody(), solver);
+      tryBalanceBlock<arith::MulIOp>(genericOp.getBody(), solver);
+      tryBalanceBlock<arith::AddFOp>(genericOp.getBody(), solver);
+      tryBalanceBlock<arith::MulFOp>(genericOp.getBody(), solver);
     });
   }
 };

--- a/tests/Transforms/operation_balancer/balance_sigmoid.mlir
+++ b/tests/Transforms/operation_balancer/balance_sigmoid.mlir
@@ -10,11 +10,11 @@
 // CHECK:     ^body(%[[CONVERTED_ARG:.*]]: tensor<1x16xf32>):
 // CHECK:       %[[COEFF_MUL_DEGREE_1:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[COEFF_1]]
 
+// CHECK:       %[[COEFF_3_MUL_ARG:.*]] = arith.mulf %[[COEFF_3]], %[[CONVERTED_ARG]]
 // CHECK:       %[[DEGREE_2:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[CONVERTED_ARG]]
-// CHECK:       %[[COEFF_3_MUL_ARG:.*]] = arith.mulf %[[CONVERTED_ARG]], %[[COEFF_3]]
-// CHECK:       %[[COEFF_MUL_DEGREE_3:.*]] = arith.mulf %[[DEGREE_2]], %[[COEFF_3_MUL_ARG]]
+// CHECK:       %[[COEFF_MUL_DEGREE_3:.*]] = arith.mulf %[[COEFF_3_MUL_ARG]], %[[DEGREE_2]]
 
-// CHECK:       %[[SUM_1:.*]] = arith.addf %[[COEFF_MUL_DEGREE_1]], %[[COEFF_0]]
+// CHECK:       %[[SUM_1:.*]] = arith.addf %[[COEFF_0]], %[[COEFF_MUL_DEGREE_1]]
 // CHECK:       %[[TOTAL_SUM:.*]] = arith.addf %[[SUM_1]], %[[COEFF_MUL_DEGREE_3]]
 // CHECK:       secret.yield %[[TOTAL_SUM]] : tensor<1x16xf32>
 // CHECK:     return %[[RET]]

--- a/tests/Transforms/operation_balancer/secrecy_aware_balance.mlir
+++ b/tests/Transforms/operation_balancer/secrecy_aware_balance.mlir
@@ -1,0 +1,45 @@
+// f(s1, s2, p1) = (s1 * c0 * s2 * p1 * c1) + (s1 + c0 + s2 + p1 + c1)
+
+// RUN: heir-opt --operation-balancer %s | FileCheck %s
+
+// CHECK:       func.func @secrecy_aware_balance(%[[ARG0:.*]]: !secret.secret<tensor<1x16xf32>>, %[[ARG1:.*]]: !secret.secret<tensor<1x16xf32>>, %[[ARG2:.*]]: tensor<1x16xf32>)
+
+// CHECK-DAG: %[[CONST_0:.*]] = arith.constant dense<5.000000e-01> : tensor<1x16xf32>
+// CHECK-DAG: %[[CONST_1:.*]] = arith.constant dense<5.000000e-02> : tensor<1x16xf32>
+
+// CHECK:       %[[RET:.*]] = secret.generic(%{{[^:]*}}: !secret.secret<tensor<1x16xf32>>, %{{[^:]*}}: !secret.secret<tensor<1x16xf32>>, %{{[^:]*}}: tensor<1x16xf32>)
+// CHECK:       ^body(%[[CONVERTED_ARG0:.*]]: tensor<1x16xf32>, %[[CONVERTED_ARG1:.*]]: tensor<1x16xf32>, %[[CONVERTED_ARG2:.*]]: tensor<1x16xf32>)
+
+// CHECK:           %[[MUL_ONE:.*]] = arith.mulf %[[CONST_0]], %[[CONVERTED_ARG2]] : tensor<1x16xf32>
+// CHECK:           %[[MUL_TWO:.*]] = arith.mulf %[[CONST_1]], %[[CONVERTED_ARG0]] : tensor<1x16xf32>
+// CHECK:           %[[MUL_THREE:.*]] = arith.mulf %[[MUL_TWO]], %[[CONVERTED_ARG1]] : tensor<1x16xf32>
+// CHECK:           %[[MUL_FOUR:.*]] = arith.mulf %[[MUL_ONE]], %[[MUL_THREE]] : tensor<1x16xf32>
+// CHECK:           %[[ADD_ONE:.*]] = arith.addf %[[CONST_0]], %[[CONVERTED_ARG2]] : tensor<1x16xf32>
+// CHECK:           %[[ADD_TWO:.*]] = arith.addf %[[ADD_ONE]], %[[CONST_1]] : tensor<1x16xf32>
+// CHECK:           %[[ADD_THREE:.*]] = arith.addf %[[MUL_FOUR]], %[[CONVERTED_ARG0]] : tensor<1x16xf32>
+// CHECK:           %[[ADD_FOUR:.*]] = arith.addf %[[ADD_THREE]], %[[CONVERTED_ARG1]] : tensor<1x16xf32>
+// CHECK:           %[[ADD_FIVE:.*]] = arith.addf %[[ADD_TWO]], %[[ADD_FOUR]] : tensor<1x16xf32>
+// CHECK:           secret.yield %[[ADD_FIVE]] : tensor<1x16xf32>
+
+// CHECK:           return %[[RET]]
+
+module {
+  func.func @secrecy_aware_balance(%arg0: !secret.secret<tensor<1x16xf32>>, %arg1: !secret.secret<tensor<1x16xf32>>, %arg2: tensor<1x16xf32>) -> !secret.secret<tensor<1x16xf32>> {
+    %cst_0 = arith.constant dense<5.000000e-01> : tensor<1x16xf32>
+    %cst_1 = arith.constant dense<5.000000e-02> : tensor<1x16xf32>
+    %1 = secret.generic(%arg0 : !secret.secret<tensor<1x16xf32>>, %arg1: !secret.secret<tensor<1x16xf32>>, %arg2: tensor<1x16xf32>) {
+    ^bb0(%arg3: tensor<1x16xf32>, %arg4: tensor<1x16xf32>, %arg5: tensor<1x16xf32>):
+      %2 = arith.mulf %arg3, %cst_0 : tensor<1x16xf32>
+      %3 = arith.mulf %2, %arg4 : tensor<1x16xf32>
+      %4 = arith.mulf %3, %arg5 : tensor<1x16xf32>
+      %5 = arith.mulf %4, %cst_1 : tensor<1x16xf32>
+      %6 = arith.addf %arg3, %cst_0 : tensor<1x16xf32>
+      %7 = arith.addf %6, %arg4 : tensor<1x16xf32>
+      %8 = arith.addf %7, %arg5 : tensor<1x16xf32>
+      %9 = arith.addf %8, %cst_1 : tensor<1x16xf32>
+      %10 = arith.addf %5, %9 : tensor<1x16xf32>
+      secret.yield %10 : tensor<1x16xf32>
+    } -> !secret.secret<tensor<1x16xf32>>
+    return %1 : !secret.secret<tensor<1x16xf32>>
+  }
+}


### PR DESCRIPTION
Add support for secrecy aware operation rebalancing using the SecretnessAnalysis solver. Addressing the following issue: (https://github.com/google/heir/issues/836)

Before rebuilding the compute graph in `tryBalanceBlock()` the code partitions the operands based on their retreived Secretness Value (public values are placed at the beginning of the list maitaining the original DFS order after partitioning).

I updated the `balance_sigmoid.mlir` since it was failing due to the re-arragement of operands. The new transformed output maintains sigmoid's computational correctness.

I added a new `secrecy_aware_balance.mlir` tests. I takes a plaintext function argument and plaintext arith.constants.