### PR TITLE
docs: add forward-insert-to-extract doctest

### DIFF
--- a/lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.td
+++ b/lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.td
@@ -12,6 +12,11 @@ def ForwardInsertToExtract : Pass<"forward-insert-to-extract"> {
 
         Does not support complex control flow within a block, nor ops with
         arbitrary subregions.
+
+        For example, extracting from a tensor after an insert can be rewritten
+        to use the inserted value directly.
+
+        (* example filepath=tests/Transforms/forward_insert_to_extract/doctest.mlir *)
     }];
 }
 

--- a/tests/Transforms/forward_insert_to_extract/doctest.mlir
+++ b/tests/Transforms/forward_insert_to_extract/doctest.mlir
@@ -1,0 +1,14 @@
+// RUN: heir-opt --forward-insert-to-extract %s | FileCheck %s
+
+// CHECK-LABEL: func.func @extract_inserted_value
+// CHECK-SAME: (%[[ARG0:.*]]: i32, %[[ARG1:.*]]: i32)
+func.func @extract_inserted_value(%arg0: i32, %arg1: i32) -> i32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %empty = tensor.empty() : tensor<2xi32>
+  %inserted = tensor.insert %arg0 into %empty[%c0] : tensor<2xi32>
+  %inserted_1 = tensor.insert %arg1 into %inserted[%c1] : tensor<2xi32>
+  %result = tensor.extract %inserted_1[%c0] : tensor<2xi32>
+  // CHECK: return %[[ARG0]] : i32
+  return %result : i32
+}


### PR DESCRIPTION
Fixes part of #2014.

## What
- Add a documentation example directive for the `forward-insert-to-extract` pass.
- Add a small doctest showing an extract from an inserted tensor value being forwarded to the inserted SSA value.

## Testing
- `bazel test //tests/Transforms/forward_insert_to_extract:doctest.mlir.test`
- `bazel test $(bazel query 'tests(//tests/Transforms/forward_insert_to_extract:*)')`