### PR TITLE
Add LWE to JaxiteWord conversion pass

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/BUILD
+++ b/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/BUILD
@@ -1,0 +1,35 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "LWEToJaxiteWord",
+    srcs = ["LWEToJaxiteWord.cpp"],
+    hdrs = ["LWEToJaxiteWord.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/JaxiteWord/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@heir//lib/Utils:ConversionUtils",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    header_filename = "LWEToJaxiteWord.h.inc",
+    pass_name = "LWEToJaxiteWord",
+    td_file = "LWEToJaxiteWord.td",
+)

--- a/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.cpp
@@ -1,0 +1,381 @@
+#include "lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/BGV/IR/BGVOps.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Dialect/JaxiteWord/IR/JaxiteWordDialect.h"
+#include "lib/Dialect/JaxiteWord/IR/JaxiteWordOps.h"
+#include "lib/Dialect/JaxiteWord/IR/JaxiteWordTypes.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Utils/ConversionUtils.h"
+#include "lib/Utils/Utils.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/TypeUtilities.h"          // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"                 // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+class JaxiteWordTypeConverter : public TypeConverter {
+ public:
+  JaxiteWordTypeConverter(MLIRContext *ctx) {
+    addConversion([](Type type) { return type; });
+    addConversion([ctx](lwe::LWEPublicKeyType type) -> Type {
+      return jaxiteword::PublicKeyType::get(ctx);
+    });
+    addConversion([ctx](lwe::LWESecretKeyType type) -> Type {
+      return jaxiteword::PrivateKeyType::get(ctx);
+    });
+    addConversion([](RankedTensorType type) -> Type {
+      return RankedTensorType::get(type.getShape(), type.getElementType());
+    });
+  }
+};
+
+#define GEN_PASS_DEF_LWETOJAXITEWORD
+#include "lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.h.inc"
+
+namespace {
+
+FailureOr<Value> getContextualCryptoContextForJaxiteWord(Operation *op) {
+  auto funcOp = op->getParentOfType<func::FuncOp>();
+  if (!funcOp) return failure();
+  if (funcOp.getNumArguments() == 0 ||
+      !mlir::isa<jaxiteword::CryptoContextType>(
+          funcOp.getArgument(0).getType())) {
+    return failure();
+  }
+  return funcOp.getArgument(0);
+}
+
+FailureOr<Value> getContextualEvalKeyForJaxiteWord(Operation *op) {
+  auto funcOp = op->getParentOfType<func::FuncOp>();
+  if (!funcOp) return failure();
+  // Based on AddCryptoContextAndKeys, EvalKey is the 2nd argument (index 1)
+  if (funcOp.getNumArguments() < 2 ||
+      !mlir::isa<jaxiteword::EvalKeyType>(funcOp.getArgument(1).getType())) {
+    return failure();
+  }
+  return funcOp.getArgument(1);
+}
+
+struct AddCryptoContextAndKeys : public OpConversionPattern<func::FuncOp> {
+  AddCryptoContextAndKeys(mlir::MLIRContext *context)
+      : OpConversionPattern<func::FuncOp>(context, /* benefit= */ 2) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      func::FuncOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto containsCryptoOps =
+        ::mlir::heir::containsDialects<lwe::LWEDialect, ckks::CKKSDialect,
+                                       bgv::BGVDialect>(op);
+    if (!containsCryptoOps) return failure();
+
+    auto cryptoContextType = jaxiteword::CryptoContextType::get(getContext());
+    auto evalKeyType = jaxiteword::EvalKeyType::get(getContext());
+
+    rewriter.modifyOpInPlace(op, [&] {
+      bool hasContext = op.getFunctionType().getNumInputs() > 0 &&
+                        mlir::isa<jaxiteword::CryptoContextType>(
+                            op.getFunctionType().getInput(0));
+      if (!hasContext) {
+        if (failed(op.insertArgument(0, evalKeyType, nullptr, op.getLoc())))
+          return failure();
+        if (failed(
+                op.insertArgument(0, cryptoContextType, nullptr, op.getLoc())))
+          return failure();
+      }
+    });
+
+    return success();
+  }
+};
+
+template <typename SourceOp, typename TargetOp>
+struct ConvertBinOp : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      SourceOp op, typename SourceOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<TargetOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getLhs(), adaptor.getRhs());
+    return success();
+  }
+};
+
+struct ConvertMulOp : public OpConversionPattern<ckks::MulOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ckks::MulOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    FailureOr<Value> evalKey = getContextualEvalKeyForJaxiteWord(op);
+    if (failed(evalKey)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::MulOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getLhs(), adaptor.getRhs(), evalKey.value());
+    return success();
+  }
+};
+
+template <typename SourceOp>
+struct ConvertNegateOp : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      SourceOp op, typename SourceOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::NegateOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput());
+    return success();
+  }
+};
+
+struct ConvertRotateOp : public OpConversionPattern<ckks::RotateOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ckks::RotateOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    FailureOr<Value> evalKey = getContextualEvalKeyForJaxiteWord(op);
+    if (failed(evalKey)) return failure();
+
+    Value dynamicShift = adaptor.getDynamicShift();
+    IntegerAttr staticShift = op.getStaticShiftAttr();
+    if (!staticShift && !dynamicShift) {
+      return rewriter.notifyMatchFailure(
+          op, "rotate op must have either static or dynamic shift");
+    }
+    if (dynamicShift) {
+      return rewriter.notifyMatchFailure(
+          op, "jaxiteword rotation requires static shift");
+    }
+
+    rewriter.replaceOpWithNewOp<jaxiteword::RotOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput(), evalKey.value(), staticShift);
+    return success();
+  }
+};
+
+struct ConvertRelinOp : public OpConversionPattern<ckks::RelinearizeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ckks::RelinearizeOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    FailureOr<Value> evalKey = getContextualEvalKeyForJaxiteWord(op);
+    if (failed(evalKey)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::RelinOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput(), evalKey.value());
+    return success();
+  }
+};
+
+template <typename SourceOp>
+struct ConvertModSwitchOp : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      SourceOp op, typename SourceOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::ModReduceOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput());
+    return success();
+  }
+};
+
+struct ConvertEncodeOp : public OpConversionPattern<lwe::RLWEEncodeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      lwe::RLWEEncodeOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::EncodeOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput());
+    return success();
+  }
+};
+
+struct ConvertEncryptOp : public OpConversionPattern<lwe::RLWEEncryptOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      lwe::RLWEEncryptOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::EncryptOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput(), adaptor.getKey());
+    return success();
+  }
+};
+
+struct ConvertDecryptOp : public OpConversionPattern<lwe::RLWEDecryptOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      lwe::RLWEDecryptOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::DecryptOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput(), adaptor.getSecretKey());
+    return success();
+  }
+};
+
+struct ConvertDecodeOp : public OpConversionPattern<lwe::RLWEDecodeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      lwe::RLWEDecodeOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> ctx = getContextualCryptoContextForJaxiteWord(op);
+    if (failed(ctx)) return failure();
+
+    rewriter.replaceOpWithNewOp<jaxiteword::DecodeOp>(
+        op, this->getTypeConverter()->convertType(op.getOutput().getType()),
+        ctx.value(), adaptor.getInput());
+    return success();
+  }
+};
+
+}  // namespace
+
+struct LWEToJaxiteWord : public impl::LWEToJaxiteWordBase<LWEToJaxiteWord> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    Operation *op = getOperation();
+
+    RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+
+    target.addLegalDialect<jaxiteword::JaxiteWordDialect,
+                           tensor::TensorDialect>();
+    target.addIllegalDialect<lwe::LWEDialect, ckks::CKKSDialect,
+                             bgv::BGVDialect>();
+    target.addLegalOp<func::ReturnOp>();
+
+    JaxiteWordTypeConverter typeConverter(context);
+
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+      auto containsCryptoOps =
+          ::mlir::heir::containsDialects<lwe::LWEDialect, ckks::CKKSDialect,
+                                         bgv::BGVDialect>(op);
+      if (!containsCryptoOps) return true;
+      bool hasArgs = op.getFunctionType().getNumInputs() >= 2;
+      return typeConverter.isSignatureLegal(op.getFunctionType()) && hasArgs &&
+             mlir::isa<jaxiteword::CryptoContextType>(
+                 op.getFunctionType().getInput(0)) &&
+             mlir::isa<jaxiteword::EvalKeyType>(
+                 op.getFunctionType().getInput(1));
+    });
+
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    addTensorConversionPatterns(typeConverter, patterns, target);
+
+    patterns.add<AddCryptoContextAndKeys>(typeConverter, context);
+    patterns.add<ConvertBinOp<lwe::AddOp, jaxiteword::AddOp>>(typeConverter,
+                                                              context);
+    patterns.add<ConvertBinOp<lwe::RAddOp, jaxiteword::AddOp>>(typeConverter,
+                                                               context);
+    patterns.add<ConvertBinOp<lwe::RSubOp, jaxiteword::SubOp>>(typeConverter,
+                                                               context);
+    patterns.add<ConvertBinOp<ckks::AddOp, jaxiteword::AddOp>>(typeConverter,
+                                                               context);
+    patterns.add<ConvertBinOp<ckks::SubOp, jaxiteword::SubOp>>(typeConverter,
+                                                               context);
+    patterns.add<ConvertMulOp>(typeConverter, context);
+    patterns.add<ConvertBinOp<lwe::RMulOp, jaxiteword::MulNoRelinOp>>(
+        typeConverter, context);
+    patterns.add<ConvertNegateOp<lwe::RNegateOp>>(typeConverter, context);
+    patterns.add<ConvertNegateOp<ckks::NegateOp>>(typeConverter, context);
+    patterns.add<ConvertRotateOp>(typeConverter, context);
+    patterns.add<ConvertRelinOp>(typeConverter, context);
+    patterns.add<ConvertModSwitchOp<bgv::ModulusSwitchOp>>(typeConverter,
+                                                           context);
+    patterns.add<ConvertModSwitchOp<ckks::RescaleOp>>(typeConverter, context);
+    patterns.add<ConvertModSwitchOp<ckks::LevelReduceOp>>(typeConverter,
+                                                          context);
+    patterns.add<ConvertEncodeOp>(typeConverter, context);
+    patterns.add<ConvertEncryptOp>(typeConverter, context);
+    patterns.add<ConvertDecryptOp>(typeConverter, context);
+    patterns.add<ConvertDecodeOp>(typeConverter, context);
+    patterns.add<ConvertBinOp<lwe::RAddPlainOp, jaxiteword::AddPlainOp>>(
+        typeConverter, context);
+    patterns.add<ConvertBinOp<lwe::RSubPlainOp, jaxiteword::SubPlainOp>>(
+        typeConverter, context);
+    patterns.add<ConvertBinOp<lwe::RMulPlainOp, jaxiteword::MulPlainOp>>(
+        typeConverter, context);
+    patterns.add<ConvertBinOp<ckks::AddPlainOp, jaxiteword::AddPlainOp>>(
+        typeConverter, context);
+    patterns.add<ConvertBinOp<ckks::SubPlainOp, jaxiteword::SubPlainOp>>(
+        typeConverter, context);
+    patterns.add<ConvertBinOp<ckks::MulPlainOp, jaxiteword::MulPlainOp>>(
+        typeConverter, context);
+
+    if (failed(applyPartialConversion(op, target, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+void registerLWEToJaxiteWordPasses() {
+  registerPass([]() -> std::unique_ptr<Pass> {
+    return std::make_unique<LWEToJaxiteWord>();
+  });
+}
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.h
+++ b/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.h
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_LWE_CONVERSIONS_LWETOJAXITEWORD_LWETOJAXITEWORD_H_
+#define LIB_DIALECT_LWE_CONVERSIONS_LWETOJAXITEWORD_LWETOJAXITEWORD_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+#define GEN_PASS_DECL_LWETOJAXITEWORD
+#include "lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.h.inc"
+
+void registerLWEToJaxiteWordPasses();
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_LWE_CONVERSIONS_LWETOJAXITEWORD_LWETOJAXITEWORD_H_

--- a/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.td
+++ b/lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.td
@@ -1,0 +1,20 @@
+#ifndef LIB_DIALECT_LWE_CONVERSIONS_LWETOJAXITWORD_LWETOJAXITWORD_TD_
+#define LIB_DIALECT_LWE_CONVERSIONS_LWETOJAXITWORD_LWETOJAXITWORD_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def LWEToJaxiteWord : Pass<"lwe-to-jaxiteword"> {
+  let summary = "Lower `lwe` to `jaxiteword` dialect.";
+
+  let description = [{
+    This pass lowers the `lwe` dialect to `jaxiteword` dialect.
+  }];
+
+  let dependentDialects = [
+    "mlir::heir::lwe::LWEDialect",
+    "mlir::heir::jaxiteword::JaxiteWordDialect",
+    "mlir::arith::ArithDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_LWE_CONVERSIONS_LWETOJAXITWORD_LWETOJAXITWORD_TD_

--- a/tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/BUILD
+++ b/tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/radd.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/radd.mlir
@@ -1,0 +1,23 @@
+// RUN: heir-opt --lwe-to-jaxiteword %s | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+module {
+  // CHECK: func.func @test_radd
+  // CHECK-SAME: (%{{[^:]*}}: !jaxiteword.crypto_context<>, %{{[^:]*}}: !jaxiteword.eval_key<>
+  func.func @test_radd(%ct: !ct_L1_, %ct_0: !ct_L1_) -> !ct_L1_ {
+    // CHECK: jaxiteword.add
+    %sum = lwe.radd %ct, %ct_0 : (!ct_L1_, !ct_L1_) -> !ct_L1_
+    return %sum : !ct_L1_
+  }
+}

--- a/tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/smoke_test.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/smoke_test.mlir
@@ -1,0 +1,45 @@
+// RUN: heir-opt --lwe-to-jaxiteword %s | FileCheck %s
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!pt_ = !lwe.lwe_plaintext<plaintext_space = <ring = #ring_Z65537_i64_1_x1024_, encoding = #full_crt_packing_encoding>>
+!pkey_L1_ = !lwe.lwe_public_key<key = #key, ring = #ring_rns_L1_1_x1024_>
+
+module {
+  // CHECK: @test_ops
+  // CHECK-SAME: (%{{[^:]*}}: !jaxiteword.crypto_context<>, %{{[^:]*}}: !jaxiteword.eval_key<>
+  func.func @test_ops(%ct: !ct_L1_, %ct2: !ct_L1_, %pt: !pt_) -> (!ct_L1_, !ct_L1_, !ct_L1_, !ct_L1_, !ct_L1_, !ct_L1_) {
+    // CHECK: jaxiteword.add
+    %add = lwe.radd %ct, %ct2 : (!ct_L1_, !ct_L1_) -> !ct_L1_
+    // CHECK: jaxiteword.sub
+    %sub = lwe.rsub %ct, %ct2 : (!ct_L1_, !ct_L1_) -> !ct_L1_
+    // CHECK: jaxiteword.negate
+    %neg = lwe.rnegate %ct : !ct_L1_
+    // CHECK: jaxiteword.add_plain
+    %add_plain = lwe.radd_plain %ct, %pt : (!ct_L1_, !pt_) -> !ct_L1_
+    // CHECK: jaxiteword.sub_plain
+    %sub_plain = lwe.rsub_plain %ct, %pt : (!ct_L1_, !pt_) -> !ct_L1_
+    // CHECK: jaxiteword.mul_plain
+    %mul_plain = lwe.rmul_plain %ct, %pt : (!ct_L1_, !pt_) -> !ct_L1_
+    return %add, %sub, %neg, %add_plain, %sub_plain, %mul_plain : !ct_L1_, !ct_L1_, !ct_L1_, !ct_L1_, !ct_L1_, !ct_L1_
+  }
+
+  // CHECK: @test_encode_encrypt
+  // CHECK-SAME: (%{{[^:]*}}: !jaxiteword.crypto_context<>, %{{[^:]*}}: !jaxiteword.eval_key<>
+  func.func @test_encode_encrypt(%input: tensor<1024xi16>, %pk: !pkey_L1_) -> !ct_L1_ {
+    // CHECK: jaxiteword.encode
+    %pt = lwe.rlwe_encode %input {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x1024_} : tensor<1024xi16> -> !pt_
+    // CHECK: jaxiteword.encrypt
+    %ct = lwe.rlwe_encrypt %pt, %pk : (!pt_, !pkey_L1_) -> !ct_L1_
+    return %ct : !ct_L1_
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -65,6 +65,7 @@ cc_binary(
         "@heir//lib/Dialect/JaxiteWord/IR:Dialect",
         "@heir//lib/Dialect/JaxiteWord/Transforms",
         "@heir//lib/Dialect/KeyMgmt/IR:Dialect",
+        "@heir//lib/Dialect/LWE/Conversions/LWEToJaxiteWord",
         "@heir//lib/Dialect/LWE/Conversions/LWEToLattigo",
         "@heir//lib/Dialect/LWE/Conversions/LWEToOpenfhe",
         "@heir//lib/Dialect/LWE/Conversions/LWEToPolynomial",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -24,6 +24,7 @@
 #include "lib/Dialect/JaxiteWord/IR/JaxiteWordDialect.h"
 #include "lib/Dialect/JaxiteWord/Transforms/Passes.h"
 #include "lib/Dialect/KeyMgmt/IR/KeyMgmtDialect.h"
+#include "lib/Dialect/LWE/Conversions/LWEToJaxiteWord/LWEToJaxiteWord.h"
 #include "lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.h"
 #include "lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.h"
 #include "lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.h"
@@ -396,6 +397,7 @@ int main(int argc, char** argv) {
 
   // Dialect conversion passes in HEIR
   bgv::registerBGVToLWEPasses();
+  lwe::registerLWEToJaxiteWordPasses();
   lwe::registerLWEToLattigoPasses();
   lwe::registerLWEToOpenfhePasses();
   lwe::registerLWEToPolynomialPasses();


### PR DESCRIPTION
Adds the lwe-to-jaxiteword conversion pass, which lowers the lwe dialect (and related ckks / bgv ops handled by the pass) to the jaxiteword dialect for CROSS / JaxiteWord codegen.

This is a follow-up to **#2946** (JaxiteWord dialect, emitter, and configure-crypto-context). That PR landed the target dialect and Python emission; this PR wires the LWE → JaxiteWord lowering so HEIR pipelines can reach CROSS backend ops from scheme-level IR.

### Changes

- New pass: lib/Dialect/LWE/Conversions/LWEToJaxiteWord/
- Pass flag: --lwe-to-jaxiteword
- Inserts jaxiteword.crypto_context and jaxiteword.eval_key on func.func when the function contains crypto ops
- Lowers homomorphic ops (e.g. add/sub/mul/rotate/relin/mod-switch, encode/encrypt/decrypt/decode, plaintext variants) to jaxiteword ops
- Register pass in heir-opt (tools/heir-opt.cpp, tools/BUILD)
- Lit tests under tests/Dialect/LWE/Conversions/lwe_to_jaxiteword/:
- smoke_test.mlir - encode + encrypt path runs without error
- radd.mlir - lwe.radd lowers to jaxiteword.add with context/eval-key args

### Notes
Intended to mirror patterns from existing LWE lowering passes (lwe-to-openfhe, lwe-to-polynomial).