### PR TITLE
Orbit's Level-Scale-Aware ILP Bootstrap and Rescale Placement

### DIFF
--- a/lib/Analysis/ILPBootstrapPlacementAnalysis/BUILD
+++ b/lib/Analysis/ILPBootstrapPlacementAnalysis/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "@com_google_ortools//ortools/math_opt/cpp:math_opt",
         "@com_google_ortools//ortools/math_opt/solvers:gscip_solver",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.cpp
+++ b/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.cpp
@@ -1,17 +1,17 @@
 #include "lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h"
 
-#include <cassert>
 #include <cmath>
-#include <cstddef>
 #include <sstream>
 #include <string>
 #include <utility>
 
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "llvm/include/llvm/ADT/DenseMap.h"                // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"               // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"             // from @llvm-project
 #include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"         // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
@@ -23,25 +23,41 @@
 #include "ortools/math_opt/cpp/math_opt.h"  // from @com_google_ortools
 
 // The level describes the remaining multiplicative depth of a ciphertext.
-// Bootstrap operations reset the level to a maximum value (or a target level
-// if specified), allowing further operations to be performed.
+// Bootstrap operations reset the level to a maximum value, after which decoded
+// management ops may reduce it to the target level chosen by the ILP. In CKKS
+// mode this analysis also tracks scale bits:
+//   Sw: waterline/base scale bits (scaleWaterline)
+//   Sf: scale bits dropped by one rescale/modreduce (scaleFactorBits)
 //
-// This implementation tracks the level state through the computation
-// and uses ILP to determine optimal bootstrap placement to minimize costs
-// while ensuring level constraints are satisfied.
+// This implementation tracks level/scale state through one secret.generic body
+// and uses ILP to determine cost-minimal bootstrap and rescale placement while
+// keeping producer values, operand edges, and op results mutually feasible.
+// A later transform decodes the solution into mgmt operations.
 //
-// ILP Formulation:
-// - Variables: level[value] for each SSA value, input_level[op] for each op,
-//   bootstrap[op] for each operation
+// ILP formulation:
+// - Variables:
+//   * level[value], scale[value] (in bits) for each secret SSA value
+//   * input_level[op], input_scale[op] for each tracked op
+//   * bootstrap[op], node_rescale[op] for management after an op
+//   * edge_rescale[use] and, for CKKS multiplication operands, edge_scale[use]
+//     for management before a consuming op
+// - Initialization:
+//   * secret.generic body args are initialized from associated mgmt.mgmt attrs
+//     when present, otherwise from (bootstrapWaterline, Sw)
 // - Constraints:
-//   * Level bounds: 0 <= level[value] <= bootstrapWaterline (levels
-//   0..bootstrapWaterline)
-//   * Operand matching: for each op, operand_i_level == input_level[op]
-//   * Multiplication: output_level = input_level - 1
-//   * Non-mult: output_level = input_level
-//   * Bootstrap (big-M): if bootstrap[op] = 1, level_after = bootstrapWaterline
-//                        else level_after = level_before
-// - Objective: minimize sum of bootstrap decisions
+//   * bounds: levels are 0..bootstrapWaterline; CKKS scales are Sw..scaleMax
+//   * level-only mode fixes all live scales to Sw
+//   * operand edges allow level/scale reduction before the consuming op
+//   * non-multiplication operands share the consumer's input_scale
+//   * CKKS multiplication input_scale is the sum of operand edge scales;
+//     plaintext constants contribute Sw
+//   * node transitions relate each op's input state to each result state by
+//     either direct rescale/modswitch management or a bootstrap transition
+//   * yielded result scales are constrained to explicit nonzero mgmt.mgmt
+//   scales
+//     on corresponding secret.generic results
+// - Objective: minimize bootstrap and rescale costs, with a small tie-breaker
+//   favoring higher remaining levels.
 
 namespace math_opt = ::operations_research::math_opt;
 
