### PR TITLE
OpenFHE codegen for torch sigmoid + cf.assert on plaintexts

### DIFF
--- a/lib/Target/OpenFhePke/BUILD
+++ b/lib/Target/OpenFhePke/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:SCFDialect",

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -32,7 +32,8 @@
 #include "llvm/include/llvm/Support/LogicalResult.h"   // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"     // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
@@ -243,12 +244,15 @@ LogicalResult OpenFhePkeEmitter::translate(Operation& op) {
           .Case<arith::ConstantOp, arith::ExtSIOp, arith::ExtUIOp,
                 arith::FloorDivSIOp, arith::IndexCastOp, arith::ExtFOp,
                 arith::RemSIOp, arith::AddIOp, arith::AddFOp, arith::AndIOp,
-                arith::SubIOp, arith::MulFOp, arith::MulIOp, arith::DivSIOp,
-                arith::CmpIOp, arith::SelectOp, arith::MaxSIOp, arith::MinSIOp>(
+                arith::SubIOp, arith::SubFOp, arith::MulFOp, arith::MulIOp,
+                arith::DivSIOp, arith::DivFOp, arith::CmpIOp, arith::CmpFOp,
+                arith::SelectOp, arith::MaxSIOp, arith::MinSIOp>(
               [&](auto op) { return printOperation(op); })
           // SCF ops
           .Case<scf::IfOp, scf::ForOp, scf::ForallOp, scf::InParallelOp,
                 scf::YieldOp>([&](auto op) { return printOperation(op); })
+          // ControlFlow ops
+          .Case<cf::AssertOp>([&](auto op) { return printOperation(op); })
           // Tensor ops
           .Case<tensor::ConcatOp, tensor::EmptyOp, tensor::InsertOp,
                 tensor::InsertSliceOp, tensor::ExtractOp,
@@ -526,6 +530,12 @@ LogicalResult OpenFhePkeEmitter::printOperation(affine::AffineYieldOp op) {
     os << variableNames->getNameForValue(operand);
     os << ";\n";
   }
+  return success();
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(cf::AssertOp op) {
+  os << "assert(" << variableNames->getNameForValue(op.getArg()) << " && \""
+     << op.getMsg() << "\");\n";
   return success();
 }
 
@@ -1258,6 +1268,14 @@ LogicalResult OpenFhePkeEmitter::printOperation(arith::SubIOp op) {
   return printBinaryOp(op, op.getLhs(), op.getRhs(), "-");
 }
 
+LogicalResult OpenFhePkeEmitter::printOperation(arith::SubFOp op) {
+  return printBinaryOp(op, op.getLhs(), op.getRhs(), "-");
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(arith::DivFOp op) {
+  return printBinaryOp(op, op.getLhs(), op.getRhs(), "/");
+}
+
 LogicalResult OpenFhePkeEmitter::printOperation(arith::DivSIOp op) {
   return printBinaryOp(op, op.getLhs(), op.getRhs(), "/");
 }
@@ -1296,6 +1314,31 @@ LogicalResult OpenFhePkeEmitter::printOperation(arith::CmpIOp op) {
       return printBinaryOp(op, op.getLhs(), op.getRhs(), ">=");
   }
   llvm_unreachable("unknown cmpi predicate kind");
+}
+
+LogicalResult OpenFhePkeEmitter::printOperation(arith::CmpFOp op) {
+  switch (op.getPredicate()) {
+    case arith::CmpFPredicate::OEQ:
+    case arith::CmpFPredicate::UEQ:
+      return printBinaryOp(op, op.getLhs(), op.getRhs(), "==");
+    case arith::CmpFPredicate::ONE:
+    case arith::CmpFPredicate::UNE:
+      return printBinaryOp(op, op.getLhs(), op.getRhs(), "!=");
+    case arith::CmpFPredicate::OLT:
+    case arith::CmpFPredicate::ULT:
+      return printBinaryOp(op, op.getLhs(), op.getRhs(), "<");
+    case arith::CmpFPredicate::OLE:
+    case arith::CmpFPredicate::ULE:
+      return printBinaryOp(op, op.getLhs(), op.getRhs(), "<=");
+    case arith::CmpFPredicate::OGT:
+    case arith::CmpFPredicate::UGT:
+      return printBinaryOp(op, op.getLhs(), op.getRhs(), ">");
+    case arith::CmpFPredicate::OGE:
+    case arith::CmpFPredicate::UGE:
+      return printBinaryOp(op, op.getLhs(), op.getRhs(), ">=");
+    default:
+      return op.emitError("Unsupported cmpf predicate");
+  }
 }
 
 LogicalResult OpenFhePkeEmitter::printOperation(arith::MaxSIOp op) {

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.h
@@ -20,7 +20,8 @@
 #include "lib/Target/OpenFhePke/OpenFheUtils.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
@@ -104,6 +105,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::arith::AddFOp op);
   LogicalResult printOperation(::mlir::arith::AndIOp op);
   LogicalResult printOperation(::mlir::arith::CmpIOp op);
+  LogicalResult printOperation(::mlir::arith::CmpFOp op);
   LogicalResult printOperation(::mlir::arith::ConstantOp op);
   LogicalResult printOperation(::mlir::arith::DivSIOp op);
   LogicalResult printOperation(::mlir::arith::ExtFOp op);
@@ -118,6 +120,8 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::arith::RemSIOp op);
   LogicalResult printOperation(::mlir::arith::SelectOp op);
   LogicalResult printOperation(::mlir::arith::SubIOp op);
+  LogicalResult printOperation(::mlir::arith::SubFOp op);
+  LogicalResult printOperation(::mlir::arith::DivFOp op);
   LogicalResult printOperation(::mlir::scf::IfOp op);
   LogicalResult printOperation(::mlir::scf::ForOp op);
   LogicalResult printOperation(::mlir::scf::ForallOp op);
@@ -134,6 +138,7 @@ class OpenFhePkeEmitter {
   LogicalResult printOperation(::mlir::tensor::ParallelInsertSliceOp op);
   LogicalResult printOperation(::mlir::tensor::SplatOp op);
   LogicalResult printOperation(::mlir::tensor::FromElementsOp op);
+  LogicalResult printOperation(::mlir::cf::AssertOp op);
   LogicalResult printOperation(::mlir::func::FuncOp op);
   LogicalResult printOperation(::mlir::func::CallOp op);
   LogicalResult printOperation(::mlir::func::ReturnOp op);

--- a/lib/Target/OpenFhePke/OpenFhePkePybindEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkePybindEmitter.cpp
@@ -92,6 +92,16 @@ LogicalResult OpenFhePkePybindEmitter::printOperation(func::FuncOp funcOp) {
       }
     }
   } else {
+    // This branch is needed to support split preprocessing, which has multiple
+    // return values.
+    if (funcOp.getNumResults() > 1) {
+      std::string structName = llvm::formatv("{0}Struct", funcName).str();
+      os << llvm::formatv(kPybindStructClassTemplate.data(), structName);
+      for (size_t i = 0; i < funcOp.getNumResults(); ++i) {
+        os << llvm::formatv(kPybindStructFieldTemplate.data(), i, structName);
+      }
+      os << "    ;\n";
+    }
     os << llvm::formatv(kPybindFunctionTemplate.data(), funcName) << "\n";
   }
   return success();

