### PR TITLE
Support linalg.matvec matrices with more rows than cols 

### DIFF
--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -85,6 +85,103 @@ TEST_P(KernelImplementationTest, HaleviShoup3x5) {
   EXPECT_EQ(std::vector<int>(actual.begin(), actual.begin() + 3), expected);
 }
 
+TEST_P(KernelImplementationTest, HaleviShoup4x2) {
+  // Original matrix (4x2):
+  // [0, 1]
+  // [2, 3]
+  // [4, 5]
+  // [6, 7]
+  //
+  // Pre-packed diagonally:
+  // diag_0 = (0, 3, 4, 7)
+  // diag_1 = (1, 2, 5, 6)
+  std::vector<std::vector<int>> matrix = {{0, 3, 4, 7}, {1, 2, 5, 6}};
+  // Replicated vector {3, 4, 3, 4}
+  std::vector<int> vector = {3, 4, 3, 4};
+  std::vector<int> expected = {4, 18, 32, 46};
+
+  LiteralValue matrixInput = matrix;
+  LiteralValue vectorInput = vector;
+
+  auto dag = implementHaleviShoup(
+      vectorInput, matrixInput, {4, 2}, DagType::intTensor(32, {4}),
+      /*zeroDiagonals=*/{}, /*unroll=*/std::get<0>(GetParam()));
+  LiteralValue result = evalKernel(dag)[0];
+  auto actual = std::get<std::vector<int>>(result.get());
+
+  EXPECT_EQ(actual, expected);
+}
+
+TEST_P(KernelImplementationTest, HaleviShoup8x4) {
+  // Original matrix (8x4):
+  // [ 0,  1,  2,  3]
+  // [ 4,  5,  6,  7]
+  // [ 8,  9, 10, 11]
+  // [12, 13, 14, 15]
+  // [16, 17, 18, 19]
+  // [20, 21, 22, 23]
+  // [24, 25, 26, 27]
+  // [28, 29, 30, 31]
+  //
+  // Pre-packed diagonally:
+  // diag_0 = (0, 5, 10, 15, 16, 21, 26, 31)
+  // diag_1 = (1, 6, 11, 12, 17, 22, 27, 28)
+  // diag_2 = (2, 7, 8, 13, 18, 23, 24, 29)
+  // diag_3 = (3, 4, 9, 14, 19, 20, 25, 30)
+  std::vector<std::vector<int>> matrix = {{0, 5, 10, 15, 16, 21, 26, 31},
+                                          {1, 6, 11, 12, 17, 22, 27, 28},
+                                          {2, 7, 8, 13, 18, 23, 24, 29},
+                                          {3, 4, 9, 14, 19, 20, 25, 30}};
+  // Replicated vector {3, 4, 5, 6, 3, 4, 5, 6}
+  std::vector<int> vector = {3, 4, 5, 6, 3, 4, 5, 6};
+  std::vector<int> expected = {32, 104, 176, 248, 320, 392, 464, 536};
+
+  LiteralValue matrixInput = matrix;
+  LiteralValue vectorInput = vector;
+
+  auto dag = implementHaleviShoup(
+      vectorInput, matrixInput, {8, 4}, DagType::intTensor(32, {8}),
+      /*zeroDiagonals=*/{}, /*unroll=*/std::get<0>(GetParam()));
+  LiteralValue result = evalKernel(dag)[0];
+  auto actual = std::get<std::vector<int>>(result.get());
+
+  EXPECT_EQ(actual, expected);
+}
+
+TEST_P(KernelImplementationTest, HaleviShoup5x3) {
+  // Original matrix (5x3):
+  // [ 0,  1,  2]
+  // [ 3,  4,  5]
+  // [ 6,  7,  8]
+  // [ 9, 10, 11]
+  // [12, 13, 14]
+  //
+  // Padded to 8x4 and packed diagonally:
+  // diag_0 = (0, 4, 8, 0, 12, 0, 0, 0)
+  // diag_1 = (1, 5, 0, 9, 13, 0, 0, 0)
+  // diag_2 = (2, 0, 6, 10, 14, 0, 0, 0)
+  // diag_3 = (0, 3, 7, 11, 0, 0, 0, 0)
+  std::vector<std::vector<int>> matrix = {{0, 4, 8, 0, 12, 0, 0, 0},
+                                          {1, 5, 0, 9, 13, 0, 0, 0},
+                                          {2, 0, 6, 10, 14, 0, 0, 0},
+                                          {0, 3, 7, 11, 0, 0, 0, 0}};
+  // Padded and replicated vector {1, 2, 3, 0, 1, 2, 3, 0}
+  std::vector<int> vector = {1, 2, 3, 0, 1, 2, 3, 0};
+  std::vector<int> expected = {8, 26, 44, 62, 80};
+
+  LiteralValue matrixInput = matrix;
+  LiteralValue vectorInput = vector;
+
+  auto dag = implementHaleviShoup(
+      vectorInput, matrixInput, {5, 3}, DagType::intTensor(32, {8}),
+      /*zeroDiagonals=*/{}, /*unroll=*/std::get<0>(GetParam()));
+  LiteralValue result = evalKernel(dag)[0];
+  auto actual = std::get<std::vector<int>>(result.get());
+
+  // The result is of size 8, but we only care about the first 5 elements.
+  EXPECT_EQ(std::vector<int>(actual.begin(), actual.begin() + 5), expected);
+}
+
 TEST(KernelImplementationTest, TestExtract) {
   std::vector<std::vector<int>> matrix = {
       {0, 5, 10, 15}, {1, 6, 11, 12}, {2, 7, 8, 13}, {3, 4, 9, 14}};

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -719,10 +719,6 @@ struct ConvertLinalgMatvecLayout
     int64_t numCols = dimensions[1];
     bool isPowerOfTwoDims = isPowerOfTwo(numRows) && isPowerOfTwo(numCols);
 
-    // TODO(#1578): If the matrix has more rows than columns, what kernel
-    // should be used?
-    bool dimensionsCompatible = numRows <= numCols;
-
     auto kernelAttr = op->getAttrOfType<secret::KernelAttr>(
         secret::SecretDialect::kKernelAttrName);
     bool isMatvecDiagonal =
@@ -730,11 +726,10 @@ struct ConvertLinalgMatvecLayout
 
     LLVM_DEBUG(llvm::dbgs()
                << "supports matvec with halevi-shoup: isPowerOfTwoDims="
-               << isPowerOfTwoDims
-               << " isDimensionsCompatible=" << dimensionsCompatible
-               << " isMatvecDiagonal=" << isMatvecDiagonal << "\n");
+               << isPowerOfTwoDims << " isMatvecDiagonal=" << isMatvecDiagonal
+               << "\n");
 
