### PR TITLE
Update nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,75 +1,179 @@
 name: Nightly release
 
-permissions: read-all
-
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+
 jobs:
-  nightly-release:
+  setup-version:
+    name: Setup version
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Get version
+        id: get-version
+        run: echo "version=$(date -u +'%Y.%m.%d')" >> "$GITHUB_OUTPUT"
+
+  build_wheels:
+    name: Build HEIR wheels on ${{ matrix.name }}
+    needs: [setup-version]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - name: linux-x86_64
+            runner: ubuntu-24.04
+          - name: linux-aarch64
+            runner: ubuntu-24.04-arm
+          - name: macos-arm64
+            runner: macos-15
+
+    steps:
+      - name: Check out HEIR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        name: Install Python 3.12
+        with:
+          python-version: "3.12"
+      - run: pip install --upgrade pip uv
+
+      - name: Build wheels on ${{ matrix.name }} using cibuildwheel
+        uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.setup-version.outputs.version }}
+          CIBW_ENVIRONMENT_PASS: SETUPTOOLS_SCM_PRETEND_VERSION
+
+      - name: Upload HEIR ${{ matrix.name }} wheels
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-${{ matrix.name }}
+          path: wheelhouse/*.whl
+
+  create_archive:
+    name: Create source archive
+    needs: [setup-version]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create Archive
+        id: archive
+        run: |
+          TAG_NAME="${{ needs.setup-version.outputs.version }}"
+          if [[ ! "$TAG_NAME" =~ ^v ]]; then
+            TAG_NAME="v$TAG_NAME"
+          fi
+          git archive --format=tar.gz --prefix=heir-$TAG_NAME/ -o heir-$TAG_NAME.tar.gz HEAD
+          sha256sum heir-$TAG_NAME.tar.gz > heir-$TAG_NAME.tar.gz.sha256
+          echo "archive_file=heir-$TAG_NAME.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "checksum_file=heir-$TAG_NAME.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: source-archive
+          path: heir-*.tar.gz*
+
+  perform_release:
+    name: Create GitHub Release and Upload Assets
+    needs: [setup-version, build_wheels, create_archive]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-      # Packages write permission required to update a release
-      packages: write
-    runs-on:
-      labels: ubuntu-24.04-16core
-    continue-on-error: true
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
 
-      - name: Install dependencies
-        run: |
-          ./.github/install_clang_version.sh 19
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: archive
+          name: source-archive
 
-      - name: "Run `bazel build`"
-        run: |
-          bazel build -c opt //tools:all
-
-      - name: Ensure binaries can run
+      - name: Extract and rename binaries
         shell: bash
         run: |
-            bazel-bin/tools/heir-opt --help
-            bazel-bin/tools/heir-translate --help
-            bazel-bin/tools/heir-lsp --help
-            [ -f bazel-bin/external/abc+/abc_bin ]
+          mkdir -p extracted
+          for whl in dist/*.whl; do
+            filename=$(basename "$whl")
+            platform=$(echo "$filename" | rev | cut -d- -f1 | rev | cut -d. -f1)
+            echo "Processing wheel $whl for platform $platform"
+            unzip -j "$whl" "heir/heir-opt" -d tmp_extract || true
+            unzip -j "$whl" "heir/heir-translate" -d tmp_extract || true
+            if [ -f tmp_extract/heir-opt ]; then
+              mv tmp_extract/heir-opt "extracted/heir-opt-$platform"
+            fi
+            if [ -f tmp_extract/heir-translate ]; then
+              mv tmp_extract/heir-translate "extracted/heir-translate-$platform"
+            fi
+            rm -rf tmp_extract
+          done
+          echo "Extracted files:"
+          ls -alh extracted/
+
+      - name: Create Dated Release
+        id: dated_release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        with:
+          tag_name: nightly-${{ needs.setup-version.outputs.version }}
+          name: Nightly ${{ needs.setup-version.outputs.version }}
+          prerelease: true
+          files: |
+            archive/*
+            extracted/*
 
       - name: Delete previous existing nightly tag and release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-            gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag
+            gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag || true
 
-      - name: GH Release
+      - name: Create Rolling Nightly Release
+        id: rolling_release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
-          prerelease: true
           tag_name: nightly
+          name: Nightly
+          prerelease: true
           files: |
-            bazel-bin/tools/heir-opt
-            bazel-bin/tools/heir-translate
-            bazel-bin/tools/heir-lsp
-            bazel-bin/external/abc+/abc_bin
-            lib/Transforms/YosysOptimizer/yosys/techmap_lut3.v
-            lib/Transforms/YosysOptimizer/yosys/techmap_lut4.v
+            archive/*
+            extracted/*
 
-  file-failure:
-    runs-on: ubuntu-latest
-    needs: nightly-release
-    if: needs.nightly-release.result == 'failure'
-    permissions:
-      actions: read
-      issues: write
-    steps:
-      - name: Create issue on failure
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
-        with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Nightly workflow failed for nightly release`,
-              body: `The nightly release workflow failed to complete successfully. Please check the workflow run for details: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
-            })
+      - name: Cleanup old nightly releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release list --limit 100 | grep "nightly-" | while read -r line; do
+            tag=$(echo "$line" | awk '{print $1}')
+            date_str=${tag#nightly-}
+            if [[ $date_str =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
+              formatted_date=${date_str//./-}
+              release_date=$(date -d "$formatted_date" +%s)
+              limit_date=$(date -d "90 days ago" +%s)
+              if [ "$release_date" -lt "$limit_date" ]; then
+                echo "Deleting old release $tag"
+                gh release delete "$tag" -y --cleanup-tag
+              fi
+            fi
+          done


### PR DESCRIPTION
This PR updates the nightly release to look more like the full releases. It:

- Builds the wheels in manylinux containers for better compatibility and to support more platforms
- Uploads the binaries from the built wheels into the GH release
- Keeps running 90-day nightlys with different tags and release names
- Makes `nightly` a floating release tag that always points to the latest nightly release

The scripts are a little bit messy, but the new parts are starting at "Create Dated Release"

Context: I am doing this so I can add a feature to rules_heir to have it opt-in to using the nightly instead of a pinned release.