### PR TITLE
Fix hermetic toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,6 @@ common --cxxopt='-std=c++20'
 common --copt=-fdiagnostics-color=always
 common --test_output=errors
 common --test_summary=terse
-
 common --enable_platform_specific_config
 
 # compilation_mode options below are `dbg` (debug symbols) `fastbuild`
@@ -14,18 +13,41 @@ common --enable_bzlmod
 # prevents changes to PATH from causing a full rebuild
 common --incompatible_strict_action_env
 
-# compile with clang on all platforms
-build --action_env=CC=clang
-build --action_env=CXX=clang++
-build --host_action_env=CC=clang
-build --host_action_env=CXX=clang++
+# extra flags for hermetic LLVM toolchain
+common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --repo_env=BAZEL_DO_NOT_DETECT_SWIFT_TOOLCHAIN=1
+common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common --@rules_python//python/config_settings:bootstrap_impl=script
+# Needed to silence hermetic LLVM build warnings, until this is enabled by
+# default in bazel 9
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
+
+# buildbuddy
+# for remote execution of the build. Add `common --config=remote` to
+# .bazelrc.user
+common:remote --bes_backend=grpcs://heir.buildbuddy.io
+common:remote --bes_results_url=https://heir.buildbuddy.io/invocation/
+common:remote --remote_cache=grpcs://heir.buildbuddy.io
+common:remote --remote_cache_compression
+common:remote --remote_timeout=10m
+common:remote --extra_execution_platforms=@llvm//:rbe_platform
+common:remote --jobs=500
+common:remote --remote_executor=grpcs://heir.buildbuddy.io
+
+# CI executions are always remote, and have extra build metadata
+common:ci --build_metadata=ROLE=CI
+common:ci --build_metadata=VISIBILITY=PUBLIC
 
 # Only show warnings for targets defined in HEIR code.
 # Warnings for external repos and generated code is (mostly) hidden; see #2616
 build --output_filter="^//(benchmark|frontend|lib|tests|tools)/"
 
-# linux-specific options
+# use lld for faster linking
 build:linux --linkopt="-fuse-ld=lld"
+
+# This is needed for golang targets with the hermetic build, when a golang
+# target links with a C++ lib.
+build:linux --linkopt="-Wl,-no-pie"
 
 # macos specific options
 # openmp is not supported in apple clang
@@ -38,13 +60,6 @@ build:macos_arm64 --macos_minimum_os=11.0
 # openmp is not supported in apple clang
 build:macos_arm64 --@openfhe//:enable_openmp=False
 
-# run with --config=gcc to force use of gcc
-# (and the default linker, usually ld) instead
-build:gcc --action_env=CC=gcc
-build:gcc --action_env=CXX=g++
-build:gcc --host_action_env=CC=gcc
-build:gcc --host_action_env=CXX=g++
-
 # run with --config=asan to enable
 build:asan --strip=never
 build:asan --copt -fsanitize=address
@@ -55,3 +70,10 @@ build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
 
 try-import %workspace%/fuzztest.bazelrc
+
+# Load any settings specific to the current user.
+# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
+# This needs to be last statement in this
+# config, as the user configuration should be able to overwrite flags from this file.
+# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
+try-import %workspace%/.bazelrc.user

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,10 +14,13 @@ jobs:
   build-and-test:
     runs-on:
       labels: ubuntu-24.04-64core
+    env:
+      BUILDBUDDY_API_KEY: ${{ github.event_name != 'pull_request' && secrets.BUILDBUDDY_API_KEY || vars.BUILDBUDDY_READ_ONLY_API_KEY }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
+      # needed to build OpenFHE and for the frontend tests
       - name: Install dependencies
         run: |
           ./.github/install_clang_version.sh 19
@@ -31,16 +34,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clang19-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}-${{ hashFiles('bazel/extensions.bzl') }}
             ${{ runner.os }}-clang19-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel') }}-
