### PR TITLE
add bufferization-preparation passes to lattigo pipeline

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -528,8 +528,8 @@ BackendPipelineBuilder toLattigoPipelineBuilder() {
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createSymbolDCEPass());
 
-    // Run one-shot-bufferize without deallocation because golang has garbage
-    // collection.
+    // Bufferize without deallocation because golang has garbage collection.
+    prepareForBufferize(pm);
     oneShotBufferize(pm, /*includeDeallocation=*/false);
 
     // Lower Linalg to loops

--- a/lib/Pipelines/PipelineRegistration.cpp
+++ b/lib/Pipelines/PipelineRegistration.cpp
@@ -34,6 +34,16 @@ using mlir::func::FuncOp;
 
 namespace mlir::heir {
 
+void prepareForBufferize(OpPassManager& manager) {
+  manager.addNestedPass<FuncOp>(createConvertElementwiseToLinalgPass());
+  // Needed to lower affine.map and affine.apply
+  manager.addNestedPass<FuncOp>(affine::createAffineExpandIndexOpsPass());
+  manager.addNestedPass<FuncOp>(affine::createSimplifyAffineStructuresPass());
+  manager.addPass(createLowerAffinePass());
+  manager.addNestedPass<FuncOp>(memref::createExpandOpsPass());
+  manager.addNestedPass<FuncOp>(memref::createExpandStridedMetadataPass());
+}
+
 void oneShotBufferize(OpPassManager& manager, bool includeDeallocation) {
   // One-shot bufferize, from
   // https://mlir.llvm.org/docs/Bufferization/#ownership-based-buffer-deallocation
@@ -77,16 +87,8 @@ void polynomialToLLVMPipelineBuilder(OpPassManager& manager) {
   manager.addPass(::mlir::heir::mod_arith::createModArithToArith());
   manager.addPass(createCanonicalizerPass());
 
-  // Linalg
-  manager.addNestedPass<FuncOp>(createConvertElementwiseToLinalgPass());
-  // Needed to lower affine.map and affine.apply
-  manager.addNestedPass<FuncOp>(affine::createAffineExpandIndexOpsPass());
-  manager.addNestedPass<FuncOp>(affine::createSimplifyAffineStructuresPass());
-  manager.addPass(createLowerAffinePass());
-  manager.addNestedPass<FuncOp>(memref::createExpandOpsPass());
-  manager.addNestedPass<FuncOp>(memref::createExpandStridedMetadataPass());
-
   // Bufferize
+  prepareForBufferize(manager);
   oneShotBufferize(manager);
 
   // Linalg must be bufferized before it can be lowered
@@ -120,16 +122,8 @@ void polynomialToLLVMPipelineBuilder(OpPassManager& manager) {
 }
 
 void basicMLIRToLLVMPipelineBuilder(OpPassManager& manager) {
-  // Linalg
-  manager.addNestedPass<FuncOp>(createConvertElementwiseToLinalgPass());
-  // Needed to lower affine.map and affine.apply
-  manager.addNestedPass<FuncOp>(affine::createAffineExpandIndexOpsPass());
-  manager.addNestedPass<FuncOp>(affine::createSimplifyAffineStructuresPass());
-  manager.addPass(createLowerAffinePass());
-  manager.addNestedPass<FuncOp>(memref::createExpandOpsPass());
-  manager.addNestedPass<FuncOp>(memref::createExpandStridedMetadataPass());
-
   // Bufferize
+  prepareForBufferize(manager);
   oneShotBufferize(manager);
 
   // Linalg must be bufferized before it can be lowered

--- a/lib/Pipelines/PipelineRegistration.h
+++ b/lib/Pipelines/PipelineRegistration.h
@@ -7,6 +7,11 @@
 
 namespace mlir::heir {
 
+// Prepares IR for `oneShotBufferize` by wrapping elementwise tensor ops in
+// `linalg.generic` and expanding any residual affine/memref ops that
+// bufferization can't handle.
+void prepareForBufferize(OpPassManager& manager);
+
 void oneShotBufferize(OpPassManager& manager, bool includeDeallocation = true);
 
 void mathToPolynomialApproximationBuilder(OpPassManager& pm);


### PR DESCRIPTION
Bufferization is pretty picky about what ops it will support, for example it does not accept `arithf.add %t1, %t2 : tensor<...>` but instead wants the `linalg.generic` version. We already do this in other bufferization-using pipelines, this PR simply gives that set of passes a nice name/helper and adds it to the lattigo pipeline, too.

PS: Sorry for the piece-meal PRs, I didn't realize the rabbit hole I'd be going down as part of rebasing our stuff onto the new bufferized lattigo backend