### PR TITLE
Fix mutability bug in Codegen

### DIFF
--- a/lib/Utils/Layout/Codegen.cpp
+++ b/lib/Utils/Layout/Codegen.cpp
@@ -404,12 +404,20 @@ FailureOr<scf::ValueVector> MLIRLoopNestGenerator::visitAstNodeIf(
   Value condVal = buildIslExpr(cond, ivToValue_, builder_, createdOpCallback_);
   isl_ast_expr_free(cond);
 
+  // The else branch is a no-op that passes the incoming iter args through
+  // unchanged. We must snapshot them now, before visiting the then branch:
+  // visiting a nested for loop overwrites currentIterArgs_ to point at that
+  // inner loop's block arguments (see visitAstNodeFor), which live in the then
+  // region and would not dominate a yield in the else region.
+  SmallVector<Value> incomingIterArgs(currentIterArgs_.begin(),
+                                      currentIterArgs_.end());
+
   // Build scf if operation with the result types of the iter args
   // Convert condVal to an i1
   auto condValI1 =
       arith::IndexCastOp::create(builder_, builder_.getI1Type(), condVal);
   auto ifOp = scf::IfOp::create(builder_, currentLoc_,
-                                TypeRange(currentIterArgs_), condValI1,
+                                TypeRange(incomingIterArgs), condValI1,
                                 /*addThenBlock=*/true, /*addElseBlock=*/true);
   createdOpCallback_(ifOp);
   createdOpCallback_(condValI1);
@@ -435,7 +443,7 @@ FailureOr<scf::ValueVector> MLIRLoopNestGenerator::visitAstNodeIf(
         scf::YieldOp::create(builder_, currentLoc_, visitBody.value());
     createdOpCallback_(yieldOp);
     builder_.setInsertionPointToEnd(&ifOp.getElseRegion().front());
-    yieldOp = scf::YieldOp::create(builder_, currentLoc_, currentIterArgs_);
+    yieldOp = scf::YieldOp::create(builder_, currentLoc_, incomingIterArgs);
     createdOpCallback_(yieldOp);
   }
 

--- a/lib/Utils/Layout/CodegenTest.cpp
+++ b/lib/Utils/Layout/CodegenTest.cpp
@@ -18,6 +18,7 @@
 #include "mlir/include/mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/ValueRange.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Verifier.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
 
 namespace mlir {
@@ -454,6 +455,59 @@ TEST(CodegenTest, VariadicOpTest) {
 
   auto result = generator.generateForLoop(rel, {}, bodyBuilder);
   ASSERT_TRUE(succeeded(result));
+
+  moduleOp.erase();
+}
+
+// Regression test for a dominance error when an scf.for is nested inside the
+// then-branch of an scf.if. The else-branch of such an scf.if must yield the
+// iter args that flow *into* the if, not whatever the (mutable)
+// currentIterArgs_ happens to point at
+TEST(CodegenTest, IfWithNestedForElseYieldDominance) {
+  MLIRContext context;
+  context
+      .loadDialect<scf::SCFDialect, arith::ArithDialect, func::FuncDialect>();
+
+  auto relation = getIntegerRelationFromIslStr(
+      "{ [i0, i1, i2] -> [ct, slot] : (30i0 - 32i1 - i2 + ct) mod 1024 = 0 and "
+      "0 <= i0 <= 63 and 0 <= i1 <= 16 and 0 <= i2 <= 2 and 0 <= ct <= 1023 "
+      "and 0 <= slot <= 4095 and 2048*floor((-30 - 30i0 + slot)/2048) >= -3967 "
+      "+ slot and 2048*floor((-30 - 30i0 + slot)/2048) >= -2079 - 30i0 + i2 + "
+      "slot and 2048*floor((-30 - 30i0 + slot)/2048) <= -2048 - 30i0 + slot "
+      "and 2048*floor((-30 - 30i0 + slot)/2048) <= -2048 - 30i0 + i2 + slot "
+      "and 2048*floor((-30 - 30i0 + slot)/2048) <= -2048 + slot }");
+  ASSERT_TRUE(succeeded(relation));
+
+  OpBuilder builder(&context);
+  auto moduleOp = ModuleOp::create(builder.getUnknownLoc());
+  builder.setInsertionPointToEnd(moduleOp.getBody());
+
+  auto funcType = builder.getFunctionType({}, {});
+  auto funcOp = func::FuncOp::create(builder, builder.getUnknownLoc(),
+                                     "test_func", funcType);
+  auto* block = funcOp.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  ImplicitLocOpBuilder locBuilder(builder.getUnknownLoc(), builder);
+
+  // A single iter arg threaded through the loop nest unchanged. This forces the
+  // generated scf.if ops to carry a result, and therefore an else-branch yield.
+  auto init = arith::ConstantIntOp::create(locBuilder, 0, 32);
+
+  MLIRLoopNestGenerator generator(locBuilder);
+  auto bodyBuilder = [](OpBuilder& b, Location loc, ValueRange ivs,
+                        ValueRange iterArgs) {
+    return scf::ValueVector(iterArgs.begin(), iterArgs.end());
+  };
+
+  SmallVector<int> domainIndicesToSchedule = {0, 1};
+  auto result = generator.generateForLoop(relation.value(), {init.getResult()},
+                                          bodyBuilder, domainIndicesToSchedule);
+  ASSERT_TRUE(succeeded(result));
+
+  func::ReturnOp::create(locBuilder, ValueRange{});
+
+  ASSERT_TRUE(succeeded(verify(moduleOp)));
 
   moduleOp.erase();
 }


### PR DESCRIPTION
CurrentIterArgs was being overwritten for complicated control flow structures (for loop inside an if/else)