-
-      - name: Confirm bazel is using the right C compiler
-        run: |
-          # Pure debugging bazel stuff: ensure the compiler installed is the
-          # one used by bazel. Note that the path to the C compiler is part of
-          # the cache, so if the compiler changes but the cache does not, it
-          # will try to use the old compiler path.
-          which -a clang | xargs ls -al
-          ls -al /etc/alternatives/clang
-          bazel cquery --output=starlark --starlark:expr="str(providers(target))" @bazel_tools//tools/cpp:current_cc_toolchain | sed 's/,/\n/g' | grep -C 5 clang
 
       # Bazel tests
       - name: "Run `bazel build`"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,8 @@ jobs:
       labels: ubuntu-24.04-16core
     permissions:
       contents: write
+    env:
+      BUILDBUDDY_API_KEY: ${{ github.event_name != 'pull_request' && secrets.BUILDBUDDY_API_KEY || vars.BUILDBUDDY_READ_ONLY_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ bazel-heir
 bazel-out
 bazel-testlogs
 
+# user-specific bazelrc
+.bazelrc.user
+
 # default cmake output directory
 build/
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,24 @@ bazel_dep(name = "rules_cc", version = "0.2.19")
 # hermetic LLVM toolchain (for C++ compiler and linker)
 bazel_dep(name = "llvm", version = "0.8.9")
 
-register_toolchains("@llvm//:all")
+register_toolchains("@llvm//toolchain:all")
+
+# The hermetic LLVM project comes with LLVM sources, but we need a newer MLIR
+# that what is in the LLVM source from a versioned release. Instead, we only
+# load the hermetic LLVM sources to get access to the `libopenmp`, needed for
+# OpenFHE. With the block below, openmp is available via
+#
+#    bazel query @hermetic_llvm//openmp:libomp
+#
+llvm = use_extension("@llvm//extensions:llvm.bzl", "llvm")
+llvm.configure(
+    targets = [
+        "AArch64",
+        "AMDGPU",
+        "X86",
+    ],
+)
+use_repo(llvm, hermetic_llvm = "llvm-project")
 
 # Apple compilation support.
 # Note this requires full xcode, not just commandline tools
@@ -40,15 +57,29 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "re2", version = "2025-08-12")
 bazel_dep(name = "isl", version = "0.27")
 bazel_dep(name = "pocketfft", version = "0.0.2")
+bazel_dep(name = "abc", version = "0.65-yosyshq")
+bazel_dep(name = "yosys", version = "0.64")
 bazel_dep(name = "openfhe", version = "1.4.2.bcr.1")
-bazel_dep(name = "abc", version = "0.64-yosyshq.bcr.1")
-bazel_dep(name = "yosys", version = "0.57.bcr.2")
+single_version_override(
+    module_name = "openfhe",
+    patch_strip = 1,
+    patches = [
+        "//patches:openfhe_module.patch",
+        "//patches:openfhe.patch",
+    ],
+)
 
 # yosys deps needing newer versions for bazel compatibility
 bazel_dep(name = "fmt", version = "12.1.0")
-bazel_dep(name = "bison", version = "3.8.2.bcr.5")
 bazel_dep(name = "m4", version = "1.4.21.bcr.1")
 bazel_dep(name = "libffi", version = "3.4.7.bcr.4")
+bazel_dep(name = "bison", version = "3.8.2.bcr.5")
+single_version_override(
+    module_name = "bison",
+    patch_strip = 1,
+    patches = ["//patches:bison.patch"],
+    version = "3.8.2.bcr.5",
+)
 
 # Clang 21 compatibility
 # Cf. https://github.com/bazelbuild/bazel-central-registry/pull/7989

--- a/bazel/openfhe/copts.bzl
+++ b/bazel/openfhe/copts.bzl
@@ -1,20 +1,6 @@
 """Build settings for OpenFHE and OpenMP."""
 
-_OPENMP_CLANG_LINKOPTS = [
-    "-fopenmp",
-    "-lomp",
-]
-
-_OPENMP_GCC_LINKOPTS = [
-    "-fopenmp",
-    "-lgomp",
-]
-
-OPENMP_LINKOPTS = select({
-    "@openfhe//:clang_openmp": _OPENMP_CLANG_LINKOPTS,
-    "@openfhe//:gcc_openmp": _OPENMP_GCC_LINKOPTS,
-    "//conditions:default": [],
-})
+OPENMP_LINKOPTS = []
 
 OPENMP_COPTS = select({
     "@openfhe//:config_enable_openmp": [

--- a/lib/Target/OpenFhePke/BUILD
+++ b/lib/Target/OpenFhePke/BUILD
@@ -136,6 +136,7 @@ cc_library(
         "@heir//lib/Dialect/Openfhe/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@hermetic_llvm//openmp:libomp",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:Analysis",

--- a/patches/BUILD
+++ b/patches/BUILD
@@ -2,3 +2,5 @@ package(
     default_applicable_licenses = ["@heir//:license"],
     default_visibility = ["//visibility:public"],
 )
+
+exports_files(glob(["*.patch"]))

--- a/patches/bison.patch
+++ b/patches/bison.patch
@@ -1,0 +1,77 @@
+bison (3.8.2.bcr.5) vendors gnulib, whose generated replacement headers
+(lib/stdio.h, lib/fcntl.h, lib/spawn.h, ... built from the *.in.h
+templates) must be found before the platform's libc headers: each uses
+#include_next to pull in the real system header and layers the gnulib-only
+machinery on top -- e.g. the _GL_ARG_NONNULL / _GL_ATTRIBUTE_DEALLOC macros
+that lib/stdio-safer.h relies on, gnulib's O_BINARY fallback that
+lib/binary-io.h needs, and the posix_spawn_file_actions_addchdir
+declaration (absent from glibc 2.28) that lib/spawn-pipe.c calls.
+
+The BCR build exposes lib/ via `includes = ["lib"]`, which Bazel lowers to
+`-isystem .../bison+/lib`. With a normal toolchain the C library headers
+are implicit and searched last, so the gnulib wrappers win. HEIR's
+hermetic LLVM toolchain instead injects its glibc headers as an explicit,
+earlier `-isystem` directory. clang searches all `-isystem` dirs in
+command-line order, so glibc's <stdio.h>/<fcntl.h>/<spawn.h> shadow
+gnulib's wrappers; the gnulib macros/declarations then never appear,
+producing errors such as:
+
+  lib/stdio-safer.h:24: error: expected function body after function
+      declarator  (fopen_safer; _GL_ARG_NONNULL/_GL_ATTRIBUTE_DEALLOC
+                   left unexpanded)
+  lib/binary-io.h:52: error: use of undeclared identifier 'O_BINARY'
+  lib/spawn-pipe.c:522: error: call to undeclared function
+      'posix_spawn_file_actions_addchdir'
+
+Adding a duplicate `-I` for lib/ does not help: clang dedups directories
+and keeps the earlier `-isystem` placement. The fix is therefore to stop
+emitting `-isystem` for lib/ at all and supply it via `-I` instead -- `-I`
+(quote/angle) directories are always searched before any `-isystem`
+directory, so the gnulib wrappers are found first and #include_next reaches
+the hermetic glibc headers as intended.
+
+Concretely: drop `includes = ["lib"]` from the `headers` library, add the
+lib/ source and gendir paths to the clang branch of BISON_COPTS (applied to
+every bison compile), and give lib/y -- the one compiled target that used
+`headers` includes but not BISON_COPTS -- the same copts. The gcc/msvc
+branches are untouched, since their implicit-system ordering already works.
+Drop once the BCR bison module exports lib/ in a way that survives an
+explicit-`-isystem` libc toolchain.
+
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -668,6 +668,12 @@
+         "-w",
+         "-std=c11",
+         "-Wno-unused-but-set-variable",
++        # gnulib replacement headers must outrank the toolchain libc headers.
++        # A -isystem dir (from includes=) loses to the hermetic glibc -isystem;
++        # pass lib/ via -I (always searched before -isystem) instead. See
++        # patches/bison.patch.
++        "-Iexternal/bison+/lib",
++        "-I$(GENDIR)/external/bison+/lib",
+     ],
+     "@rules_cc//cc/compiler:gcc": [
+         "-w",
+@@ -765,7 +771,10 @@
+         "src/scan-skel.c",
+         ":configmake_h_src",
+     ],
+-    includes = ["lib"],
++    # includes=["lib"] removed: it emitted -isystem for lib/, which the
++    # hermetic clang toolchain ranks below its own glibc -isystem, shadowing
++    # gnulib's replacement headers. lib/ is now supplied via -I in
++    # BISON_COPTS, which wins. See patches/bison.patch.
+     textual_hdrs = [
+         "lib/timevar.def",
+         "lib/printf-frexp.c",
+@@ -949,6 +958,9 @@
+         "lib/main.c",
+         "lib/yyerror.c",
+     ],
++    # BISON_COPTS now carries the -I lib/ flags that headers used to provide
++    # via includes=.
++    copts = BISON_COPTS,
+     implementation_deps = [":headers"],
+     local_defines = LOCAL_DEFINES,
+ )

--- a/patches/openfhe.patch
+++ b/patches/openfhe.patch
@@ -1,0 +1,64 @@
+--- a/BUILD
++++ b/BUILD
+@@ -59,21 +59,7 @@
+     },
+ )
+
+-_OPENMP_CLANG_LINKOPTS = [
+-    "-fopenmp",
+-    "-lomp",
+-]
+-
+-_OPENMP_GCC_LINKOPTS = [
+-    "-fopenmp",
+-    "-lgomp",
+-]
+-
+-OPENMP_LINKOPTS = select({
+-    "//:clang_openmp": _OPENMP_CLANG_LINKOPTS,
+-    "//:gcc_openmp": _OPENMP_GCC_LINKOPTS,
+-    "//conditions:default": [],
+-})
++OPENMP_LINKOPTS = []
+
+ OPENMP_COPTS = select({
+     "//:config_enable_openmp": [
+@@ -84,6 +70,11 @@
+     "//conditions:default": [],
+ })
+
++OPENMP_DEPS = select({
++    "//:config_enable_openmp": ["@hermetic_llvm//openmp:libomp"],
++    "//conditions:default": [],
++})
++
+ genrule(
+     name = "generate_config_core_h",
+     outs = ["src/core/include/config_core.h"],
+@@ -137,7 +128,7 @@
+         ":generate_config_core_h",
+         ":prng",
+         "@cereal",
+-    ],
++    ] + OPENMP_DEPS,
+ )
+
+ cc_library(
+@@ -156,7 +147,7 @@
+     deps = [
+         ":core",
+         ":generate_config_core_h",
+-    ],
++    ] + OPENMP_DEPS,
+ )
+
+ cc_library(
+@@ -182,7 +173,7 @@
+         ":core",
+         ":generate_config_core_h",
+         "@cereal",
+-    ],
++    ] + OPENMP_DEPS,
+ )
+
+ # Generates a shared library that can be shipped with the python frontend.

