### PR TITLE
Added ModArith::LiftOp

### DIFF
--- a/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -12,6 +12,7 @@
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Utils/APIntUtils.h"
 #include "lib/Utils/ConversionUtils.h"
+#include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/Support/Casting.h"        // from @llvm-project
 #include "llvm/include/llvm/Support/ErrorHandling.h"  // from @llvm-project
 #include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
@@ -72,9 +73,7 @@ Type convertModArithOrRNSLikeType(ShapedType type) {
 // A helper function to generate the attribute or type
 // needed to represent the result of mod_arith op as an integer
 // before applying a remainder operation
-template <typename Op>
-TypedAttr modulusAttr(Op op, bool mul = false) {
-  auto type = op.getResult().getType();
+TypedAttr modulusAttr(mlir::MLIRContext* ctx, Type type, bool mul = false) {
   auto elementType = getElementTypeOrSelf(type);
 
   auto getModWidth = [&](ModArithType t) {
@@ -85,7 +84,7 @@ TypedAttr modulusAttr(Op op, bool mul = false) {
   if (auto modArithType = dyn_cast<ModArithType>(elementType)) {
     APInt modulus = modArithType.getModulus().getValue();
     auto width = getModWidth(modArithType);
-    auto intType = IntegerType::get(op.getContext(), width);
+    auto intType = IntegerType::get(ctx, width);
     auto truncmod = modulus.zextOrTrunc(width);
 
     if (auto st = mlir::dyn_cast<ShapedType>(type)) {
@@ -100,7 +99,7 @@ TypedAttr modulusAttr(Op op, bool mul = false) {
     // The RNSTypeInterface ensures that all basis storage types are the same.
     auto firstMod = cast<ModArithType>(basisTypes[0]);
     auto width = getModWidth(firstMod);
-    auto intType = IntegerType::get(op.getContext(), width);
+    auto intType = IntegerType::get(ctx, width);
 
     SmallVector<APInt> moduli;
     for (auto b : basisTypes) {
@@ -131,9 +130,13 @@ TypedAttr modulusAttr(Op op, bool mul = false) {
 }
 
 // used for extui/trunci
-template <typename Op>
-inline Type modulusType(Op op, bool mul = false) {
-  return modulusAttr(op, mul).getType();
+inline Type modulusType(mlir::MLIRContext* ctx, Type type, bool mul = false) {
+  return modulusAttr(ctx, type, mul).getType();
+}
+
+TypedAttr intAttr(Type type, int64_t value) {
+  auto elementType = cast<IntegerType>(getElementTypeOrSelf(type));
+  return getScalarOrDenseAttr(type, APInt(elementType.getWidth(), value));
 }
 
 }  // namespace
@@ -176,6 +179,48 @@ struct ConvertExtract : public OpConversionPattern<ExtractOp> {
       ExtractOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
     rewriter.replaceOp(op, adaptor.getOperands()[0]);
+    return success();
+  }
+};
+
+struct ConvertLift : public OpConversionPattern<LiftOp> {
+  ConvertLift(mlir::MLIRContext* context)
+      : OpConversionPattern<LiftOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      LiftOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+    Type intTy = adaptor.getOperands()[0].getType();
+    // This could be the same as the lowering for ReduceOp,
+    // but I'm using one mod instead of two
+    Value q = arith::ConstantOp::create(
+        b, modulusAttr(op.getContext(), op.getInput().getType()));
+    // prduces a result in (-q, q)
+    Value rems = arith::RemSIOp::create(b, adaptor.getOperands()[0], q);
+    Value zero = arith::ConstantOp::create(b, intAttr(intTy, 0));
+    Value is_neg =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::slt, rems, zero);
+    Value rems_plus_q = arith::AddIOp::create(b, rems, q);
+    Value r_pos = arith::SelectOp::create(b, is_neg, rems_plus_q, rems);
+    Value result = r_pos;
+
+    if (op.getLiftType() == LiftType::CENTERED) {
+      auto one = arith::ConstantOp::create(b, intAttr(intTy, 1));
+      auto two = arith::ConstantOp::create(b, intAttr(intTy, 2));
+      auto q_plus_one = arith::AddIOp::create(b, q, one);
+      auto bound = arith::DivSIOp::create(b, q_plus_one, two);
+
+      auto is_ge =
+          arith::CmpIOp::create(b, arith::CmpIPredicate::sge, r_pos, bound);
+      auto r_pos_minus_q = arith::SubIOp::create(b, r_pos, q);
+      result = arith::SelectOp::create(b, is_ge, r_pos_minus_q, r_pos);
+    }
+
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -298,7 +343,8 @@ struct ConvertReduce : public OpConversionPattern<ReduceOp> {
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto cmod = arith::ConstantOp::create(b, modulusAttr(op));
+    auto cmod = arith::ConstantOp::create(
+        b, modulusAttr(op.getContext(), op.getResult().getType()));
     // ModArithType ensures cmod can be correctly interpreted as a signed number
     auto rems = arith::RemSIOp::create(b, adaptor.getOperands()[0], cmod);
     auto add = arith::AddIOp::create(b, rems, cmod);
@@ -322,7 +368,8 @@ struct ConvertAdd : public OpConversionPattern<AddOp> {
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto cmod = arith::ConstantOp::create(b, modulusAttr(op));
+    auto cmod = arith::ConstantOp::create(
+        b, modulusAttr(op.getContext(), op.getResult().getType()));
     auto add = arith::AddIOp::create(b, adaptor.getLhs(), adaptor.getRhs());
     auto remu = arith::RemUIOp::create(b, add, cmod);
 
@@ -342,7 +389,8 @@ struct ConvertSub : public OpConversionPattern<SubOp> {
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto cmod = arith::ConstantOp::create(b, modulusAttr(op));
+    auto cmod = arith::ConstantOp::create(
+        b, modulusAttr(op.getContext(), op.getResult().getType()));
     auto sub = arith::SubIOp::create(b, adaptor.getLhs(), adaptor.getRhs());
     auto add = arith::AddIOp::create(b, sub, cmod);
     auto remu = arith::RemUIOp::create(b, add, cmod);
@@ -363,14 +411,18 @@ struct ConvertMul : public OpConversionPattern<MulOp> {
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto cmod = arith::ConstantOp::create(b, modulusAttr(op, true));
-    auto lhs =
-        arith::ExtUIOp::create(b, modulusType(op, true), adaptor.getLhs());
-    auto rhs =
-        arith::ExtUIOp::create(b, modulusType(op, true), adaptor.getRhs());
+    auto cmod = arith::ConstantOp::create(
+        b, modulusAttr(op.getContext(), op.getResult().getType(), true));
+    auto lhs = arith::ExtUIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType(), true),
+        adaptor.getLhs());
+    auto rhs = arith::ExtUIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType(), true),
+        adaptor.getRhs());
     auto mul = arith::MulIOp::create(b, lhs, rhs);
     auto remu = arith::RemUIOp::create(b, mul, cmod);
-    auto trunc = arith::TruncIOp::create(b, modulusType(op), remu);
+    auto trunc = arith::TruncIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType()), remu);
 
     rewriter.replaceOp(op, trunc);
     return success();
@@ -388,17 +440,22 @@ struct ConvertMac : public OpConversionPattern<MacOp> {
       ConversionPatternRewriter& rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
-    auto cmod = arith::ConstantOp::create(b, modulusAttr(op, true));
-    auto x = arith::ExtUIOp::create(b, modulusType(op, true),
-                                    adaptor.getOperands()[0]);
-    auto y = arith::ExtUIOp::create(b, modulusType(op, true),
-                                    adaptor.getOperands()[1]);
-    auto acc = arith::ExtUIOp::create(b, modulusType(op, true),
-                                      adaptor.getOperands()[2]);
+    auto cmod = arith::ConstantOp::create(
+        b, modulusAttr(op.getContext(), op.getResult().getType(), true));
+    auto x = arith::ExtUIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType(), true),
+        adaptor.getOperands()[0]);
+    auto y = arith::ExtUIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType(), true),
+        adaptor.getOperands()[1]);
+    auto acc = arith::ExtUIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType(), true),
+        adaptor.getOperands()[2]);
     auto mul = arith::MulIOp::create(b, x, y);
     auto add = arith::AddIOp::create(b, mul, acc);
     auto remu = arith::RemUIOp::create(b, add, cmod);
-    auto trunc = arith::TruncIOp::create(b, modulusType(op), remu);
+    auto trunc = arith::TruncIOp::create(
+        b, modulusType(op.getContext(), op.getResult().getType()), remu);
 
     rewriter.replaceOp(op, trunc);
     return success();
@@ -610,13 +667,13 @@ void ModArithToArith::runOnOperation() {
 
   RewritePatternSet patterns(context);
   rewrites::populateWithGenerated(patterns);
-  patterns.add<
-      ConvertEncapsulate, ConvertExtract, ConvertReduce, ConvertAdd, ConvertSub,
-      ConvertMul, ConvertMac, ConvertModSwitch, ConvertBarrettReduce,
-      ConvertConstant, ConvertRNSExtractResidue, ConvertRNSExtractSlice,
-      ConvertRNSPack, ConvertAny<>, ConvertAny<affine::AffineForOp>,
-      ConvertAny<affine::AffineYieldOp>, ConvertAny<linalg::GenericOp> >(
-      typeConverter, context);
+  patterns
+      .add<ConvertEncapsulate, ConvertExtract, ConvertLift, ConvertReduce,
+           ConvertAdd, ConvertSub, ConvertMul, ConvertMac, ConvertModSwitch,
+           ConvertBarrettReduce, ConvertConstant, ConvertRNSExtractResidue,
+           ConvertRNSExtractSlice, ConvertRNSPack, ConvertAny<>,
+           ConvertAny<affine::AffineForOp>, ConvertAny<affine::AffineYieldOp>,
+           ConvertAny<linalg::GenericOp> >(typeConverter, context);
 
   addStructuralConversionPatterns(typeConverter, patterns, target);
   addTensorOfTensorConversionPatterns(typeConverter, patterns, target);

--- a/lib/Dialect/ModArith/IR/BUILD
+++ b/lib/Dialect/ModArith/IR/BUILD
@@ -28,6 +28,7 @@ cc_library(
         ":attributes_inc_gen",
         ":canonicalization_inc_gen",
         ":dialect_inc_gen",
+        ":enums_inc_gen",
         ":ops_inc_gen",
         ":type_interfaces_inc_gen",
         ":types_inc_gen",
@@ -57,6 +58,7 @@ td_library(
         "ModArithAttributes.td",
         "ModArithCanonicalization.td",
         "ModArithDialect.td",
+        "ModArithEnums.td",
         "ModArithOps.td",
         "ModArithTypes.td",
     ],
@@ -102,6 +104,17 @@ add_heir_dialect_library(
     dialect_doc_name = "mod_arith",
     kind = "attribute",
     td_file = "ModArithAttributes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "ModArith",
+    dialect_doc_name = "mod_arith",
+    kind = "enum",
+    td_file = "ModArithEnums.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/ModArith/IR/ModArithDialect.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithDialect.cpp
@@ -22,6 +22,7 @@
 #include "lib/Dialect/ModArith/IR/ModArithTypes.cpp.inc"
 
 #define GET_OP_CLASSES
+#include "lib/Dialect/ModArith/IR/ModArithEnums.cpp.inc"
 #include "lib/Dialect/ModArith/IR/ModArithOps.cpp.inc"
 
 namespace mlir {

--- a/lib/Dialect/ModArith/IR/ModArithEnums.td
+++ b/lib/Dialect/ModArith/IR/ModArithEnums.td
@@ -1,0 +1,15 @@
+#ifndef LIB_DIALECT_MODARITH_IR_MODARITHENUMS_TD_
+#define LIB_DIALECT_MODARITH_IR_MODARITHENUMS_TD_
+
+include "lib/Dialect/ModArith/IR/ModArithDialect.td"
+include "mlir/IR/EnumAttr.td"
+
+def ModArith_LiftType_STANDARD : I32EnumAttrCase<"STANDARD", 0, "standard">;
+def ModArith_LiftType_CENTERED : I32EnumAttrCase<"CENTERED", 1, "centered">;
+
+def ModArith_LiftTypeEnum : I32EnumAttr<"LiftType", "ModArith lift type",
+    [ModArith_LiftType_STANDARD, ModArith_LiftType_CENTERED]> {
+  let cppNamespace = "::mlir::heir::mod_arith";
+}
+
+#endif  // LIB_DIALECT_MODARITH_IR_MODARITHENUMS_TD_

--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -119,6 +119,10 @@ LogicalResult ExtractOp::verify() {
   return verifyTypeLowering(*this, getInput().getType(), getOutput().getType());
 }
 
+LogicalResult LiftOp::verify() {
+  return verifyTypeLowering(*this, getInput().getType(), getOutput().getType());
+}
+
 template <typename OpType>
 LogicalResult verifySingleToMultiModSwitch(OpType op,
                                            ModQTypeInterface singleTy,

--- a/lib/Dialect/ModArith/IR/ModArithOps.h
+++ b/lib/Dialect/ModArith/IR/ModArithOps.h
@@ -10,6 +10,8 @@
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 // IWYU pragma: end_keep
 
+#include "lib/Dialect/ModArith/IR/ModArithEnums.h.inc"
+
 #define GET_OP_CLASSES
 #include "lib/Dialect/ModArith/IR/ModArithOps.h.inc"
 

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_MODARITH_IR_MODARITHOPS_TD_
 
 include "lib/Dialect/ModArith/IR/ModArithDialect.td"
+include "lib/Dialect/ModArith/IR/ModArithEnums.td"
 include "lib/Dialect/ModArith/IR/ModArithTypes.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/CommonTypeConstraints.td"
@@ -65,6 +66,33 @@ def ModArith_ExtractOp : ModArith_Op<"extract", [Pure]> {
   let results = (outs SignlessIntegerLike:$output);
   let hasVerifier = 1;
   let assemblyFormat = "operands attr-dict `:` type($input) `->` type($output)";
+}
+
+def ModArith_LiftOp : ModArith_Op<"lift", [Pure]> {
+  let summary = "lift a modular value to an integer representative";
+
+  let description = [{
+    `mod_arith.lift` converts a modular value to a canonical integer representative.
+    The `standard` lift produces a representative in `[0, q)`, and the
+    `centered` lift produces a representative in `[-q/2, q/2)`.
+
+    It is required that the bitwidth of the output (tensor of) integer type is
+    the same as that of the storage type of the input modular type.
+
+    Examples:
+    ```
+    %m0 = mod_arith.lift centered %c0 : i32 -> mod_arith.int<65537 : i32>
+    %m0 = mod_arith.lift standard %c0 : i32 -> mod_arith.int<65537 : i32>
+    ```
+  }];
+
+  let arguments = (ins
+    ModArithLike:$input,
+    ModArith_LiftTypeEnum:$lift_type
+  );
+  let results = (outs SignlessIntegerLike:$output);
+  let hasVerifier = 1;
+  let assemblyFormat = "$lift_type $input attr-dict `:` type($input) `->` type($output)";
 }
 
 def ModArith_ModSwitchOp : ModArith_Op<"mod_switch", [Pure]> {

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
@@ -39,6 +39,59 @@ func.func @test_lower_extract_vec(%lhs : !Zpv) -> tensor<4xi32> {
   return %res : tensor<4xi32>
 }
 
+// CHECK: @standard
+func.func @standard(%arg0: !Zp) -> i32 {
+  // CHECK: arith.constant 65537 : i32
+  // CHECK: arith.remsi
+  // CHECK: arith.constant 0 : i32
+  // CHECK: arith.cmpi
+  // CHECK: arith.addi
+  // CHECK: arith.select
+  // CHECK: return
+  %0 = mod_arith.lift standard %arg0 : !Zp -> i32
+  return %0 : i32
+}
+
+// CHECK: @centered
+func.func @centered(%arg0: !Zp) -> i32 {
+  // CHECK: arith.constant 65537 : i32
+  // CHECK: arith.remsi
+  // CHECK: arith.constant 0 : i32
+  // CHECK: arith.cmpi
+  // CHECK: arith.addi
+  // CHECK: arith.select
+  // CHECK: arith.constant 1 : i32
+  // CHECK: arith.constant 2 : i32
+  // CHECK: arith.addi
+  // CHECK: arith.divsi
+  // CHECK: arith.cmpi
+  // CHECK: arith.subi
+  // CHECK: arith.select
+  // CHECK: return
+  %0 = mod_arith.lift centered %arg0 : !Zp -> i32
+  return %0 : i32
+}
+
+// CHECK: @centered_tensor
+func.func @centered_tensor(%arg0: !Zpv) -> tensor<4xi32> {
+  // CHECK: arith.constant dense<65537> : tensor<4xi32>
+  // CHECK: arith.remsi
+  // CHECK: arith.constant dense<0> : tensor<4xi32>
+  // CHECK: arith.cmpi
+  // CHECK: arith.addi
+  // CHECK: arith.select
+  // CHECK: arith.constant dense<1> : tensor<4xi32>
+  // CHECK: arith.constant dense<2> : tensor<4xi32>
+  // CHECK: arith.addi
+  // CHECK: arith.divsi
+  // CHECK: arith.cmpi
+  // CHECK: arith.subi
+  // CHECK: arith.select
+  // CHECK: return
+  %0 = mod_arith.lift centered %arg0 : !Zpv -> tensor<4xi32>
+  return %0 : tensor<4xi32>
+}
+
 // CHECK: @test_lower_reduce
 // CHECK-SAME: (%[[LHS:.*]]: [[T:.*]]) -> [[T]] {
 func.func @test_lower_reduce(%lhs : !Zp) -> !Zp {

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -57,6 +57,11 @@ func.func @test_arith_syntax() {
   %extract = mod_arith.extract %m4 : !Zp -> i10
   %extract_vec = mod_arith.extract %m_vec : !Zp_vec -> tensor<4xi10>
 
+  // CHECK: mod_arith.lift standard
+  %standard_lift = mod_arith.lift standard %m4 : !Zp -> i10
+  // CHECK: mod_arith.lift centered
+  %centered_lift = mod_arith.lift centered %m4 : !Zp -> i10
+
   // CHECK: mod_arith.add
   // CHECK: mod_arith.add
   %add = mod_arith.add %m5, %m6 : !Zp
@@ -130,4 +135,25 @@ func.func @test_rns_single_limb_shape(%arg0: tensor<5x1xi10>, %arg1: !rns1_vec) 
   %enc = mod_arith.encapsulate %arg0 : tensor<5x1xi10> -> !rns1_vec
   %ext = mod_arith.extract %arg1 : !rns1_vec -> tensor<5x1xi10>
   return
+}
+
+// CHECK: @standard
+func.func @standard(%arg0: !Zp) -> i10 {
+  // CHECK: mod_arith.lift standard
+  %0 = mod_arith.lift standard %arg0 : !Zp -> i10
+  return %0 : i10
+}
+
+// CHECK: @centered
+func.func @centered(%arg0: !Zp) -> i10 {
+  // CHECK: mod_arith.lift centered
+  %0 = mod_arith.lift centered %arg0 : !Zp -> i10
+  return %0 : i10
+}
+
+// CHECK: @centered_tensor
+func.func @centered_tensor(%arg0: !Zp_vec) -> tensor<4xi10> {
+  // CHECK: mod_arith.lift centered
+  %0 = mod_arith.lift centered %arg0 : !Zp_vec -> tensor<4xi10>
+  return %0 : tensor<4xi10>
 }


### PR DESCRIPTION
This PR adds `ModArith::LiftOp`. A future PR will remove `ModArith::ExtractOp` and replace all uses of it.