### PR TITLE
Add guards to prevent lowering eval-form polynomial constants

### DIFF
--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
@@ -298,6 +298,11 @@ struct ConvertConstant : public OpConversionPattern<ConstantOp> {
           op, "failed to construct common conversion info");
 
     auto typeInfo = res.value();
+    // TODO(#97): support compile-time NTT
+    if (typeInfo.polynomialType.getForm() == Form::EVAL) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported eval-form polynomial constant");
+    }
 
     auto attr = dyn_cast<TypedIntPolynomialAttr>(op.getValue());
     if (!attr)
@@ -392,6 +397,47 @@ struct ConvertMonomial : public OpConversionPattern<MonomialOp> {
     }
     auto storageTensorType =
         RankedTensorType::get(storageShape, typeInfo.coefficientStorageType);
+
+    // TODO(#97): support compile-time NTT
+    // We don't have proper support for EVAL-form constants, but we can
+    // at least support degree-zero polynomial constants in EVAL form. The
+    // NTT of a degree-zero polynomial is a vector where each coefficient is the
+    // constant term.
+    if (typeInfo.polynomialType.getForm() == Form::EVAL) {
+      IntegerAttr degreeAttr;
+      if (!matchPattern(adaptor.getDegree(), m_Constant(&degreeAttr)) ||
+          degreeAttr.getInt() != 0) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported eval-form non-constant monomial");
+      }
+
+      Value result;
+      if (auto modQTy = dyn_cast<ModQTypeInterface>(typeInfo.coefficientType)) {
+        Type extractedType = modQTy.getLoweringType();
+        Value extracted = mod_arith::ExtractOp::create(
+            b, extractedType, adaptor.getCoefficient());
+        Value replicatedStorage;
+        if (isa<ShapedType>(extractedType)) {
+          auto init = tensor::EmptyOp::create(b, storageTensorType.getShape(),
+                                              typeInfo.coefficientStorageType);
+          // Broadcast an RNS constant coefficient along the degree axis
+          replicatedStorage = linalg::BroadcastOp::create(b, extracted, init,
+                                                          ArrayRef<int64_t>{0})
+                                  .getResult()[0];
+        } else {
+          replicatedStorage =
+              tensor::SplatOp::create(b, extracted, storageTensorType);
+        }
+        result = mod_arith::EncapsulateOp::create(b, typeInfo.tensorType,
+                                                  replicatedStorage)
+                     .getResult();
+      } else {
+        result = tensor::SplatOp::create(b, adaptor.getCoefficient(),
+                                         typeInfo.tensorType);
+      }
+      rewriter.replaceOp(op, result);
+      return success();
+    }
 
     auto tensor = arith::ConstantOp::create(
         b, DenseElementsAttr::get(
@@ -536,6 +582,10 @@ struct ConvertMonicMonomialMul
       return rewriter.notifyMatchFailure(
           op, "failed to construct common conversion info");
     auto typeInfo = res.value();
+    if (typeInfo.polynomialType.getForm() == Form::EVAL) {
+      return rewriter.notifyMatchFailure(
+          op, "MonicMonomialMul requires COEFF form input");
+    }
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     // In general, a rotation would correspond to multiplication by x^n,
@@ -622,6 +672,10 @@ struct ConvertLeadingTerm : public OpConversionPattern<LeadingTermOp> {
       return rewriter.notifyMatchFailure(
           op, "failed to construct common conversion info");
     auto typeInfo = res.value();
+    if (typeInfo.polynomialType.getForm() == Form::EVAL) {
+      return rewriter.notifyMatchFailure(
+          op, "LeadingTerm requires COEFF form input");
+    }
 
     auto c0 = arith::ConstantOp::create(
         b, b.getIntegerAttr(typeInfo.coefficientStorageType, 0));
@@ -677,6 +731,10 @@ struct ConvertApplyCoefficientwise
       return rewriter.notifyMatchFailure(
           op, "failed to construct common conversion info");
     auto typeInfo = res.value();
+    if (typeInfo.polynomialType.getForm() == Form::EVAL) {
+      return rewriter.notifyMatchFailure(
+          op, "ApplyCoefficientwise requires COEFF form input");
+    }
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     Value inputTensor = adaptor.getInput();

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/eval_form_errors.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/eval_form_errors.mlir
@@ -1,0 +1,24 @@
+// RUN: heir-opt --polynomial-to-mod-arith --verify-diagnostics --split-input-file %s
+
+#poly = #polynomial.int_polynomial<1 + x**4>
+#ring = #polynomial.ring<coefficientType=i32, polynomialModulus=#poly>
+!poly_ty = !polynomial.polynomial<ring=#ring, form=eval>
+
+func.func @eval_constant() -> !poly_ty {
+  // expected-error@+1 {{failed to legalize operation}}
+  %0 = polynomial.constant int<1> : !poly_ty
+  return %0 : !poly_ty
+}
+
+// -----
+
+#poly = #polynomial.int_polynomial<1 + x**4>
+#ring = #polynomial.ring<coefficientType=i32, polynomialModulus=#poly>
+!poly_ty = !polynomial.polynomial<ring=#ring, form=eval>
+
+func.func @eval_nonconstant_monomial(%coeff: i32) -> !poly_ty {
+  %c1 = arith.constant 1 : index
+  // expected-error@+1 {{failed to legalize operation}}
+  %0 = polynomial.monomial %coeff, %c1 : (i32, index) -> !poly_ty
+  return %0 : !poly_ty
+}

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/eval_monomial.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/eval_monomial.mlir
@@ -1,0 +1,31 @@
+// RUN: heir-opt --polynomial-to-mod-arith --mlir-print-local-scope %s | FileCheck %s
+
+#poly = #polynomial.int_polynomial<1 + x**4>
+#ring_i32 = #polynomial.ring<coefficientType=i32, polynomialModulus=#poly>
+!poly_i32 = !polynomial.polynomial<ring=#ring_i32, form=eval>
+
+// CHECK: func @eval_constant_monomial_int
+// CHECK-SAME: (%[[ARG0:.*]]: i32)
+func.func @eval_constant_monomial_int(%coeff: i32) -> !poly_i32 {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[SPLAT:.*]] = tensor.splat %[[ARG0]] : tensor<4xi32>
+  // CHECK: return %[[SPLAT]]
+  %0 = polynomial.monomial %coeff, %c0 : (i32, index) -> !poly_i32
+  return %0 : !poly_i32
+}
+
+!coeff_ty = !mod_arith.int<17 : i32>
+#ring_mod = #polynomial.ring<coefficientType=!coeff_ty, polynomialModulus=#poly>
+!poly_mod = !polynomial.polynomial<ring=#ring_mod, form=eval>
+
+// CHECK: func @eval_constant_monomial_mod
+// CHECK-SAME: (%[[ARG0:.*]]: !mod_arith.int<17 : i32>)
+func.func @eval_constant_monomial_mod(%coeff: !coeff_ty) -> !poly_mod {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[EXTRACTED:.*]] = mod_arith.extract %[[ARG0]] : !mod_arith.int<17 : i32> -> i32
+  // CHECK: %[[SPLAT:.*]] = tensor.splat %[[EXTRACTED]] : tensor<4xi32>
+  // CHECK: %[[ENCAPSULATED:.*]] = mod_arith.encapsulate %[[SPLAT]] : tensor<4xi32> -> tensor<4x!mod_arith.int<17 : i32>>
+  // CHECK: return %[[ENCAPSULATED]]
+  %0 = polynomial.monomial %coeff, %c0 : (!coeff_ty, index) -> !poly_mod
+  return %0 : !poly_mod
+}


### PR DESCRIPTION
PolyMulToNTT can create EVAL-form constants, but the PolynomialToModArith lowering didn't look at the form when lowering the constants, resulting in bogus lowerings (e.g., the constant polynomial f(x)=5 with the EVAL tag would be lowered to the tensor [5, 0, 0, ..., 0]). This PR adds guards to prevent such lowerings. It also adds support for lowering eval-form constants in one special case, namely when the constant is a degree-zero polynomial, because the NTT of a degree-zero polynomial with constant-term `c` is [c, c, c, c, ...., c].

Note that there are discussions about changing the behavior of PolyMulToNTT so that constants are _forced_ into COEFF form, which forces PolyMulToNTT to insert explicit NTTs, which would subsequently be removed by an sccf pass. Until we get that working, I'm keeping the behavior of PolyMulToNTT on constants unchanged.

I realized that this is more or less what #2902 was trying to do, so I incorporated those changes here. Here's the rundown:
- PolyMulToNTT allows constants to be emitted in either form, since it is efficient materialize EVAL-form constants rather than performing a runtime NTT. However, we don't have the code to actually *do* the compile-time NTT, so this resulted in invalid lowerings. That's what the initial PR guarded against.
- For non-constant Polynomial ops, PolyMulToNTT already enforces the expected input/output forms. For example, the pass requires a COEFF-form polynomial as input to `LeadingTermOp`. #2902 added guards for those ops as well. This is the safe thing to do, although the current code never emitted EVAL-form inputs to these ops.
- ToTensorOp and FromTensorOp are a bit special: if you know what you're doing, there's nothing wrong with extracting the NTT coefficients of a polynomial. In fact, we [need to] do so in the NTT tests. The PolyMulToNTT pass requires COEFF-form inputs/outputs for these ops, but I do *not* enforce that in the PolynomialToModArith lowering since we need EVAL-form inputs/outputs for the tests.

The implementation of the degree-zero NTT was done by AI.