### PR TITLE
docs: add forward-store-to-load doctest

### DIFF
--- a/lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.td
+++ b/lib/Transforms/ForwardStoreToLoad/ForwardStoreToLoad.td
@@ -12,6 +12,8 @@ def ForwardStoreToLoad : Pass<"forward-store-to-load"> {
 
     Does not support complex control flow within a block, nor ops
     with arbitrary subregions.
+
+    (* example filepath=tests/Transforms/forward_store_to_load/doctest.mlir *)
   }];
   let dependentDialects = [
     "mlir::affine::AffineDialect",

--- a/tests/Transforms/forward_store_to_load/doctest.mlir
+++ b/tests/Transforms/forward_store_to_load/doctest.mlir
@@ -1,0 +1,15 @@
+// RUN: heir-opt --forward-store-to-load %s | FileCheck %s
+
+// CHECK: func.func @single_store
+// CHECK-SAME: %[[ARG0:.*]]: memref<10xi8>
+func.func @single_store(%arg0: memref<10xi8>) -> i8 {
+  // CHECK-NEXT: %[[VAL:.*]] = arith.constant 7 : i8
+  // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-NEXT: memref.store %[[VAL]], %[[ARG0]][%[[C0]]] : memref<10xi8>
+  // CHECK-NEXT: return %[[VAL]] : i8
+  %0 = arith.constant 7 : i8
+  %c0 = arith.constant 0 : index
+  memref.store %0, %arg0[%c0] : memref<10xi8>
+  %1 = memref.load %arg0[%c0] : memref<10xi8>
+  return %1 : i8
+}


### PR DESCRIPTION
## Summary

- Adds a documentation example directive for the `forward-store-to-load` pass.
- Adds a focused `doctest.mlir` derived from the existing store-to-load forwarding LIT coverage.

Contributes to #2014.

## Testing

- `SDK=/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk; CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" SDKROOT="$SDK" bazel test --macos_minimum_os=15.0 --host_macos_minimum_os=15.0 --action_env=SDKROOT="$SDK" --action_env=CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" //tests/Transforms/forward_store_to_load:doctest.mlir.test`
- `SDK=/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk; CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" SDKROOT="$SDK" bazel test --macos_minimum_os=15.0 --host_macos_minimum_os=15.0 --action_env=SDKROOT="$SDK" --action_env=CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" $(bazel query 'tests(//tests/Transforms/forward_store_to_load:*)')`