### PR TITLE
Add lowering for RNSExtractSliceOp and PolynomialExtractSliceOp

### DIFF
--- a/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -206,6 +206,48 @@ struct ConvertRNSExtractResidue
   }
 };
 
+struct ConvertRNSExtractSlice
+    : public OpConversionPattern<rns::ExtractSliceOp> {
+  ConvertRNSExtractSlice(mlir::MLIRContext* context)
+      : OpConversionPattern<rns::ExtractSliceOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      rns::ExtractSliceOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto inputType = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+    if (!inputType) {
+      return rewriter.notifyMatchFailure(
+          op, "expected RNS value lowered to a ranked tensor");
+    }
+    auto resultType = dyn_cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getOutput().getType()));
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "result type conversion failed");
+    }
+
+    SmallVector<OpFoldResult> offsets(inputType.getRank(),
+                                      rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> sizes;
+    for (int64_t dim : inputType.getShape()) {
+      if (ShapedType::isDynamic(dim)) {
+        return rewriter.notifyMatchFailure(op, "expected static input shape");
+      }
+      sizes.push_back(rewriter.getIndexAttr(dim));
+    }
+    SmallVector<OpFoldResult> strides(inputType.getRank(),
+                                      rewriter.getIndexAttr(1));
+
+    offsets.back() = rewriter.getIndexAttr(op.getStart().getSExtValue());
+    sizes.back() = rewriter.getIndexAttr(op.getSize().getSExtValue());
+
+    rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
+        op, resultType, adaptor.getInput(), offsets, sizes, strides);
+    return success();
+  }
+};
+
 struct ConvertRNSPack : public OpConversionPattern<rns::PackOp> {
   ConvertRNSPack(mlir::MLIRContext* context)
       : OpConversionPattern<rns::PackOp>(context) {}
@@ -562,18 +604,19 @@ void ModArithToArith::runOnOperation() {
 
   ConversionTarget target(*context);
   target.addIllegalDialect<ModArithDialect>();
-  target.addIllegalOp<rns::ExtractResidueOp, rns::PackOp>();
+  target
+      .addIllegalOp<rns::ExtractResidueOp, rns::ExtractSliceOp, rns::PackOp>();
   target.addLegalDialect<arith::ArithDialect>();
 
   RewritePatternSet patterns(context);
   rewrites::populateWithGenerated(patterns);
-  patterns
-      .add<ConvertEncapsulate, ConvertExtract, ConvertReduce, ConvertAdd,
-           ConvertSub, ConvertMul, ConvertMac, ConvertModSwitch,
-           ConvertBarrettReduce, ConvertConstant, ConvertRNSExtractResidue,
-           ConvertRNSPack, ConvertAny<>, ConvertAny<affine::AffineForOp>,
-           ConvertAny<affine::AffineYieldOp>, ConvertAny<linalg::GenericOp> >(
-          typeConverter, context);
+  patterns.add<
+      ConvertEncapsulate, ConvertExtract, ConvertReduce, ConvertAdd, ConvertSub,
+      ConvertMul, ConvertMac, ConvertModSwitch, ConvertBarrettReduce,
+      ConvertConstant, ConvertRNSExtractResidue, ConvertRNSExtractSlice,
+      ConvertRNSPack, ConvertAny<>, ConvertAny<affine::AffineForOp>,
+      ConvertAny<affine::AffineYieldOp>, ConvertAny<linalg::GenericOp> >(
+      typeConverter, context);
 
   addStructuralConversionPatterns(typeConverter, patterns, target);
   addTensorOfTensorConversionPatterns(typeConverter, patterns, target);

--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
@@ -19,6 +19,7 @@
 #include "lib/Dialect/Polynomial/IR/PolynomialOps.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialTypes.h"
 #include "lib/Dialect/RNS/IR/RNSAttributes.h"
+#include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Utils/APIntUtils.h"
 #include "lib/Utils/ConversionUtils.h"
@@ -255,6 +256,28 @@ struct ConvertToTensor : public OpConversionPattern<ToTensorOp> {
       ToTensorOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
     rewriter.replaceOp(op, adaptor.getOperands()[0].getDefiningOp());
+    return success();
+  }
+};
+
+struct ConvertPolynomialExtractSlice
+    : public OpConversionPattern<ExtractSliceOp> {
+  ConvertPolynomialExtractSlice(mlir::MLIRContext* context)
+      : OpConversionPattern<ExtractSliceOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      ExtractSliceOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto resultType = getTypeConverter()->convertType(op.getOutput().getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, "result type conversion failed");
+    }
+
+    rewriter.replaceOpWithNewOp<rns::ExtractSliceOp>(
+        op, resultType, adaptor.getInput(), op.getStartAttr(),
+        op.getSizeAttr());
     return success();
   }
 };
