### PR TITLE
Suppress warnings generated when compiling with -c opt

### DIFF
--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.cpp
@@ -36,8 +36,9 @@ namespace heir {
 //===----------------------------------------------------------------------===//
 // LevelAnalysis (Forward)
 //===----------------------------------------------------------------------===//
-static void debugLog(StringRef opName, ArrayRef<const LevelLattice*> operands,
-                     const LevelState& result) {
+[[maybe_unused]] static void debugLog(StringRef opName,
+                                      ArrayRef<const LevelLattice*> operands,
+                                      const LevelState& result) {
   LLVM_DEBUG({
     llvm::dbgs() << "transferForward: " << opName << "(";
     for (auto* operand : operands) {
@@ -160,9 +161,9 @@ void LevelAnalysis::visitExternalCall(
 //===----------------------------------------------------------------------===//
 // LevelAnalysis (Backward)
 //===----------------------------------------------------------------------===//
-static void debugLogBackwards(StringRef opName,
-                              ArrayRef<const LevelLattice*> results,
-                              const LevelState& operand, unsigned operandNum) {
+[[maybe_unused]] static void debugLogBackwards(
+    StringRef opName, ArrayRef<const LevelLattice*> results,
+    const LevelState& operand, unsigned operandNum) {
   LLVM_DEBUG({
     llvm::dbgs() << "transferBackward: " << opName << " results(";
     for (auto* result : results) {

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
@@ -132,7 +132,7 @@ void LayoutOptimization::runOnOperation() {
               // run automatically instead of doing it manually here
               LLVM_DEBUG(llvm::dbgs() << "Visiting op: " << op->getName()
                                       << " with hoistable interface\n");
-              KernelName kernelName = KernelName::Trivial;
+              [[maybe_unused]] KernelName kernelName = KernelName::Trivial;
               if (op->hasAttr(kKernelAttrName)) {
                 kernelName =
                     op->getAttrOfType<KernelAttr>(kKernelAttrName).getName();


### PR DESCRIPTION
There are some definitions that are only used inside `LLVM_DEBUG`, which are compiled away when using `- c opt`. This results in warnings about unused functions/values. This PR adds `[[maybe_unused]]` tags (available in C++17) to suppress the warnings when using -c opt.