--- a/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
+++ b/lib/Target/OpenFhePke/OpenFhePkeTemplates.h
@@ -8,12 +8,15 @@ namespace heir {
 namespace openfhe {
 
 constexpr std::string_view kSourceRelativeOpenfheImport = R"cpp(
+#include <cassert>
 #include "src/pke/include/openfhe.h"  // from @openfhe
 )cpp";
 constexpr std::string_view kInstallationRelativeOpenfheImport = R"cpp(
+#include <cassert>
 #include "openfhe/pke/openfhe.h"  // from @openfhe
 )cpp";
 constexpr std::string_view kEmbeddedOpenfheImport = R"cpp(
+#include <cassert>
 #include "openfhe.h"
 )cpp";
 
@@ -95,6 +98,7 @@ void bind_common(py::module &m)
         .def_readwrite("secretKey", &KeyPair<DCRTPoly>::secretKey);
     py::class_<CiphertextImpl<DCRTPoly>, std::shared_ptr<CiphertextImpl<DCRTPoly>>>(m, "Ciphertext", py::module_local())
         .def(py::init<>());
+    py::class_<PlaintextImpl, std::shared_ptr<PlaintextImpl>>(m, "Plaintext", py::module_local());
     py::class_<CryptoContextImpl<DCRTPoly>, std::shared_ptr<CryptoContextImpl<DCRTPoly>>>(m, "CryptoContext", py::module_local())
         .def(py::init<>())
         .def("KeyGen", &CryptoContextImpl<DCRTPoly>::KeyGen);
