### PR TITLE
Bump fmt dep to 12.1.0 to fix macOS build with clang 22

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -89,6 +89,11 @@ bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "soplex", version = "7.1.4.bcr.1")
 bazel_dep(name = "or-tools", version = "9.12", repo_name = "com_google_ortools")
 
+# fmt 11.1.3 relies on <cstdlib> being transitively available for malloc/free.
+# Newer libc++ (e.g. Homebrew clang 22) no longer leaks that include.
+# Bump to 12.1.0, which includes <stdlib.h> explicitly.
+bazel_dep(name = "fmt", version = "12.1.0")
+
 # openfhe deps that are needed for bundling openfhe with the python frontend
 bazel_dep(name = "cereal", version = "1.3.2.bcr.3")
 bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20250205")


### PR DESCRIPTION
I added the ci:macos tag, but our CI (not just macOS, but even linux, iirc) never runs with clang22 anyway. 