### PR TITLE
Support linalg.dot and zero-dimensional tensors in HEIR

### DIFF
--- a/lib/Kernel/Kernel.cpp
+++ b/lib/Kernel/Kernel.cpp
@@ -30,6 +30,7 @@ static std::unordered_map<KernelName, std::vector<std::string>>
         {KernelName::MatmulDiagonal, {"linalg.matmul"}},
         {KernelName::MatmulDiagonal, {"linalg.conv2d"}},
         {KernelName::MatmulBicyclic, {"linalg.matmul"}},
+        {KernelName::Dot, {"linalg.dot"}},
 };
 
 std::set<std::string> requiredNontrivial = {"linalg"};
@@ -78,6 +79,8 @@ std::string kernelNameAsStr(const KernelName& kernelName) {
       return "VecmatDiagonal";
     case KernelName::MatmulBicyclic:
       return "MatmulBicyclic";
+    case KernelName::Dot:
+      return "Dot";
     default:
       return "Unknown";
   }

--- a/lib/Kernel/Kernel.h
+++ b/lib/Kernel/Kernel.h
@@ -31,6 +31,7 @@ struct FieldParser<heir::KernelName> {
     if (kernelName == "VecmatDiagonal") return heir::KernelName::VecmatDiagonal;
     if (kernelName == "MatmulDiagonal") return heir::KernelName::MatmulDiagonal;
     if (kernelName == "MatmulBicyclic") return heir::KernelName::MatmulBicyclic;
+    if (kernelName == "Dot") return heir::KernelName::Dot;
 
     return failure();
   }

--- a/lib/Kernel/KernelImplementation.h
+++ b/lib/Kernel/KernelImplementation.h
@@ -74,17 +74,26 @@ implementMatvec(KernelName kernelName, const T& matrix, const T& vector) {
 template <typename T>
 std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
                  std::shared_ptr<ArithmeticDagNode<T>>>
-implementRotateAndReduceAccumulation(const T& vector, int64_t period,
-                                     int64_t steps, DagReducer<T> reduceFunc) {
+implementRotateAndReduceAccumulation(
+    std::shared_ptr<ArithmeticDagNode<T>> vectorDag, int64_t period,
+    int64_t steps, DagReducer<T> reduceFunc) {
   using NodeTy = ArithmeticDagNode<T>;
-  auto vectorDag = NodeTy::leaf(vector);
-
   for (int64_t shiftSize = steps / 2; shiftSize > 0; shiftSize /= 2) {
     auto rotated = NodeTy::leftRotate(vectorDag, shiftSize * period);
     auto reduced = reduceFunc(vectorDag, rotated);
     vectorDag = reduced;
   }
   return vectorDag;
+}
+
+template <typename T>
+std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
+                 std::shared_ptr<ArithmeticDagNode<T>>>
+implementRotateAndReduceAccumulation(const T& vector, int64_t period,
+                                     int64_t steps, DagReducer<T> reduceFunc) {
+  using NodeTy = ArithmeticDagNode<T>;
+  return implementRotateAndReduceAccumulation<T>(NodeTy::leaf(vector), period,
+                                                 steps, reduceFunc);
 }
 
 // Rolled version of implementRotateAndReduceAccumulation.
@@ -436,6 +445,18 @@ implementRotateAndReduce(const T& vector, std::optional<T> plaintexts,
   return implementBabyStepGiantStepRolled<T>(
       vector, plaintexts.value(), period, steps, dagType, dynamicExtractFunc,
       defaultDagDerivedRotationIndexFn<T>);
+}
+
+// Returns an arithmetic DAG that implements a dot product kernel.
+template <typename T>
+std::enable_if_t<std::is_base_of<AbstractValue, T>::value,
+                 std::shared_ptr<ArithmeticDagNode<T>>>
+implementDot(const T& lhs, const T& rhs, int64_t steps,
+             const DagType& dagType) {
+  using NodeTy = ArithmeticDagNode<T>;
+  auto mulDag = NodeTy::mul(NodeTy::leaf(lhs), NodeTy::leaf(rhs));
+  return implementRotateAndReduceAccumulation<T>(mulDag, /*period=*/1, steps,
+                                                 NodeTy::add);
 }
 
 // Returns an arithmetic DAG that implements a baby-step-giant-step between

--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -737,6 +737,32 @@ INSTANTIATE_TEST_SUITE_P(WithAndWithoutRolledSuite, KernelImplementationTest,
                          testing::Combine(testing::Values(false, true),
                                           testing::Values(false, true)));
 
+TEST(KernelImplementationTest, TestDot) {
+  std::vector<int> lhs = {1, 2, 3, 4};
+  std::vector<int> rhs = {5, 6, 7, 8};
+  std::vector<int> expected = {70, 70, 70, 70};
+
+  LiteralValue lhsInput = lhs;
+  LiteralValue rhsInput = rhs;
+
+  auto dag = implementDot(lhsInput, rhsInput, 4, DagType::intTensor(32, {4}));
+  LiteralValue result = evalKernel(dag)[0];
+  auto actual = std::get<std::vector<int>>(result.get());
+
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(KernelImplementationTest, TestDotRotationCount) {
+  SymbolicValue lhsVector({4}, true);
+  SymbolicValue rhsVector({4}, true);
+  auto dag = implementDot(lhsVector, rhsVector, 4, DagType::intTensor(32, {4}));
+
+  RotationCountVisitor rotationCounter;
+  int64_t rotationCount = rotationCounter.process(dag);
+
+  EXPECT_EQ(rotationCount, 2);
+}
+
 }  // namespace
 }  // namespace kernel
 }  // namespace heir