@@ -1596,13 +1619,14 @@ void PolynomialToModArith::runOnOperation() {
   target.addIllegalDialect<PolynomialDialect>();
   RewritePatternSet patterns(context);
 
-  patterns.add<ConvertFromTensor, ConvertToTensor,
-               ConvertPolyBinop<AddOp, arith::AddIOp, mod_arith::AddOp>,
-               ConvertPolyBinop<SubOp, arith::SubIOp, mod_arith::SubOp>,
-               ConvertLeadingTerm, ConvertMonomial, ConvertMonicMonomialMul,
-               ConvertConstant, ConvertMulScalar, ConvertNTT, ConvertINTT,
-               ConvertApplyCoefficientwise, ConvertMulEvalForm>(typeConverter,
-                                                                context);
+  patterns
+      .add<ConvertFromTensor, ConvertToTensor, ConvertPolynomialExtractSlice,
+           ConvertPolyBinop<AddOp, arith::AddIOp, mod_arith::AddOp>,
+           ConvertPolyBinop<SubOp, arith::SubIOp, mod_arith::SubOp>,
+           ConvertLeadingTerm, ConvertMonomial, ConvertMonicMonomialMul,
+           ConvertConstant, ConvertMulScalar, ConvertNTT, ConvertINTT,
+           ConvertApplyCoefficientwise, ConvertMulEvalForm>(typeConverter,
+                                                            context);
   patterns.add<ConvertMulCoeffForm>(typeConverter, patterns.getContext(),
                                     getDivmodOp);
   addStructuralConversionPatterns(typeConverter, patterns, target);

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
@@ -257,6 +257,25 @@ func.func @test_lower_barrett_reduce_int(%arg : i10) -> i10 {
 !Zp_same_width = !mod_arith.int<33181787 : i26>
 !Zp_smaller_width = !mod_arith.int<257 : i10>
 !RNS = !rns.rns<!mod_arith.int<829 : i11>, !mod_arith.int<101 : i11>, !mod_arith.int<37 : i11>>
+!RNS_slice = !rns.rns<!mod_arith.int<101 : i11>, !mod_arith.int<37 : i11>>
+
+// CHECK: @test_lower_rns_extract_slice
+// CHECK-SAME: (%[[ARG:.*]]: tensor<3xi11>) -> tensor<2xi11>
+func.func @test_lower_rns_extract_slice(%arg : !RNS) -> !RNS_slice {
+  // CHECK: %[[SLICE:.*]] = tensor.extract_slice %[[ARG]][1] [2] [1] : tensor<3xi11> to tensor<2xi11>
+  %res = rns.extract_slice %arg {start = 1 : index, size = 2 : index} : !RNS -> !RNS_slice
+  // CHECK: return %[[SLICE]]
+  return %res : !RNS_slice
+}
+
+// CHECK: @test_lower_tensor_rns_extract_slice
+// CHECK-SAME: (%[[ARG:.*]]: tensor<4x3xi11>) -> tensor<4x2xi11>
+func.func @test_lower_tensor_rns_extract_slice(%arg : tensor<4x!RNS>) -> tensor<4x!RNS_slice> {
+  // CHECK: %[[SLICE:.*]] = tensor.extract_slice %[[ARG]][0, 1] [4, 2] [1, 1] : tensor<4x3xi11> to tensor<4x2xi11>
+  %res = rns.extract_slice %arg {start = 1 : index, size = 2 : index} : tensor<4x!RNS> -> tensor<4x!RNS_slice>
+  // CHECK: return %[[SLICE]]
+  return %res : tensor<4x!RNS_slice>
+}
 
 // CHECK: @test_lower_mod_switch_decompose
 // CHECK-SAME: (%[[ARG:.*]]: [[INT_TYPE:.*]]) -> [[TENSOR_TYPE:.*]] {

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/extract_slice.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/extract_slice.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt --polynomial-to-mod-arith %s | FileCheck %s
+
+!Z0 = !mod_arith.int<270337 : i64>
+!Z1 = !mod_arith.int<188417 : i64>
+!Z2 = !mod_arith.int<286721 : i64>
+!rns = !rns.rns<!Z0, !Z1, !Z2>
+!rns0 = !rns.rns<!Z0>
+#ring = #polynomial.ring<coefficientType = !rns, polynomialModulus = <1 + x**4096>>
+#ring0 = #polynomial.ring<coefficientType = !rns0, polynomialModulus = <1 + x**4096>>
+!poly = !polynomial.polynomial<ring = #ring>
+!poly0 = !polynomial.polynomial<ring = #ring0>
+
+// CHECK: @extract_slice
+// CHECK-SAME: (%[[ARG:.*]]: tensor<4096x!{{.*}}>)
+func.func @extract_slice(%arg0: !poly) -> !poly0 {
+  // CHECK: %[[SLICE:.*]] = rns.extract_slice %[[ARG]] {size = 1 : index, start = 0 : index}
+  %slice = polynomial.extract_slice %arg0 {start = 0 : index, size = 1 : index} : !poly -> !poly0
+  // CHECK: return %[[SLICE]]
+  return %slice : !poly0
+}


### PR DESCRIPTION
rns::ExtractSliceOp and polynomial::ExtractSliceOp currently don't have any lowerings. This PR adds a lowering for both ops. Assisted by AI.