### PR TITLE
docs: add drop-unit-dims doctest

### DIFF
--- a/lib/Transforms/DropUnitDims/DropUnitDims.td
+++ b/lib/Transforms/DropUnitDims/DropUnitDims.td
@@ -11,6 +11,8 @@ def DropUnitDims : Pass<"drop-unit-dims"> {
 
   For example, a `linalg.matmul` whose RHS has type `tensor<32x1xi32>` is
   converted to a `linalg.matvec` op on the underlying `tensor<32xi32>`.
+
+  (* example filepath=tests/Transforms/drop_unit_dims/doctest.mlir *)
   }];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",

--- a/tests/Transforms/drop_unit_dims/doctest.mlir
+++ b/tests/Transforms/drop_unit_dims/doctest.mlir
@@ -1,0 +1,16 @@
+// RUN: heir-opt %s --drop-unit-dims | FileCheck %s
+
+// CHECK-LABEL: func.func @collapse_matmul_rhs
+// CHECK-NOT: linalg.matmul
+// CHECK: tensor.collapse_shape
+// CHECK: linalg.matvec
+func.func @collapse_matmul_rhs(%vec: !secret.secret<tensor<4x1xi16>>) -> !secret.secret<tensor<4x1xi16>> {
+  %matrix = arith.constant dense<[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]> : tensor<4x4xi16>
+  %bias = arith.constant dense<[[17], [18], [19], [20]]> : tensor<4x1xi16>
+  %out = secret.generic(%vec: !secret.secret<tensor<4x1xi16>>) {
+  ^body(%pt_vec: tensor<4x1xi16>):
+    %0 = linalg.matmul ins(%matrix, %pt_vec : tensor<4x4xi16>, tensor<4x1xi16>) outs(%bias : tensor<4x1xi16>) -> tensor<4x1xi16>
+    secret.yield %0 : tensor<4x1xi16>
+  } -> !secret.secret<tensor<4x1xi16>>
+  return %out : !secret.secret<tensor<4x1xi16>>
+}


### PR DESCRIPTION
## Summary

- Adds a documentation example directive for the `drop-unit-dims` pass.
- Adds a focused doctest covering the documented `linalg.matmul` to `linalg.matvec` conversion when the RHS has a unit dimension.

Contributes to #2014.

## Testing

- `SDK=/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk; CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" SDKROOT="$SDK" bazel test --macos_minimum_os=15.0 --host_macos_minimum_os=15.0 --action_env=SDKROOT="$SDK" --action_env=CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" //tests/Transforms/drop_unit_dims:doctest.mlir.test`
- `SDK=/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk; CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" SDKROOT="$SDK" bazel test --macos_minimum_os=15.0 --host_macos_minimum_os=15.0 --action_env=SDKROOT="$SDK" --action_env=CPLUS_INCLUDE_PATH="$SDK/usr/include/c++/v1" $(bazel query 'tests(//tests/Transforms/drop_unit_dims:*)')`