--- a/patches/openfhe_module.patch
+++ b/patches/openfhe_module.patch
@@ -1,0 +1,10 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -12,3 +12,7 @@
+
+ openfhe_ext = use_extension("//:openfhe_config.bzl", "openfhe_config")
+ use_repo(openfhe_ext, "openfhe_config")
++
++bazel_dep(name = "llvm", version = "0.8.9")
++llvm = use_extension("@llvm//extensions:llvm.bzl", "llvm")
++use_repo(llvm, hermetic_llvm = "llvm-project")

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -185,6 +185,7 @@ cc_binary(
         "@heir//lib/Transforms/TensorToScalars",
         "@heir//lib/Transforms/UnusedMemRef",
         "@heir//lib/Transforms/ValidateNoise",
+        "@hermetic_llvm//openmp:libomp",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineToStandard",


### PR DESCRIPTION
Fixes https://github.com/google/heir/issues/3047

A simplification and borrowing parts of https://github.com/google/heir/pull/3045/

Change summary:

1. Bump hermetic llvm to a version that has openmp
2. Patch openfhe locally to pull from the hermetic llvm's openmp
3. Bump fmt to a working version
4. Move zlib to MODULE.bazel to avoid the need to patch
5. Patch bison same as https://github.com/google/heir/pull/3045/
6. Use `@hermetic_llvm//openmp:libomp` in the places in HEIR that need openmp
7. Enable BAZEL_TRACK_SOURCE_DIRECTORIES to silence some warnings introduced by hermetic llvm (this will go away by default in bazel 9, but we're still on bazel 8)
8. Add `-no-pie` for golang tests
9. Enable remote build execution and caching with buildbuddy, but don't yet update main CI workflow to use it.