@@ -50,30 +66,50 @@ namespace math_opt = ::operations_research::math_opt;
 namespace mlir {
 namespace heir {
 
-// Helper to get secret operands
-static void getSecretOperands(Operation* op, DataFlowSolver* solver,
-                              SmallVector<Value>& secretOperands) {
-  for (OpOperand& operand : op->getOpOperands()) {
-    if (isSecret(operand.get(), solver)) {
-      secretOperands.push_back(operand.get());
-    }
-  }
+using ScaleMode = ILPBootstrapPlacementAnalysis::ScaleMode;
+
+static bool isMultiplication(Operation* op) {
+  return isa<arith::MulFOp>(op) || isa<arith::MulIOp>(op);
 }
 
-LogicalResult ILPBootstrapPlacementAnalysis::solve() {
-  math_opt::Model model("ILPBootstrapPlacementAnalysis");
+static bool isConstantLike(Value value) {
+  return value.getDefiningOp<arith::ConstantOp>() != nullptr;
+}
 
-  // Get the secret.generic operation
-  auto genericOp = dyn_cast<secret::GenericOp>(opToRunOn);
-  if (!genericOp) {
-    return failure();
+static int roundedValue(const math_opt::VariableMap<double>& varMap,
+                        const math_opt::Variable& var) {
+  return static_cast<int>(std::round(varMap.at(var)));
+}
+
+struct ILPModelState {
+  ILPModelState(Block* body, DataFlowSolver* solver, int bootstrapWaterline,
+                int scaleWaterline, int scaleFactorBits, ScaleMode scaleMode)
+      : model("ILPBootstrapPlacementAnalysis"),
+        body(body),
+        solver(solver),
+        bootstrapWaterline(bootstrapWaterline),
+        levelOnly(scaleMode == ScaleMode::kLevelOnly),
+        sw(scaleWaterline),
+        sf(scaleFactorBits),
+        scaleMax(levelOnly ? sw : sf + 2 * sw),
+        bigM(bootstrapWaterline + 1),
+        scaleBigM(4 * scaleMax + sf * (bootstrapWaterline + 1)) {}
+
+  math_opt::Variable addLevelVar(int lower, int upper,
+                                 const std::string& name) {
+    return model.AddIntegerVariable(lower, upper, name);
   }
 
-  Block* body = genericOp.getBody();
+  math_opt::Variable addValueLevelVar(int lower, int upper,
+                                      const std::string& name) {
+    return model.AddContinuousVariable(lower, upper, name);
+  }
 
-  int nextOpaqueId = 0;
-  llvm::DenseMap<Operation*, int> opaqueIds;
-  auto uniqueName = [&](Operation* op) {
+  math_opt::Variable addScaleVar(const std::string& name) {
+    return model.AddIntegerVariable(sw, scaleMax, name);
+  }
+
+  std::string uniqueName(Operation* op) {
     std::string varName;
     llvm::raw_string_ostream ss(varName);
     ss << op->getName().getStringRef() << "_";
@@ -81,186 +117,396 @@ LogicalResult ILPBootstrapPlacementAnalysis::solve() {
       opaqueIds.insert(std::make_pair(op, nextOpaqueId++));
     ss << opaqueIds.lookup(op);
     return ss.str();
-  };
+  }
 
-  // Map operations to bootstrap decision variables
-  llvm::DenseMap<Operation*, math_opt::Variable> decisionVariables;
-  // Map SSA values to level variables (after bootstrap decision)
-  llvm::DenseMap<Value, math_opt::Variable> levelVars;
-  // Map SSA values to level variables before bootstrap
-  llvm::DenseMap<Value, math_opt::Variable> beforeBootstrapVars;
-  // Input level: level at which operands are consumed
+  math_opt::Model model;
+  Block* body;
+  DataFlowSolver* solver;
+  int bootstrapWaterline;
+  bool levelOnly;
+  int sw;
+  int sf;
+  int scaleMax;
+  int bigM;
+  int scaleBigM;
+  int nextOpaqueId = 0;
+  llvm::DenseMap<Operation*, int> opaqueIds;
+  llvm::DenseMap<Value, math_opt::Variable> valueLevelVars;
+  llvm::DenseMap<Value, math_opt::Variable> valueScaleVars;
   llvm::DenseMap<Operation*, math_opt::Variable> inputLevelVars;
+  llvm::DenseMap<Operation*, math_opt::Variable> inputScaleVars;
+  llvm::DenseMap<Operation*, math_opt::Variable> nodeRescaleVars;
+  llvm::DenseMap<Operation*, math_opt::Variable> bootstrapVars;
+  llvm::DenseMap<OpOperand*, math_opt::Variable> edgeScaleVars;
+  llvm::DenseMap<OpOperand*, math_opt::Variable> edgeRescaleVars;
+  SmallVector<Operation*> trackedOps;
+};
 
-  // Big-M constant for big-M method
-  // NOTE: This BIG_M does not account for "freshly encrypted" ciphertexts
-  // starting at a higher level than the bootstrap waterline. This should
-  // be addressed in future work.
-  const int BIG_M = bootstrapWaterline;
+static LogicalResult addBodyArgumentVariables(ILPModelState& state) {
+  for (BlockArgument arg : state.body->getArguments()) {
+    if (!isSecret(arg, state.solver)) continue;
 
-  // Create variables for all SSA values in the body
-  // First, handle block arguments (inputs)
-  for (BlockArgument arg : body->getArguments()) {
-    if (!isSecret(arg, solver)) continue;
+    int initialLevel = state.bootstrapWaterline;
+    int initialScale = state.sw;
+    if (mgmt::MgmtAttr mgmtAttr = mgmt::findMgmtAttrAssociatedWith(arg)) {
+      initialLevel = mgmtAttr.getLevel();
+      if (!state.levelOnly && mgmtAttr.getScale() != 0) {
+        initialScale = mgmtAttr.getScale();
+      }
+    }
 
-    std::stringstream ss;
-    ss << "levelArg" << arg.getArgNumber();
+    Operation* parentOp = state.body->getParentOp();
+    if (initialLevel < 0 || initialLevel > state.bootstrapWaterline) {
+      parentOp->emitError()
+          << "cannot initialize ILP variable for secret.generic argument "
+          << arg.getArgNumber() << " from mgmt.mgmt level " << initialLevel
+          << "; expected level in [0, " << state.bootstrapWaterline << "]";
+      return failure();
+    }
+    if (initialScale < state.sw || initialScale > state.scaleMax) {
+      parentOp->emitError()
+          << "cannot initialize ILP variable for secret.generic argument "
+          << arg.getArgNumber() << " from mgmt.mgmt scale " << initialScale
+          << "; expected scale in [" << state.sw << ", " << state.scaleMax
+          << "]";
+      return failure();
+    }
+
+    std::stringstream ssLevel;
+    ssLevel << "levelArg" << arg.getArgNumber();
     auto levelVar =
-        model.AddContinuousVariable(0, bootstrapWaterline, ss.str());
-    levelVars.insert(std::make_pair(arg, levelVar));
-    // Inputs start at maximum level (bootstrapWaterline)
-    model.AddLinearConstraint(
-        levelVar == bootstrapWaterline,
+        state.addValueLevelVar(0, state.bootstrapWaterline, ssLevel.str());
+    state.valueLevelVars.insert(std::make_pair(arg, levelVar));
+
+    std::stringstream ssScale;
+    ssScale << "scaleArg" << arg.getArgNumber();
+    auto scaleVar = state.addScaleVar(ssScale.str());
+    state.valueScaleVars.insert(std::make_pair(arg, scaleVar));
+
+    state.model.AddLinearConstraint(
+        levelVar == initialLevel,
         "initLevelArg" + std::to_string(arg.getArgNumber()));
+    state.model.AddLinearConstraint(
+        scaleVar == initialScale,
+        "initScaleArg" + std::to_string(arg.getArgNumber()));
   }
+  return success();
+}
 
-  // Walk operations in the body
-  for (Operation& op : body->getOperations()) {
-    // Check if this operation produces secret results
-    if (llvm::none_of(op.getResults(), [&](OpResult result) {
-          return isSecret(result, solver);
-        })) {
-      continue;
-    }
-    if (isa<secret::YieldOp>(op)) continue;
+static bool hasSecretResult(Operation& op, DataFlowSolver* solver) {
+  return llvm::any_of(op.getResults(), [&](OpResult result) {
+    return isSecret(result, solver);
+  });
+}
 
-    std::string opName = uniqueName(&op);
+static bool shouldTrackOperation(Operation& op, DataFlowSolver* solver) {
+  return !isa<secret::YieldOp>(op) && hasSecretResult(op, solver);
+}
 
-    // Create bootstrap decision variable for this operation
-    auto bootstrapVar = model.AddBinaryVariable("bootstrap" + opName);
-    decisionVariables.insert(std::make_pair(&op, bootstrapVar));
+static void addOperationDecisionVariables(ILPModelState& state, Operation* op,
+                                          const std::string& opName) {
+  auto inputLevelVar =
+      state.addLevelVar(0, state.bootstrapWaterline, "inputLevel" + opName);
+  state.inputLevelVars.insert(std::make_pair(op, inputLevelVar));
+  auto inputScaleVar = state.addScaleVar("inputScale" + opName);
+  state.inputScaleVars.insert(std::make_pair(op, inputScaleVar));
+  auto nodeRescaleVar =
+      state.addLevelVar(0, state.bootstrapWaterline, "nodeRescale" + opName);
+  state.nodeRescaleVars.insert(std::make_pair(op, nodeRescaleVar));
+  auto bootstrapVar = state.model.AddBinaryVariable("bootstrap" + opName);
+  state.bootstrapVars.insert(std::make_pair(op, bootstrapVar));
 
-    // Create input level variable: level at which operands are consumed
-    auto inputLevelVar = model.AddContinuousVariable(0, bootstrapWaterline,
-                                                     "inputLevel" + opName);
-    inputLevelVars.insert(std::make_pair(&op, inputLevelVar));
+  if (state.levelOnly) {
+    state.model.AddLinearConstraint(inputScaleVar == state.sw,
+                                    "levelOnlyInputScale" + opName);
+  }
+}
 
-    // Create level variables for results
-    for (OpResult result : op.getResults()) {
-      if (!isSecret(result, solver)) continue;
+static void addOperationResultVariables(ILPModelState& state, Operation* op,
+                                        const std::string& opName) {
+  for (OpResult result : op->getResults()) {
+    if (!isSecret(result, state.solver)) continue;
 
-      std::stringstream ss;
-      ss << "level" << opName << result.getResultNumber();
-      auto levelVar =
-          model.AddContinuousVariable(0, bootstrapWaterline, ss.str());
-      levelVars.insert(std::make_pair(result, levelVar));
+    std::stringstream ssLevel;
+    ssLevel << "level" << opName << result.getResultNumber();
+    auto levelVar =
+        state.addValueLevelVar(0, state.bootstrapWaterline, ssLevel.str());
+    state.valueLevelVars.insert(std::make_pair(result, levelVar));
 
-      std::stringstream ss2;
-      ss2 << "levelBefore" << opName << result.getResultNumber();
-      auto beforeVar =
-          model.AddContinuousVariable(0, bootstrapWaterline, ss2.str());
-      beforeBootstrapVars.insert(std::make_pair(result, beforeVar));
+    std::stringstream ssScale;
+    ssScale << "scale" << opName << result.getResultNumber();
+    auto scaleVar = state.addScaleVar(ssScale.str());
+    state.valueScaleVars.insert(std::make_pair(result, scaleVar));
+    if (state.levelOnly) {
+      state.model.AddLinearConstraint(
+          scaleVar == state.sw, "levelOnlyResultScale" + opName +
+                                    std::to_string(result.getResultNumber()));
     }
   }
+}
 
-  // Add constraints for operations
-  for (auto& [op, _] : opaqueIds) {
-    std::string opName = uniqueName(op);
+static void addTrackedOperationVariables(ILPModelState& state) {
+  for (Operation& op : state.body->getOperations()) {
+    if (!shouldTrackOperation(op, state.solver)) continue;
 
-    // Get secret operands
-    SmallVector<Value> secretOperands;
-    getSecretOperands(op, solver, secretOperands);
+    state.trackedOps.push_back(&op);
+    std::string opName = state.uniqueName(&op);
+    addOperationDecisionVariables(state, &op, opName);
+    addOperationResultVariables(state, &op, opName);
+  }
+}
 
-    // Operand matching: all operands must be at the same level when consumed.
-    // inputLevel = level at which operands are consumed.
-    auto inputLevelVar = inputLevelVars.at(op);
-    for (size_t i = 0; i < secretOperands.size(); ++i) {
-      Value operand = secretOperands[i];
-      if (!levelVars.contains(operand)) continue;
+// Add constraints for one producer value flowing into one operand use of an op.
+// The edge rescale variable models management inserted before the consumer.
+// Non-multiplication ops share one input scale across all operands; CKKS
+// multiplications use per-edge scales so their combined scale can be modeled
+// separately in addMultiplicationInputScaleConstraint.
+static void addSingleOperandEdgeConstraints(ILPModelState& state, Operation* op,
+                                            OpOperand& operandUse,
+                                            const std::string& opName) {
+  Value operand = operandUse.get();
+  if (!isSecret(operand, state.solver)) return;
+  if (!state.valueLevelVars.contains(operand)) return;
 
-      std::stringstream ss;
-      ss << "operandMatch" << opName << "Op" << i;
-      model.AddLinearConstraint(levelVars.at(operand) == inputLevelVar,
-                                ss.str());
+  std::stringstream ss;
+  ss << opName << "Op" << operandUse.getOperandNumber();
+  std::string edgeName = ss.str();
+
+  auto inputLevelVar = state.inputLevelVars.at(op);
+  auto inputScaleVar = state.inputScaleVars.at(op);
+  auto edgeRescaleVar =
+      state.addLevelVar(0, state.bootstrapWaterline, "edgeRescale" + edgeName);
+  state.edgeRescaleVars.insert(std::make_pair(&operandUse, edgeRescaleVar));
+
+  math_opt::Variable edgeScaleVar =
+      (!state.levelOnly && isMultiplication(op))
+          ? state.addScaleVar("edgeScale" + edgeName)
+          : inputScaleVar;
+  state.edgeScaleVars.insert(std::make_pair(&operandUse, edgeScaleVar));
+
+  state.model.AddLinearConstraint(
+      inputLevelVar <= state.valueLevelVars.at(operand) - edgeRescaleVar,
+      "edgeLevel" + edgeName);
+  state.model.AddLinearConstraint(
+      edgeScaleVar >=
+          state.valueScaleVars.at(operand) - state.sf * edgeRescaleVar,
+      "edgeScale" + edgeName);
+  if (state.levelOnly) {
+    state.model.AddLinearConstraint(edgeScaleVar == state.sw,
+                                    "levelOnlyEdgeScale" + edgeName);
+  }
+}
+
+// Add the CKKS multiplication scale-composition constraint. After each operand
+// edge chooses its aligned scale, the multiplication's raw input scale is the
+// sum of those operand scales; plaintext constants contribute the waterline
+// scale. Result/output scale constraints are added by
+// addNodeTransitionConstraints.
+static void addMultiplicationInputScaleConstraint(ILPModelState& state,
+                                                  Operation* op,
+                                                  const std::string& opName) {
+  if (state.levelOnly || !isMultiplication(op)) return;
+
+  math_opt::LinearExpression inputScale;
+  for (OpOperand& operandUse : op->getOpOperands()) {
+    Value operand = operandUse.get();
+    if (isSecret(operand, state.solver) &&
+        state.edgeScaleVars.contains(&operandUse)) {
+      inputScale += state.edgeScaleVars.at(&operandUse);
+    } else if (isConstantLike(operand)) {
+      inputScale += state.sw;
     }
+  }
+  state.model.AddLinearConstraint(state.inputScaleVars.at(op) == inputScale,
+                                  "mulInputScale" + opName);
+}
 
-    // Output level: for multiplication, output = input - 1; else output = input
-    if (isa<arith::MulFOp>(op) || isa<arith::MulIOp>(op)) {
-      for (OpResult result : op->getResults()) {
-        if (!isSecret(result, solver)) continue;
-        if (!beforeBootstrapVars.contains(result)) continue;
-
-        auto resultBeforeVar = beforeBootstrapVars.at(result);
-        // outputLevel = inputLevel - 1
-        std::stringstream ss;
-        ss << "mulOutput" << opName << result.getResultNumber();
-        model.AddLinearConstraint(resultBeforeVar == inputLevelVar - 1,
-                                  ss.str());
-        std::stringstream ssMin;
-        ssMin << "mulLevelMin" << opName << result.getResultNumber();
-        model.AddLinearConstraint(resultBeforeVar >= 0, ssMin.str());
-      }
-    } else {
-      for (OpResult result : op->getResults()) {
-        if (!isSecret(result, solver)) continue;
-        if (!beforeBootstrapVars.contains(result)) continue;
-
-        auto resultBeforeVar = beforeBootstrapVars.at(result);
-        // outputLevel = inputLevel (level flows through unchanged)
-        std::stringstream ss;
-        ss << "flowOutput" << opName << result.getResultNumber();
-        model.AddLinearConstraint(resultBeforeVar == inputLevelVar, ss.str());
-      }
+static void addOperandEdgeConstraints(ILPModelState& state) {
+  for (Operation* op : state.trackedOps) {
+    std::string opName = state.uniqueName(op);
+    for (OpOperand& operandUse : op->getOpOperands()) {
+      addSingleOperandEdgeConstraints(state, op, operandUse, opName);
     }
+    addMultiplicationInputScaleConstraint(state, op, opName);
+  }
+}
 
-    // Add bootstrap constraints using big-M method
+// Add output-boundary scale constraints for values yielded from secret.generic.
+// A yield is constrained only when the corresponding generic result has an
+// explicit nonzero mgmt.mgmt scale; otherwise the ILP may choose any supported
+// result scale and the later annotation pass records that chosen state.
+static LogicalResult addYieldConstraints(ILPModelState& state) {
+  auto genericOp = cast<secret::GenericOp>(state.body->getParentOp());
+  for (Operation& op : state.body->getOperations()) {
+    auto yieldOp = dyn_cast<secret::YieldOp>(op);
+    if (!yieldOp) continue;
+    for (auto [index, operand] : llvm::enumerate(yieldOp->getOperands())) {
+      if (!isSecret(operand, state.solver)) continue;
+      if (!state.valueScaleVars.contains(operand)) continue;
+      if (state.levelOnly) continue;
+
+      mgmt::MgmtAttr mgmtAttr =
+          mgmt::findMgmtAttrAssociatedWith(genericOp.getResult(index));
+      if (!mgmtAttr || mgmtAttr.getScale() == 0) continue;
+
+      int resultScale = mgmtAttr.getScale();
+      if (resultScale < state.sw || resultScale > state.scaleMax) {
+        genericOp->emitError() << "cannot constrain yielded value " << index
+                               << " from secret.generic result mgmt.mgmt scale "
+                               << resultScale << "; expected scale in ["
+                               << state.sw << ", " << state.scaleMax << "]";
+        return failure();
+      }
+      state.model.AddLinearConstraint(
+          state.valueScaleVars.at(operand) == resultScale,
+          "yieldResultScale" + std::to_string(index));
+    }
+  }
+  return success();
+}
+
+// Add constraints for each tracked op's result state after the op and any
+// management chosen on the node. This is the result/output counterpart to the
+// edge constraints: it relates the op's input level/scale to each secret result
+// through either a direct transition or a bootstrap transition.
+static void addNodeTransitionConstraints(ILPModelState& state,
+                                         int bootstrapLevelLowerBound) {
+  for (Operation* op : state.trackedOps) {
+    std::string opName = state.uniqueName(op);
+    auto inputLevelVar = state.inputLevelVars.at(op);
+    auto inputScaleVar = state.inputScaleVars.at(op);
+    auto nodeRescaleVar = state.nodeRescaleVars.at(op);
+    auto bootstrapVar = state.bootstrapVars.at(op);
+    int intrinsicLevelConsumption =
+        state.levelOnly && isMultiplication(op) ? 1 : 0;
+
     for (OpResult result : op->getResults()) {
-      if (!isSecret(result, solver)) continue;
-      if (!levelVars.contains(result) || !beforeBootstrapVars.contains(result))
-        continue;
+      if (!isSecret(result, state.solver)) continue;
+      if (!state.valueLevelVars.contains(result)) continue;
 
-      auto resultLevelVar = levelVars.at(result);
-      auto resultBeforeVar = beforeBootstrapVars.at(result);
-      auto bootstrapVar = decisionVariables.at(op);
-
+      auto outputLevelVar = state.valueLevelVars.at(result);
+      auto outputScaleVar = state.valueScaleVars.at(result);
       std::stringstream ss;
-      ss << "bootstrapOutput" << opName << result.getResultNumber();
+      ss << opName << "Result" << result.getResultNumber();
 
-      // If bootstrap = 1: level_after = bootstrapWaterline
-      // If bootstrap = 0: levelAfter = levelBefore
-      // Using big-M:
-      // levelAfter <= bootstrapWaterline + BIG_M * (1 - bootstrap)
-      // levelAfter >= bootstrapWaterline - BIG_M * (1 - bootstrap)
-      // levelAfter <= levelBefore + BIG_M * bootstrap
-      // levelAfter >= levelBefore - BIG_M * bootstrap
+      // If bootstrap is false, this is the direct Orbit rescale/modswitch
+      // transition. Level-only modswitch is allowed by the <= relation without
+      // charging nodeRescaleVar.
+      state.model.AddLinearConstraint(
+          outputLevelVar <= inputLevelVar - intrinsicLevelConsumption -
+                                nodeRescaleVar + state.bigM * bootstrapVar,
+          "nodeDirectLevel" + ss.str());
+      state.model.AddLinearConstraint(
+          outputScaleVar >= inputScaleVar - state.sf * nodeRescaleVar -
+                                state.scaleBigM * bootstrapVar,
+          "nodeDirectScale" + ss.str());
 
-      std::string cstName1 = ss.str() + "_1";
-      model.AddLinearConstraint(
-          resultLevelVar <= bootstrapWaterline + BIG_M * (1 - bootstrapVar),
-          cstName1);
+      // If bootstrap is true, input must be bootstrappable and output must be
+      // in Orbit's bootstrapped level/scale range.
+      state.model.AddLinearConstraint(
+          inputScaleVar <=
+              state.sf * (inputLevelVar - bootstrapLevelLowerBound + 1) +
+                  state.scaleBigM * (1 - bootstrapVar),
+          "bootstrapInputFeasible" + ss.str());
+      state.model.AddLinearConstraint(
+          outputLevelVar >=
+              (bootstrapLevelLowerBound + 1) - state.bigM * (1 - bootstrapVar),
+          "bootstrapOutputLevel" + ss.str());
+      state.model.AddLinearConstraint(
+          outputScaleVar >= state.sf - state.scaleBigM * (1 - bootstrapVar),
+          "bootstrapOutputScale" + ss.str());
+    }
+  }
+}
 
-      std::string cstName2 = ss.str() + "_2";
-      model.AddLinearConstraint(
-          resultLevelVar >= bootstrapWaterline - BIG_M * (1 - bootstrapVar),
-          cstName2);
+static void addObjective(ILPModelState& state, int bootstrapCost,
+                         int rescaleCost) {
+  math_opt::LinearExpression objective;
+  for (auto& [op, bootstrapVar] : state.bootstrapVars) {
+    objective += bootstrapCost * bootstrapVar;
+  }
+  for (auto& [op, rescaleVar] : state.nodeRescaleVars) {
+    objective += rescaleCost * rescaleVar;
+  }
+  for (auto& [operand, rescaleVar] : state.edgeRescaleVars) {
+    objective += rescaleCost * rescaleVar;
+  }
+  // Tie-breaker: level constraints are one-sided, so among equal-cost
+  // solutions the solver could pick gratuitously low levels (free modswitches).
+  // The small negative weight prefers the highest feasible level for each
+  // value without outweighing a unit of bootstrap/rescale cost. TODO: remove
+  // in the next iteration, when the objective minimizes performance cost and
+  // per-level operation costs make level choices matter directly.
+  for (auto& [value, levelVar] : state.valueLevelVars) {
+    objective += -0.001 * levelVar;
+  }
+  state.model.Minimize(objective);
+}
 
-      std::string cstName3 = ss.str() + "_3";
-      model.AddLinearConstraint(
-          resultLevelVar <= resultBeforeVar + BIG_M * bootstrapVar, cstName3);
+static void populateSolution(
+    const math_opt::SolveResult& result, ILPModelState& state,
+    llvm::DenseMap<Operation*, bool>& solution,
+    llvm::DenseMap<Value, int>& solutionLevelBeforeBootstrap,
+    llvm::DenseMap<Value, int>& solutionLevelAfterBootstrap,
+    llvm::SmallVector<ILPBootstrapPlacementAnalysis::NodeManagement, 32>&
+        nodeManagement,
+    llvm::SmallVector<ILPBootstrapPlacementAnalysis::EdgeManagement, 32>&
+        edgeManagement) {
+  auto varMap = result.variable_values();
+  for (Operation* op : state.trackedOps) {
+    bool useBootstrap = varMap.at(state.bootstrapVars.at(op)) > 0.5;
+    solution.insert(std::make_pair(op, useBootstrap));
 
-      std::string cstName4 = ss.str() + "_4";
-      model.AddLinearConstraint(
-          resultLevelVar >= resultBeforeVar - BIG_M * bootstrapVar, cstName4);
+    int inputLevel = roundedValue(varMap, state.inputLevelVars.at(op));
+    int inputScale = roundedValue(varMap, state.inputScaleVars.at(op));
+    for (OpResult result : op->getResults()) {
+      if (!isSecret(result, state.solver)) continue;
+      int outputLevel = roundedValue(varMap, state.valueLevelVars.at(result));
+      int outputScale = roundedValue(varMap, state.valueScaleVars.at(result));
+      solutionLevelBeforeBootstrap.insert(std::make_pair(result, inputLevel));
+      solutionLevelAfterBootstrap.insert(std::make_pair(result, outputLevel));
+      nodeManagement.push_back({result, inputLevel, inputScale, outputLevel,
+                                outputScale, useBootstrap});
     }
   }
 
-  // Objective: minimize number of bootstraps
-  math_opt::LinearExpression obj;
-  for (auto& [op, decisionVar] : decisionVariables) {
-    obj += decisionVar;
+  for (Operation* op : state.trackedOps) {
+    int targetLevel = roundedValue(varMap, state.inputLevelVars.at(op));
+    for (OpOperand& operandUse : op->getOpOperands()) {
+      if (!state.edgeScaleVars.contains(&operandUse)) continue;
+      Value operand = operandUse.get();
+      int sourceLevel = roundedValue(varMap, state.valueLevelVars.at(operand));
+      int sourceScale = roundedValue(varMap, state.valueScaleVars.at(operand));
+      int targetScale =
+          roundedValue(varMap, state.edgeScaleVars.at(&operandUse));
+      edgeManagement.push_back({op, operandUse.getOperandNumber(), sourceLevel,
+                                sourceScale, targetLevel, targetScale});
+    }
   }
-  model.Minimize(obj);
+}
+
+LogicalResult ILPBootstrapPlacementAnalysis::solve() {
+  auto genericOp = dyn_cast<secret::GenericOp>(opToRunOn);
+  if (!genericOp) return failure();
+
+  ILPModelState state(genericOp.getBody(), solver, bootstrapWaterline,
+                      scaleWaterline, scaleFactorBits, scaleMode);
+
+  if (failed(addBodyArgumentVariables(state))) return failure();
+  addTrackedOperationVariables(state);
+  addOperandEdgeConstraints(state);
+  if (failed(addYieldConstraints(state))) return failure();
+  addNodeTransitionConstraints(state, bootstrapLevelLowerBound);
+  addObjective(state, bootstrapCost, rescaleCost);
 
   LLVM_DEBUG({
     std::stringstream ss;
-    ss << model;
+    ss << state.model;
     llvm::dbgs() << "--- ILP model ---\n" << ss.str() << "--- end model ---\n";
   });
 
-  // Solve the ILP
   const absl::StatusOr<math_opt::SolveResult> status =
-      math_opt::Solve(model, math_opt::SolverType::kGscip);
-
+      math_opt::Solve(state.model, math_opt::SolverType::kGscip);
   if (!status.ok()) {
     std::stringstream ss;
     ss << "Error solving the problem: " << status.status() << "\n";
@@ -269,7 +515,6 @@ LogicalResult ILPBootstrapPlacementAnalysis::solve() {
   }
 
   const math_opt::SolveResult& result = status.value();
-
   switch (result.termination.reason) {
     case math_opt::TerminationReason::kOptimal:
     case math_opt::TerminationReason::kFeasible:
@@ -277,40 +522,14 @@ LogicalResult ILPBootstrapPlacementAnalysis::solve() {
     default:
       llvm::errs() << "The problem does not have a feasible solution. "
                       "Termination status code: "
-                   << (int)result.termination.reason << "\n";
+                   << static_cast<int>(result.termination.reason) << "\n";
       return failure();
   }
 
-  // Extract solution
-  auto varMap = result.variable_values();
-  for (auto& [op, decisionVar] : decisionVariables) {
-    solution.insert(std::make_pair(op, varMap[decisionVar] > 0.5));
-  }
-
-  for (auto& [value, beforeVar] : beforeBootstrapVars) {
-    solutionLevelBeforeBootstrap.insert(
-        std::make_pair(value, (int)std::round(varMap[beforeVar])));
-  }
-  for (auto& [value, levelVar] : levelVars) {
-    solutionLevelAfterBootstrap.insert(
-        std::make_pair(value, (int)std::round(varMap[levelVar])));
-  }
+  populateSolution(result, state, solution, solutionLevelBeforeBootstrap,
+                   solutionLevelAfterBootstrap, nodeManagement, edgeManagement);
 
   return success();
-}
-
-llvm::SmallVector<Value, 32>
-ILPBootstrapPlacementAnalysis::getValuesToBootstrap() const {
-  llvm::SmallVector<Value, 32> out;
-  auto genericOp = dyn_cast<secret::GenericOp>(opToRunOn);
-  if (!genericOp || !solver) return out;
-  for (const auto& [op, insert] : solution) {
-    if (!insert) continue;
-    for (OpResult result : op->getResults()) {
-      if (isSecret(result, solver)) out.push_back(result);
-    }
-  }
-  return out;
 }
 
 void ILPBootstrapPlacementAnalysis::printSolution(llvm::raw_ostream& os) const {
@@ -323,9 +542,10 @@ void ILPBootstrapPlacementAnalysis::printSolution(llvm::raw_ostream& os) const {
   if (!body) return;
 
   os << "--- ILP bootstrap placement solution ---\n";
-  os << "bootstrap waterline: " << bootstrapWaterline << "\n\n";
+  os << "bootstrap waterline: " << bootstrapWaterline << "\n";
+  os << "scale waterline: " << scaleWaterline << "\n";
+  os << "scale factor bits: " << scaleFactorBits << "\n\n";
 
-  // Block arguments (inputs): print as in IR, level after only
   for (BlockArgument arg : body->getArguments()) {
     auto it = solutionLevelAfterBootstrap.find(arg);
     if (it != solutionLevelAfterBootstrap.end()) {
@@ -335,29 +555,17 @@ void ILPBootstrapPlacementAnalysis::printSolution(llvm::raw_ostream& os) const {
     }
   }
 
-  // Ops in body order: print op and operands (as in IR), then bootstrap/levels
   for (Operation& op : body->getOperations()) {
     if (isa<secret::YieldOp>(op)) continue;
     bool insertBootstrap = solution.lookup(&op);
     os << "  ";
     op.print(os);
     os << "  bootstrap=" << (insertBootstrap ? "yes" : "no");
-    for (OpResult result : op.getResults()) {
-      auto beforeIt = solutionLevelBeforeBootstrap.find(result);
-      auto afterIt = solutionLevelAfterBootstrap.find(result);
-      if (beforeIt != solutionLevelBeforeBootstrap.end() ||
-          afterIt != solutionLevelAfterBootstrap.end()) {
-        os << " level(before=";
-        if (beforeIt != solutionLevelBeforeBootstrap.end())
-          os << beforeIt->second;
-        else
-          os << "?";
-        os << " after=";
-        if (afterIt != solutionLevelAfterBootstrap.end())
-          os << afterIt->second;
-        else
-          os << "?";
-        os << ")";
+    for (const auto& placement : nodeManagement) {
+      if (placement.value.getDefiningOp() == &op) {
+        os << " transition=(" << placement.inputLevel << ","
+           << placement.inputScale << ")->(" << placement.outputLevel << ","
+           << placement.outputScale << ")";
       }
     }
     os << "\n";

--- a/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h
+++ b/lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h
@@ -16,18 +16,53 @@ namespace mlir {
 namespace heir {
 class ILPBootstrapPlacementAnalysis {
  public:
+  enum class ScaleMode { kCKKS, kLevelOnly };
+
+  struct NodeManagement {
+    Value value;
+    int inputLevel;
+    int inputScale;
+    int outputLevel;
+    int outputScale;
+    bool useBootstrap;
+  };
+
+  struct EdgeManagement {
+    Operation* op;
+    unsigned operandNumber;
+    int inputLevel;
+    int inputScale;
+    int outputLevel;
+    int outputScale;
+  };
+
   ILPBootstrapPlacementAnalysis(Operation* op, DataFlowSolver* solver,
-                                int bootstrapWaterline)
-      : opToRunOn(op), solver(solver), bootstrapWaterline(bootstrapWaterline) {}
+                                int bootstrapWaterline, int scaleWaterline,
+                                int scaleFactorBits,
+                                int bootstrapLevelLowerBound, int bootstrapCost,
+                                int rescaleCost, ScaleMode scaleMode)
+      : opToRunOn(op),
+        solver(solver),
+        bootstrapWaterline(bootstrapWaterline),
+        scaleWaterline(scaleWaterline),
+        scaleFactorBits(scaleFactorBits),
+        bootstrapLevelLowerBound(bootstrapLevelLowerBound),
+        bootstrapCost(bootstrapCost),
+        rescaleCost(rescaleCost),
+        scaleMode(scaleMode) {}
   ~ILPBootstrapPlacementAnalysis() = default;
 
   LogicalResult solve();
 
-  // Return the set of SSA values that the ILP decided should have a bootstrap
-  // inserted after their definition. Used by the pass to insert bootstraps
-  // without iterating by op index; Values remain valid across modreduce/
-  // relinearize insertion.
-  llvm::SmallVector<Value, 32> getValuesToBootstrap() const;
+  // Return per-result management transitions chosen by the ILP.
+  llvm::SmallVector<NodeManagement, 32> getNodeManagement() const {
+    return nodeManagement;
+  }
+
+  // Return per-use management transitions chosen by the ILP.
+  llvm::SmallVector<EdgeManagement, 32> getEdgeManagement() const {
+    return edgeManagement;
+  }
 
   // Return the level at the given SSA value, as determined by the
   // solution to the optimization problem. When the input value is the result
@@ -40,16 +75,25 @@ class ILPBootstrapPlacementAnalysis {
     return solutionLevelBeforeBootstrap.lookup(value);
   }
 
-  // Debug: print the entire solution (bootstrap decisions and levels) to os.
+  // Debug: print the entire solution (bootstrap/rescale decisions and levels)
+  // to os.
   void printSolution(llvm::raw_ostream& os) const;
 
  private:
   Operation* opToRunOn;
   DataFlowSolver* solver;
   int bootstrapWaterline;
+  int scaleWaterline;
+  int scaleFactorBits;
+  int bootstrapLevelLowerBound;
+  int bootstrapCost;
+  int rescaleCost;
+  ScaleMode scaleMode;
   llvm::DenseMap<Operation*, bool> solution;
   llvm::DenseMap<Value, int> solutionLevelBeforeBootstrap;
   llvm::DenseMap<Value, int> solutionLevelAfterBootstrap;
+  llvm::SmallVector<NodeManagement, 32> nodeManagement;
+  llvm::SmallVector<EdgeManagement, 32> edgeManagement;
 };
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.cpp
+++ b/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.cpp
@@ -1,5 +1,10 @@
 #include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h"
 
+#include <cmath>
+#include <optional>
+#include <string>
+#include <utility>
+
 #include "lib/Analysis/ILPBootstrapPlacementAnalysis/ILPBootstrapPlacementAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
@@ -7,6 +12,8 @@
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Transforms/SecretInsertMgmt/Pipeline.h"
 #include "llvm/include/llvm/Support/Debug.h"               // from @llvm-project
+#include "llvm/include/llvm/Support/JSON.h"                // from @llvm-project
+#include "llvm/include/llvm/Support/MemoryBuffer.h"        // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlow/Utils.h"     // from @llvm-project
 #include "mlir/include/mlir/Analysis/DataFlowFramework.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"                 // from @llvm-project
@@ -26,57 +33,382 @@ namespace heir {
 #define GEN_PASS_DEF_ILPBOOTSTRAPPLACEMENT
 #include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h.inc"
 
+struct OrbitCostModel {
+  int bootstrapCost;
+  int rescaleCost;
+};
+
+static std::optional<int> averagePositiveLatency(const llvm::json::Object& root,
+                                                 llvm::StringRef opName) {
+  const llvm::json::Object* latencyTable = root.getObject("latencyTable");
+  if (!latencyTable) return std::nullopt;
+
+  const llvm::json::Array* latencies = latencyTable->getArray(opName);
+  if (!latencies) return std::nullopt;
+
+  double sum = 0;
+  int count = 0;
+  for (const llvm::json::Value& latencyValue : *latencies) {
+    std::optional<double> latency = latencyValue.getAsNumber();
+    if (!latency || *latency <= 0) continue;
+    sum += *latency;
+    ++count;
+  }
+  if (count == 0) return std::nullopt;
+  return static_cast<int>(std::llround(sum / count));
+}
+
+static FailureOr<OrbitCostModel> loadOrbitCostModel(llvm::StringRef path) {
+  auto bufferOrError = llvm::MemoryBuffer::getFile(path);
+  if (!bufferOrError) return failure();
+
+  llvm::Expected<llvm::json::Value> parsed =
+      llvm::json::parse((*bufferOrError)->getBuffer());
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return failure();
+  }
+
+  const llvm::json::Object* root = parsed->getAsObject();
+  if (!root) return failure();
+
+  std::optional<int> parsedBootstrapCost =
+      averagePositiveLatency(*root, "bootstrap");
+  std::optional<int> parsedRescaleCost =
+      averagePositiveLatency(*root, "rescale");
+  if (!parsedBootstrapCost || !parsedRescaleCost) return failure();
+
+  return OrbitCostModel{*parsedBootstrapCost, *parsedRescaleCost};
+}
+
 struct ILPBootstrapPlacement
     : impl::ILPBootstrapPlacementBase<ILPBootstrapPlacement> {
   using ILPBootstrapPlacementBase::ILPBootstrapPlacementBase;
 
+  struct ScaleConfig {
+    bool isCKKS;
+    int scaleWaterline;
+    int scaleFactorBits;
+
+    bool levelOnly() const { return !isCKKS; }
+    ILPBootstrapPlacementAnalysis::ScaleMode analysisScaleMode() const {
+      return isCKKS ? ILPBootstrapPlacementAnalysis::ScaleMode::kCKKS
+                    : ILPBootstrapPlacementAnalysis::ScaleMode::kLevelOnly;
+    }
+  };
+
+  bool hasCKKSAttrs(Operation* op) {
+    return op->hasAttr("ckks.schemeParam") || op->hasAttr("scheme.ckks");
+  }
+
+  bool moduleTargetsCKKS(Operation* module) {
+    if (hasCKKSAttrs(module)) return true;
+    bool found = false;
+    module->walk([&](Operation* op) {
+      if (hasCKKSAttrs(op)) {
+        found = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    return found;
+  }
+
+  ScaleConfig getScaleConfig(Operation* module) {
+    bool isCKKS = moduleTargetsCKKS(module);
+    int effectiveScaleWaterline = scaleWaterline;
+    int effectiveScaleFactorBits =
+        isCKKS ? scaleFactorBits : effectiveScaleWaterline;
+    return {isCKKS, effectiveScaleWaterline, effectiveScaleFactorBits};
+  }
+
+  void eraseExistingPlacementMgmtOps(secret::GenericOp genericOp) {
+    SmallVector<Operation*> opsToErase;
+    genericOp->walk([&](Operation* op) {
+      if (isa<mgmt::RelinearizeOp, mgmt::ModReduceOp, mgmt::LevelReduceOp,
+              mgmt::AdjustScaleOp, mgmt::BootstrapOp>(op)) {
+        opsToErase.push_back(op);
+      }
+    });
+    for (Operation* op : opsToErase) {
+      op->getResult(0).replaceAllUsesWith(op->getOperand(0));
+      op->erase();
+    }
+  }
+
   LogicalResult processSecretGenericOp(
       secret::GenericOp genericOp, DataFlowSolver* solver,
-      SmallVector<Value, 32>* valuesToBootstrap) {
-    genericOp->walk([&](mgmt::BootstrapOp op) {
-      op.getResult().replaceAllUsesWith(op.getOperand());
-      op.erase();
-    });
+      const ScaleConfig& scaleConfig,
+      SmallVector<ILPBootstrapPlacementAnalysis::NodeManagement, 32>*
+          nodeManagement,
+      SmallVector<ILPBootstrapPlacementAnalysis::EdgeManagement, 32>*
+          edgeManagement) {
+    int effectiveBootstrapCost = bootstrapCost;
+    int effectiveRescaleCost = rescaleCost;
+    if (!orbitCostModel.empty()) {
+      FailureOr<OrbitCostModel> loadedCostModel =
+          loadOrbitCostModel(orbitCostModel);
+      if (failed(loadedCostModel)) {
+        llvm::errs() << "failed to load Orbit cost model from `"
+                     << orbitCostModel << "`\n";
+        genericOp->emitError() << "failed to load Orbit cost model from `"
+                               << orbitCostModel << "`";
+        return failure();
+      }
+      effectiveBootstrapCost = loadedCostModel->bootstrapCost;
+      effectiveRescaleCost = loadedCostModel->rescaleCost;
+    }
 
-    ILPBootstrapPlacementAnalysis analysis(genericOp, solver,
-                                           bootstrapWaterline);
+    ILPBootstrapPlacementAnalysis analysis(
+        genericOp, solver, bootstrapWaterline, scaleConfig.scaleWaterline,
+        scaleConfig.scaleFactorBits, bootstrapLevelLowerBound,
+        effectiveBootstrapCost, effectiveRescaleCost,
+        scaleConfig.analysisScaleMode());
     if (failed(analysis.solve())) {
       genericOp->emitError(
           "Failed to solve the bootstrap placement optimization problem");
       return failure();
     }
     LLVM_DEBUG(analysis.printSolution(llvm::dbgs()));
-    for (Value v : analysis.getValuesToBootstrap())
-      valuesToBootstrap->push_back(v);
+    for (auto placement : analysis.getNodeManagement())
+      nodeManagement->push_back(placement);
+    for (auto placement : analysis.getEdgeManagement())
+      edgeManagement->push_back(placement);
     return success();
   }
 
-  void insertBootstrapsForValues(ArrayRef<Value> valuesToBootstrap) {
-    OpBuilder b(&getContext());
-    for (Value v : valuesToBootstrap) {
-      // After modreduce/relinearize we have mul -> relinearize -> modreduce.
-      // Follow the chain so we bootstrap the modreduce result (correct level
-      // refresh) and insert after it.
-      Value toBootstrap = v;
-      Operation* insertAfter = v.getDefiningOp();
-      while (toBootstrap.hasOneUse()) {
-        Operation* user = *toBootstrap.getUsers().begin();
-        if (isa<mgmt::RelinearizeOp>(user) || isa<mgmt::ModReduceOp>(user)) {
-          toBootstrap = user->getResult(0);
-          insertAfter = user;
-        } else {
-          break;
-        }
+  std::pair<Value, Operation*> followMgmtChain(Value value) {
+    Value chainValue = value;
+    Operation* chainEnd = value.getDefiningOp();
+    while (chainValue.hasOneUse()) {
+      Operation* user = *chainValue.getUsers().begin();
+      if (isa<mgmt::RelinearizeOp, mgmt::ModReduceOp, mgmt::LevelReduceOp,
+              mgmt::AdjustScaleOp, mgmt::BootstrapOp>(user)) {
+        chainValue = user->getResult(0);
+        chainEnd = user;
+        continue;
       }
-      b.setInsertionPointAfter(insertAfter);
-      auto bootstrapOp =
-          mgmt::BootstrapOp::create(b, insertAfter->getLoc(), toBootstrap);
-      toBootstrap.replaceAllUsesExcept(bootstrapOp.getResult(), {bootstrapOp});
+      break;
     }
+    return {chainValue, chainEnd};
+  }
+
+  int ceilDivPositive(int numerator, int denominator) {
+    if (numerator <= 0) return 0;
+    return (numerator + denominator - 1) / denominator;
+  }
+
+  Value insertAfterCurrent(OpBuilder& b, Value current, Operation*& insertAfter,
+                           Value original, Operation* newOp) {
+    current.replaceAllUsesExcept(newOp->getResult(0), newOp);
+    if (current == original) {
+      original.replaceAllUsesExcept(newOp->getResult(0), newOp);
+    }
+    insertAfter = newOp;
+    return newOp->getResult(0);
+  }
+
+  FailureOr<Value> decodeDirectTransitionAfter(OpBuilder& b, Value value,
+                                               Operation*& insertAfter,
+                                               int inputLevel, int inputScale,
+                                               int outputLevel, int outputScale,
+                                               const ScaleConfig& scaleConfig) {
+    Value current = value;
+    int currentLevel = inputLevel;
+    int currentScale = inputScale;
+    int scaleMax = scaleConfig.scaleFactorBits + 2 * scaleConfig.scaleWaterline;
+    bool levelOnly = scaleConfig.levelOnly();
+
+    int rescaleCount = levelOnly ? 0
+                                 : ceilDivPositive(currentScale - outputScale,
+                                                   scaleConfig.scaleFactorBits);
+    if (outputLevel + rescaleCount < currentLevel) {
+      int levelToDrop = currentLevel - outputLevel - rescaleCount;
+      b.setInsertionPointAfter(insertAfter);
+      auto levelReduceOp = mgmt::LevelReduceOp::create(
+          b, insertAfter->getLoc(), current, b.getI64IntegerAttr(levelToDrop));
+      current = insertAfterCurrent(b, current, insertAfter, value,
+                                   levelReduceOp.getOperation());
+      currentLevel -= levelToDrop;
+    }
+
+    for (int i = rescaleCount - 1; i >= 0; --i) {
+      int targetScale = std::min(scaleMax - scaleConfig.scaleFactorBits,
+                                 outputScale + i * scaleConfig.scaleFactorBits);
+      if (currentScale < targetScale + scaleConfig.scaleFactorBits) {
+        b.setInsertionPointAfter(insertAfter);
+        auto adjustScaleOp = mgmt::AdjustScaleOp::create(
+            b, insertAfter->getLoc(), current,
+            b.getI64IntegerAttr(adjustScaleIdCounter++));
+        current = insertAfterCurrent(b, current, insertAfter, value,
+                                     adjustScaleOp.getOperation());
+        currentScale = targetScale + scaleConfig.scaleFactorBits;
+      }
+
+      b.setInsertionPointAfter(insertAfter);
+      auto modReduceOp =
+          mgmt::ModReduceOp::create(b, insertAfter->getLoc(), current);
+      current = insertAfterCurrent(b, current, insertAfter, value,
+                                   modReduceOp.getOperation());
+      --currentLevel;
+      currentScale -= scaleConfig.scaleFactorBits;
+    }
+
+    if (!levelOnly && currentScale < outputScale) {
+      b.setInsertionPointAfter(insertAfter);
+      auto adjustScaleOp = mgmt::AdjustScaleOp::create(
+          b, insertAfter->getLoc(), current,
+          b.getI64IntegerAttr(adjustScaleIdCounter++));
+      current = insertAfterCurrent(b, current, insertAfter, value,
+                                   adjustScaleOp.getOperation());
+      currentScale = outputScale;
+    }
+
+    if (currentLevel != outputLevel || currentScale != outputScale) {
+      insertAfter->emitError()
+          << "failed to decode Orbit node transition from (" << inputLevel
+          << ", " << inputScale << ") to (" << outputLevel << ", "
+          << outputScale << ")";
+      return failure();
+    }
+    return current;
+  }
+
+  FailureOr<Value> decodeDirectTransitionBefore(
+      OpBuilder& b, Operation* op, Value current, int inputLevel,
+      int inputScale, int outputLevel, int outputScale,
+      const ScaleConfig& scaleConfig) {
+    int currentLevel = inputLevel;
+    int currentScale = inputScale;
+    int scaleMax = scaleConfig.scaleFactorBits + 2 * scaleConfig.scaleWaterline;
+    bool levelOnly = scaleConfig.levelOnly();
+
+    int rescaleCount = levelOnly ? 0
+                                 : ceilDivPositive(currentScale - outputScale,
+                                                   scaleConfig.scaleFactorBits);
+    if (outputLevel + rescaleCount < currentLevel) {
+      int levelToDrop = currentLevel - outputLevel - rescaleCount;
+      b.setInsertionPoint(op);
+      current = mgmt::LevelReduceOp::create(b, op->getLoc(), current,
+                                            b.getI64IntegerAttr(levelToDrop));
+      currentLevel -= levelToDrop;
+    }
+
+    for (int i = rescaleCount - 1; i >= 0; --i) {
+      int targetScale = std::min(scaleMax - scaleConfig.scaleFactorBits,
+                                 outputScale + i * scaleConfig.scaleFactorBits);
+      if (currentScale < targetScale + scaleConfig.scaleFactorBits) {
+        b.setInsertionPoint(op);
+        current = mgmt::AdjustScaleOp::create(
+            b, op->getLoc(), current,
+            b.getI64IntegerAttr(adjustScaleIdCounter++));
+        currentScale = targetScale + scaleConfig.scaleFactorBits;
+      }
+      b.setInsertionPoint(op);
+      current = mgmt::ModReduceOp::create(b, op->getLoc(), current);
+      --currentLevel;
+      currentScale -= scaleConfig.scaleFactorBits;
+    }
+
+    if (!levelOnly && currentScale < outputScale) {
+      b.setInsertionPoint(op);
+      current = mgmt::AdjustScaleOp::create(
+          b, op->getLoc(), current,
+          b.getI64IntegerAttr(adjustScaleIdCounter++));
+      currentScale = outputScale;
+    }
+
+    if (currentLevel != outputLevel || currentScale != outputScale) {
+      op->emitError() << "failed to decode Orbit edge transition from ("
+                      << inputLevel << ", " << inputScale << ") to ("
+                      << outputLevel << ", " << outputScale << ")";
+      return failure();
+    }
+    return current;
+  }
+
+  FailureOr<Value> decodeNodeTransition(
+      const ILPBootstrapPlacementAnalysis::NodeManagement& placement,
+      const ScaleConfig& scaleConfig) {
+    auto [current, insertAfter] = followMgmtChain(placement.value);
+    if (!insertAfter) return failure();
+
+    OpBuilder b(&getContext());
+    if (!placement.useBootstrap) {
+      return decodeDirectTransitionAfter(
+          b, current, insertAfter, placement.inputLevel, placement.inputScale,
+          placement.outputLevel, placement.outputScale, scaleConfig);
+    }
+
+    FailureOr<Value> beforeBootstrap = decodeDirectTransitionAfter(
+        b, current, insertAfter, placement.inputLevel, placement.inputScale,
+        bootstrapLevelLowerBound, scaleConfig.scaleFactorBits, scaleConfig);
+    if (failed(beforeBootstrap)) return failure();
+
+    int postBootstrapRescales =
+        scaleConfig.levelOnly() ? 0
+                                : ceilDivPositive(scaleConfig.scaleFactorBits -
+                                                      placement.outputScale,
+                                                  scaleConfig.scaleFactorBits);
+    int bootstrapTargetLevel = placement.outputLevel + postBootstrapRescales;
+    if (bootstrapTargetLevel > bootstrapWaterline) {
+      insertAfter->emitError()
+          << "decoded bootstrap target level " << bootstrapTargetLevel
+          << " exceeds bootstrap waterline " << bootstrapWaterline;
+      return failure();
+    }
+
+    b.setInsertionPointAfter(insertAfter);
+    auto bootstrapOp =
+        mgmt::BootstrapOp::create(b, insertAfter->getLoc(), *beforeBootstrap);
+    Value afterBootstrap =
+        insertAfterCurrent(b, *beforeBootstrap, insertAfter, placement.value,
+                           bootstrapOp.getOperation());
+
+    int currentLevel = bootstrapWaterline;
+    if (bootstrapTargetLevel < bootstrapWaterline) {
+      int levelToDrop = bootstrapWaterline - bootstrapTargetLevel;
+      b.setInsertionPointAfter(insertAfter);
+      auto levelReduceOp =
+          mgmt::LevelReduceOp::create(b, insertAfter->getLoc(), afterBootstrap,
+                                      b.getI64IntegerAttr(levelToDrop));
+      afterBootstrap =
+          insertAfterCurrent(b, afterBootstrap, insertAfter, placement.value,
+                             levelReduceOp.getOperation());
+      currentLevel = bootstrapTargetLevel;
+    }
+
+    return decodeDirectTransitionAfter(
+        b, afterBootstrap, insertAfter, currentLevel,
+        scaleConfig.scaleFactorBits, placement.outputLevel,
+        placement.outputScale, scaleConfig);
+  }
+
+  LogicalResult decodeEdgeTransition(
+      const ILPBootstrapPlacementAnalysis::EdgeManagement& placement,
+      const ScaleConfig& scaleConfig) {
+    Operation* op = placement.op;
+    if (!op || placement.operandNumber >= op->getNumOperands())
+      return success();
+    OpBuilder b(&getContext());
+    Value current = op->getOperand(placement.operandNumber);
+    FailureOr<Value> managed = decodeDirectTransitionBefore(
+        b, op, current, placement.inputLevel, placement.inputScale,
+        placement.outputLevel, placement.outputScale, scaleConfig);
+    if (failed(managed)) return failure();
+    op->setOperand(placement.operandNumber, *managed);
+    return success();
   }
 
   void runOnOperation() override {
     Operation* module = getOperation();
+
+    SmallVector<secret::GenericOp> genericOps;
+    module->walk(
+        [&](secret::GenericOp genericOp) { genericOps.push_back(genericOp); });
+    for (secret::GenericOp genericOp : genericOps) {
+      eraseExistingPlacementMgmtOps(genericOp);
+    }
 
     DataFlowSolver solver;
     dataflow::loadBaselineAnalyses(solver);
@@ -88,10 +420,15 @@ struct ILPBootstrapPlacement
       return;
     }
 
-    SmallVector<Value, 32> valuesToBootstrap;
+    ScaleConfig scaleConfig = getScaleConfig(module);
+
+    SmallVector<ILPBootstrapPlacementAnalysis::NodeManagement, 32>
+        nodeManagement;
+    SmallVector<ILPBootstrapPlacementAnalysis::EdgeManagement, 32>
+        edgeManagement;
     auto result = module->walk([&](secret::GenericOp genericOp) {
-      if (failed(
-              processSecretGenericOp(genericOp, &solver, &valuesToBootstrap)))
+      if (failed(processSecretGenericOp(genericOp, &solver, scaleConfig,
+                                        &nodeManagement, &edgeManagement)))
         return WalkResult::interrupt();
       return WalkResult::advance();
     });
@@ -100,16 +437,22 @@ struct ILPBootstrapPlacement
       return;
     }
 
-    // Modreduce after every mul.
-    insertModReduceBeforeOrAfterMult(getOperation(), /*afterMul=*/true,
-                                     /*beforeMulIncludeFirstMul=*/false,
-                                     /*includeFloats=*/true);
-
     // Relinearize after every mul.
     insertRelinearizeAfterMult(getOperation(), /*includeFloats=*/true);
 
-    // Insert bootstraps at the Values the ILP chose. Values remain valid.
-    insertBootstrapsForValues(valuesToBootstrap);
+    for (const auto& placement : nodeManagement) {
+      if (failed(decodeNodeTransition(placement, scaleConfig))) {
+        signalPassFailure();
+        return;
+      }
+    }
+
+    for (const auto& placement : edgeManagement) {
+      if (failed(decodeEdgeTransition(placement, scaleConfig))) {
+        signalPassFailure();
+        return;
+      }
+    }
 
     OpPassManager nested("builtin.module");
     nested.addPass(createCanonicalizerPass());
@@ -120,6 +463,8 @@ struct ILPBootstrapPlacement
       return;
     }
   }
+
+  int64_t adjustScaleIdCounter = 0;
 };
 
 }  // namespace heir

--- a/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.td
+++ b/lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.td
@@ -6,22 +6,28 @@ include "mlir/Pass/PassBase.td"
 def ILPBootstrapPlacement : Pass <"ilp-bootstrap-placement"> {
     let summary = "Optimize placement of bootstrap ops using ILP";
     let description = [{
-        This pass uses an integer linear program to determine the optimal level
-        of each term in the MLIR, and thus the placement of bootstrap and
-        modreduce operations.
+        This pass uses an integer linear program to determine feasible levels
+        and Orbit-style scales for each term in the MLIR, and thus the
+        placement of mod-down, rescale, upscale, and bootstrap operations.
 
-        The pass runs on [ciphertext-semantic](https://heir.dev/docs/design/layout/#data-semantic-and-ciphertext-semantic-tensors)
-        IR (secret.generic with arith ops operating on pre-packed tensors). It
-        1) Inserts mgmt.modreduce after each level-consuming op (e.g. mul in
-           CKKS, where level drops only at multiplications).
-        2) Inserts mgmt.bootstrap at the positions chosen by the ILP.
-        3) Inserts mgmt.relinearize after each mul. Resulting order is mul ->
-           relinearize -> modreduce, with bootstrap after modreduce or after
-           the op where the ILP chose.
+        The pass runs on
+        [ciphertext-semantic](https://heir.dev/docs/design/layout/#data-semantic-and-ciphertext-semantic-tensors)
+        IR (`secret.generic` with `arith` ops operating on pre-packed
+        tensors). It does the following:
 
-        Note: The ILP formulation does not account for a freshly encrypted
-        ciphertext starting at a higher level than the bootstrap waterline.
-        This will be implemented as future work.
+        1. Inserts `mgmt.level_reduce` for decoded level-only mod-down.
+        2. Inserts `mgmt.adjust_scale` for decoded upscale.
+        3. Inserts `mgmt.modreduce` for decoded rescale. In CKKS lowering,
+           `mgmt.modreduce` becomes `ckks.rescale`.
+        4. Inserts `mgmt.bootstrap` at the positions chosen by the ILP.
+        5. Inserts `mgmt.relinearize` after each mul. Resulting order is mul ->
+           relinearize, with rescale/bootstrap chains inserted after
+           relinearize when the ILP chooses them on a mul result.
+
+        The ILP formulation is inspired by [Orbit](https://eprint.iacr.org/2026/213.pdf).
+        CKKS scale modeling is selected from CKKS module attributes. Modules
+        without CKKS attributes use the generic level-only model, where the
+        effective waterline scale and rescaling factor are equal.
     }];
 
     let dependentDialects = ["mlir::heir::mgmt::MgmtDialect"];
@@ -32,6 +38,36 @@ def ILPBootstrapPlacement : Pass <"ilp-bootstrap-placement"> {
            "int",
            /*default=*/"3",
            "Bootstrap waterline (max level). Levels are 0..bootstrap-waterline (inclusive); inputs start at bootstrap-waterline.">,
+    Option<"scaleWaterline",
+           "scale-waterline",
+           "int",
+           /*default=*/"40",
+           "Orbit waterline/base scale bits (Sw). Non-CKKS level-only mode uses this for both Sw and Sf.">,
+    Option<"scaleFactorBits",
+           "scale-factor-bits",
+           "int",
+           /*default=*/"51",
+           "Orbit rescale factor bits (Sf), i.e. scale bits dropped by one rescale/modreduce.">,
+    Option<"bootstrapLevelLowerBound",
+           "bootstrap-level-lower-bound",
+           "int",
+           /*default=*/"0",
+           "Minimum input level at which bootstrap is allowed in the Orbit-inspired scale constraints.">,
+    Option<"orbitCostModel",
+           "orbit-cost-model",
+           "std::string",
+           /*default=*/"""",
+           "Path to a JSON cost model. When provided, bootstrap-cost and rescale-cost are loaded from latencyTable.bootstrap and latencyTable.rescale. See lib/Transforms/ILPBootstrapPlacement/README.md for the schema.">,
+    Option<"bootstrapCost",
+           "bootstrap-cost",
+           "int",
+           /*default=*/"69320650",
+           "Cost of one bootstrap in the ILP objective. Default is the positive-latency average from Orbit's profiled 64k Lattigo base cost model.">,
+    Option<"rescaleCost",
+           "rescale-cost",
+           "int",
+           /*default=*/"40988",
+           "Cost of one ILP-chosen rescale in the objective. This is loaded from Orbit's rescale latency when orbit-cost-model is provided. Default is the positive-latency average from Orbit's profiled 64k Lattigo base cost model.">,
   ];
 }
 

--- a/lib/Transforms/ILPBootstrapPlacement/README.md
+++ b/lib/Transforms/ILPBootstrapPlacement/README.md
@@ -1,0 +1,17 @@
+# ILP Bootstrap Placement
+
+## Cost Model JSON
+
+`--ilp-bootstrap-placement="orbit-cost-model=PATH"` loads an optional JSON cost
+model and uses it to override the `bootstrap-cost` and `rescale-cost` pass
+options. The units of latency are in microseconds. If level-dependent costs are
+needed, the next step would be to extend this schema and the ILP objective.
+
+Required fields:
+
+- `latencyTable.bootstrap`: numeric latency samples for one bootstrap chosen by
+  the ILP.
+- `latencyTable.rescale`: numeric latency samples for one unit of rescale,
+  modreduce, or level-reduce management chosen by the ILP.
+
+<!-- mdformat global-off -->

--- a/tests/Transforms/ilp_bootstrap_placement/BUILD
+++ b/tests/Transforms/ilp_bootstrap_placement/BUILD
@@ -2,9 +2,20 @@ load("//bazel:lit.bzl", "glob_lit_tests")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
+filegroup(
+    name = "orbit_cost_model",
+    srcs = [
+        "orbit_bad_cost_model.json",
+        "orbit_cost_model.json",
+    ],
+)
+
 glob_lit_tests(
     name = "all_tests",
-    data = ["@heir//tests:test_utilities"],
+    data = [
+        ":orbit_cost_model",
+        "@heir//tests:test_utilities",
+    ],
     driver = "@heir//tests:run_lit.sh",
     test_file_exts = ["mlir"],
 )

--- a/tests/Transforms/ilp_bootstrap_placement/annotated_generic_inputs.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/annotated_generic_inputs.mlir
@@ -1,0 +1,21 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s --check-prefix=CHECK-LEVEL
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+// CHECK-LEVEL: func.func @uses_annotated_input_level
+// CHECK-LEVEL: secret.generic
+// CHECK-LEVEL: arith.mulf
+// CHECK-LEVEL: mgmt.bootstrap
+// CHECK-LEVEL: arith.mulf
+func.func @uses_annotated_input_level(
+    %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 1>}) -> !ct_ty {
+  %0 = secret.generic(
+      %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 1>}) {
+  ^body(%input0: !pt_ty):
+    %l1 = arith.mulf %input0, %input0 : !pt_ty
+    %l2 = arith.mulf %l1, %input0 : !pt_ty
+    secret.yield %l2 : !pt_ty
+  } -> !ct_ty
+  return %0 : !ct_ty
+}

--- a/tests/Transforms/ilp_bootstrap_placement/annotated_generic_scale.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/annotated_generic_scale.mlir
@@ -1,0 +1,57 @@
+// RUN: heir-opt --ilp-bootstrap-placement="bootstrap-waterline=3 scale-waterline=40 scale-factor-bits=51" %s | FileCheck %s
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+module attributes {scheme.ckks} {
+  // CHECK: func.func @uses_annotated_input_and_output_scale
+  // CHECK: secret.generic
+  // CHECK: arith.mulf
+  // CHECK: mgmt.modreduce
+  func.func @uses_annotated_input_and_output_scale(
+      %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 51>})
+      -> (!ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 51>}) {
+    %0 = secret.generic(
+        %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 51>}) {
+    ^body(%input0: !pt_ty):
+      %l1 = arith.mulf %input0, %input0 : !pt_ty
+      secret.yield %l1 : !pt_ty
+    } -> (!ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 51>})
+    return %0 : !ct_ty
+  }
+
+  // CHECK: func.func @adds_mismatched_annotated_input_scales
+  // CHECK: secret.generic
+  // CHECK: mgmt.adjust_scale
+  // CHECK: arith.addf
+  func.func @adds_mismatched_annotated_input_scales(
+      %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 40>},
+      %arg1: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 51>}) -> !ct_ty {
+    %0 = secret.generic(
+        %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 40>},
+        %arg1: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 51>}) {
+    ^body(%input0: !pt_ty, %input1: !pt_ty):
+      %out = arith.addf %input0, %input1 : !pt_ty
+      secret.yield %out : !pt_ty
+    } -> !ct_ty
+    return %0 : !ct_ty
+  }
+
+  // CHECK: func.func @multiplies_mismatched_annotated_input_scales
+  // CHECK: secret.generic
+  // CHECK: arith.mulf
+  // CHECK: mgmt.relinearize
+  // CHECK: mgmt.adjust_scale
+  func.func @multiplies_mismatched_annotated_input_scales(
+      %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 40>},
+      %arg1: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 51>}) -> !ct_ty {
+    %0 = secret.generic(
+        %arg0: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 40>},
+        %arg1: !ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 3, scale = 51>}) {
+    ^body(%input0: !pt_ty, %input1: !pt_ty):
+      %out = arith.mulf %input0, %input1 : !pt_ty
+      secret.yield %out : !pt_ty
+    } -> !ct_ty
+    return %0 : !ct_ty
+  }
+}

--- a/tests/Transforms/ilp_bootstrap_placement/bootstrap_placement_comparison.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/bootstrap_placement_comparison.mlir
@@ -1,10 +1,10 @@
 // RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s --check-prefix=CHECK-ILP
+// RUN: heir-opt --ilp-bootstrap-placement="bootstrap-waterline=3 orbit-cost-model=%S/orbit_cost_model.json" %s | FileCheck %s --check-prefix=CHECK-COST-MODEL
 // RUN: heir-opt --secret-insert-mgmt-ckks=bootstrap-waterline=3 %s | FileCheck %s --check-prefix=CHECK-GREEDY
 
 // Compare the greedy bootstrap placement against the ILP bootstrap placement
-// with bootstrap-waterline=3. Greedy gives 3 bootstraps after L5, L6, L7 (each
-// bootstrap immediately after the modreduce that brings that branch to level
-// 0). ILP places 2 bootstraps (optimal for this DAG with levels 0..3):
+// with bootstrap-waterline=3. Greedy gives 3 bootstraps after L5, L6, L7. ILP
+// places 2 bootstraps (optimal for this DAG with levels 0..3):
 //
 // Computation:
 // L1 = I1 * I2   (level 2)
@@ -21,55 +21,48 @@
 // CHECK-ILP-COUNT-2: mgmt.bootstrap
 // CHECK-ILP-NOT: mgmt.bootstrap
 // CHECK-GREEDY-COUNT-3: mgmt.bootstrap
+// CHECK-COST-MODEL-COUNT-2: mgmt.bootstrap
+// CHECK-COST-MODEL-NOT: mgmt.bootstrap
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
 
 func.func @bootstrap_placement_test(
-    %arg0: !secret.secret<tensor<8xf32>>,
-    %arg1: !secret.secret<tensor<8xf32>>,
-    %arg2: !secret.secret<tensor<8xf32>>,
-    %arg3: !secret.secret<tensor<8xf32>>,
-    %arg4: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+    %arg0: !ct_ty, %arg1: !ct_ty, %arg2: !ct_ty, %arg3: !ct_ty, %arg4: !ct_ty) -> !ct_ty {
   %0 = secret.generic(
-      %arg0: !secret.secret<tensor<8xf32>>,
-      %arg1: !secret.secret<tensor<8xf32>>,
-      %arg2: !secret.secret<tensor<8xf32>>,
-      %arg3: !secret.secret<tensor<8xf32>>,
-      %arg4: !secret.secret<tensor<8xf32>>) {
-  ^body(%input0: tensor<8xf32>,
-        %input1: tensor<8xf32>,
-        %input2: tensor<8xf32>,
-        %input3: tensor<8xf32>,
-        %input4: tensor<8xf32>):
+      %arg0: !ct_ty, %arg1: !ct_ty, %arg2: !ct_ty, %arg3: !ct_ty, %arg4: !ct_ty) {
+  ^body(%input0: !pt_ty, %input1: !pt_ty, %input2: !pt_ty, %input3: !pt_ty, %input4: !pt_ty):
     // L1 = I1 * I2
-    %l1 = arith.mulf %input0, %input1 : tensor<8xf32>
+    %l1 = arith.mulf %input0, %input1 : !pt_ty
 
     // L2 = I2 * I3
-    %l2 = arith.mulf %input1, %input2 : tensor<8xf32>
+    %l2 = arith.mulf %input1, %input2 : !pt_ty
 
     // L3 = I4 * I5
-    %l3 = arith.mulf %input3, %input4 : tensor<8xf32>
+    %l3 = arith.mulf %input3, %input4 : !pt_ty
 
     // L4 = L1 * L2
-    %l4 = arith.mulf %l1, %l2 : tensor<8xf32>
+    %l4 = arith.mulf %l1, %l2 : !pt_ty
 
     // L5 = I1 * L4
-    %l5 = arith.mulf %input0, %l4 : tensor<8xf32>
+    %l5 = arith.mulf %input0, %l4 : !pt_ty
 
     // L6 = L4 * I4
-    %l6 = arith.mulf %l4, %input3 : tensor<8xf32>
+    %l6 = arith.mulf %l4, %input3 : !pt_ty
 
     // L7 = L3 * L4
-    %l7 = arith.mulf %l3, %l4 : tensor<8xf32>
+    %l7 = arith.mulf %l3, %l4 : !pt_ty
 
     // L8 = L5 * L6
-    %l8 = arith.mulf %l5, %l6 : tensor<8xf32>
+    %l8 = arith.mulf %l5, %l6 : !pt_ty
 
     // L9 = L6 * L7
-    %l9 = arith.mulf %l6, %l7 : tensor<8xf32>
+    %l9 = arith.mulf %l6, %l7 : !pt_ty
 
     // L10 = L8 * L9
-    %l10 = arith.mulf %l8, %l9 : tensor<8xf32>
+    %l10 = arith.mulf %l8, %l9 : !pt_ty
 
-    secret.yield %l10 : tensor<8xf32>
-  } -> !secret.secret<tensor<8xf32>>
-  return %0 : !secret.secret<tensor<8xf32>>
+    secret.yield %l10 : !pt_ty
+  } -> !ct_ty
+  return %0 : !ct_ty
 }

--- a/tests/Transforms/ilp_bootstrap_placement/ilp_relin_modreduce_placement.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/ilp_relin_modreduce_placement.mlir
@@ -1,52 +1,39 @@
 // RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s
 
-// Test relinearize and modreduce operations are inserted correctly after the
-// ILP bootstrap placement pass, i.e., each multiplication should be followed by
-// a `mgmt.relinearize` and a `mgmt.modreduce`. This test samples 3 mul ops and
-// checks that these mgmt operations are inserted.
+// Test that relinearize is inserted after multiplications and that modreduce is
+// only inserted at rescale positions chosen by the ILP, not unconditionally
+// after every multiplication.
 
 // CHECK: func.func @bootstrap_placement_test
 // CHECK: secret.generic
-// CHECK: arith.mulf %input3, %input4
+// CHECK: arith.mulf %input0, %input1
 // CHECK-NEXT: mgmt.relinearize
-// CHECK-NEXT: mgmt.modreduce
-// CHECK: arith.mulf %3, %6
-// CHECK-NEXT: mgmt.relinearize
-// CHECK-NEXT: mgmt.modreduce
-// CHECK: arith.mulf %10, %14
-// CHECK-NEXT: mgmt.relinearize
-// CHECK-NEXT: mgmt.modreduce
+// CHECK-NEXT: arith.mulf %input1, %input2
+// CHECK: mgmt.modreduce
+// CHECK: mgmt.bootstrap
 // CHECK: secret.yield
 
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
 
-func.func @bootstrap_placement_test(
-    %arg0: !secret.secret<tensor<8xf32>>,
-    %arg1: !secret.secret<tensor<8xf32>>,
-    %arg2: !secret.secret<tensor<8xf32>>,
-    %arg3: !secret.secret<tensor<8xf32>>,
-    %arg4: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
-  %0 = secret.generic(
-      %arg0: !secret.secret<tensor<8xf32>>,
-      %arg1: !secret.secret<tensor<8xf32>>,
-      %arg2: !secret.secret<tensor<8xf32>>,
-      %arg3: !secret.secret<tensor<8xf32>>,
-      %arg4: !secret.secret<tensor<8xf32>>) {
-  ^body(%input0: tensor<8xf32>,
-        %input1: tensor<8xf32>,
-        %input2: tensor<8xf32>,
-        %input3: tensor<8xf32>,
-        %input4: tensor<8xf32>):
-    %l1 = arith.mulf %input0, %input1 : tensor<8xf32>
-    %l2 = arith.mulf %input1, %input2 : tensor<8xf32>
-    %l3 = arith.mulf %input3, %input4 : tensor<8xf32>
-    %l4 = arith.mulf %l1, %l2 : tensor<8xf32>
-    %l5 = arith.mulf %input0, %l4 : tensor<8xf32>
-    %l6 = arith.mulf %l4, %input3 : tensor<8xf32>
-    %l7 = arith.mulf %l3, %l4 : tensor<8xf32>
-    %l8 = arith.mulf %l5, %l6 : tensor<8xf32>
-    %l9 = arith.mulf %l6, %l7 : tensor<8xf32>
-    %l10 = arith.mulf %l8, %l9 : tensor<8xf32>
-    secret.yield %l10 : tensor<8xf32>
-  } -> !secret.secret<tensor<8xf32>>
-  return %0 : !secret.secret<tensor<8xf32>>
+module attributes {scheme.ckks} {
+  func.func @bootstrap_placement_test(
+      %arg0: !ct_ty, %arg1: !ct_ty, %arg2: !ct_ty, %arg3: !ct_ty, %arg4: !ct_ty) -> !ct_ty {
+    %0 = secret.generic(
+        %arg0: !ct_ty, %arg1: !ct_ty, %arg2: !ct_ty, %arg3: !ct_ty, %arg4: !ct_ty) {
+    ^body(%input0: !pt_ty, %input1: !pt_ty, %input2: !pt_ty, %input3: !pt_ty, %input4: !pt_ty):
+      %l1 = arith.mulf %input0, %input1 : !pt_ty
+      %l2 = arith.mulf %input1, %input2 : !pt_ty
+      %l3 = arith.mulf %input3, %input4 : !pt_ty
+      %l4 = arith.mulf %l1, %l2 : !pt_ty
+      %l5 = arith.mulf %input0, %l4 : !pt_ty
+      %l6 = arith.mulf %l4, %input3 : !pt_ty
+      %l7 = arith.mulf %l3, %l4 : !pt_ty
+      %l8 = arith.mulf %l5, %l6 : !pt_ty
+      %l9 = arith.mulf %l6, %l7 : !pt_ty
+      %l10 = arith.mulf %l8, %l9 : !pt_ty
+      secret.yield %l10 : !pt_ty
+    } -> !ct_ty
+    return %0 : !ct_ty
+  }
 }

--- a/tests/Transforms/ilp_bootstrap_placement/orbit_bad_cost_model.json
+++ b/tests/Transforms/ilp_bootstrap_placement/orbit_bad_cost_model.json
@@ -1,0 +1,1 @@
+{ "latencyTable": { "bootstrap": [

--- a/tests/Transforms/ilp_bootstrap_placement/orbit_cost_model.json
+++ b/tests/Transforms/ilp_bootstrap_placement/orbit_cost_model.json
@@ -1,0 +1,10 @@
+{
+  "latencyTable": {
+    "bootstrap": [
+      69320650
+    ],
+    "rescale": [
+      40988
+    ]
+  }
+}

--- a/tests/Transforms/ilp_bootstrap_placement/orbit_cost_model_error.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/orbit_cost_model_error.mlir
@@ -1,0 +1,17 @@
+// RUN: not heir-opt --ilp-bootstrap-placement="orbit-cost-model=%S/does_not_exist.json" %s 2>&1 | FileCheck %s --check-prefix=MISSING
+// RUN: not heir-opt --ilp-bootstrap-placement="orbit-cost-model=%S/orbit_bad_cost_model.json" %s 2>&1 | FileCheck %s --check-prefix=MALFORMED
+
+// MISSING: failed to load Orbit cost model
+// MALFORMED: failed to load Orbit cost model
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+func.func @orbit_cost_model_error(%arg0: !ct_ty) -> !ct_ty {
+  %0 = secret.generic(%arg0: !ct_ty) {
+  ^body(%input0: !pt_ty):
+    %out = arith.addf %input0, %input0 : !pt_ty
+    secret.yield %out : !pt_ty
+  } -> !ct_ty
+  return %0 : !ct_ty
+}

--- a/tests/Transforms/ilp_bootstrap_placement/orbit_edge_rescale_placement.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/orbit_edge_rescale_placement.mlir
@@ -1,0 +1,39 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s --check-prefix=CHECK-CKKS
+// RUN: heir-opt --ilp-bootstrap-placement="bootstrap-waterline=3 scale-waterline=51 scale-factor-bits=51" %s | FileCheck %s --check-prefix=CHECK-CKKS-ALIGNED
+
+// CKKS mode is inferred from the module attribute. It keeps Sw and Sf distinct
+// by default, and still targets CKKS when Sw == Sf.
+
+// CHECK-CKKS: func.func @orbit_edge_rescale_placement
+// CHECK-CKKS: secret.generic
+// CHECK-CKKS: arith.mulf %input0, %input0
+// CHECK-CKKS-NEXT: mgmt.relinearize
+// CHECK-CKKS: mgmt.adjust_scale
+// CHECK-CKKS: arith.addf
+// CHECK-CKKS: mgmt.adjust_scale
+// CHECK-CKKS-NEXT: mgmt.modreduce
+// CHECK-CKKS-NOT: mgmt.bootstrap
+
+// CHECK-CKKS-ALIGNED: func.func @orbit_edge_rescale_placement
+// CHECK-CKKS-ALIGNED: secret.generic
+// CHECK-CKKS-ALIGNED: arith.mulf %input0, %input0
+// CHECK-CKKS-ALIGNED-NEXT: mgmt.relinearize
+// CHECK-CKKS-ALIGNED: mgmt.modreduce
+// CHECK-CKKS-ALIGNED-NOT: mgmt.bootstrap
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+module attributes {scheme.ckks} {
+  func.func @orbit_edge_rescale_placement(
+      %arg0: !ct_ty)
+      -> (!ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 51>}) {
+    %0 = secret.generic(%arg0: !ct_ty) {
+    ^body(%input0: !pt_ty):
+      %l1 = arith.mulf %input0, %input0 : !pt_ty
+      %out = arith.addf %input0, %l1 : !pt_ty
+      secret.yield %out : !pt_ty
+    } -> (!ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 51>})
+    return %0 : !ct_ty
+  }
+}

--- a/tests/Transforms/ilp_bootstrap_placement/orbit_level_only_placement.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/orbit_level_only_placement.mlir
@@ -1,0 +1,26 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s
+
+// Without CKKS module attributes, the ILP uses generic level-only management
+// with equal effective Sw/Sf. This should not require callers to manually set
+// the scale options equal.
+
+// CHECK: func.func @orbit_level_only_placement
+// CHECK: secret.generic
+// CHECK: arith.mulf %input0, %input0
+// CHECK-NEXT: mgmt.relinearize
+// CHECK-NEXT: mgmt.level_reduce
+// CHECK-NOT: mgmt.adjust_scale
+// CHECK-NOT: mgmt.modreduce
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+func.func @orbit_level_only_placement(%arg0: !ct_ty) -> !ct_ty {
+  %0 = secret.generic(%arg0: !ct_ty) {
+  ^body(%input0: !pt_ty):
+    %l1 = arith.mulf %input0, %input0 : !pt_ty
+    %out = arith.addf %input0, %l1 : !pt_ty
+    secret.yield %out : !pt_ty
+  } -> !ct_ty
+  return %0 : !ct_ty
+}

--- a/tests/Transforms/ilp_bootstrap_placement/orbit_output_rescale_placement.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/orbit_output_rescale_placement.mlir
@@ -1,0 +1,34 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s
+
+// Orbit-style decoding can place scale management at a shared node or at a
+// later node when that is cheaper. This case checks that a CKKS run decodes a
+// scale-changing mgmt.modreduce only where the ILP assignment needs it.
+
+// CHECK: func.func @orbit_output_rescale_placement
+// CHECK: %[[SHARED:.*]] = arith.mulf %input0, %input1
+// CHECK-NEXT: %[[RELIN:.*]] = mgmt.relinearize %[[SHARED]]
+// CHECK: arith.addf
+// CHECK: arith.subf
+// CHECK: arith.addf
+// CHECK: mgmt.adjust_scale
+// CHECK-NEXT: mgmt.modreduce
+// CHECK-NOT: mgmt.bootstrap
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+module attributes {scheme.ckks} {
+  func.func @orbit_output_rescale_placement(
+      %arg0: !ct_ty, %arg1: !ct_ty)
+      -> (!ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 51>}) {
+    %0 = secret.generic(%arg0: !ct_ty, %arg1: !ct_ty) {
+    ^body(%input0: !pt_ty, %input1: !pt_ty):
+      %shared = arith.mulf %input0, %input1 : !pt_ty
+      %use0 = arith.addf %shared, %input0 : !pt_ty
+      %use1 = arith.subf %shared, %input1 : !pt_ty
+      %out = arith.addf %use0, %use1 : !pt_ty
+      secret.yield %out : !pt_ty
+    } -> (!ct_ty {mgmt.mgmt = #mgmt.mgmt<level = 2, scale = 51>})
+    return %0 : !ct_ty
+  }
+}

--- a/tests/Transforms/ilp_bootstrap_placement/strip_existing_management.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/strip_existing_management.mlir
@@ -1,0 +1,33 @@
+// RUN: heir-opt --ilp-bootstrap-placement=bootstrap-waterline=3 %s | FileCheck %s
+
+// The ILP pass recomputes management placement, so pre-existing management ops
+// in a secret.generic body should be removed before solving.
+
+!pt_ty = tensor<8xf32>
+!ct_ty = !secret.secret<!pt_ty>
+
+module attributes {scheme.ckks} {
+  // CHECK: func.func @strips_existing_management
+  // CHECK: secret.generic
+  // CHECK: arith.addf %input0, %input0
+  // CHECK-NOT: id = 77
+  // CHECK-NOT: mgmt.modreduce
+  // CHECK-NOT: mgmt.level_reduce
+  // CHECK-NOT: mgmt.bootstrap
+  // CHECK-NOT: mgmt.relinearize
+  // CHECK: secret.yield
+  func.func @strips_existing_management(%arg0: !ct_ty) -> !ct_ty {
+    %0 = secret.generic(%arg0: !ct_ty) {
+    ^body(%input0: !pt_ty):
+      %old_adjust = mgmt.adjust_scale %input0 {id = 77 : i64} : !pt_ty
+      %old_modreduce = mgmt.modreduce %old_adjust : !pt_ty
+      %old_level_reduce = mgmt.level_reduce %old_modreduce
+          {levelToDrop = 2 : i64} : !pt_ty
+      %old_bootstrap = mgmt.bootstrap %old_level_reduce : !pt_ty
+      %old_relinearize = mgmt.relinearize %old_bootstrap : !pt_ty
+      %out = arith.addf %old_relinearize, %input0 : !pt_ty
+      secret.yield %out : !pt_ty
+    } -> !ct_ty
+    return %0 : !ct_ty
+  }
+}


### PR DESCRIPTION
The ILP formulation is inspired by [Orbit](https://eprint.iacr.org/2026/213.pdf)

This PR extends the ILP bootstrap placement model to solve for both bootstrap and rescale placement. 

Changes:
- level and scale constraints for CKKS placement decisions
- weighted objective function, rather than solely minimizing the bootstrap count 
- a toy JSON cost model from Orbit 
- updates to the mgmt dialect to annotate the input level and scale 