-    return isPowerOfTwoDims && dimensionsCompatible && isMatvecDiagonal;
+    return isPowerOfTwoDims && isMatvecDiagonal;
   }
 
   void haleviShoupKernel(
@@ -841,10 +836,6 @@ struct ConvertLinalgConv2D
     int64_t numCols = dimensions[1];
     bool isPowerOfTwoDims = isPowerOfTwo(numRows) && isPowerOfTwo(numCols);
 
-    // TODO(#1578): If the matrix has more rows than columns, what kernel
-    // should be used?
-    bool isMatrixCompatible = numRows <= numCols;
-
     auto kernelAttr = op->getAttrOfType<secret::KernelAttr>(
         secret::SecretDialect::kKernelAttrName);
     bool isConv2dAsMatvec =
@@ -853,10 +844,9 @@ struct ConvertLinalgConv2D
     LLVM_DEBUG(llvm::dbgs()
                << "supports expanded conv2d as matvec with halevi-shoup: "
                << "isPowerOfTwoDims=" << isPowerOfTwoDims
-               << " isMatrixCompatible=" << isMatrixCompatible
                << " isConv2dAsMatvec=" << isConv2dAsMatvec << "\n");
 
-    return isPowerOfTwoDims && isMatrixCompatible && isConv2dAsMatvec;
+    return isPowerOfTwoDims && isConv2dAsMatvec;
   }
 
   void haleviShoupKernel(
@@ -975,10 +965,6 @@ struct ConvertLinalgConv2DNchwFchw
     int64_t numCols = dimensions[1];
     bool isPowerOfTwoDims = isPowerOfTwo(numRows) && isPowerOfTwo(numCols);
 
-    // TODO(#1578): If the matrix has more rows than columns, what kernel
-    // should be used?
-    bool isMatrixCompatible = numRows <= numCols;
-
     auto kernelAttr = op->getAttrOfType<secret::KernelAttr>(
         secret::SecretDialect::kKernelAttrName);
     bool isConv2dAsMatvec =
@@ -987,10 +973,9 @@ struct ConvertLinalgConv2DNchwFchw
     LLVM_DEBUG(llvm::dbgs()
                << "supports expanded conv2d as matvec with halevi-shoup: "
                << "isPowerOfTwoDims=" << isPowerOfTwoDims
-               << " isMatrixCompatible=" << isMatrixCompatible
                << " isConv2dAsMatvec=" << isConv2dAsMatvec << "\n");
 
-    return isPowerOfTwoDims && isMatrixCompatible && isConv2dAsMatvec;
+    return isPowerOfTwoDims && isConv2dAsMatvec;
   }
 
   void haleviShoupKernel(

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
@@ -527,11 +527,6 @@ LogicalResult LayoutPropagation::visitOperation(MatvecOp op) {
   auto matrix = matvecOp.lhs();
   auto matrixType = cast<RankedTensorType>(matrix.getType());
 
-  // Number of rows must be less than or equal to the number of columns.
-  if (matrixType.getDimSize(0) > matrixType.getDimSize(1)) {
-    return op->emitError() << "Matrix rows must be less than columns";
-  }
-
   // TODO(#1597): a layout optimizer should really be selecting the diagonal
   // layout instead of this pass.
 

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -1,5 +1,6 @@
 #include "lib/Utils/Layout/Utils.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -290,9 +291,9 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
   unsigned int cols = matrixType.getDimSize(1);
 
   // The diagonals of the result must be able to fit an entire diagonal of the
-  // matrix, so ensure that the number of columns (diagonal size) is less than
+  // matrix, so ensure that the diagonal size is less than
   // the result's columns.
-  assert(cols <= ciphertextSize);
+  assert(std::max(rows, cols) <= ciphertextSize);
 
   // The number of rows must divide the number of columns.
   int64_t paddedCols = isPowerOfTwo(cols) ? cols : nextPowerOfTwo(cols);
@@ -310,7 +311,8 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
   for (int i = 0; i < 2; ++i) {
     result.addBound(BoundType::LB, rangeOffset + i, 0);
   }
-  result.addBound(BoundType::UB, rangeOffset, paddedRows - 1);
+  int64_t numDiagonals = std::min(paddedRows, paddedCols);
+  result.addBound(BoundType::UB, rangeOffset, numDiagonals - 1);
   result.addBound(BoundType::UB, rangeOffset + 1, ciphertextSize - 1);
 
   // Add diagonal layout constraints:

--- a/tests/Examples/common/conv2d_nchw_tall_1.mlir
+++ b/tests/Examples/common/conv2d_nchw_tall_1.mlir
@@ -1,0 +1,8 @@
+module {
+  func.func @conv2d_nchw(%arg0 : tensor<1x1x4x4xf32> {secret.secret}) -> tensor<1x8x2x2xf32> {
+    %filter = arith.constant dense<1.0> : tensor<8x1x2x2xf32>
+    %out = arith.constant dense<0.0> : tensor<1x8x2x2xf32>
+    %0 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%arg0, %filter : tensor<1x1x4x4xf32>, tensor<8x1x2x2xf32>) outs(%out : tensor<1x8x2x2xf32>) -> tensor<1x8x2x2xf32>
+    return %0 : tensor<1x8x2x2xf32>
+  }
+}

--- a/tests/Examples/common/conv2d_nchw_tall_2.mlir
+++ b/tests/Examples/common/conv2d_nchw_tall_2.mlir
@@ -1,0 +1,8 @@
+module {
+  func.func @conv2d_nchw(%arg0 : tensor<1x1x8x8xf32> {secret.secret}) -> tensor<1x8x4x4xf32> {
+    %filter = arith.constant dense<1.0> : tensor<8x1x2x2xf32>
+    %out = arith.constant dense<0.0> : tensor<1x8x4x4xf32>
+    %0 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%arg0, %filter : tensor<1x1x8x8xf32>, tensor<8x1x2x2xf32>) outs(%out : tensor<1x8x4x4xf32>) -> tensor<1x8x4x4xf32>
+    return %0 : tensor<1x8x4x4xf32>
+  }
+}

