### PR TITLE
support DenseResourceElementsAttr in memref'ed lattigo emitter

### DIFF
--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -1112,6 +1112,11 @@ LogicalResult LattigoEmitter::printOperation(memref::GlobalOp op) {
     return op.emitError("memref.global must have an initial value");
   }
 
+  if (auto resourceAttr = dyn_cast<DenseResourceElementsAttr>(initAttr)) {
+    initAttr = DenseElementsAttr::getFromRawBuffer(resourceAttr.getType(),
+                                                   resourceAttr.getData());
+  }
+
   if (auto denseAttr = dyn_cast<DenseElementsAttr>(initAttr)) {
     if (denseAttr.isSplat()) {
       imports.insert(std::string(kSlicesImport));

--- a/tests/Emitter/Lattigo/memref.mlir
+++ b/tests/Emitter/Lattigo/memref.mlir
@@ -4,6 +4,9 @@ module attributes {backend.lattigo, scheme.ckks} {
 
 memref.global "private" constant @__constant_1024xf32 : memref<1024xf32> = dense<1.000000e+00>
 
+// CHECK: var __constant_4xi32 = []int32{1, 2, 3, 4}
+memref.global "private" constant @__constant_4xi32 : memref<4xi32> = dense_resource<weights>
+
 // CHECK: func test_memref(_ []float32) ([]float32, int64) {
 func.func @test_memref(%arg0: memref<1024xf32>) -> (memref<1024xf32>, index) {
   %c0 = arith.constant 0 : index
@@ -48,6 +51,12 @@ func.func @test_shape(%arg0: memref<1024xf32>) -> memref<1024xf32> {
   return %collapse : memref<1024xf32>
 }
 
-
-
 }
+
+{-#
+  dialect_resources: {
+    builtin: {
+      weights: "0x4000000001000000020000000300000004000000"
+    }
+  }
+#-}


### PR DESCRIPTION
Missing support for model weights in dense resources popped up when we rebased our internal ML pipeline onto the new bufferizied lattigo emitter. 🤖-generated fix.