### PR TITLE
contributing: add note about meeting a maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,24 @@ This project follows
 
 ## Contribution process
 
+### Meet the maintainers
+
+New contributors not recognized by the maintainers should meet a project
+maintainer in a non-textual format before their first contribution will be
+accepted. This includes:
+
+- Meeting a maintainer in person.
+- Attending office hours or a working group meeting (cf. our
+  [community calendar](/community/)).
+- Scheduling a video call with a maintainer (reach out via
+  [Discord](/community/) or email).
+
+New PRs, issues, and issue comments from unrecognized contributors that appear
+to be AI-generated will be forwarded to this policy. The maintainers may make
+exceptions for new contributors with a strong prior connection to the community,
+such as known authors of relevant academic publications or related open source
+projects.
+
 ### AI Tool Use Policy
 
 Please see our

--- a/docs/content/en/docs/Development/ai_policy.md
+++ b/docs/content/en/docs/Development/ai_policy.md
@@ -66,6 +66,20 @@ squanders the learning opportunity and doesn't add much value to the project.
 **New contributors using AI tools to fix issues labelled as "good first issues"
 is forbidden**.
 
+Finally, new contributors not recognized by the maintainers should first meet a
+project maintainer in a non-textual format before their first contribution will
+be accepted. This includes:
+
+- Meeting a maintainer in person.
+- Attending office hours or a working group meeting (cf. our
+  [community calendar](/community/)).
+- Scheduling a video call with a maintainer (reach out via
+  [Discord](/community/) or email).
+
+New PRs from unrecognized contributors that appear to be AI-generated will be
+closed with a reference to this policy. New issues or issue comments from
+unrecognized contributors will be directed to this policy.
+
 ## Extractive Contributions
 
 The reason for our "human-in-the-loop" contribution policy is that processing


### PR DESCRIPTION
We had been considering and discussing adding a requirement for contributors to meet a maintainer. This PR makes that official.