### PR TITLE
Move KeySwitchInnerOp from CKKS dialect to LWE dialect

### DIFF
--- a/lib/Dialect/CKKS/IR/CKKSOps.cpp
+++ b/lib/Dialect/CKKS/IR/CKKSOps.cpp
@@ -39,7 +39,80 @@ LogicalResult MulPlainOp::verify() { return lwe::verifyMulPlainOp(this); }
 
 LogicalResult RotateOp::verify() { return lwe::verifyRotateOp(this); }
 
-LogicalResult RelinearizeOp::verify() { return lwe::verifyRelinearizeOp(this); }
+LogicalResult RelinearizeOp::verify() {
+  // verify that the key-switch keys have the expected basis
+  // eventually, this should be moved into verifyRelinearizeOp, but
+  // BGV::RelinearizeOp doesn't take keyswitching keys right now.
+  SchemeParamAttr schemeParamAttr =
+      getOperation()
+          ->getParentOfType<ModuleOp>()
+          ->getAttrOfType<SchemeParamAttr>(CKKSDialect::kSchemeParamAttrName);
+  auto ksk = getKeySwitchingKey();
+  if (schemeParamAttr && ksk) {
+    RankedTensorType keyTensorType = ksk.getType();
+    auto keyCtType =
+        dyn_cast<lwe::LWECiphertextType>(keyTensorType.getElementType());
+    if (!keyCtType) {
+      return emitOpError() << "KSKs must be a tensor of Ciphertexts";
+    }
+    polynomial::RingAttr keyRingType = keyCtType.getCiphertextSpace().getRing();
+    auto keyRNSType = dyn_cast<rns::RNSType>(keyRingType.getCoefficientType());
+    if (!keyRNSType) {
+      return emitOpError()
+             << "Keyswitch key must be a ring element of RNS types";
+    }
+
+    auto inputType =
+        cast<lwe::LWECiphertextType>(getElementTypeOrSelf(getInput()));
+    auto inputRingType = inputType.getCiphertextSpace().getRing();
+    auto inputRNSType =
+        dyn_cast<rns::RNSType>(inputRingType.getCoefficientType());
+    if (!inputRNSType) {
+      return emitOpError() << "Input must be a ring element of RNS types";
+    }
+
+    int kskRank = keyTensorType.getRank();
+    if (kskRank != 1) {
+      return emitOpError()
+             << "KeySwitchingKey must be a rank-1 tensor, but it has rank  "
+             << kskRank;
+    }
+
+    SmallVector<Type> extModuli;
+    Builder b(getContext());
+    for (auto ty : inputRNSType.getBasisTypes()) {
+      extModuli.push_back(ty);
+    }
+    auto schemeParam = getSchemeParamFromAttr(schemeParamAttr);
+    for (auto prime : schemeParam.getPi()) {
+      extModuli.push_back(mod_arith::ModArithType::get(
+          getContext(), b.getI64IntegerAttr(prime)));
+    }
+    rns::RNSType expectedKeyRNSType =
+        rns::RNSType::get(getContext(), extModuli);
+
+    if (keyRNSType != expectedKeyRNSType) {
+      return emitOpError() << "Key's RNS type " << keyRNSType
+                           << " must be the same as the input's RNS type "
+                           << inputRNSType << ", plus the key-switch moduli "
+                           << schemeParam.getPi();
+    }
+
+    int64_t partSize = schemeParam.getPi().size();
+    int rnsLength = inputRNSType.getBasisTypes().size();
+    int64_t numFullPartitions = rnsLength / partSize;
+    int64_t extraPartStart = partSize * numFullPartitions;
+    int64_t extraPartSize = rnsLength - extraPartStart;
+    int64_t numParts = numFullPartitions + extraPartSize;
+    int kskLen = keyTensorType.getShape()[0];
+    if (kskLen != numParts) {
+      return emitOpError() << "KeySwitchingKey must have shape " << numParts
+                           << "xRNS, but it has shape " << kskLen << "xRNS";
+    }
+  }
+
+  return lwe::verifyRelinearizeOp(this);
+}
 
 LogicalResult RescaleOp::verify() {
   return lwe::verifyModulusSwitchOrRescaleOp(this);
@@ -117,89 +190,6 @@ LogicalResult LevelReduceOp::inferReturnTypes(
     MLIRContext* ctx, std::optional<Location>, LevelReduceOp::Adaptor adaptor,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   return lwe::inferLevelReduceOpReturnTypes(ctx, adaptor, inferredReturnTypes);
-}
-
-LogicalResult KeySwitchInnerOp::inferReturnTypes(
-    MLIRContext* ctx, std::optional<Location>, ValueRange operands,
-    DictionaryAttr attrs, mlir::PropertyRef properties,
-    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
-  KeySwitchInnerOpAdaptor op(operands, attrs, properties, regions);
-  auto ringEltType = cast<lwe::LWERingEltType>(op.getValue().getType());
-  lwe::LWERingEltType outRingType =
-      lwe::LWERingEltType::get(ctx, ringEltType.getRing());
-  results.push_back(outRingType);
-  results.push_back(outRingType);
-  return success();
-}
-
-LogicalResult KeySwitchInnerOp::verify() {
-  RankedTensorType keyTensorType = getKeySwitchingKey().getType();
-  auto ctType =
-      dyn_cast<lwe::LWECiphertextType>(keyTensorType.getElementType());
-  if (!ctType) {
-    return emitOpError() << "KSKs must be a tensor of Ciphertexts";
-  }
-  polynomial::RingAttr ringType = ctType.getCiphertextSpace().getRing();
-  auto keyRNSType = dyn_cast<rns::RNSType>(ringType.getCoefficientType());
-  if (!keyRNSType) {
-    return emitOpError() << "Keyswitch key must be a ring element of RNS types";
-  }
-
-  auto ringEltType = cast<lwe::LWERingEltType>(getValue().getType());
-  auto inputRNSType =
-      dyn_cast<rns::RNSType>(ringEltType.getRing().getCoefficientType());
-  if (!inputRNSType) {
-    return emitOpError() << "Value must be a ring element of RNS types";
-  }
-
-  int kskRank = keyTensorType.getRank();
-  if (kskRank != 1) {
-    return emitOpError()
-           << "KeySwitchingKey must be a rank-1 tensor, but it has rank  "
-           << kskRank;
-  }
-
-  SchemeParamAttr schemeParamAttr =
-      getOperation()
-          ->getParentOfType<ModuleOp>()
-          ->getAttrOfType<SchemeParamAttr>(CKKSDialect::kSchemeParamAttrName);
-  if (!schemeParamAttr) {
-    return emitOpError()
-           << "Cannot find scheme param attribute on parent module";
-  }
-  auto schemeParam = getSchemeParamFromAttr(schemeParamAttr);
-
-  SmallVector<Type> extModuli;
-  Builder b(getContext());
-  for (auto ty : inputRNSType.getBasisTypes()) {
-    extModuli.push_back(ty);
-  }
-  for (auto prime : schemeParam.getPi()) {
-    extModuli.push_back(
-        mod_arith::ModArithType::get(getContext(), b.getI64IntegerAttr(prime)));
-  }
-  rns::RNSType expectedKeyRNSType = rns::RNSType::get(getContext(), extModuli);
-
-  if (keyRNSType != expectedKeyRNSType) {
-    return emitOpError() << "Key's RNS type " << keyRNSType
-                         << " must be the same as the input's RNS type "
-                         << inputRNSType << ", plus the key-switch moduli "
-                         << schemeParam.getPi();
-  }
-
-  int64_t partSize = schemeParam.getPi().size();
-  int rnsLength = inputRNSType.getBasisTypes().size();
-  int64_t numFullPartitions = rnsLength / partSize;
-  int64_t extraPartStart = partSize * numFullPartitions;
-  int64_t extraPartSize = rnsLength - extraPartStart;
-  int64_t numParts = numFullPartitions + extraPartSize;
-  int kskLen = keyTensorType.getShape()[0];
-  if (kskLen != numParts) {
-    return emitOpError() << "KeySwitchingKey must have shape " << numParts
-                         << "xRNS, but it has shape " << kskLen << "xRNS";
-  }
-
-  return success();
 }
 
 void MulPlainOp::getCanonicalizationPatterns(RewritePatternSet& results,

--- a/lib/Dialect/CKKS/IR/CKKSOps.td
+++ b/lib/Dialect/CKKS/IR/CKKSOps.td
@@ -226,35 +226,4 @@ def CKKS_BootstrapOp : CKKS_Op<"bootstrap", [ElementwiseMappable, ResetsMulDepth
   let assemblyFormat = "operands attr-dict `:` qualified(type($input)) `->` qualified(type($output))" ;
 }
 
-def CKKS_KeySwitchInnerOp : CKKS_Op<"key_switch_inner", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
-  let summary = "Fundamental key-switching kernel.";
-  let description = [{
-    The key-switching key is the encryption of a key `s_{in}` under the key `s_{out}`.
-    The input `value` is a ring element of a ciphertext that gets multiplied with
-    `s_{in}`. KeySwitchInner outputs a linear ciphertext `ct'` such that decrypting
-    `ct'` under `s_{out}` is `value * s_{in}`. By adding `ct'` to the components
-    of the original ciphertext that do are *not* multiplied by `s_{in}`, we obtain
-    a ciphertext that encrypts the same message as the original ciphertext, but under
-    `s_{out}`.
-
-    Concretely, for relinearization, a ciphertext `[c_0, c_1, c_2]` decrypts as
-    `c_0 + c_1*s + c_2*s^2`, and the key-switch key is an encryption of `s^2` under `s`.
-    Then we apply `KeySwitchInner` to `c_2`, which produces `[c_0', c_1']`, where
-    `c_0'+c_1'*s = c_2 * s^2`. Then relinearization outputs `[c_0+c_0', c_1+c_1']`.
-
-    This operation is intended to be an internal implementation detail of
-    higher-level ciphertext operations such as `ckks.relinearize`, isolated
-    here for reuse among multiple op lowerings.
-  }];
-  let arguments = (ins
-      LWERingElt:$value,
-      RankedTensorOf<[LWECiphertext]>: $keySwitchingKey
-  );
-  let results = (outs
-    LWERingElt:$constTerm,
-    LWERingElt:$linearTerm
-  );
-  let hasVerifier = 1;
-}
-
 #endif  // LIB_DIALECT_CKKS_IR_CKKSOPS_TD_

--- a/lib/Dialect/CKKS/Transforms/BUILD
+++ b/lib/Dialect/CKKS/Transforms/BUILD
@@ -11,7 +11,6 @@ cc_library(
     hdrs = ["Passes.h"],
     deps = [
         ":CKKSToLWE",
-        ":DecomposeKeySwitch",
         ":DecomposeRelinearize",
         ":pass_inc_gen",
         "@heir//lib/Dialect/CKKS/IR:Dialect",
@@ -48,26 +47,6 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TransformUtils",
-    ],
-)
-
-cc_library(
-    name = "DecomposeKeySwitch",
-    srcs = ["DecomposeKeySwitch.cpp"],
-    hdrs = ["DecomposeKeySwitch.h"],
-    deps = [
-        ":pass_inc_gen",
-        "@heir//lib/Dialect/CKKS/IR:Dialect",
-        "@heir//lib/Dialect/LWE/IR:Dialect",
-        "@heir//lib/Dialect/ModArith/IR:Dialect",
-        "@heir//lib/Dialect/RNS/IR:Dialect",
-        "@heir//lib/Parameters/CKKS:Params",
-        "@llvm-project//mlir:ArithDialect",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/lib/Dialect/CKKS/Transforms/DecomposeRelinearize.cpp
+++ b/lib/Dialect/CKKS/Transforms/DecomposeRelinearize.cpp
@@ -48,8 +48,8 @@ LogicalResult DecomposeRelinearizePattern::matchAndRewrite(
   lwe::LWECiphertextType outCTType = lwe::LWECiphertextType::get(
       op.getContext(), ctType.getPlaintextSpace(), ctAttr, ctType.getKey(),
       ctType.getModulusChain());
-  KeySwitchInnerOp ksPoly =
-      KeySwitchInnerOp::create(b, input2, op.getKeySwitchingKey());
+  lwe::KeySwitchInnerOp ksPoly =
+      lwe::KeySwitchInnerOp::create(b, input2, op.getKeySwitchingKey());
   Value ksCT = lwe::FromCoeffsOp::create(
       b, outCTType, {ksPoly.getConstTerm(), ksPoly.getLinearTerm()});
   Value linearCT = lwe::FromCoeffsOp::create(b, outCTType, {input0, input1});

--- a/lib/Dialect/CKKS/Transforms/Passes.h
+++ b/lib/Dialect/CKKS/Transforms/Passes.h
@@ -4,7 +4,6 @@
 // IWYU pragma: begin_keep
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 #include "lib/Dialect/CKKS/Transforms/CKKSToLWE.h"
-#include "lib/Dialect/CKKS/Transforms/DecomposeKeySwitch.h"
 #include "lib/Dialect/CKKS/Transforms/DecomposeRelinearize.h"
 #include "mlir/include/mlir/Pass/Pass.h"          // from @llvm-project
 #include "mlir/include/mlir/Pass/PassRegistry.h"  // from @llvm-project

--- a/lib/Dialect/CKKS/Transforms/Passes.td
+++ b/lib/Dialect/CKKS/Transforms/Passes.td
@@ -11,14 +11,6 @@ def DecomposeRelinearize : Pass<"ckks-decompose-relinearize"> {
   let dependentDialects = ["mlir::heir::ckks::CKKSDialect"];
 }
 
-def DecomposeKeySwitch : Pass<"ckks-decompose-keyswitch"> {
-  let summary = "Decomposes ckks:key_switch_inner into more primitive CKKS ops";
-  let description = [{
-  (* example filepath=tests/Dialect/CKKS/Transforms/decompose_keyswitch.mlir *)
-  }];
-  let dependentDialects = ["mlir::heir::ckks::CKKSDialect", "tensor::TensorDialect"];
-}
-
 def CKKSToLWE : Pass<"ckks-to-lwe"> {
   let summary = "Lower `ckks` to `lwe` dialect.";
 

--- a/lib/Dialect/LWE/IR/LWEOps.cpp
+++ b/lib/Dialect/LWE/IR/LWEOps.cpp
@@ -226,6 +226,36 @@ LogicalResult ExtractSliceOp::verify() {
   return verifyExtractSliceOp(this, rnsType, start, size);
 }
 
+LogicalResult KeySwitchInnerOp::verify() {
+  RankedTensorType keyTensorType = getKeySwitchingKey().getType();
+  auto ctType =
+      dyn_cast<lwe::LWECiphertextType>(keyTensorType.getElementType());
+  if (!ctType) {
+    return emitOpError() << "KSKs must be a tensor of Ciphertexts";
+  }
+  polynomial::RingAttr ringType = ctType.getCiphertextSpace().getRing();
+  auto keyRNSType = dyn_cast<rns::RNSType>(ringType.getCoefficientType());
+  if (!keyRNSType) {
+    return emitOpError() << "Keyswitch key must be a ring element of RNS types";
+  }
+
+  auto ringEltType = cast<lwe::LWERingEltType>(getValue().getType());
+  auto inputRNSType =
+      dyn_cast<rns::RNSType>(ringEltType.getRing().getCoefficientType());
+  if (!inputRNSType) {
+    return emitOpError() << "Value must be a ring element of RNS types";
+  }
+
+  int kskRank = keyTensorType.getRank();
+  if (kskRank != 1) {
+    return emitOpError()
+           << "KeySwitchingKey must be a rank-1 tensor, but it has rank  "
+           << kskRank;
+  }
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Op type inference.
 //===----------------------------------------------------------------------===//
@@ -313,6 +343,17 @@ LogicalResult ConvertBasisOp::inferReturnTypes(
   lwe::LWERingEltType resultType =
       lwe::LWERingEltType::get(ctx, outputRingAttr);
   results.push_back(resultType);
+  return success();
+}
+
+LogicalResult KeySwitchInnerOp::inferReturnTypes(
+    MLIRContext* ctx, std::optional<Location>, ValueRange operands,
+    DictionaryAttr attrs, mlir::PropertyRef properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
+  KeySwitchInnerOpAdaptor op(operands, attrs, properties, regions);
+  auto ringEltType = cast<lwe::LWERingEltType>(op.getValue().getType());
+  results.push_back(ringEltType);
+  results.push_back(ringEltType);
   return success();
 }
 

--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -338,4 +338,38 @@ def LWE_ConvertBasisOp : LWE_Op<"convert_basis", [Pure, DeclareOpInterfaceMethod
   let assemblyFormat = "$value attr-dict `:` type($value) `->` type($output)";
 }
 
+def LWE_KeySwitchInnerOp : LWE_Op<"key_switch_inner", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
+  let summary = "Fundamental key-switching kernel.";
+  let description = [{
+    The key-switching key is the encryption of a key `s_{in}` under the key `s_{out}`.
+    The input `value` is a ring element of a ciphertext that gets multiplied with
+    `s_{in}`. KeySwitchInner outputs a linear ciphertext `ct'` such that decrypting
+    `ct'` under `s_{out}` is `value * s_{in}`. By adding `ct'` to the components
+    of the original ciphertext that do are *not* multiplied by `s_{in}`, we obtain
+    a ciphertext that encrypts the same message as the original ciphertext, but under
+    `s_{out}`.
+
+    Using relinearization as an example, a ciphertext `[c_0, c_1, c_2]` decrypts as
+    `c_0 + c_1*s + c_2*s^2`, and the key-switch key is an encryption of `s^2` under `s`.
+    Then we apply `KeySwitchInner` to `c_2`, which produces `[c_0', c_1']`, where
+    `c_0'+c_1'*s = c_2 * s^2`. Then relinearization outputs `[c_0+c_0', c_1+c_1']`.
+
+    This operation is intended to be an internal implementation detail of
+    higher-level ciphertext operations such as `ckks.relinearize`, isolated
+    here for reuse among multiple op lowerings.
+
+    The basis of the `keySwitchingKey`s must be the basis of `value` concatenated
+    with the key-switching primes.
+  }];
+  let arguments = (ins
+      LWERingElt:$value,
+      RankedTensorOf<[LWECiphertext]>: $keySwitchingKey
+  );
+  let results = (outs
+    LWERingElt:$constTerm,
+    LWERingElt:$linearTerm
+  );
+  let hasVerifier = 1;
+}
+
 #endif  // LIB_DIALECT_LWE_IR_LWEOPS_TD_

--- a/lib/Dialect/LWE/Transforms/BUILD
+++ b/lib/Dialect/LWE/Transforms/BUILD
@@ -13,6 +13,7 @@ cc_library(
     ],
     deps = [
         ":AddDebugPort",
+        ":DecomposeKeySwitch",
         ":ImplementTrivialEncryptionAsAddition",
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
@@ -36,6 +37,24 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "DecomposeKeySwitch",
+    srcs = ["DecomposeKeySwitch.cpp"],
+    hdrs = ["DecomposeKeySwitch.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )
 

--- a/lib/Dialect/LWE/Transforms/DecomposeKeySwitch.cpp
+++ b/lib/Dialect/LWE/Transforms/DecomposeKeySwitch.cpp
@@ -1,16 +1,14 @@
-#include "lib/Dialect/CKKS/Transforms/DecomposeKeySwitch.h"
+#include "lib/Dialect/LWE/Transforms/DecomposeKeySwitch.h"
 
 #include <cstdint>
 #include <utility>
 
-#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
-#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
-#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Dialect/LWE/IR/LWEAttributes.h"
+#include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
-#include "lib/Parameters/CKKS/Params.h"
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
@@ -26,25 +24,60 @@
 
 namespace mlir {
 namespace heir {
-namespace ckks {
+namespace lwe {
 
 #define GEN_PASS_DEF_DECOMPOSEKEYSWITCH
-#include "lib/Dialect/CKKS/Transforms/Passes.h.inc"
+#include "lib/Dialect/LWE/Transforms/Passes.h.inc"
 
 LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
     KeySwitchInnerOp op, PatternRewriter& rewriter) const {
   ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-  SchemeParamAttr schemeParamAttr =
-      op->getParentOfType<ModuleOp>()->getAttrOfType<SchemeParamAttr>(
-          CKKSDialect::kSchemeParamAttrName);
-  if (!schemeParamAttr) {
-    return op->emitOpError()
-           << "Cannot find scheme param attribute on parent module";
+  auto ringEltType = cast<lwe::LWERingEltType>(op.getValue().getType());
+  auto inputRNSType =
+      dyn_cast<rns::RNSType>(ringEltType.getRing().getCoefficientType());
+  if (!inputRNSType) {
+    return op->emitOpError() << "input type must be an RNS ring element";
   }
-  auto schemeParam = getSchemeParamFromAttr(schemeParamAttr);
 
-  int64_t partSize = schemeParam.getPi().size();
+  RankedTensorType keyTensorType = op.getKeySwitchingKey().getType();
+  auto keyCtType =
+      dyn_cast<lwe::LWECiphertextType>(keyTensorType.getElementType());
+  if (!keyCtType) {
+    return op->emitOpError()
+           << "key-switching key must be a tensor of ciphertexts";
+  }
+  auto keyRNSType = dyn_cast<rns::RNSType>(
+      keyCtType.getCiphertextSpace().getRing().getCoefficientType());
+  if (!keyRNSType) {
+    return op->emitOpError()
+           << "key-switching key must have an RNS coefficient type";
+  }
+
+  ArrayRef<Type> inputBasis = inputRNSType.getBasisTypes();
+  ArrayRef<Type> keyBasis = keyRNSType.getBasisTypes();
+  if (keyBasis.size() <= inputBasis.size()) {
+    return op->emitOpError()
+           << "key-switching key basis must contain the input basis plus "
+              "key-switch primes";
+  }
+  if (!std::equal(inputBasis.begin(), inputBasis.end(), keyBasis.begin())) {
+    return op->emitOpError()
+           << "key-switching key basis must start with the input basis";
+  }
+
+  SmallVector<int64_t> keySwitchPrimes;
+  for (Type ty : keyBasis.drop_front(inputBasis.size())) {
+    auto modArithType = dyn_cast<mod_arith::ModArithType>(ty);
+    if (!modArithType) {
+      return op->emitOpError()
+             << "key-switching prime basis element must be a mod_arith type";
+    }
+    keySwitchPrimes.push_back(
+        modArithType.getModulus().getValue().getSExtValue());
+  }
+
+  int64_t partSize = keySwitchPrimes.size();
   if (!partSize) {
     return rewriter.notifyMatchFailure(
         op, "Cannot lower key_switch_inner with empty modulus chain");
@@ -53,14 +86,6 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
   // #############################
   // ## Step 1: Decompose Input ##
   // #############################
-
-  auto ringEltType = cast<lwe::LWERingEltType>(op.getValue().getType());
-  auto inputRNSType =
-      dyn_cast<rns::RNSType>(ringEltType.getRing().getCoefficientType());
-  if (!inputRNSType) {
-    return rewriter.notifyMatchFailure(
-        op, "Input type must be an RNS ring element");
-  }
 
   int rnsLength = inputRNSType.getBasisTypes().size();
   int64_t numFullPartitions = rnsLength / partSize;
@@ -91,6 +116,12 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
         b, op.getValue(), b.getIndexAttr(extraPartStart),
         b.getIndexAttr(extraPartSize)));
   }
+  int64_t kskLen = op.getKeySwitchingKey().getType().getShape()[0];
+  if (kskLen != static_cast<int64_t>(partitions.size())) {
+    return op->emitOpError()
+           << "KeySwitchingKey must have shape " << partitions.size()
+           << "xRNS, but it has shape " << kskLen << "xRNS";
+  }
 
   // ###########################################
   // ## Step 2: Extend the basis of each part ##
@@ -107,7 +138,7 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
   for (auto ty : inputRNSType.getBasisTypes()) {
     extModuli.push_back(ty);
   }
-  for (auto prime : schemeParam.getPi()) {
+  for (auto prime : keySwitchPrimes) {
     extModuli.push_back(mod_arith::ModArithType::get(
         op.getContext(), b.getI64IntegerAttr(prime)));
   }
@@ -164,6 +195,6 @@ struct DecomposeKeySwitch : impl::DecomposeKeySwitchBase<DecomposeKeySwitch> {
   }
 };
 
-}  // namespace ckks
+}  // namespace lwe
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/LWE/Transforms/DecomposeKeySwitch.h
+++ b/lib/Dialect/LWE/Transforms/DecomposeKeySwitch.h
@@ -1,21 +1,21 @@
-#ifndef LIB_DIALECT_CKKS_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
-#define LIB_DIALECT_CKKS_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
+#ifndef LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
+#define LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
 
-#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 
 // IWYU pragma: begin_keep
-#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
 // IWYU pragma: end_keep
 
 namespace mlir {
 namespace heir {
-namespace ckks {
+namespace lwe {
 
 #define GEN_PASS_DECL_DECOMPOSEKEYSWITCH
-#include "lib/Dialect/CKKS/Transforms/Passes.h.inc"
+#include "lib/Dialect/LWE/Transforms/Passes.h.inc"
 
 struct DecomposeKeySwitchPattern : public OpRewritePattern<KeySwitchInnerOp> {
   using OpRewritePattern<KeySwitchInnerOp>::OpRewritePattern;
@@ -25,8 +25,8 @@ struct DecomposeKeySwitchPattern : public OpRewritePattern<KeySwitchInnerOp> {
                                 PatternRewriter& rewriter) const override;
 };
 
-}  // namespace ckks
+}  // namespace lwe
 }  // namespace heir
 }  // namespace mlir
 
-#endif  // LIB_DIALECT_CKKS_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
+#endif  // LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_

--- a/lib/Dialect/LWE/Transforms/Passes.h
+++ b/lib/Dialect/LWE/Transforms/Passes.h
@@ -4,6 +4,7 @@
 // IWYU pragma: begin_keep
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
+#include "lib/Dialect/LWE/Transforms/DecomposeKeySwitch.h"
 #include "lib/Dialect/LWE/Transforms/ImplementTrivialEncryptionAsAddition.h"
 // IWYU pragma: end_keep
 

--- a/lib/Dialect/LWE/Transforms/Passes.td
+++ b/lib/Dialect/LWE/Transforms/Passes.td
@@ -58,4 +58,16 @@ def ImplementTrivialEncryptionAsAddition : Pass<"implement-trivial-encryption-as
   let options = [];
 }
 
+def DecomposeKeySwitch : Pass<"lwe-decompose-keyswitch"> {
+  let summary = "Decomposes lwe.key_switch_inner into primitive LWE ops";
+  let description = [{
+  (* example filepath=tests/Dialect/LWE/Transforms/decompose_keyswitch.mlir *)
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::heir::lwe::LWEDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
 #endif  // LIB_DIALECT_LWE_TRANSFORMS_PASSES_TD_

--- a/tests/Dialect/CKKS/IR/ops.mlir
+++ b/tests/Dialect/CKKS/IR/ops.mlir
@@ -4,14 +4,18 @@
 
 !Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
 !Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z36028797019488257_i64_ = !mod_arith.int<36028797019488257 : i64>
+!Z36028797020209153_i64_ = !mod_arith.int<36028797020209153 : i64>
 !Z65537_i64_ = !mod_arith.int<65537 : i64>
 
 !rns_L0_ = !rns.rns<!Z1095233372161_i64_>
 !rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+!rns_L1_ksk_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_, !Z36028797019488257_i64_, !Z36028797020209153_i64_>
 
 #ring_Z65537_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**1024>>
 #ring_rns_L0_1_x1024_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**1024>>
 #ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+#ksk_ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_ksk_, polynomialModulus = <1 + x**1024>>
 
 #inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 0>
 #key = #lwe.key<>
@@ -26,10 +30,12 @@
 #ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x1024_, encryption_type = lsb>
 #ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
 #ciphertext_space_L1_D3_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb, size = 3>
+#ksk_ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ksk_ring_rns_L1_1_x1024_, encryption_type = lsb>
 
 !ct = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
 !ct1 = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_D3_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
 !ct2 = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L5_C0_>
+!ct_ksk = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ksk_ciphertext_space_L1_, key = #key>
 
 !ct_tensor = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
 !ct_scalar = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
@@ -47,7 +53,7 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [3602879
   }
 
   // CHECK: @test_multiply
-  func.func @test_multiply(%arg0 : !ct, %arg1: !ct, %ksk: tensor<10x!ct>) -> !ct {
+  func.func @test_multiply(%arg0 : !ct, %arg1: !ct, %ksk: tensor<1x!ct_ksk>) -> !ct {
     %add = ckks.add %arg0, %arg1 : (!ct, !ct) -> !ct
     %sub = ckks.sub %arg0, %arg1 : (!ct, !ct) -> !ct
     %neg = ckks.negate %arg0 : !ct
@@ -55,7 +61,7 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [3602879
     // CHECK: ring = <coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>, !mod_arith.int<1032955396097 : i64>>, polynomialModulus = <1 + x**1024>>
     // CHECK: size = 3
     %0 = ckks.mul %arg0, %arg1  : (!ct, !ct) -> !ct1
-    %1 = ckks.relinearize %0, %ksk {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!ct1, tensor<10x!ct>) -> !ct
+    %1 = ckks.relinearize %0, %ksk {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (!ct1, tensor<1x!ct_ksk>) -> !ct
     %2 = ckks.rescale %1  {to_ring = #ring_rns_L0_1_x1024_} : !ct -> !ct2
     // CHECK: ring = <coefficientType = !rns.rns<!mod_arith.int<1095233372161 : i64>>, polynomialModulus = <1 + x**1024>>
     return %arg0 : !ct
@@ -77,13 +83,13 @@ module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 14, Q = [3602879
   }
 
   // CHECK: @test_multiply_elementwise
-  func.func @test_multiply_elementwise(%arg0 : tensor<5x!ct>, %arg1: tensor<5x!ct>, %ksk: tensor<10x!ct>) -> tensor<5x!ct> {
+  func.func @test_multiply_elementwise(%arg0 : tensor<5x!ct>, %arg1: tensor<5x!ct>, %ksk: tensor<1x!ct_ksk>) -> tensor<5x!ct> {
     %add = ckks.add %arg0, %arg1 : (tensor<5x!ct>, tensor<5x!ct>) -> tensor<5x!ct>
     %sub = ckks.sub %arg0, %arg1 : (tensor<5x!ct>, tensor<5x!ct>) -> tensor<5x!ct>
     %neg = ckks.negate %arg0 : tensor<5x!ct>
 
     %0 = ckks.mul %arg0, %arg1  : (tensor<5x!ct>, tensor<5x!ct>) -> tensor<5x!ct1>
-    %1 = ckks.relinearize %0, %ksk {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (tensor<5x!ct1>, tensor<10x!ct>) -> tensor<5x!ct>
+    %1 = ckks.relinearize %0, %ksk {from_basis = array<i32: 0, 1, 2>, to_basis = array<i32: 0, 1> } : (tensor<5x!ct1>, tensor<1x!ct_ksk>) -> tensor<5x!ct>
     %2 = ckks.rescale %1  {to_ring = #ring_rns_L0_1_x1024_} : tensor<5x!ct> -> tensor<5x!ct2>
     return %arg0 : tensor<5x!ct>
   }

--- a/tests/Dialect/CKKS/Transforms/decompose_relinearize.mlir
+++ b/tests/Dialect/CKKS/Transforms/decompose_relinearize.mlir
@@ -52,7 +52,7 @@ module attributes {
     // CHECK-DAG: [[C0:%.+]] = lwe.extract_coeff [[X]] {index = 0 : index}
     // CHECK-DAG: [[C1:%.+]] = lwe.extract_coeff [[X]] {index = 1 : index}
     // CHECK-DAG: [[C2:%.+]] = lwe.extract_coeff [[X]] {index = 2 : index}
-    // CHECK-DAG: [[ksConstTerm:%.+]], [[ksLinearTerm:%.+]] = ckks.key_switch_inner [[C2]], [[ksk]]
+    // CHECK-DAG: [[ksConstTerm:%.+]], [[ksLinearTerm:%.+]] = lwe.key_switch_inner [[C2]], [[ksk]]
     // CHECK-DAG: [[ksct:%.+]] = lwe.from_coeffs [[ksConstTerm]], [[ksLinearTerm]]
     // CHECK-DAG: [[subct:%.+]] = lwe.from_coeffs [[C0]], [[C1]]
     // CHECK-DAG: [[result:%.+]] = ckks.add [[ksct]], [[subct]]

--- a/tests/Dialect/LWE/Conversions/lwe_to_polynomial/lower_relinearize_to_polynomial.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_polynomial/lower_relinearize_to_polynomial.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-decompose-relinearize --ckks-decompose-keyswitch --ckks-to-lwe --lwe-to-polynomial --convert-polynomial-mul-to-ntt --attach-ntt-roots --rns-lower-convert-basis %s
+// RUN: heir-opt --ckks-decompose-relinearize --ckks-to-lwe --lwe-decompose-keyswitch --lwe-to-polynomial --convert-polynomial-mul-to-ntt --attach-ntt-roots --rns-lower-convert-basis %s
 
 !Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
 !Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>

--- a/tests/Dialect/LWE/Transforms/decompose_keyswitch.mlir
+++ b/tests/Dialect/LWE/Transforms/decompose_keyswitch.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-decompose-keyswitch %s | FileCheck %s
+// RUN: heir-opt --lwe-decompose-keyswitch %s | FileCheck %s
 
 !Zq0 = !mod_arith.int<1095233372161 : i64>
 !Zq1 = !mod_arith.int<1032955396097 : i64>
@@ -46,7 +46,7 @@ module attributes {
     // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L0} : !ringelt1 -> !ringelt
     // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L0} : !ringelt1 -> !ringelt
     // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt, !ringelt
-    %constTerm, %linearTerm = ckks.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<1x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
+    %constTerm, %linearTerm = lwe.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<1x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
     return %constTerm, %linearTerm: !ringelt_L1, !ringelt_L1
   }
 }

--- a/tests/Dialect/LWE/Transforms/decompose_keyswitch_multipart.mlir
+++ b/tests/Dialect/LWE/Transforms/decompose_keyswitch_multipart.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-decompose-keyswitch %s | FileCheck %s
+// RUN: heir-opt --lwe-decompose-keyswitch %s | FileCheck %s
 
 !Zq0 = !mod_arith.int<1095233372161 : i64>
 !Zq1 = !mod_arith.int<1032955396097 : i64>
@@ -57,7 +57,7 @@ module attributes {
     // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L1} : !ringelt3 -> !ringelt
     // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L1} : !ringelt3 -> !ringelt
     // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt, !ringelt
-    %constTerm, %linearTerm = ckks.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<2x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
+    %constTerm, %linearTerm = lwe.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<2x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
     return %constTerm, %linearTerm: !ringelt_L1, !ringelt_L1
   }
 }
@@ -113,7 +113,7 @@ module attributes {
     // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L4} : !ringelt7 -> !ringelt4
     // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L4} : !ringelt7 -> !ringelt4
     // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt4, !ringelt4
-    %constTerm, %linearTerm = ckks.key_switch_inner %x, %arg0 : (!ringelt_L5, tensor<3x!ct_L7>) -> (!ringelt_L5, !ringelt_L5)
+    %constTerm, %linearTerm = lwe.key_switch_inner %x, %arg0 : (!ringelt_L5, tensor<3x!ct_L7>) -> (!ringelt_L5, !ringelt_L5)
     return %constTerm, %linearTerm: !ringelt_L5, !ringelt_L5
   }
 }


### PR DESCRIPTION
The primary goal of this PR is to move KeySwitchInnerOp from the CKKS dialect to the LWE dialect. The reason for this change is that (after getting some exposure to other FHE schemes), this algorithm is the same for multiple FHE schemes.

I tried to make as few changes as possible in the process. There was one complicating factor, however: the scheme parameters. KeySwitching previously relied on scheme parameters to obtain keyswitching parameters, like the special key-switch primes. However, this information is not available at the lower LWE dialect (technically, it's still in the IR, I think, but due to circular dependencies, I can't match on CKKS::SchemeParamAttr). The other options were to pass explicit attributes to the KeySwitchInnerOp, or to infer them from other information. I opted for the latter: the special primes are now inferred from the keySwitchingKeys, which (before and after the change) had to have an RNS basis equal to the input basis plus the keyswitch primes.

As a result:
- The KeySwitchInnerOp verifier no longer checks that the keySwitchingKeys basis matches the expected basis, since we are instead *inferring* the keyswitch primes from the type of the keySwitchingKeys. 
- I moved the logic that ensure compatibility between ksks and inputs to ckks::RelinearizeOp, where CKKS:SchemeParamAttr is available.
- This caused some tests that only use `ckks::relinarize` without the lowering to fail; I updated the types appropriately.

Assisted by AI.