--- a/tests/Examples/common/matvec_8x4.mlir
+++ b/tests/Examples/common/matvec_8x4.mlir
@@ -1,0 +1,15 @@
+module {
+  func.func @matvec(%arg0 : tensor<4xf32> {secret.secret}) -> tensor<8xf32> {
+    %matrix = arith.constant dense<[[0.0, 1.0, 2.0, 3.0],
+                                    [4.0, 5.0, 6.0, 7.0],
+                                    [8.0, 9.0, 10.0, 11.0],
+                                    [12.0, 13.0, 14.0, 15.0],
+                                    [16.0, 17.0, 18.0, 19.0],
+                                    [20.0, 21.0, 22.0, 23.0],
+                                    [24.0, 25.0, 26.0, 27.0],
+                                    [28.0, 29.0, 30.0, 31.0]]> : tensor<8x4xf32>
+    %out = arith.constant dense<0.0> : tensor<8xf32>
+    %0 = linalg.matvec ins(%matrix, %arg0 : tensor<8x4xf32>, tensor<4xf32>) outs(%out : tensor<8xf32>) -> tensor<8xf32>
+    return %0 : tensor<8xf32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_tall_1/BUILD
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_tall_1/BUILD
@@ -1,0 +1,22 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv2d_nchw_tall_1",
+    go_library_name = "conv2dnchwtall1",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=1024",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "@heir//tests/Examples/common:conv2d_nchw_tall_1.mlir",
+)
+
+go_test(
+    name = "conv2dnchwtall1_test",
+    size = "small",
+    srcs = ["conv2d_nchw_tall_1_test.go"],
+    embed = [":conv2dnchwtall1"],
+)

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_tall_1/conv2d_nchw_tall_1_test.go
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_tall_1/conv2d_nchw_tall_1_test.go
@@ -1,0 +1,34 @@
+package conv2dnchwtall1
+
+import (
+	"math"
+	"testing"
+)
+
+func TestConv2D(t *testing.T) {
+	evaluator, params, ecd, enc, dec := conv2d_nchw__configure()
+
+	cols := 16 // input elements
+	arg0 := make([]float32, cols)
+	for i := 0; i < cols; i++ {
+		arg0[i] = float32(i)
+	}
+
+	expectedSingleChannel := []float32{10, 18, 42, 50}
+	expected := make([]float32, 32)
+	for c := 0; c < 8; c++ {
+		for i := 0; i < 4; i++ {
+			expected[c*4+i] = expectedSingleChannel[i]
+		}
+	}
+
+	ct0 := conv2d_nchw__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	resultCt := conv2d_nchw(evaluator, params, ecd, ct0)
+	result := conv2d_nchw__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+	errorThreshold := float64(0.5)
+	for i := 0; i < 32; i++ {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: %.2f != %.2f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_tall_2/BUILD
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_tall_2/BUILD
@@ -1,0 +1,22 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv2d_nchw_tall_2",
+    go_library_name = "conv2dnchwtall2",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=1024",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "@heir//tests/Examples/common:conv2d_nchw_tall_2.mlir",
+)
+
+go_test(
+    name = "conv2dnchwtall2_test",
+    size = "small",
+    srcs = ["conv2d_nchw_tall_2_test.go"],
+    embed = [":conv2dnchwtall2"],
+)

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_tall_2/conv2d_nchw_tall_2_test.go
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_tall_2/conv2d_nchw_tall_2_test.go
@@ -1,0 +1,34 @@
+package conv2dnchwtall2
+
+import (
+	"math"
+	"testing"
+)
+
+func TestConv2D(t *testing.T) {
+	evaluator, params, ecd, enc, dec := conv2d_nchw__configure()
+
+	cols := 64 // input elements
+	arg0 := make([]float32, cols)
+	for i := 0; i < cols; i++ {
+		arg0[i] = float32(i)
+	}
+
+	expectedSingleChannel := []float32{18, 26, 34, 42, 82, 90, 98, 106, 146, 154, 162, 170, 210, 218, 226, 234}
+	expected := make([]float32, 128)
+	for c := 0; c < 8; c++ {
+		for i := 0; i < 16; i++ {
+			expected[c*16+i] = expectedSingleChannel[i]
+		}
+	}
+
+	ct0 := conv2d_nchw__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	resultCt := conv2d_nchw(evaluator, params, ecd, ct0)
+	result := conv2d_nchw__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+	errorThreshold := float64(0.5)
+	for i := 0; i < 128; i++ {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: %.2f != %.2f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/ckks/matvec_tall/BUILD
+++ b/tests/Examples/lattigo/ckks/matvec_tall/BUILD
@@ -1,0 +1,22 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "matvec_tall",
+    go_library_name = "matvectall",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=1024",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "@heir//tests/Examples/common:matvec_8x4.mlir",
+)
+
+go_test(
+    name = "matvectall_test",
+    size = "small",
+    srcs = ["matvec_tall_test.go"],
+    embed = [":matvectall"],
+)

--- a/tests/Examples/lattigo/ckks/matvec_tall/matvec_tall_test.go
+++ b/tests/Examples/lattigo/ckks/matvec_tall/matvec_tall_test.go
@@ -1,0 +1,28 @@
+package matvectall
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMatvec(t *testing.T) {
+	evaluator, params, ecd, enc, dec := matvec__configure()
+
+	cols := 4
+	rows := 8
+	arg0 := make([]float32, cols)
+	for i := 0; i < cols; i++ {
+		arg0[i] = float32(i + 1)
+	}
+
+	expected := []float32{20, 60, 100, 140, 180, 220, 260, 300}
+	ct0 := matvec__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	resultCt := matvec(evaluator, params, ecd, ct0)
+	result := matvec__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+	errorThreshold := float64(0.5)
+	for i := 0; i < rows; i++ {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: %.2f != %.2f", i, result[i], expected[i])
+		}
+	}
+}


### PR DESCRIPTION
Turns out, the existing matvec kernels works on "tall and skinny" matrices as-is. The wraparound logic we added for "squat" matrices works verbatim, and only superficial changes are required to remove the guards.

Fixes https://github.com/google/heir/issues/1578

Assisted by Jetski