@@ -116,6 +120,18 @@ PYBIND11_MODULE({0}, m) {{
 // relinquished on entry and re-acquired on exit.
 constexpr std::string_view kPybindFunctionTemplate =
     "m.def(\"{0}\", &{0}, py::call_guard<py::gil_scoped_release>());";
+
+// Emit a pybind11 class binding for a struct, used for functions with multiple
+// return values. {0} is the struct name.
+constexpr std::string_view kPybindStructClassTemplate =
+    R"cpp(py::class_<{0}>(m, "{0}", py::module_local()).def(py::init<>())
+    )cpp";
+
+// Emit a pybind11 field binding for a struct member.
+// {0} is the field index (e.g., 0, 1).
+// {1} is the struct name.
+constexpr std::string_view kPybindStructFieldTemplate =
+    "    .def_readwrite(\"arg{0}\", &{1}::arg{0})\n";
 
 // clang-format off
 constexpr std::string_view KdebugHeaderImports = R"cpp(

--- a/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
+++ b/lib/Target/OpenFhePke/OpenFheTranslateRegistration.cpp
@@ -18,7 +18,8 @@
 #include "llvm/include/llvm/Support/ManagedStatic.h"  // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
@@ -85,11 +86,12 @@ void registerTranslateOptions() {
 
 // Common func to register dialects
 static void registerRelevantDialects(DialectRegistry& registry) {
-  registry.insert<arith::ArithDialect, func::FuncDialect,
-                  openfhe::OpenfheDialect, lwe::LWEDialect,
-                  tensor_ext::TensorExtDialect, polynomial::PolynomialDialect,
-                  tensor::TensorDialect, mod_arith::ModArithDialect,
-                  rns::RNSDialect, affine::AffineDialect, scf::SCFDialect>();
+  registry
+      .insert<arith::ArithDialect, func::FuncDialect, openfhe::OpenfheDialect,
+              lwe::LWEDialect, tensor_ext::TensorExtDialect,
+              polynomial::PolynomialDialect, tensor::TensorDialect,
+              mod_arith::ModArithDialect, rns::RNSDialect,
+              affine::AffineDialect, scf::SCFDialect, cf::ControlFlowDialect>();
 }
 
 void registerToOpenFhePkeTranslation() {

--- a/tests/Emitter/Openfhe/emit_pybind.mlir
+++ b/tests/Emitter/Openfhe/emit_pybind.mlir
@@ -34,6 +34,11 @@
 // CHECK:   m.def("__heir_debug", py::overload_cast<CryptoContextT, PrivateKeyT, CiphertextT, const std::map<std::string, std::string>&>(&__heir_debug), py::call_guard<py::gil_scoped_release>());
 // CHECK:   m.def("__heir_debug", py::overload_cast<CryptoContextT, PrivateKeyT, std::vector<CiphertextT>, const std::map<std::string, std::string>&>(&__heir_debug), py::call_guard<py::gil_scoped_release>());
 // CHECK-NOT: m.def("__heir_debug"
+// CHECK:   py::class_<simple_sum_multiStruct>(m, "simple_sum_multiStruct", py::module_local()).def(py::init<>())
+// CHECK-NEXT:           .def_readwrite("arg0", &simple_sum_multiStruct::arg0)
+// CHECK-NEXT:       .def_readwrite("arg1", &simple_sum_multiStruct::arg1)
+// CHECK-NEXT:       ;
+// CHECK:   m.def("simple_sum_multi", &simple_sum_multi, py::call_guard<py::gil_scoped_release>());
 // CHECK: }
 
 !cc = !openfhe.crypto_context
@@ -79,4 +84,9 @@ func.func @__heir_debug_vec(%arg0: !openfhe.crypto_context, %arg1: !openfhe.priv
 
 func.func @__heir_debug_dup(%arg0: !openfhe.crypto_context, %arg1: !openfhe.private_key, %arg2: !openfhe.ciphertext) {
   return
+}
+
+func.func @simple_sum_multi(%arg0: !openfhe.crypto_context, %arg1: !ct) -> (!ct, !ct) {
+  %1 = openfhe.rot %arg0, %arg1 { static_shift = 16 } : (!openfhe.crypto_context, !ct) -> !ct
+  return %arg1, %1 : !ct, !ct
 }

--- a/tests/Examples/openfhe/ckks/batchnorm_sigmoid/BUILD
+++ b/tests/Examples/openfhe/ckks/batchnorm_sigmoid/BUILD
@@ -1,0 +1,18 @@
+load("@heir//tests/Examples/openfhe:test.bzl", "openfhe_end_to_end_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+openfhe_end_to_end_test(
+    name = "batchnorm_sigmoid_test",
+    generated_lib_header = "batchnorm_sigmoid_lib.h",
+    heir_opt_flags = [
+        "--annotate-module=backend=openfhe scheme=ckks",
+        "--activation-canonicalizations",
+        "--mlir-to-ckks=ciphertext-degree=1024 split-preprocessing=0",
+        "--scheme-to-openfhe",
+    ],
+    heir_translate_flags = [],
+    mlir_src = "batchnorm_sigmoid.mlir",
+    tags = ["notap"],
+    test_src = "batchnorm_sigmoid_test.cpp",
+)

--- a/tests/Examples/openfhe/ckks/batchnorm_sigmoid/batchnorm_sigmoid.mlir
+++ b/tests/Examples/openfhe/ckks/batchnorm_sigmoid/batchnorm_sigmoid.mlir
@@ -1,0 +1,22 @@
+func.func @batchnorm_sigmoid(%x: f32 {secret.secret}, %mean: f32, %var: f32, %gamma: f32, %beta: f32) -> f32 {
+  %epsilon = arith.constant 1.000000e-05 : f32
+  %var_eps = arith.addf %var, %epsilon : f32
+  %sqrt_var_eps = math.sqrt %var_eps : f32
+
+  %c0 = arith.constant 0.0 : f32
+  %not_zero = arith.cmpf one, %sqrt_var_eps, %c0 : f32
+  cf.assert %not_zero, "variance is zero"
+
+  %inv_sqrt_var_eps = arith.divf %gamma, %sqrt_var_eps : f32
+  %x_minus_mean = arith.subf %x, %mean : f32
+  %normalized = arith.mulf %x_minus_mean, %inv_sqrt_var_eps : f32
+  %bn_out = arith.addf %normalized, %beta : f32
+
+  %neg_bn_out = arith.negf %bn_out : f32
+  %exp = math.exp %neg_bn_out {degree = 3 : i32, domain_lower = -5.0 : f64, domain_upper = 5.0 : f64} : f32
+  %c1 = arith.constant 1.0 : f32
+  %denom = arith.addf %exp, %c1 : f32
+  %sigmoid = arith.divf %c1, %denom {degree = 3 : i32, domain_lower = 1.0 : f64, domain_upper = 150.0 : f64} : f32
+
+  return %sigmoid : f32
+}

--- a/tests/Examples/openfhe/ckks/batchnorm_sigmoid/batchnorm_sigmoid_test.cpp
+++ b/tests/Examples/openfhe/ckks/batchnorm_sigmoid/batchnorm_sigmoid_test.cpp
@@ -1,0 +1,41 @@
+#include <vector>
+
+#include "gtest/gtest.h"  // from @googletest
+
+// Generated headers (block clang-format from messing up order)
+#include "tests/Examples/openfhe/ckks/batchnorm_sigmoid/batchnorm_sigmoid_lib.h"
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+TEST(BatchNormSigmoidTest, RunTest) {
+  auto cryptoContext = batchnorm_sigmoid__generate_crypto_context();
+  auto keyPair = cryptoContext->KeyGen();
+  auto publicKey = keyPair.publicKey;
+  auto secretKey = keyPair.secretKey;
+  cryptoContext =
+      batchnorm_sigmoid__configure_crypto_context(cryptoContext, secretKey);
+
+  float x = 0.5;
+  float mean = 0.1;
+  float var = 0.2;
+  float gamma = 1.0;
+  float beta = 0.0;
+  float expected = 0.709798;  // 1 / (1 + exp(-0.8944))
+
+  auto xEncrypted =
+      batchnorm_sigmoid__encrypt__arg0(cryptoContext, x, publicKey);
+
+  auto outputEncrypted =
+      batchnorm_sigmoid(cryptoContext, xEncrypted, mean, var, gamma, beta);
+
+  auto actual = batchnorm_sigmoid__decrypt__result0(cryptoContext,
+                                                    outputEncrypted, secretKey);
+
+  EXPECT_NEAR(expected, actual, 1e-1);
+}
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir


### PR DESCRIPTION
This is mirroring an example from a user involving a torch sigmoid operator. They are lowering to OpenFHE.