--- a/lib/Kernel/KernelName.h
+++ b/lib/Kernel/KernelName.h
@@ -30,6 +30,9 @@ enum KernelName : int {
 
   // Ciphertext-ciphertext matmul using the bicyclic packing method.
   MatmulBicyclic,
+
+  // Product and sum of two vectors, using a log2 rotate-and-reduce approach.
+  Dot,
 };
 
 std::ostream& operator<<(std::ostream& os, const KernelName& k);

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -1027,9 +1027,13 @@ LogicalResult LattigoEmitter::printOperation(tensor::EmptyOp op) {
 LogicalResult LattigoEmitter::printOperation(tensor::ExtractOp op) {
   std::string resultName = getName(op.getResult());
   os << getName(op.getResult()) << " := " << getName(op.getTensor()) << "[";
-  os << flattenIndexExpression(
-      op.getTensor().getType(), op.getIndices(),
-      [&](Value value) { return variableNames->getNameForValue(value); });
+  if (op.getIndices().empty()) {
+    os << "0";
+  } else {
+    os << flattenIndexExpression(
+        op.getTensor().getType(), op.getIndices(),
+        [&](Value value) { return variableNames->getNameForValue(value); });
+  }
   os << "]\n";
   return success();
 }
@@ -1197,8 +1201,12 @@ LogicalResult LattigoEmitter::printOperation(tensor::InsertOp op) {
   }
   // result[index] = value
   os << resultName << "[";
-  os << flattenIndexExpression(op.getResult().getType(), op.getIndices(),
-                               [&](Value value) { return getName(value); });
+  if (op.getIndices().empty()) {
+    os << "0";
+  } else {
+    os << flattenIndexExpression(op.getResult().getType(), op.getIndices(),
+                                 [&](Value value) { return getName(value); });
+  }
   os << "] = " << getName(op.getScalar()) << "\n";
   return success();
 }

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -1372,11 +1372,15 @@ LogicalResult OpenFhePkeEmitter::printOperation(tensor::ExtractOp op) {
   }
   os << variableNames->getNameForValue(op.getTensor());
   os << "[";
-  os << flattenIndexExpression(
-      op.getTensor().getType(), op.getIndices(), [&](Value value) {
-        auto constantStr = getStringForConstant(value);
-        return constantStr.value_or(variableNames->getNameForValue(value));
-      });
+  if (op.getIndices().empty()) {
+    os << "0";
+  } else {
+    os << flattenIndexExpression(
+        op.getTensor().getType(), op.getIndices(), [&](Value value) {
+          auto constantStr = getStringForConstant(value);
+          return constantStr.value_or(variableNames->getNameForValue(value));
+        });
+  }
   os << "];\n";
   return success();
 }
