### PR TITLE
docs: add doctest for ForwardStoreToLoad pass

### DIFF
--- a/lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.td
+++ b/lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.td
@@ -12,6 +12,8 @@ def ForwardStoreToLoad : Pass<"forward-store-to-load"> {
 
     Does not support complex control flow within a block, nor ops
     with arbitrary subregions.
+
+    (* example filepath=tests/Transforms/forward_store_to_load/doctest.mlir *)
   }];
   let dependentDialects = [
     "mlir::affine::AffineDialect",

--- a/tests/Transforms/forward_store_to_load/doctest.mlir
+++ b/tests/Transforms/forward_store_to_load/doctest.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --forward-store-to-load %s | FileCheck %s
+
+// CHECK: func.func @single_store
+// CHECK-SAME: %[[ARG0:.*]]: memref<10xi8>
+func.func @single_store(%arg0: memref<10xi8>) -> i8 {
+  // CHECK-NEXT: %[[VAL:.*]] = arith.constant 7
+  // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-NEXT: memref.store %[[VAL]], %[[ARG0]][%[[C0]]] : memref<10xi8>
+  // CHECK-NEXT: return %[[VAL]] : i8
+  %0 = arith.constant 7 : i8
+  %c0 = arith.constant 0 : index
+  memref.store %0, %arg0[%c0] : memref<10xi8>
+  %1 = memref.load %arg0[%c0] : memref<10xi8>
+  return %1 : i8
+}


### PR DESCRIPTION
Closes #2014.

Adds a `doctest.mlir` for the `--forward-store-to-load` pass and wires
the `(* example filepath=... *)` directive in `ForwardStoreToLoad.td`
so the example shows up on the pass docs page at heir.dev.

The example shows the core behavior: a store immediately followed by a
load at the same index is simplified so the load is replaced by the
stored value directly.

Note: `OperationBalancer` already has a doctest (added in
5a6890d), so I picked the next uncovered pass instead.