### PR TITLE
fix: cleanup scheme parameters in correct place

### DIFF
--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -274,7 +274,6 @@ LogicalResult convertFuncForScheme(func::FuncOp op) {
   int logN = LattigoScheme::getLogN(moduleOp);
   auto paramAttr =
       LattigoScheme::getParametersLiteralAttr(builder.getContext(), moduleOp);
-  LattigoScheme::cleanSchemeParamAttr(moduleOp);
 
   auto paramType = ParameterType::get(builder.getContext());
   auto params =
@@ -367,6 +366,9 @@ LogicalResult convertFuncForScheme(func::FuncOp op) {
 
   results.append({evaluator, params, encoder, encryptor, decryptor});
   func::ReturnOp::create(builder, results);
+
+  LattigoScheme::cleanSchemeParamAttr(moduleOp);
+
   return success();
 }
 

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_bootstrap.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_bootstrap.mlir
@@ -19,6 +19,6 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 17, Q = [1106058
 // CHECK: @bootstrap__configure
 // CHECK-SAME: -> (![[btEvalType]], ![[evalType]],
 // CHECK: %[[param:.*]] = lattigo.ckks.new_parameters_from_literal
-// CHECK: %[[btParams:.*]] = lattigo.ckks.new_bootstrapping_parameters_from_literal %[[param]] {btParamsLiteral = #lattigo.ckks.bootstrapping_parameters_literal<logN = 14>}
+// CHECK: %[[btParams:.*]] = lattigo.ckks.new_bootstrapping_parameters_from_literal %[[param]] {btParamsLiteral = #lattigo.ckks.bootstrapping_parameters_literal<logN = 17>}
 // CHECK: %[[btEvalKeys:.*]] = lattigo.ckks.gen_evaluation_keys_bootstrapping %[[btParams]]
 // CHECK: %[[btEval:.*]] = lattigo.ckks.new_bootstrapping_evaluator %[[btParams]], %[[btEvalKeys]]


### PR DESCRIPTION
I encountered this bug when running a more complex neural network through HEIR with log N = 16 with `--scheme-to-lattigo`. 

IIUC, this is due to the cleanup of the CKKS parameters happening before the bootstrapping parameters are derived. Let me know if you need more information! 

Cheers,
David