@@ -1591,11 +1595,15 @@ LogicalResult OpenFhePkeEmitter::printOperation(tensor::InsertOp op) {
   // dest[idx] = scalar;
   os << variableNames->getNameForValue(op.getDest());
   os << "[";
-  os << flattenIndexExpression(
-      op.getResult().getType(), op.getIndices(), [&](Value value) {
-        auto constantStr = getStringForConstant(value);
-        return constantStr.value_or(variableNames->getNameForValue(value));
-      });
+  if (op.getIndices().empty()) {
+    os << "0";
+  } else {
+    os << flattenIndexExpression(
+        op.getResult().getType(), op.getIndices(), [&](Value value) {
+          auto constantStr = getStringForConstant(value);
+          return constantStr.value_or(variableNames->getNameForValue(value));
+        });
+  }
   os << "]";
   os << " = " << variableNames->getNameForValue(op.getScalar()) << ";\n";
 

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -687,6 +687,81 @@ class ConvertLinalgReduce
   }
 };
 
+struct ConvertLinalgDot
+    : public ContextAwareOpConversionPattern<linalg::DotOp> {
+ public:
+  using ContextAwareOpConversionPattern<
+      linalg::DotOp>::ContextAwareOpConversionPattern;
+
+  LayoutAttr getLayoutAttr(Value value) const {
+    auto layoutLookup = getTypeConverter()->getContextualAttr(value);
+    if (failed(layoutLookup)) {
+      return nullptr;
+    }
+    return dyn_cast<LayoutAttr>(layoutLookup.value());
+  }
+
+  LogicalResult matchAndRewrite(
+      linalg::DotOp op, OpAdaptor adaptor,
+      ContextAwareConversionPatternRewriter& rewriter) const final {
+    Value lhs = adaptor.getInputs()[0];
+    Value rhs = adaptor.getInputs()[1];
+    Value acc = adaptor.getOutputs()[0];
+
+    LayoutAttr lhsLayout = getLayoutAttr(lhs);
+    LayoutAttr rhsLayout = getLayoutAttr(rhs);
+    if (!lhsLayout || !rhsLayout) {
+      return rewriter.notifyMatchFailure(
+          op, "missing new layout attribute for inputs");
+    }
+
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    Type elementType = cast<RankedTensorType>(lhs.getType()).getElementType();
+    std::string reduceOpName;
+    if (isa<FloatType>(elementType)) {
+      reduceOpName = "arith.addf";
+    } else if (isa<IntegerType>(elementType)) {
+      reduceOpName = "arith.addi";
+    } else {
+      return op.emitError("unsupported element type for linalg.dot");
+    }
+
+    auto originalShape =
+        cast<RankedTensorType>(op.getInputs()[0].getType()).getShape();
+    unsigned steps = originalShape[0];
+
+    std::shared_ptr<ArithmeticDagNode<SSAValue>> implementedKernel;
+    kernel::DagType dagType = kernel::mlirTypeToDagType(lhs.getType());
+
+    implementedKernel =
+        implementDot(SSAValue(lhs), SSAValue(rhs), steps, dagType);
+
+    rewriter.setInsertionPointAfter(op);
+
+    auto layoutAttr = cast<LayoutAttr>(op->getAttr(kLayoutAttrName));
+
+    auto convertedType =
+        getTypeConverter()->convertType(lhs.getType(), layoutAttr);
+
+    IRMaterializingVisitor visitor(convertedType, [&](Operation* createdOp) {
+      setMaterializedAttr(createdOp);
+    });
+    Value finalOutput = visitor.process(implementedKernel, b)[0];
+
+    auto* finalOutputOp = finalOutput.getDefiningOp();
+    finalOutputOp->setAttr(kLayoutAttrName, layoutAttr);
+    setMaterializedAttr(finalOutputOp);
+
+    Operation* addBias =
+        makeAppropriatelyTypedAddOp(b, op->getLoc(), finalOutput, acc);
+    addBias->setAttr(kLayoutAttrName, layoutAttr);
+    setMaterializedAttr(addBias);
+    rewriter.replaceOp(op, addBias);
+
+    return success();
+  }
+};
+
 struct ConvertLinalgMatvecLayout
     : public ContextAwareOpConversionPattern<linalg::MatvecOp> {
  public:
@@ -2244,10 +2319,11 @@ struct ConvertToCiphertextSemantics
 
     patterns.add<ConvertAnyAddingMaterializedAttr, ConvertConvertLayout,
                  ConvertFunc, ConvertLinalgMatmul, ConvertLinalgReduce,
-                 ConvertSecretGeneric, ConvertTensorCollapseShape,
-                 ConvertTensorExpandShape, ConvertTensorExtractLayout,
-                 ConvertTensorExtractSlice, ConvertTensorInsertLayout,
-                 ConvertTensorInsertSlice>(typeConverter, context);
+                 ConvertLinalgDot, ConvertSecretGeneric,
+                 ConvertTensorCollapseShape, ConvertTensorExpandShape,
+                 ConvertTensorExtractLayout, ConvertTensorExtractSlice,
+                 ConvertTensorInsertLayout, ConvertTensorInsertSlice>(
+        typeConverter, context);
     patterns.add<ConvertLinalgMatvecLayout, ConvertLinalgConv2D,
                  ConvertLinalgConv2DNchwFchw>(typeConverter, context,
                                               unrollKernels);

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
@@ -474,6 +474,24 @@ static FailureOr<Cost> computeKernelCostFromDAG(KernelName kernel,
       return costModel.process(implementedKernel);
     }
 
+    case KernelName::Dot: {
+      auto lhsType = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+      if (!lhsType) return failure();
+      auto rhsType = dyn_cast<RankedTensorType>(op->getOperand(1).getType());
+      if (!rhsType) return failure();
+      auto shape = lhsType.getShape();
+      auto dagType = kernel::mlirTypeToDagType(lhsType);
+
+      SymbolicValue lhsVector({shape[0]}, /*isSecret=*/true);
+      SymbolicValue rhsVector({shape[0]}, /*isSecret=*/true);
+
+      auto kernelDag =
+          kernel::implementDot(lhsVector, rhsVector, shape[0], dagType);
+
+      if (!kernelDag) return failure();
+      return costModel.process(kernelDag);
+    }
+
     default:
       return failure();
   }

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
@@ -62,6 +62,7 @@ namespace heir {
 
 using linalg::Conv2DNchwFchwOp;
 using linalg::Conv2DOp;
+using linalg::DotOp;
 using linalg::MatmulOp;
 using linalg::MatvecOp;
 using linalg::ReduceOp;
@@ -146,6 +147,7 @@ struct LayoutPropagation : impl::LayoutPropagationBase<LayoutPropagation> {
   LogicalResult visitOperation(VecmatOp op);
   LogicalResult visitOperation(MatvecOp op);
   LogicalResult visitOperation(MatmulOp op);
+  LogicalResult visitOperation(DotOp op);
   LogicalResult visitOperation(YieldOp op);
   LogicalResult visitOperation(affine::AffineForOp op);
   LogicalResult visitOperation(func::FuncOp op);
@@ -162,6 +164,7 @@ struct LayoutPropagation : impl::LayoutPropagationBase<LayoutPropagation> {
   CompatibilityResult hasCompatibleArgumentLayouts(Operation* op);
 
   // Op-specific compatibility functions
+  CompatibilityResult hasCompatibleArgumentLayouts(DotOp op);
   CompatibilityResult hasCompatibleArgumentLayouts(Conv2DOp op);
   CompatibilityResult hasCompatibleArgumentLayouts(Conv2DNchwFchwOp op);
   CompatibilityResult hasCompatibleArgumentLayouts(ReduceOp op);
@@ -174,6 +177,7 @@ struct LayoutPropagation : impl::LayoutPropagationBase<LayoutPropagation> {
   void rectifyIncompatibleOperandLayouts(Operation* op);
 
   // Op-specific overrides
+  void rectifyIncompatibleOperandLayouts(DotOp op);
   void rectifyIncompatibleOperandLayouts(ReduceOp op);
   void rectifyIncompatibleOperandLayouts(tensor::InsertOp op);
   void rectifyIncompatibleOperandLayouts(tensor::InsertSliceOp op);
@@ -290,8 +294,8 @@ LogicalResult LayoutPropagation::visitOperation(Operation* op) {
       // secret ops
       .Case<GenericOp, YieldOp>([&](auto op) { return visitOperation(op); })
       // linalg ops
-      .Case<MatvecOp, VecmatOp, ReduceOp, MatmulOp, Conv2DOp, Conv2DNchwFchwOp>(
-          [&](auto op) { return visitOperation(op); })
+      .Case<DotOp, MatvecOp, VecmatOp, ReduceOp, MatmulOp, Conv2DOp,
+            Conv2DNchwFchwOp>([&](auto op) { return visitOperation(op); })
       // affine ops
       .Case<affine::AffineForOp>([&](auto op) { return visitOperation(op); })
       // tensor ops
@@ -582,6 +586,26 @@ LogicalResult LayoutPropagation::visitOperation(MatvecOp op) {
   MLIRContext* ctx = &getContext();
   auto kernelAttr =
       secret::KernelAttr::get(ctx, KernelName::MatvecDiagonal, /*force=*/false);
+  op->setAttr(secret::SecretDialect::kKernelAttrName, kernelAttr);
+
+  return success();
+}
+
+LogicalResult LayoutPropagation::visitOperation(DotOp op) {
+  LLVM_DEBUG(llvm::dbgs() << "visitOperation(DotOp): " << op << "\n");
+  Value result = op.getResult(0);
+  FailureOr<LayoutAttr> layout = defaultLayoutForType(result.getType());
+  if (failed(layout)) {
+    return failure();
+  }
+  assignedLayouts.insert({result, layout.value()});
+  setResultLayoutAttr(op);
+  debugAssignLayout(result, layout.value());
+
+  // Add secret.kernel attribute for Dot
+  MLIRContext* ctx = &getContext();
+  auto kernelAttr =
+      secret::KernelAttr::get(ctx, KernelName::Dot, /*force=*/false);
   op->setAttr(secret::SecretDialect::kKernelAttrName, kernelAttr);
 
   return success();
@@ -1015,7 +1039,7 @@ CompatibilityResult LayoutPropagation::hasCompatibleArgumentLayouts(
             affine::AffineYieldOp>(
           [&](auto op) { return CompatibilityResult{true, std::nullopt}; })
       // Ops with special rules
-      .Case<ReduceOp, MatvecOp, VecmatOp, Conv2DOp, Conv2DNchwFchwOp,
+      .Case<DotOp, ReduceOp, MatvecOp, VecmatOp, Conv2DOp, Conv2DNchwFchwOp,
             tensor::InsertSliceOp>(
           [&](auto op) { return hasCompatibleArgumentLayouts(op); })
       // By default, assume operands must all have the same layout.
@@ -1049,6 +1073,23 @@ CompatibilityResult LayoutPropagation::hasCompatibleArgumentLayouts(
 
         return CompatibilityResult{true, std::nullopt};
       });
+}
+
+CompatibilityResult LayoutPropagation::hasCompatibleArgumentLayouts(DotOp op) {
+  LayoutAttr lhsLayout = assignedLayouts.at(op.getOperand(0));
+  LayoutAttr rhsLayout = assignedLayouts.at(op.getOperand(1));
+
+  if (lhsLayout != rhsLayout) {
+    return {false, std::nullopt};
+  }
+
+  // Outs operand (operand 2) should be 0D.
+  LayoutAttr outsLayout = assignedLayouts.at(op.getOperand(2));
+  if (outsLayout.getIntegerRelation().getNumDomainVars() != 0) {
+    return {false, std::nullopt};
+  }
+
+  return {true, std::nullopt};
 }
 
 CompatibilityResult LayoutPropagation::hasCompatibleArgumentLayouts(
@@ -1195,7 +1236,7 @@ void LayoutPropagation::rectifyIncompatibleOperandLayouts(Operation* op) {
 
   TypeSwitch<Operation*>(op)
       // Ops with special rules
-      .Case<ReduceOp, tensor::InsertOp, tensor::InsertSliceOp>(
+      .Case<DotOp, ReduceOp, tensor::InsertOp, tensor::InsertSliceOp>(
           [&](auto op) { return rectifyIncompatibleOperandLayouts(op); })
       .Default([&](Operation* op) {
         // Default target layout is chosen arbitrarily as the first operand's
@@ -1232,6 +1273,48 @@ void LayoutPropagation::rectifyIncompatibleOperandLayouts(Operation* op) {
           }
         }
       });
+}
+
+void LayoutPropagation::rectifyIncompatibleOperandLayouts(DotOp op) {
+  mlir::IRRewriter builder(&getContext());
+  builder.setInsertionPoint(op);
+
+  LayoutAttr lhsLayout = assignedLayouts.at(op.getOperand(0));
+  LayoutAttr rhsLayout = assignedLayouts.at(op.getOperand(1));
+
+  if (lhsLayout != rhsLayout) {
+    // Convert RHS to match LHS layout
+    ConvertLayoutOp convertOp = ConvertLayoutOp::create(
+        builder, op->getLoc(), op.getOperand(1), rhsLayout, lhsLayout);
+    auto* lattice =
+        solver->getOrCreateState<SecretnessLattice>(convertOp.getResult());
+    lattice->getValue().setSecretness(isSecret(op.getOperand(1), solver));
+
+    builder.replaceUsesWithIf(
+        op.getOperand(1), convertOp.getResult(),
+        [&](OpOperand& operand) { return operand.getOwner() == op; });
+    assignedLayouts.insert({convertOp.getResult(), lhsLayout});
+  }
+
+  // Ensure Outs is 0D.
+  LayoutAttr outsLayout = assignedLayouts.at(op.getOperand(2));
+  if (outsLayout.getIntegerRelation().getNumDomainVars() != 0) {
+    FailureOr<LayoutAttr> default0D =
+        defaultLayoutForType(op.getOperand(2).getType());
+    if (succeeded(default0D)) {
+      ConvertLayoutOp convertOp =
+          ConvertLayoutOp::create(builder, op->getLoc(), op.getOperand(2),
+                                  outsLayout, default0D.value());
+      auto* lattice =
+          solver->getOrCreateState<SecretnessLattice>(convertOp.getResult());
+      lattice->getValue().setSecretness(isSecret(op.getOperand(2), solver));
+
+      builder.replaceUsesWithIf(
+          op.getOperand(2), convertOp.getResult(),
+          [&](OpOperand& operand) { return operand.getOwner() == op; });
+      assignedLayouts.insert({convertOp.getResult(), default0D.value()});
+    }
+  }
 }
 
 void LayoutPropagation::rectifyIncompatibleOperandLayouts(ReduceOp op) {
@@ -1356,7 +1439,17 @@ FailureOr<LayoutAttr> LayoutPropagation::defaultLayoutForType(Type type) {
 
   RankedTensorType tensorType = dyn_cast<RankedTensorType>(ty);
   if (!tensorType) {
+    LLVM_DEBUG(llvm::dbgs() << "defaultLayoutForType: not a tensor, calling "
+                               "defaultLayoutForScalarType\n");
     return defaultLayoutForScalarType(ty);
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "defaultLayoutForType: tensor rank="
+                          << tensorType.getRank() << "\n");
+  if (tensorType.getRank() == 0) {
+    LLVM_DEBUG(llvm::dbgs() << "defaultLayoutForType: rank 0 tensor, calling "
+                               "defaultLayoutForScalarType\n");
+    return defaultLayoutForScalarType(tensorType.getElementType());
   }
 
   // By default, each tensor is laid out in row-major order. The slots will be

--- a/tests/Emitter/Lattigo/emit_0d_tensor.mlir
+++ b/tests/Emitter/Lattigo/emit_0d_tensor.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-translate %s --emit-lattigo | FileCheck %s
+
+module attributes {scheme.bgv} {
+  func.func @test_0d_tensor(%arg0: tensor<f32>) -> f32 {
+    // CHECK: func test_0d_tensor([[arg0:[^ ]*]] []float32)
+    // CHECK: [[v0:[^ ]*]] := [[arg0]][0]
+    // CHECK: return [[v0]]
+    %0 = tensor.extract %arg0[] : tensor<f32>
+    return %0 : f32
+  }
+
+  func.func @test_0d_tensor_insert(%arg0: tensor<f32>, %v: f32) -> tensor<f32> {
+    // CHECK: func test_0d_tensor_insert([[arg0:[^ ]*]] []float32, [[v:[^ ]*]] float32)
+    // CHECK: [[v0:[^ ]*]] := append(make([]float32, 0, len([[arg0]])), [[arg0]]...)
+    // CHECK: [[v0]][0] = [[v]]
+    // CHECK: return [[v0]]
+    %0 = tensor.insert %v into %arg0[] : tensor<f32>
+    return %0 : tensor<f32>
+  }
+}

--- a/tests/Emitter/Openfhe/emit_0d_tensor.mlir
+++ b/tests/Emitter/Openfhe/emit_0d_tensor.mlir
@@ -1,0 +1,24 @@
+// RUN: heir-translate %s --emit-openfhe-pke | FileCheck %s
+
+!cc = !openfhe.crypto_context
+!pt = !openfhe.plaintext
+!pk = !openfhe.public_key
+!ct = !openfhe.ciphertext
+
+module attributes {scheme.bgv} {
+  func.func @test_0d_tensor(%arg0: tensor<f32>) -> f32 {
+    // CHECK: float test_0d_tensor(std::vector<float> [[arg0:[^ ]*]])
+    // CHECK: float [[v0:[^ ]*]] = [[arg0]][0];
+    // CHECK: return [[v0]];
+    %0 = tensor.extract %arg0[] : tensor<f32>
+    return %0 : f32
+  }
+
+  func.func @test_0d_tensor_insert(%arg0: tensor<f32>, %v: f32) -> tensor<f32> {
+    // CHECK: std::vector<float> test_0d_tensor_insert(std::vector<float> [[arg0:[^ ]*]], float [[v:[^ ]*]])
+    // CHECK: [[arg0]][0] = [[v]];
+    // CHECK: return [[arg0]];
+    %0 = tensor.insert %v into %arg0[] : tensor<f32>
+    return %0 : tensor<f32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/linalg_dot/BUILD
+++ b/tests/Examples/lattigo/ckks/linalg_dot/BUILD
@@ -1,0 +1,23 @@
+# See README.md for setup required to run these tests
+
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "linalg_dot",
+    go_library_name = "linalgdot",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--mlir-to-ckks=ciphertext-degree=2048 first-mod-bits=0",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "linalg_dot.mlir",
+)
+
+go_test(
+    name = "linalgdot_test",
+    srcs = ["linalg_dot_test.go"],
+    embed = [":linalgdot"],
+)

--- a/tests/Examples/lattigo/ckks/linalg_dot/linalg_dot.mlir
+++ b/tests/Examples/lattigo/ckks/linalg_dot/linalg_dot.mlir
@@ -1,0 +1,5 @@
+func.func @dot_product(%arg0: tensor<1024xf32> {secret.secret}, %arg1: tensor<1024xf32> {secret.secret}) -> (tensor<f32> {secret.secret}) {
+  %cst = arith.constant dense<0.000000e+00> : tensor<f32>
+  %0 = linalg.dot {secret.secret} ins(%arg0, %arg1 : tensor<1024xf32>, tensor<1024xf32>) outs(%cst : tensor<f32>) -> tensor<f32>
+  return %0 : tensor<f32>
+}

--- a/tests/Examples/lattigo/ckks/linalg_dot/linalg_dot_test.go
+++ b/tests/Examples/lattigo/ckks/linalg_dot/linalg_dot_test.go
@@ -1,0 +1,36 @@
+package linalgdot
+
+import (
+	"math"
+	"testing"
+)
+
+func TestLinalgDot(t *testing.T) {
+	evaluator, params, ecd, enc, dec := dot_product__configure()
+
+	// Vector of plaintext values
+	arg0 := make([]float32, 1024)
+	arg1 := make([]float32, 1024)
+	for i := 0; i < 1024; i++ {
+		arg0[i] = float32(i) / 1024.0
+		arg1[i] = float32(i) / 1024.0
+	}
+
+	// Compute expected result
+	expected := float32(0.0)
+	for i := 0; i < 1024; i++ {
+		expected += arg0[i] * arg1[i]
+	}
+
+	ct0 := dot_product__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ct1 := dot_product__encrypt__arg1(evaluator, params, ecd, enc, arg1)
+
+	resultCt := dot_product(evaluator, params, ecd, ct0, ct1)
+
+	result := dot_product__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	errorThreshold := float64(0.001)
+	if math.Abs(float64(result[0]-expected)) > errorThreshold {
+		t.Errorf("Decryption error %.4f != %.4f", result[0], expected)
+	}
+}


### PR DESCRIPTION
This PR adds support for `linalg.dot` and zero-dimensional tensors into the default layout engine.