### PR TITLE
fix cleanup of old nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -146,7 +146,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-            gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag || true
+            gh release view "nightly" --repo ${{ github.repository }} && gh release delete "nightly" -y --cleanup-tag --repo ${{ github.repository }} || true
 
       - name: Create Rolling Nightly Release
         id: rolling_release
@@ -164,7 +164,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release list --limit 100 | grep "nightly-" | while read -r line; do
+          gh release list --limit 100 --repo ${{ github.repository }} | grep "nightly-" | while read -r line; do
             tag=$(echo "$line" | awk '{print $1}')
             date_str=${tag#nightly-}
             if [[ $date_str =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
@@ -173,7 +173,7 @@ jobs:
               limit_date=$(date -d "90 days ago" +%s)
               if [ "$release_date" -lt "$limit_date" ]; then
                 echo "Deleting old release $tag"
-                gh release delete "$tag" -y --cleanup-tag
+                gh release delete "$tag" -y --cleanup-tag --repo ${{ github.repository }}
               fi
             fi
           done


### PR DESCRIPTION
Cf. https://github.com/google/heir/actions/runs/26611144275/job/78429392619

The git repo was not checked out, so the `gh` command needs an extra flag to point it to the right repo.