### PR TITLE
Rewrite dilated convolutions by expanding the kernel

### DIFF
--- a/lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.cpp
+++ b/lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.cpp
@@ -1002,6 +1002,173 @@ struct DropCfAssertInLinalg : public OpRewritePattern<linalg::GenericOp> {
   }
 };
 
+// Rewrites a linalg.conv_1d_ncw_fcw operation with dilation > 1 into an
+// equivalent dilation=1 convolution This materializes the filter to insert
+// `dilation-1` zeros between the filter entries See
+// https://github.com/vdumoulin/conv_arithmetic/blob/af6f818b0bb396c26da79899554682a8a499101d/gif/dilation.gif
+// for a visualization of dilation
+struct UndilateConv1DNcwFcw
+    : public OpRewritePattern<mlir::linalg::Conv1DNcwFcwOp> {
+ public:
+  UndilateConv1DNcwFcw(MLIRContext* context)
+      : OpRewritePattern<mlir::linalg::Conv1DNcwFcwOp>(context) {}
+
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::linalg::Conv1DNcwFcwOp convOp,
+                                PatternRewriter& rewriter) const override {
+    auto dilations = convOp.getDilations();
+    if (!dilations)
+      return rewriter.notifyMatchFailure(convOp, "no dilations attribute");
+    int64_t d = *dilations.getValues<int64_t>().begin();
+
+    if (d == 1) return rewriter.notifyMatchFailure(convOp, "already undilated");
+
+    Value input = convOp.getInputs()[0];
+    Value filter = convOp.getInputs()[1];
+    auto filterTy = cast<RankedTensorType>(filter.getType());
+    if (!filterTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(convOp, "dynamic filter shape");
+
+    // filter is (F, C, KW); dilation acts on KW. New KW' = d*(KW-1) + 1.
+    ArrayRef<int64_t> shape = filterTy.getShape();
+    int64_t f = shape[0], c = shape[1], kw = shape[2];
+    int64_t newKw = d * (kw - 1) + 1;
+    Type eltTy = filterTy.getElementType();
+    auto newFilterTy = filterTy.clone({f, c, newKw});
+
+    TypedAttr constAttr;
+    if (!matchPattern(filter, m_Constant(&constAttr)))
+      return rewriter.notifyMatchFailure(convOp, "filter must be a constant");
+
+    auto denseAttr = dyn_cast<DenseElementsAttr>(constAttr);
+
+    // handle denseResource
+    if (auto denseResourceAttr =
+            dyn_cast<DenseResourceElementsAttr>(constAttr)) {
+      const auto data = denseResourceAttr.getData();
+      // Limit size to avoid huge constants in IR.
+      if (data.size() > 1024 * 1024)
+        return rewriter.notifyMatchFailure(convOp,
+                                           "filter too large to undilate");
+      denseAttr = DenseElementsAttr::getFromRawBuffer(
+          denseResourceAttr.getType(), data);
+    }
+    if (!denseAttr)
+      return rewriter.notifyMatchFailure(
+          convOp, "filter constant must be a dense elements attribute");
+
+    SmallVector<Attribute> values(f * c * newKw, rewriter.getZeroAttr(eltTy));
+    auto inputValues = denseAttr.getValues<Attribute>();
+    for (int64_t fi = 0; fi < f; ++fi) {
+      for (int64_t ci = 0; ci < c; ++ci) {
+        for (int64_t ki = 0; ki < kw; ++ki) {
+          int64_t src = fi * (c * kw) + ci * kw + ki;
+          int64_t dst = fi * (c * newKw) + ci * newKw + ki * d;
+          values[dst] = inputValues[src];
+        }
+      }
+    }
+    Value newFilter = arith::ConstantOp::create(
+        rewriter, convOp.getLoc(), DenseElementsAttr::get(newFilterTy, values));
+
+    rewriter.replaceOpWithNewOp<linalg::Conv1DNcwFcwOp>(
+        convOp, convOp.getResultTypes(), ValueRange{input, newFilter},
+        ValueRange{convOp.getDpsInits()[0]}, convOp.getStrides(),
+        rewriter.getI64TensorAttr({1}));
+    return success();
+  }
+};
+
+// Rewrites a linalg.conv_2d_nchw_fchw operation with dilation > 1 into an
+// equivalent dilation=1 convolution This materializes the filter to insert
+// `dilation-1` zeros between the filter entries See
+// https://github.com/vdumoulin/conv_arithmetic/blob/af6f818b0bb396c26da79899554682a8a499101d/gif/dilation.gif
+// for a visualization of dilation
+struct UndilateConv2DNchwFchw
+    : public OpRewritePattern<mlir::linalg::Conv2DNchwFchwOp> {
+ public:
+  UndilateConv2DNchwFchw(MLIRContext* context)
+      : OpRewritePattern<mlir::linalg::Conv2DNchwFchwOp>(context) {}
+
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::linalg::Conv2DNchwFchwOp convOp,
+                                PatternRewriter& rewriter) const override {
+    auto dilations = convOp.getDilations();
+    if (!dilations)
+      return rewriter.notifyMatchFailure(convOp, "no dilations attribute");
+    SmallVector<int64_t> dilationValues =
+        llvm::to_vector(dilations.getValues<int64_t>());
+
+    int64_t dh = dilationValues[0];
+    int64_t dw =
+        (dilationValues.size() > 1) ? dilationValues[1] : dilationValues[0];
+
+    if (dh == 1 && dw == 1)
+      return rewriter.notifyMatchFailure(convOp, "already undilated");
+
+    Value input = convOp.getInputs()[0];
+    Value filter = convOp.getInputs()[1];
+    auto filterTy = cast<RankedTensorType>(filter.getType());
+    if (!filterTy.hasStaticShape())
+      return rewriter.notifyMatchFailure(convOp, "dynamic filter shape");
+
+    // filter is (F, C, KH, KW); dilation acts on (KH, KW).
+    // New KH' = dh*(KH-1) + 1 and KW' = dw*(KW-1) + 1.
+    ArrayRef<int64_t> shape = filterTy.getShape();
+    int64_t f = shape[0], c = shape[1], kh = shape[2], kw = shape[3];
+    int64_t newKh = dh * (kh - 1) + 1;
+    int64_t newKw = dw * (kw - 1) + 1;
+    Type eltTy = filterTy.getElementType();
+    auto newFilterTy = filterTy.clone({f, c, newKh, newKw});
+
+    TypedAttr constAttr;
+    if (!matchPattern(filter, m_Constant(&constAttr)))
+      return rewriter.notifyMatchFailure(convOp, "filter must be a constant");
+
+    auto denseAttr = dyn_cast<DenseElementsAttr>(constAttr);
+
+    // handle denseResource
+    if (auto denseResourceAttr =
+            dyn_cast<DenseResourceElementsAttr>(constAttr)) {
+      const auto data = denseResourceAttr.getData();
+      // Limit size to avoid huge constants in IR.
+      if (data.size() > 1024 * 1024)
+        return rewriter.notifyMatchFailure(convOp,
+                                           "filter too large to undilate");
+      denseAttr = DenseElementsAttr::getFromRawBuffer(
+          denseResourceAttr.getType(), data);
+    }
+    if (!denseAttr)
+      return rewriter.notifyMatchFailure(
+          convOp, "filter constant must be a dense elements attribute");
+
+    SmallVector<Attribute> values(f * c * newKh * newKw,
+                                  rewriter.getZeroAttr(eltTy));
+    auto inputValues = denseAttr.getValues<Attribute>();
+    for (int64_t fi = 0; fi < f; ++fi) {
+      for (int64_t ci = 0; ci < c; ++ci) {
+        for (int64_t khi = 0; khi < kh; ++khi) {
+          for (int64_t kwi = 0; kwi < kw; ++kwi) {
+            int64_t src = ((fi * c + ci) * kh + khi) * kw + kwi;
+            int64_t dst = ((fi * c + ci) * newKh + khi * dh) * newKw + kwi * dw;
+            values[dst] = inputValues[src];
+          }
+        }
+      }
+    }
+    Value newFilter = arith::ConstantOp::create(
+        rewriter, convOp.getLoc(), DenseElementsAttr::get(newFilterTy, values));
+
+    rewriter.replaceOpWithNewOp<linalg::Conv2DNchwFchwOp>(
+        convOp, convOp.getResultTypes(), ValueRange{input, newFilter},
+        ValueRange{convOp.getDpsInits()[0]}, convOp.getStrides(),
+        rewriter.getI64TensorAttr({1, 1}));
+    return success();
+  }
+};
+
 struct LinalgCanonicalizations
     : public impl::LinalgCanonicalizationsBase<LinalgCanonicalizations> {
   void runOnOperation() override {
@@ -1014,7 +1181,8 @@ struct LinalgCanonicalizations
         FoldConstantBroadcast, FoldConstantFill, FoldConstantLinalgTranspose,
         LinalgGenericToElementwise, LinalgMapToElementwise,
         MaterializeBroadcasts, RewriteAvgPoolAsConv1D, RewriteAvgPoolAsConv2D,
-        RewriteTransposedMatvec, RewriteTransposedVecmat>(context);
+        RewriteTransposedMatvec, RewriteTransposedVecmat, UndilateConv1DNcwFcw,
+        UndilateConv2DNchwFchw>(context);
 
     mlir::linalg::populateDecomposeProjectedPermutationPatterns(patterns);
 

--- a/tests/Examples/lattigo/ckks/conv1d_dilated/BUILD
+++ b/tests/Examples/lattigo/ckks/conv1d_dilated/BUILD
@@ -1,0 +1,23 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv1d_dilated",
+    go_library_name = "conv1d_dilated",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--torch-linalg-to-ckks=ciphertext-degree=1024 scaling-mod-bits=45 first-mod-bits=60 split-preprocessing=1",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "conv1d_dilated.mlir",
+    split_preprocessing = True,
+)
+
+go_test(
+    name = "conv1d_dilated_test",
+    srcs = ["conv1d_dilated_test.go"],
+    embed = [":conv1d_dilated"],
+    deps = [":conv1d_dilated_utils"],
+)

--- a/tests/Examples/lattigo/ckks/conv1d_dilated/conv1d_dilated.mlir
+++ b/tests/Examples/lattigo/ckks/conv1d_dilated/conv1d_dilated.mlir
@@ -1,0 +1,10 @@
+module {
+  func.func @conv1d_dilated(%arg0: tensor<1x1x28xf32> {secret.secret}) -> tensor<1x4x24xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x4x24xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x4x24xf32>) -> tensor<1x4x24xf32>
+    %filter = arith.constant dense<1.000000e+00> : tensor<4x1x3xf32>
+    %2 = linalg.conv_1d_ncw_fcw {dilations = dense<2> : vector<1xi64>, strides = dense<1> : vector<1xi64>} ins(%arg0, %filter : tensor<1x1x28xf32>, tensor<4x1x3xf32>) outs(%1 : tensor<1x4x24xf32>) -> tensor<1x4x24xf32>
+    return %2 : tensor<1x4x24xf32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/conv1d_dilated/conv1d_dilated_test.go
+++ b/tests/Examples/lattigo/ckks/conv1d_dilated/conv1d_dilated_test.go
@@ -1,0 +1,59 @@
+package conv1d_dilated
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"tests/Examples/lattigo/ckks/conv1d_dilated/conv1d_dilated_utils"
+)
+
+func TestConv1DDilated(t *testing.T) {
+	evaluator, params, ecd, enc, dec := conv1d_dilated__configure()
+
+	// Input: 1x1x28
+	const W = 28
+	arg0 := make([]float32, W)
+	for i := range arg0 {
+		arg0[i] = float32(i)
+	}
+
+	// Filter is dense<1.0> : tensor<4x1x3xf32>, dilation=2, stride=1.
+	// New filter width after undilation is d*(KW-1)+1 = 5: [1, 0, 1, 0, 1].
+	// Output[f, wo] = arg0[wo] + arg0[wo+2] + arg0[wo+4] for every output
+	// channel f, since the filter is all-ones.
+	const F = 4
+	const KW = 3
+	const D = 2
+	const OW = W - D*(KW-1) // = 24 with stride 1
+
+	expected := make([]float32, F*OW)
+	for f := 0; f < F; f++ {
+		for wo := 0; wo < OW; wo++ {
+			var sum float32
+			for ki := 0; ki < KW; ki++ {
+				sum += arg0[wo+D*ki]
+			}
+			expected[f*OW+wo] = sum
+		}
+	}
+
+	ct0 := conv1d_dilated__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+
+	startPre := time.Now()
+	filterPlains := conv1d_dilated_utils.Conv1d_dilated__preprocessing(params, ecd)
+	t.Logf("Preprocessing took %s", time.Since(startPre))
+
+	start := time.Now()
+	resultCt := conv1d_dilated__preprocessed(evaluator, params, ecd, ct0, filterPlains)
+	t.Logf("Conv1d_dilated (preprocessed) took %s", time.Since(start))
+
+	result := conv1d_dilated__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	errorThreshold := float64(0.5)
+	for i := range expected {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: %.4f != %.4f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/ckks/conv2d_dilated/BUILD
+++ b/tests/Examples/lattigo/ckks/conv2d_dilated/BUILD
@@ -1,0 +1,23 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv2d_dilated",
+    go_library_name = "conv2d_dilated",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--torch-linalg-to-ckks=ciphertext-degree=1024 scaling-mod-bits=45 first-mod-bits=60 split-preprocessing=1",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "conv2d_dilated.mlir",
+    split_preprocessing = True,
+)
+
+go_test(
+    name = "conv2d_dilated_test",
+    srcs = ["conv2d_dilated_test.go"],
+    embed = [":conv2d_dilated"],
+    deps = [":conv2d_dilated_utils"],
+)

--- a/tests/Examples/lattigo/ckks/conv2d_dilated/conv2d_dilated.mlir
+++ b/tests/Examples/lattigo/ckks/conv2d_dilated/conv2d_dilated.mlir
@@ -1,0 +1,10 @@
+module {
+  func.func @conv2d_dilated(%arg0: tensor<1x1x10x10xf32> {secret.secret}) -> tensor<1x4x6x6xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x4x6x6xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x4x6x6xf32>) -> tensor<1x4x6x6xf32>
+    %filter = arith.constant dense<1.000000e+00> : tensor<4x1x3x3xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<2> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%arg0, %filter : tensor<1x1x10x10xf32>, tensor<4x1x3x3xf32>) outs(%1 : tensor<1x4x6x6xf32>) -> tensor<1x4x6x6xf32>
+    return %2 : tensor<1x4x6x6xf32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/conv2d_dilated/conv2d_dilated_test.go
+++ b/tests/Examples/lattigo/ckks/conv2d_dilated/conv2d_dilated_test.go
@@ -1,0 +1,65 @@
+package conv2d_dilated
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"tests/Examples/lattigo/ckks/conv2d_dilated/conv2d_dilated_utils"
+)
+
+func TestConv2DDilated(t *testing.T) {
+	evaluator, params, ecd, enc, dec := conv2d_dilated__configure()
+
+	const H = 10
+	const W = 10
+	arg0 := make([]float32, H*W)
+	for i := range arg0 {
+		arg0[i] = float32(i)
+	}
+
+	// Filter is dense<1.0> : tensor<4x1x3x3xf32>, dilation=2, stride=1.
+	// New filter size after undilation is d*(K-1)+1 = 5x5 with zeros inserted
+	// between the original taps.
+	// Output[f, ho, wo] = sum_{kh, kw} arg0[ho+2*kh, wo+2*kw] for every output
+	// channel f, since the filter is all-ones.
+	const F = 4
+	const K = 3
+	const D = 2
+	const OH = H - D*(K-1) // = 6 with stride 1
+	const OW = W - D*(K-1) // = 6 with stride 1
+
+	expected := make([]float32, F*OH*OW)
+	for f := 0; f < F; f++ {
+		for ho := 0; ho < OH; ho++ {
+			for wo := 0; wo < OW; wo++ {
+				var sum float32
+				for kh := 0; kh < K; kh++ {
+					for kw := 0; kw < K; kw++ {
+						sum += arg0[(ho+D*kh)*W+(wo+D*kw)]
+					}
+				}
+				expected[(f*OH+ho)*OW+wo] = sum
+			}
+		}
+	}
+
+	ct0 := conv2d_dilated__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+
+	startPre := time.Now()
+	filterPlains := conv2d_dilated_utils.Conv2d_dilated__preprocessing(params, ecd)
+	t.Logf("Preprocessing took %s", time.Since(startPre))
+
+	start := time.Now()
+	resultCt := conv2d_dilated__preprocessed(evaluator, params, ecd, ct0, filterPlains)
+	t.Logf("Conv2d_dilated (preprocessed) took %s", time.Since(start))
+
+	result := conv2d_dilated__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	errorThreshold := float64(0.5)
+	for i := range expected {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: %.4f != %.4f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Transforms/linalg_canonicalizations/conv1d_dilated.mlir
+++ b/tests/Transforms/linalg_canonicalizations/conv1d_dilated.mlir
@@ -1,0 +1,81 @@
+// RUN: heir-opt --linalg-canonicalizations --split-input-file %s | FileCheck %s
+
+// Rewrite a dilated conv1d kernel as a conv1d with a filter with 0s inserted
+module {
+  // CHECK: func.func @main
+  // CHECK-SAME: (%[[arg0:.*]]: tensor<1x1x8xf32>)
+  // CHECK-DAG: %[[out:.*]] = arith.constant {{.*}} tensor<1x1x4xf32>
+  // CHECK-DAG: %[[new_filter:.*]] = arith.constant
+  // CHECK-SAME: 1.000000e+00, 0.000000e+00, 2.000000e+00, 0.000000e+00, 3.000000e+00
+  // CHECK-SAME: tensor<1x1x5xf32>
+  // CHECK: linalg.conv_1d_ncw_fcw
+  // CHECK-SAME: dilations = dense<1>
+  // CHECK-SAME: strides = dense<1>
+  // CHECK-SAME: ins(%[[arg0]], %[[new_filter]] : tensor<1x1x8xf32>, tensor<1x1x5xf32>) outs(%[[out]] : tensor<1x1x4xf32>)
+  // CHECK: return
+  func.func @main(%arg0: tensor<1x1x8xf32>) -> tensor<1x1x4xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x1x4xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
+    %filter = arith.constant dense<[[[1.000000e+00, 2.000000e+00, 3.000000e+00]]]> : tensor<1x1x3xf32>
+    %2 = linalg.conv_1d_ncw_fcw {dilations = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} ins(%arg0, %filter : tensor<1x1x8xf32>, tensor<1x1x3xf32>) outs(%1 : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
+    return %2 : tensor<1x1x4xf32>
+  }
+}
+
+// -----
+
+// Rewrite a dilation=3 conv1d kernel as a conv1d with a filter with 0s inserted
+module {
+  // CHECK: func.func @main
+  // CHECK-SAME: (%[[arg0:.*]]: tensor<1x1x8xf32>)
+  // CHECK-DAG: %[[out:.*]] = arith.constant {{.*}} tensor<1x1x2xf32>
+  // CHECK-DAG: %[[new_filter:.*]] = arith.constant
+  // CHECK-SAME: 1.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0.000000e+00, 0.000000e+00, 3.000000e+00
+  // CHECK-SAME: tensor<1x1x7xf32>
+  // CHECK: linalg.conv_1d_ncw_fcw
+  // CHECK-SAME: dilations = dense<1>
+  // CHECK-SAME: strides = dense<1>
+  // CHECK-SAME: ins(%[[arg0]], %[[new_filter]] : tensor<1x1x8xf32>, tensor<1x1x7xf32>) outs(%[[out]] : tensor<1x1x2xf32>)
+  // CHECK: return
+  func.func @main(%arg0: tensor<1x1x8xf32>) -> tensor<1x1x2xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x1x2xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x1x2xf32>) -> tensor<1x1x2xf32>
+    %filter = arith.constant dense<[[[1.000000e+00, 2.000000e+00, 3.000000e+00]]]> : tensor<1x1x3xf32>
+    %2 = linalg.conv_1d_ncw_fcw {dilations = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} ins(%arg0, %filter : tensor<1x1x8xf32>, tensor<1x1x3xf32>) outs(%1 : tensor<1x1x2xf32>) -> tensor<1x1x2xf32>
+    return %2 : tensor<1x1x2xf32>
+  }
+}
+
+// -----
+
+module {
+  // CHECK: func.func @main_dense_resource
+  // CHECK-SAME: (%[[arg0:.*]]: tensor<1x1x8xf32>)
+  // CHECK-DAG: %[[out:.*]] = arith.constant {{.*}} tensor<1x1x4xf32>
+  // CHECK-DAG: %[[new_filter:.*]] = arith.constant
+  // CHECK-SAME: 1.000000e+00, 0.000000e+00, 2.000000e+00, 0.000000e+00, 3.000000e+00
+  // CHECK-SAME: tensor<1x1x5xf32>
+  // CHECK: linalg.conv_1d_ncw_fcw
+  // CHECK-SAME: dilations = dense<1>
+  // CHECK-SAME: strides = dense<1>
+  // CHECK-SAME: ins(%[[arg0]], %[[new_filter]] : tensor<1x1x8xf32>, tensor<1x1x5xf32>) outs(%[[out]] : tensor<1x1x4xf32>)
+  // CHECK: return
+  func.func @main_dense_resource(%arg0: tensor<1x1x8xf32>) -> tensor<1x1x4xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x1x4xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
+    %filter = arith.constant dense_resource<filter_data> : tensor<1x1x3xf32>
+    %2 = linalg.conv_1d_ncw_fcw {dilations = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} ins(%arg0, %filter : tensor<1x1x8xf32>, tensor<1x1x3xf32>) outs(%1 : tensor<1x1x4xf32>) -> tensor<1x1x4xf32>
+    return %2 : tensor<1x1x4xf32>
+  }
+}
+
+{-#
+  dialect_resources: {
+    builtin: {
+      filter_data: "0x040000000000803F0000004000004040"
+    }
+  }
+#-}

--- a/tests/Transforms/linalg_canonicalizations/conv2d_dilated.mlir
+++ b/tests/Transforms/linalg_canonicalizations/conv2d_dilated.mlir
@@ -1,0 +1,56 @@
+// RUN: heir-opt --linalg-canonicalizations --split-input-file %s | FileCheck %s
+
+// Rewrite a dilated conv2d kernel as a conv2d with a filter with 0s inserted
+module {
+  // CHECK: func.func @main
+  // CHECK-SAME: (%[[arg0:.*]]: tensor<1x1x8x8xf32>)
+  // CHECK-DAG: %[[out:.*]] = arith.constant {{.*}} tensor<1x1x4x4xf32>
+  // CHECK-DAG: %[[new_filter:.*]] = arith.constant
+  // CHECK-SAME: [1.000000e+00, 0.000000e+00, 2.000000e+00, 0.000000e+00, 3.000000e+00]
+  // CHECK-SAME: [0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00]
+  // CHECK-SAME: [4.000000e+00, 0.000000e+00, 5.000000e+00, 0.000000e+00, 6.000000e+00]
+  // CHECK-SAME: [0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00]
+  // CHECK-SAME: [7.000000e+00, 0.000000e+00, 8.000000e+00, 0.000000e+00, 9.000000e+00]
+  // CHECK-SAME: tensor<1x1x5x5xf32>
+  // CHECK: linalg.conv_2d_nchw_fchw
+  // CHECK-SAME: dilations = dense<1>
+  // CHECK-SAME: strides = dense<1>
+  // CHECK-SAME: ins(%[[arg0]], %[[new_filter]] : tensor<1x1x8x8xf32>, tensor<1x1x5x5xf32>) outs(%[[out]] : tensor<1x1x4x4xf32>)
+  // CHECK: return
+  func.func @main(%arg0: tensor<1x1x8x8xf32>) -> tensor<1x1x4x4xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x1x4x4xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x1x4x4xf32>) -> tensor<1x1x4x4xf32>
+    %filter = arith.constant dense<[[[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00, 9.000000e+00]]]]> : tensor<1x1x3x3xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<2> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %filter : tensor<1x1x8x8xf32>, tensor<1x1x3x3xf32>) outs(%1 : tensor<1x1x4x4xf32>) -> tensor<1x1x4x4xf32>
+    return %2 : tensor<1x1x4x4xf32>
+  }
+}
+
+// -----
+
+// Rewrite a conv2d kernel with different dilations per dimension (2 along H,
+// 3 along W)
+module {
+  // CHECK: func.func @main
+  // CHECK-SAME: (%[[arg0:.*]]: tensor<1x1x8x8xf32>)
+  // CHECK-DAG: %[[out:.*]] = arith.constant {{.*}} tensor<1x1x6x2xf32>
+  // CHECK-DAG: %[[new_filter:.*]] = arith.constant
+  // CHECK-SAME: [1.000000e+00, 0.000000e+00, 0.000000e+00, 2.000000e+00, 0.000000e+00, 0.000000e+00, 3.000000e+00]
+  // CHECK-SAME: [0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00]
+  // CHECK-SAME: [4.000000e+00, 0.000000e+00, 0.000000e+00, 5.000000e+00, 0.000000e+00, 0.000000e+00, 6.000000e+00]
+  // CHECK-SAME: tensor<1x1x3x7xf32>
+  // CHECK: linalg.conv_2d_nchw_fchw
+  // CHECK-SAME: dilations = dense<1>
+  // CHECK-SAME: strides = dense<1>
+  // CHECK-SAME: ins(%[[arg0]], %[[new_filter]] : tensor<1x1x8x8xf32>, tensor<1x1x3x7xf32>) outs(%[[out]] : tensor<1x1x6x2xf32>)
+  // CHECK: return
+  func.func @main(%arg0: tensor<1x1x8x8xf32>) -> tensor<1x1x6x2xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tensor.empty() : tensor<1x1x6x2xf32>
+    %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x1x6x2xf32>) -> tensor<1x1x6x2xf32>
+    %filter = arith.constant dense<[[[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]]]> : tensor<1x1x2x3xf32>
+    %2 = linalg.conv_2d_nchw_fchw {dilations = dense<[2, 3]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %filter : tensor<1x1x8x8xf32>, tensor<1x1x2x3xf32>) outs(%1 : tensor<1x1x6x2xf32>) -> tensor<1x1x6x2xf32>
+    return %2 : tensor<1x1x6x2xf32>
+  }
+}


### PR DESCRIPTION
The dilation argument adds 0 between the kernel values:

[1,2,3], dilation=3 -> [1,0,0,2,0,0,3], dilation=1

This pass rewrites a dilated convolution operator to a convolution operator with dilation=1 by explicitly inserting the 0s in the kernel.

If you agree with approach, I can also port it to the 2d convolution operator.

I am opening this as a draft PR because it is blocked by #3003 . The bug is unrelated to these changes, but it is making the integration test fail. Let me know if I can help you somehow with the resolution of #3003 @asraa . I am happy to sit down and try to figure this out together if you think that would be helpful.