### PR TITLE
move TensorToScalars pattern into anonymous namespace

### DIFF
--- a/lib/Transforms/TensorToScalars/TensorToScalars.cpp
+++ b/lib/Transforms/TensorToScalars/TensorToScalars.cpp
@@ -95,6 +95,8 @@ static SmallVector<Value> buildExtractOps(OpBuilder& builder,
   return values;
 }
 
+namespace {
+
 class ConvertFromElementsOp
     : public OpConversionPattern<tensor::FromElementsOp> {
  public:
@@ -235,6 +237,8 @@ class ConvertConstantOp : public OpConversionPattern<arith::ConstantOp> {
     return success();
   }
 };
+
+}  // namespace
 
 struct TensorToScalars : impl::TensorToScalarsBase<TensorToScalars> {
   using TensorToScalarsBase::TensorToScalarsBase;


### PR DESCRIPTION
Found while debugging for [this discord conversation](https://discord.com/channels/901152454077452399/1504160397056544838/1504210170480169010):

Both SecretToGeneric and TensorToScalars had a pattern called `ConvertFromElementsOp` in the `mlir::heir` namespace, which caused a crash in `--convert-tensor-to-scalars` when it would try and cast its pattern to its parent class but actually ended up casting the matching pattern from the other pass...which didn't inherit from the same parent class.

Moving the TensorToScalars pattern into an anonymous namespace fixes this, but in the bigger picture, this should probably also be done for SecretToGeneric and/or we should check the entire codebase for potential ODR violation footguns like this. Not sure if there's a nice way to automatically find them, though....