### PR TITLE
fix crash in LayoutOptimization

### DIFF
--- a/lib/Transforms/LayoutOptimization/Patterns.cpp
+++ b/lib/Transforms/LayoutOptimization/Patterns.cpp
@@ -109,9 +109,9 @@ LogicalResult HoistArgLayouts::matchAndRewrite(
     auto maybeLayoutOps =
         llvm::map_range(blockArg.getUses(), getFirstLayoutConversionOp);
     if (maybeLayoutOps.empty()) continue;
+    auto layoutOpsVec = llvm::to_vector(maybeLayoutOps);
     auto maybeLayouts = llvm::map_range(
-        llvm::to_vector(maybeLayoutOps),
-        [](auto& maybeLayoutOp) -> std::optional<Attribute> {
+        layoutOpsVec, [](auto& maybeLayoutOp) -> std::optional<Attribute> {
           if (!maybeLayoutOp.has_value()) return std::nullopt;
           auto toLayout = maybeLayoutOp.value().getToLayoutAttr();
           if (!toLayout) return std::nullopt;


### PR DESCRIPTION
Fixes a potential crash (never happened on macOS for me, but did happen on linux x86_64 sometimes):

`llvm::map_range(llvm::to_vector(maybeLayoutOps), ...)` just forwards iterators over the temporary `llvm::to_vector(...)` so if that gets freed (e.g., because the SmallVector grows beyond its starting capacity), accessing maybeLayouts later can cause a crash.