### PR TITLE
Removed mod_arith::ExtractOp

### DIFF
--- a/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
+++ b/lib/Dialect/ModArith/Conversions/ModArithToArith/ModArithToArith.cpp
@@ -169,20 +169,6 @@ struct ConvertEncapsulate : public OpConversionPattern<EncapsulateOp> {
   }
 };
 
-struct ConvertExtract : public OpConversionPattern<ExtractOp> {
-  ConvertExtract(mlir::MLIRContext* context)
-      : OpConversionPattern<ExtractOp>(context) {}
-
-  using OpConversionPattern::OpConversionPattern;
-
-  LogicalResult matchAndRewrite(
-      ExtractOp op, OpAdaptor adaptor,
-      ConversionPatternRewriter& rewriter) const override {
-    rewriter.replaceOp(op, adaptor.getOperands()[0]);
-    return success();
-  }
-};
-
 struct ConvertLift : public OpConversionPattern<LiftOp> {
   ConvertLift(mlir::MLIRContext* context)
       : OpConversionPattern<LiftOp>(context) {}
@@ -667,13 +653,13 @@ void ModArithToArith::runOnOperation() {
 
   RewritePatternSet patterns(context);
   rewrites::populateWithGenerated(patterns);
-  patterns
-      .add<ConvertEncapsulate, ConvertExtract, ConvertLift, ConvertReduce,
-           ConvertAdd, ConvertSub, ConvertMul, ConvertMac, ConvertModSwitch,
-           ConvertBarrettReduce, ConvertConstant, ConvertRNSExtractResidue,
-           ConvertRNSExtractSlice, ConvertRNSPack, ConvertAny<>,
-           ConvertAny<affine::AffineForOp>, ConvertAny<affine::AffineYieldOp>,
-           ConvertAny<linalg::GenericOp> >(typeConverter, context);
+  patterns.add<
+      ConvertEncapsulate, ConvertLift, ConvertReduce, ConvertAdd, ConvertSub,
+      ConvertMul, ConvertMac, ConvertModSwitch, ConvertBarrettReduce,
+      ConvertConstant, ConvertRNSExtractResidue, ConvertRNSExtractSlice,
+      ConvertRNSPack, ConvertAny<>, ConvertAny<affine::AffineForOp>,
+      ConvertAny<affine::AffineYieldOp>, ConvertAny<linalg::GenericOp> >(
+      typeConverter, context);
 
   addStructuralConversionPatterns(typeConverter, patterns, target);
   addTensorOfTensorConversionPatterns(typeConverter, patterns, target);

--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -115,10 +115,6 @@ LogicalResult EncapsulateOp::verify() {
   return verifyTypeLowering(*this, getOutput().getType(), getInput().getType());
 }
 
-LogicalResult ExtractOp::verify() {
-  return verifyTypeLowering(*this, getInput().getType(), getOutput().getType());
-}
-
 LogicalResult LiftOp::verify() {
   return verifyTypeLowering(*this, getInput().getType(), getOutput().getType());
 }

--- a/lib/Dialect/ModArith/IR/ModArithOps.td
+++ b/lib/Dialect/ModArith/IR/ModArithOps.td
@@ -40,34 +40,6 @@ def ModArith_EncapsulateOp : ModArith_Op<"encapsulate", [Pure]> {
   let assemblyFormat = "operands attr-dict `:` type($input) `->` type($output)";
 }
 
-def ModArith_ExtractOp : ModArith_Op<"extract", [Pure]> {
-  let summary = "extract the integer stored inside mod_arith type";
-
-  let description = [{
-    `mod_arith.extract` extracts the integer inside the modular type.
-
-    It is required that the bitwidth of the output (tensor of) integer type is
-    the same as that of the storage type of the input modular type.
-
-    For RNS structure traversal, prefer `rns.extract_slice`.
-
-    Examples:
-    ```
-    %m0 = mod_arith.encapsulate %c0 : i32 -> mod_arith.int<65537 : i32>
-    %m1 = mod_arith.encapsulate %c1 : i64 -> mod_arith.int<65537 : i64>
-    %c3 = mod_arith.extract %m0 : mod_arith.int<65537 : i32> -> i32
-    %c4 = mod_arith.extract %m1 : mod_arith.int<65537 : i64> -> i64
-    ```
-  }];
-
-  let arguments = (ins
-    ModQLike:$input
-  );
-  let results = (outs SignlessIntegerLike:$output);
-  let hasVerifier = 1;
-  let assemblyFormat = "operands attr-dict `:` type($input) `->` type($output)";
-}
-
 def ModArith_LiftOp : ModArith_Op<"lift", [Pure]> {
   let summary = "lift a modular value to an integer representative";
 

--- a/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
+++ b/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp
@@ -411,30 +411,8 @@ struct ConvertMonomial : public OpConversionPattern<MonomialOp> {
             op, "unsupported eval-form non-constant monomial");
       }
 
-      Value result;
-      if (auto modQTy = dyn_cast<ModQTypeInterface>(typeInfo.coefficientType)) {
-        Type extractedType = modQTy.getLoweringType();
-        Value extracted = mod_arith::ExtractOp::create(
-            b, extractedType, adaptor.getCoefficient());
-        Value replicatedStorage;
-        if (isa<ShapedType>(extractedType)) {
-          auto init = tensor::EmptyOp::create(b, storageTensorType.getShape(),
-                                              typeInfo.coefficientStorageType);
-          // Broadcast an RNS constant coefficient along the degree axis
-          replicatedStorage = linalg::BroadcastOp::create(b, extracted, init,
-                                                          ArrayRef<int64_t>{0})
-                                  .getResult()[0];
-        } else {
-          replicatedStorage =
-              tensor::SplatOp::create(b, extracted, storageTensorType);
-        }
-        result = mod_arith::EncapsulateOp::create(b, typeInfo.tensorType,
-                                                  replicatedStorage)
-                     .getResult();
-      } else {
-        result = tensor::SplatOp::create(b, adaptor.getCoefficient(),
-                                         typeInfo.tensorType);
-      }
+      Value result = tensor::SplatOp::create(b, adaptor.getCoefficient(),
+                                             typeInfo.tensorType);
       rewriter.replaceOp(op, result);
       return success();
     }
@@ -483,6 +461,15 @@ struct ConvertMulScalar : public OpConversionPattern<MulScalarOp> {
 
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
 
+    if (isa<RNSType>(typeInfo.coefficientType)) {
+      Value replicatedScalar =
+          tensor::SplatOp::create(b, adaptor.getScalar(), typeInfo.tensorType);
+      auto mulOp = mod_arith::MulOp::create(b, adaptor.getPolynomial(),
+                                            replicatedScalar);
+      rewriter.replaceOp(op, mulOp);
+      return success();
+    }
+
     // We need to repeat the `scalar` operand to match the tensor shape of the
     // `polynomial` operand, and then it can be lowered to a simple
     // mod_arith.mul.
@@ -500,8 +487,9 @@ struct ConvertMulScalar : public OpConversionPattern<MulScalarOp> {
           op, "expected coefficient type to implement ModQTypeInterface");
     }
 
-    auto extracted =
-        mod_arith::ExtractOp::create(b, extractedType, adaptor.getScalar());
+    // either representative suffices since we are re-encapsulating
+    auto extracted = mod_arith::LiftOp::create(
+        b, extractedType, adaptor.getScalar(), mod_arith::LiftType::STANDARD);
 
     Value replicatedScalar;
     if (isa<ShapedType>(extractedType)) {
@@ -693,9 +681,10 @@ struct ConvertLeadingTerm : public OpConversionPattern<LeadingTermOp> {
           Value index = args[0];
           ImplicitLocOpBuilder b(nestedLoc, nestedBuilder);
           auto coeff = tensor::ExtractOp::create(b, coeffs, ValueRange{index});
-          auto normalizedCoeff = mod_arith::ReduceOp::create(b, coeff);
-          auto extractedCoeff = mod_arith::ExtractOp::create(
-              b, typeInfo.coefficientStorageType, normalizedCoeff);
+          // either representative suffices since both lift 0 to 0
+          auto extractedCoeff =
+              mod_arith::LiftOp::create(b, typeInfo.coefficientStorageType,
+                                        coeff, mod_arith::LiftType::STANDARD);
           auto cmpOp = arith::CmpIOp::create(b, arith::CmpIPredicate::eq,
                                              extractedCoeff, c0);
           scf::ConditionOp::create(b, cmpOp.getResult(), index);

--- a/lib/Dialect/RNS/IR/BUILD
+++ b/lib/Dialect/RNS/IR/BUILD
@@ -34,9 +34,12 @@ cc_library(
         "@heir//lib/Dialect/ModArith/IR:TypeInterfaces",
         "@heir//lib/Utils:APIntUtils",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )
 

--- a/lib/Dialect/RNS/IR/RNSOps.cpp
+++ b/lib/Dialect/RNS/IR/RNSOps.cpp
@@ -10,6 +10,9 @@
 #include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "lib/Utils/APIntUtils.h"
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypeInterfaces.h"  // from @llvm-project
@@ -52,7 +55,8 @@ FailureOr<SmallVector<Value>> computeMixedRadixCoeffs(
   auto c0Reduced = ExtractResidueOp::create(b, input, b.getIndexAttr(0));
   Type intType =
       cast<mod_arith::ModArithType>(c0Reduced.getType()).getLoweringType();
-  Value c0Lifted = mod_arith::ExtractOp::create(b, intType, c0Reduced);
+  Value c0Lifted = mod_arith::LiftOp::create(b, intType, c0Reduced,
+                                             mod_arith::LiftType::CENTERED);
   mrcs.push_back(c0Lifted);
 
   // Subsequent coefficients depend on prior coefficients
@@ -74,13 +78,35 @@ FailureOr<SmallVector<Value>> computeMixedRadixCoeffs(
     // mod, and accumulate into temp.
     Value temp = mod_arith::EncapsulateOp::create(b, limbTy, mrcs[i - 1]);
     temp = mod_arith::ReduceOp::create(b, limbTy, temp);
-    for (int j = i - 2; j >= 0; j--) {
-      // reduce c_j mod q_i
-      Value reducedCj = mod_arith::EncapsulateOp::create(b, limbTy, mrcs[j]);
-      reducedCj = mod_arith::ReduceOp::create(b, limbTy, reducedCj);
+    if (i > 1) {
       Value qjConst =
           mod_arith::ConstantOp::create(b, limbTy, limbTy.getModulus());
-      temp = mod_arith::MacOp::create(b, temp, qjConst, reducedCj);
+      RankedTensorType tensorTy =
+          RankedTensorType::get({static_cast<int64_t>(mrcs.size())}, intType);
+      Value mrcsTensor = tensor::FromElementsOp::create(b, tensorTy, mrcs);
+      Value zero = arith::ConstantIndexOp::create(b, 0);
+      Value loopBound = arith::ConstantIndexOp::create(b, i - 1);
+      Value upper = arith::ConstantIndexOp::create(b, i - 2);
+      Value one = arith::ConstantIndexOp::create(b, 1);
+      auto loop = scf::ForOp::create(
+          b, zero, loopBound, one, ValueRange{temp},
+          [&](OpBuilder& nestedBuilder, Location nestedLoc, Value index,
+              ValueRange iterArgs) {
+            ImplicitLocOpBuilder b(nestedLoc, nestedBuilder);
+            Value j = arith::SubIOp::create(b, upper, index);
+
+            // reduce c_j mod q_i
+            Value cj = tensor::ExtractOp::create(b, mrcsTensor, ValueRange{j});
+            Value reducedCj = mod_arith::EncapsulateOp::create(b, limbTy, cj);
+            // cj is a centered representative, meaning it could be negative
+            // ModArith doesn't handle negatives well right now, so immediately
+            // put it back in its standard representative mod q
+            reducedCj = mod_arith::ReduceOp::create(b, reducedCj);
+            Value mac = mod_arith::MacOp::create(b, iterArgs.front(), qjConst,
+                                                 reducedCj);
+            scf::YieldOp::create(b, mac);
+          });
+      temp = loop.getResult(0);
     }
     Value ci = mod_arith::SubOp::create(b, xi, temp);
     mod_arith::ModArithAttr maAttr = qInvProds[i - 1];
@@ -93,7 +119,8 @@ FailureOr<SmallVector<Value>> computeMixedRadixCoeffs(
     Value qInvConst =
         mod_arith::ConstantOp::create(b, limbTy, maAttr.getValue());
     ci = mod_arith::MulOp::create(b, ci, qInvConst);
-    Value liftedCi = mod_arith::ExtractOp::create(b, intType, ci);
+    Value liftedCi = mod_arith::LiftOp::create(b, intType, ci,
+                                               mod_arith::LiftType::CENTERED);
     mrcs.push_back(liftedCi);
   }
   return mrcs;

--- a/lib/Dialect/RNS/Transforms/BUILD
+++ b/lib/Dialect/RNS/Transforms/BUILD
@@ -25,9 +25,12 @@ cc_library(
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/lib/Dialect/RNS/Transforms/LowerConvertBasis.cpp
+++ b/lib/Dialect/RNS/Transforms/LowerConvertBasis.cpp
@@ -4,8 +4,10 @@
 #include <utility>
 
 #include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
 #include "lib/Dialect/ModArith/IR/ModArithOps.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
 #include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
 #include "llvm/include/llvm/ADT/APInt.h"      // from @llvm-project
@@ -15,15 +17,18 @@
 // IWYU pragma: begin_keep
 #include "llvm/include/llvm/ADT/SmallString.h"  // from @llvm-project
 // IWYU pragma: end_keep
-#include "mlir/include/mlir/IR/Builders.h"            // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
-#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
-#include "mlir/include/mlir/IR/Types.h"               // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
-#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
 #include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
 
 namespace mlir {
@@ -76,15 +81,44 @@ struct LowerConvertBasisOp : public OpRewritePattern<ConvertBasisOp> {
     // We need a map from modulus to index (on the input basis) for
     // short-circuiting
     llvm::DenseMap<APInt, size_t> inputBasisIndexByModulus;
+    SmallVector<mod_arith::ModArithType> maInputBasisTys;
     for (auto [i, basisTy] : llvm::enumerate(inputBasisTy.getBasisTypes())) {
       auto inputLimbTy = dyn_cast<mod_arith::ModArithType>(basisTy);
       if (!inputLimbTy) {
         return op.emitError() << "expected input basis limb to be ModArithType";
       }
+      APInt modulusValue = inputLimbTy.getModulus().getValue();
+      if (!modulusValue[0]) {
+        SmallString<16> modulusStr;
+        modulusValue.toStringUnsigned(modulusStr);
+        return op.emitError()
+               << "basis conversion requires odd moduli, "
+               << "but input basis contains even modulus " << modulusStr;
+      }
       inputBasisIndexByModulus[inputLimbTy.getModulus().getValue()] = i;
+      maInputBasisTys.push_back(inputLimbTy);
     }
 
     ArrayRef<Type> targetBasisTypes = targetBasisTy.getBasisTypes();
+    SmallVector<mod_arith::ModArithType> maTargetBasisTys;
+    maTargetBasisTys.reserve(targetBasisTypes.size());
+    for (Type basisTy : targetBasisTypes) {
+      auto targetLimbTy = dyn_cast<mod_arith::ModArithType>(basisTy);
+      if (!targetLimbTy) {
+        return op.emitError()
+               << "expected target basis limb to be ModArithType";
+      }
+      APInt modulusValue = targetLimbTy.getModulus().getValue();
+      if (!modulusValue[0]) {
+        SmallString<16> modulusStr;
+        modulusValue.toStringUnsigned(modulusStr);
+        return op.emitError()
+               << "basis conversion requires odd moduli, "
+               << "but target basis contains even modulus " << modulusStr;
+      }
+      maTargetBasisTys.push_back(targetLimbTy);
+    }
+
     FailureOr<SmallVector<Value>> maybeMrcs =
         rns::computeMixedRadixCoeffs(b, x, *qInvProdsFailable);
     if (failed(maybeMrcs)) {
@@ -96,46 +130,18 @@ struct LowerConvertBasisOp : public OpRewritePattern<ConvertBasisOp> {
     }
 
     SmallVector<Value>& mrcs = *maybeMrcs;
-    SmallVector<mod_arith::ModArithType> maInputBasisTys;
-    for (auto [i, basisTy] : llvm::enumerate(inputBasisTy.getBasisTypes())) {
-      auto qi = dyn_cast<mod_arith::ModArithType>(basisTy);
-      if (!qi) {
-        return op.emitError()
-               << "expected source basis limb to be ModArithType";
-      }
-      APInt modulusValue = qi.getModulus().getValue();
-      if (!modulusValue[0]) {
-        SmallString<16> modulusStr;
-        modulusValue.toStringUnsigned(modulusStr);
-        return op.emitError()
-               << "basis conversion requires odd moduli, "
-               << "but input basis contains even modulus " << modulusStr;
-      }
-      maInputBasisTys.push_back(qi);
-    }
+    RankedTensorType tensorTy =
+        RankedTensorType::get({static_cast<int64_t>(mrcs.size())},
+                              maTargetBasisTys[0].getLoweringType());
+    Value mrcsTensor = tensor::FromElementsOp::create(b, tensorTy, mrcs);
     IntegerType storageTy =
-        cast<IntegerType>(cast<mod_arith::ModArithType>(targetBasisTypes[0])
-                              .getModulus()
-                              .getType());
+        cast<IntegerType>(maTargetBasisTys[0].getModulus().getType());
 
     SmallVector<Value> outputLimbs;
     outputLimbs.reserve(targetBasisTypes.size());
     for (int i = 0; i < targetBasisTypes.size(); i++) {
-      mod_arith::ModArithType targetLimbTy =
-          dyn_cast<mod_arith::ModArithType>(targetBasisTypes[i]);
-      if (!targetLimbTy) {
-        return op.emitError()
-               << "expected target basis limb to be ModArithType";
-      }
+      mod_arith::ModArithType targetLimbTy = maTargetBasisTys[i];
       APInt targetModulusValue = targetLimbTy.getModulus().getValue();
-      if (!targetModulusValue[0]) {
-        SmallString<16> modulusStr;
-        targetModulusValue.toStringUnsigned(modulusStr);
-        return op.emitError()
-               << "basis conversion requires odd moduli, "
-               << "but target basis contains even modulus " << modulusStr;
-      }
-
       // This short-circuit optimization may not be optimal on all backends;
       // this block can be commented out while preserving correctness.
       llvm::DenseMap<APInt, size_t>::const_iterator inputIndexIt =
@@ -152,17 +158,49 @@ struct LowerConvertBasisOp : public OpRewritePattern<ConvertBasisOp> {
       Value temp =
           mod_arith::EncapsulateOp::create(b, targetLimbTy, mrcs.back());
       temp = mod_arith::ReduceOp::create(b, targetLimbTy, temp);
-      for (int j = static_cast<int>(mrcs.size()) - 2; j >= 0; j--) {
-        // get q_j, extend it to q_i's width, and reduce it mod q_i.
-        mod_arith::ModArithType sourceLimbTy = maInputBasisTys[j];
-        IntegerAttr qjAttr = IntegerAttr::get(
-            storageTy, sourceLimbTy.getModulus().getValue().zextOrTrunc(
-                           storageTy.getWidth()));
-        Value qjConst = mod_arith::ConstantOp::create(b, targetLimbTy, qjAttr);
-        Value reducedCj =
-            mod_arith::EncapsulateOp::create(b, targetLimbTy, mrcs[j]);
-        reducedCj = mod_arith::ReduceOp::create(b, targetLimbTy, reducedCj);
-        temp = mod_arith::MacOp::create(b, temp, qjConst, reducedCj);
+      if (mrcs.size() > 1) {
+        SmallVector<Value> qjConsts;
+        qjConsts.reserve(mrcs.size() - 1);
+        for (size_t j = 0; j < mrcs.size() - 1; ++j) {
+          mod_arith::ModArithType sourceLimbTy = maInputBasisTys[j];
+          IntegerAttr qjAttr = IntegerAttr::get(
+              storageTy, sourceLimbTy.getModulus().getValue().zextOrTrunc(
+                             storageTy.getWidth()));
+          Value qjConst =
+              mod_arith::ConstantOp::create(b, targetLimbTy, qjAttr);
+          qjConsts.push_back(qjConst);
+        }
+        RankedTensorType tensorTy = RankedTensorType::get(
+            {static_cast<int64_t>(qjConsts.size())}, targetLimbTy);
+        Value qjConstsTensor =
+            tensor::FromElementsOp::create(b, tensorTy, qjConsts);
+        Value zero = arith::ConstantIndexOp::create(b, 0);
+        Value loopBound = arith::ConstantIndexOp::create(
+            b, static_cast<int>(mrcs.size()) - 1);
+        Value upper = arith::ConstantIndexOp::create(
+            b, static_cast<int>(mrcs.size()) - 2);
+        Value one = arith::ConstantIndexOp::create(b, 1);
+        auto loop = scf::ForOp::create(
+            b, zero, loopBound, one, ValueRange{temp},
+            [&](OpBuilder& nestedBuilder, Location nestedLoc, Value index,
+                ValueRange iterArgs) {
+              ImplicitLocOpBuilder b(nestedLoc, nestedBuilder);
+              Value j = arith::SubIOp::create(b, upper, index);
+              Value qjConst =
+                  tensor::ExtractOp::create(b, qjConstsTensor, ValueRange{j});
+              Value cj =
+                  tensor::ExtractOp::create(b, mrcsTensor, ValueRange{j});
+              Value reducedCj =
+                  mod_arith::EncapsulateOp::create(b, targetLimbTy, cj);
+              // cj is a centered representative, meaning it could be negative
+              // ModArith doesn't handle negatives well right now, so
+              // immediately put it back in its standard representative mod q
+              reducedCj = mod_arith::ReduceOp::create(b, reducedCj);
+              Value mac = mod_arith::MacOp::create(b, iterArgs.front(), qjConst,
+                                                   reducedCj);
+              scf::YieldOp::create(b, mac);
+            });
+        temp = loop.getResult(0);
       }
       outputLimbs.push_back(temp);
     }

--- a/lib/Dialect/RNS/Transforms/Passes.td
+++ b/lib/Dialect/RNS/Transforms/Passes.td
@@ -11,8 +11,11 @@ def LowerConvertBasis : Pass<"rns-lower-convert-basis"> {
     (* example filepath=tests/Dialect/RNS/Transforms/lower_convert_basis.mlir *)
   }];
   let dependentDialects = [
+    "mlir::arith::ArithDialect",
     "mlir::heir::mod_arith::ModArithDialect",
     "mlir::heir::rns::RNSDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::tensor::TensorDialect",
   ];
 }
 

--- a/lib/Dialect/Secret/Conversions/SecretToModArith/SecretToModArith.cpp
+++ b/lib/Dialect/Secret/Conversions/SecretToModArith/SecretToModArith.cpp
@@ -338,16 +338,13 @@ struct ConvertReveal : public OpConversionPattern<secret::RevealOp> {
       beforeTrunc = shapedType.cloneWith(shapedType.getShape(), modulusType);
     }
 
-    auto extractOp =
-        mod_arith::ExtractOp::create(b, beforeTrunc, adaptor.getInput());
-    Value result = extractOp.getResult();
+    Value result = mod_arith::LiftOp::create(b, beforeTrunc, adaptor.getInput(),
+                                             mod_arith::LiftType::STANDARD);
 
     Type truncatedType = op.getResult().getType();
     if (getElementTypeOrSelf(truncatedType).getIntOrFloatBitWidth() <
-        getElementTypeOrSelf(extractOp.getResult().getType())
-            .getIntOrFloatBitWidth()) {
-      auto truncOp = arith::TruncIOp::create(b, truncatedType, result);
-      result = truncOp.getResult();
+        getElementTypeOrSelf(result.getType()).getIntOrFloatBitWidth()) {
+      result = arith::TruncIOp::create(b, truncatedType, result);
     }
 
     rewriter.replaceOp(op, result);

--- a/lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.cpp
+++ b/lib/Transforms/LinalgCanonicalizations/LinalgCanonicalizations.cpp
@@ -948,8 +948,8 @@ struct MaterializeBroadcasts : public OpRewritePattern<linalg::GenericOp> {
     auto collapsedType =
         RankedTensorType::get(targetShape, inputType.getElementType());
 
-    auto collapseOp = rewriter.create<tensor::CollapseShapeOp>(
-        loc, collapsedType, value, reassociation);
+    auto collapseOp = tensor::CollapseShapeOp::create(
+        rewriter, loc, collapsedType, value, reassociation);
 
     value = collapseOp.getResult();
     map = map.dropResults(dimsToDrop);

--- a/lib/Utils/BUILD
+++ b/lib/Utils/BUILD
@@ -82,6 +82,7 @@ cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FuncTransforms",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/lib/Utils/ConversionUtils.cpp
+++ b/lib/Utils/ConversionUtils.cpp
@@ -8,6 +8,7 @@
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
@@ -190,33 +191,82 @@ struct ConvertFromElements
   LogicalResult matchAndRewrite(
       tensor::FromElementsOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
+    auto resultType = dyn_cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    if (!resultType) {
+      return failure();
+    }
+    if (adaptor.getElements().empty()) {
+      rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, resultType.getShape(),
+                                                   resultType.getElementType());
+      return success();
+    }
     // Expand each of the (converted) operands:
     SmallVector<Value> newOperands;
+
     for (auto o : adaptor.getElements()) {
       // extend tensor<...xT> to tensor<1x...xT>
-      if (auto tensorType = mlir::dyn_cast<RankedTensorType>(o.getType())) {
-        auto shape = tensorType.getShape();
-        SmallVector<int64_t> newShape(1, 1);
-        newShape.append(shape.begin(), shape.end());
-
-        // Create a dense constant for targetShape
-        auto shapeOp = mlir::arith::ConstantOp::create(
-            rewriter, op.getLoc(),
-            RankedTensorType::get(newShape.size(), rewriter.getIndexType()),
-            rewriter.getIndexTensorAttr(newShape));
-
-        auto reshapeOp = tensor::ReshapeOp::create(
-            rewriter, op.getLoc(),
-            RankedTensorType::get(newShape, tensorType.getElementType()), o,
-            shapeOp);
-        newOperands.push_back(reshapeOp);
-      } else {
-        newOperands.push_back(o);
+      auto tensorType = mlir::dyn_cast<RankedTensorType>(o.getType());
+      if (!tensorType) {
+        // If the input tensor elements don't lower to a tensor,
+        // this pattern doesn't apply.
+        return failure();
       }
+
+      auto shape = tensorType.getShape();
+      SmallVector<int64_t> newShape(1, 1);
+      newShape.append(shape.begin(), shape.end());
+
+      // Create a dense constant for targetShape
+      auto shapeOp = mlir::arith::ConstantOp::create(
+          rewriter, op.getLoc(),
+          RankedTensorType::get(newShape.size(), rewriter.getIndexType()),
+          rewriter.getIndexTensorAttr(newShape));
+
+      auto reshapeOp = tensor::ReshapeOp::create(
+          rewriter, op.getLoc(),
+          RankedTensorType::get(newShape, tensorType.getElementType()), o,
+          shapeOp);
+      newOperands.push_back(reshapeOp);
     }
     // Create the final tensor.concat operation
     rewriter.replaceOpWithNewOp<tensor::ConcatOp>(op, 0, newOperands);
 
+    return success();
+  }
+};
+
+struct ConvertSplat : public OpConversionPattern<tensor::SplatOp> {
+  ConvertSplat(mlir::MLIRContext* context)
+      : OpConversionPattern<tensor::SplatOp>(context, /*benefit=*/2) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor::SplatOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto resultType = dyn_cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    auto inputType = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+    if (!resultType || !inputType) {
+      return failure();
+    }
+
+    if (resultType.getRank() < inputType.getRank()) {
+      return failure();
+    }
+
+    auto init =
+        tensor::EmptyOp::create(rewriter, op.getLoc(), resultType.getShape(),
+                                resultType.getElementType());
+    SmallVector<int64_t> dimensions;
+    int64_t numOrigDims = resultType.getRank() - inputType.getRank();
+    for (int64_t i = 0; i < numOrigDims; i++) {
+      dimensions.push_back(i);
+    }
+    auto broadcast = linalg::BroadcastOp::create(
+        rewriter, op.getLoc(), adaptor.getInput(), init, dimensions);
+    rewriter.replaceOp(op, broadcast.getResult()[0]);
     return success();
   }
 };
@@ -251,8 +301,9 @@ void addTensorOfTensorConversionPatterns(TypeConverter& typeConverter,
   target.addDynamicallyLegalDialect<affine::AffineDialect>(
       [&](Operation* op) { return typeConverter.isLegal(op); });
 
-  patterns.add<ConvertExtract, ConvertInsert, ConvertFromElements>(
-      typeConverter, patterns.getContext());
+  patterns
+      .add<ConvertExtract, ConvertInsert, ConvertFromElements, ConvertSplat>(
+          typeConverter, patterns.getContext());
 }
 
 void addStructuralConversionPatterns(TypeConverter& typeConverter,

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
@@ -21,53 +21,37 @@ func.func @test_lower_encapsulate_vec(%lhs : tensor<4xi32>) -> !Zpv {
   return %res : !Zpv
 }
 
-// CHECK: @test_lower_extract
-// CHECK-SAME: (%[[LHS:.*]]: [[T:.*]]) -> [[T]] {
-func.func @test_lower_extract(%lhs : !Zp) -> i32 {
-  // CHECK-NOT: mod_arith.extract
-  // CHECK: return %[[LHS]] : [[T]]
-  %res = mod_arith.extract %lhs: !Zp -> i32
-  return %res : i32
-}
-
-// CHECK: @test_lower_extract_vec
-// CHECK-SAME: (%[[LHS:.*]]: [[T:.*]]) -> [[T]] {
-func.func @test_lower_extract_vec(%lhs : !Zpv) -> tensor<4xi32> {
-  // CHECK-NOT: mod_arith.extract
-  // CHECK: return %[[LHS]] : [[T]]
-  %res = mod_arith.extract %lhs: !Zpv -> tensor<4xi32>
-  return %res : tensor<4xi32>
-}
-
 // CHECK: @standard
+// CHECK-SAME: (%[[arg0:.*]]: [[T:.*]]) -> [[T]] {
 func.func @standard(%arg0: !Zp) -> i32 {
-  // CHECK: arith.constant 65537 : i32
-  // CHECK: arith.remsi
-  // CHECK: arith.constant 0 : i32
-  // CHECK: arith.cmpi
-  // CHECK: arith.addi
-  // CHECK: arith.select
-  // CHECK: return
+  // CHECK: %[[q:.*]] = arith.constant 65537 : i32
+  // CHECK: %[[rems:.*]] = arith.remsi %[[arg0]], %[[q]] : i32
+  // CHECK: %[[c0:.*]] = arith.constant 0 : i32
+  // CHECK: %[[isneg:.*]] = arith.cmpi slt, %[[rems]], %[[c0]] : i32
+  // CHECK: %[[remsPos:.*]] = arith.addi %[[rems]], %[[q]] : i32
+  // CHECK: %[[stdResult:.*]] = arith.select %[[isneg]], %[[remsPos]], %[[rems]] : i32
+  // CHECK: return %[[stdResult]] : i32
   %0 = mod_arith.lift standard %arg0 : !Zp -> i32
   return %0 : i32
 }
 
 // CHECK: @centered
+// CHECK-SAME: (%[[arg0:.*]]: [[T:.*]]) -> [[T]] {
 func.func @centered(%arg0: !Zp) -> i32 {
-  // CHECK: arith.constant 65537 : i32
-  // CHECK: arith.remsi
-  // CHECK: arith.constant 0 : i32
-  // CHECK: arith.cmpi
-  // CHECK: arith.addi
-  // CHECK: arith.select
-  // CHECK: arith.constant 1 : i32
-  // CHECK: arith.constant 2 : i32
-  // CHECK: arith.addi
-  // CHECK: arith.divsi
-  // CHECK: arith.cmpi
-  // CHECK: arith.subi
-  // CHECK: arith.select
-  // CHECK: return
+  // CHECK: %[[q:.*]] = arith.constant 65537 : i32
+  // CHECK: %[[rems:.*]] = arith.remsi %[[arg0]], %[[q]] : i32
+  // CHECK: %[[c0:.*]] = arith.constant 0 : i32
+  // CHECK: %[[isneg:.*]] = arith.cmpi slt, %[[rems]], %[[c0]] : i32
+  // CHECK: %[[remsPos:.*]] = arith.addi %[[rems]], %[[q]] : i32
+  // CHECK: %[[stdResult:.*]] = arith.select %[[isneg]], %[[remsPos]], %[[rems]] : i32
+  // CHECK: %[[c1:.*]] = arith.constant 1 : i32
+  // CHECK: %[[c2:.*]] = arith.constant 2 : i32
+  // CHECK: %[[qp1:.*]] = arith.addi %[[q]], %[[c1]] : i32
+  // CHECK: %[[bound:.*]] = arith.divsi %[[qp1]], %[[c2]] : i32
+  // CHECK: %[[tooBig:.*]] = arith.cmpi sge, %[[stdResult]], %[[bound]] : i32
+  // CHECK: %[[lb:.*]] = arith.subi %[[stdResult]], %[[q]] : i32
+  // CHECK: %[[cResult:.*]] = arith.select %[[tooBig]], %[[lb]], %[[stdResult]] : i32
+  // CHECK: return %[[cResult]] : i32
   %0 = mod_arith.lift centered %arg0 : !Zp -> i32
   return %0 : i32
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/BUILD
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/BUILD
@@ -14,6 +14,17 @@ llvm_runner_test(
 )
 
 llvm_runner_test(
+    name = "lower_lift",
+    heir_opt_flags = [
+        "--mod-arith-to-arith",
+        "--emit-c-interface",
+        "--heir-polynomial-to-llvm",
+    ],
+    main_c_src = "lower_lift_test.cc",
+    mlir_src = "lower_lift.mlir",
+)
+
+llvm_runner_test(
     name = "lower_barrett_reduce",
     heir_opt_flags = [
         "--mod-arith-to-arith",

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_add.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_add.mlir
@@ -11,6 +11,6 @@ func.func @test_lower_add() -> tensor<4xi26> {
   %mx = mod_arith.reduce %ex : !Zpv
   %my = mod_arith.reduce %ey : !Zpv
   %m1 = mod_arith.add %mx, %my : !Zpv
-  %1 = mod_arith.extract %m1 : !Zpv -> tensor<4xi26>
+  %1 = mod_arith.lift standard %m1 : !Zpv -> tensor<4xi26>
   return %1 : tensor<4xi26>
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_lift.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_lift.mlir
@@ -1,0 +1,48 @@
+!Zp3 = !mod_arith.int<3 : i32>
+!Zp4 = !mod_arith.int<4 : i32>
+!TZ3 = tensor<3x!Zp3>
+!TZ4 = tensor<4x!Zp4>
+
+func.func @test_lower_lift_centered() -> tensor<14xi32> {
+  %x3 = arith.constant dense<[0, 1, 2]> : tensor<3xi32>
+  %x3c = arith.constant dense<[0, 1, -1]> : tensor<3xi32>
+  %x4 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
+  %x4c = arith.constant dense<[0, 1, -2, -1]> : tensor<4xi32>
+
+  %ex3 = mod_arith.encapsulate %x3 : tensor<3xi32> -> !TZ3
+  %ex3c = mod_arith.encapsulate %x3c : tensor<3xi32> -> !TZ3
+  %ex4 = mod_arith.encapsulate %x4 : tensor<4xi32> -> !TZ4
+  %ex4c = mod_arith.encapsulate %x4c : tensor<4xi32> -> !TZ4
+
+  %lx3 = mod_arith.lift centered %ex3 : !TZ3 -> tensor<3xi32>
+  %lx3c = mod_arith.lift centered %ex3c : !TZ3 -> tensor<3xi32>
+  %lx4 = mod_arith.lift centered %ex4 : !TZ4 -> tensor<4xi32>
+  %lx4c = mod_arith.lift centered %ex4c : !TZ4 -> tensor<4xi32>
+
+  %t1 = tensor.concat dim(0) %lx3, %lx3c : (tensor<3xi32>, tensor<3xi32>) -> tensor<6xi32>
+  %t2 = tensor.concat dim(0) %t1, %lx4 : (tensor<6xi32>, tensor<4xi32>) -> tensor<10xi32>
+  %result = tensor.concat dim(0) %t2, %lx4c : (tensor<10xi32>, tensor<4xi32>) -> tensor<14xi32>
+  return %result : tensor<14xi32>
+}
+
+func.func @test_lower_lift_standard() -> tensor<14xi32> {
+  %x3 = arith.constant dense<[0, 1, 2]> : tensor<3xi32>
+  %x3c = arith.constant dense<[0, 1, -1]> : tensor<3xi32>
+  %x4 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
+  %x4c = arith.constant dense<[0, 1, -2, -1]> : tensor<4xi32>
+
+  %ex3 = mod_arith.encapsulate %x3 : tensor<3xi32> -> !TZ3
+  %ex3c = mod_arith.encapsulate %x3c : tensor<3xi32> -> !TZ3
+  %ex4 = mod_arith.encapsulate %x4 : tensor<4xi32> -> !TZ4
+  %ex4c = mod_arith.encapsulate %x4c : tensor<4xi32> -> !TZ4
+
+  %lx3 = mod_arith.lift standard %ex3 : !TZ3 -> tensor<3xi32>
+  %lx3c = mod_arith.lift standard %ex3c : !TZ3 -> tensor<3xi32>
+  %lx4 = mod_arith.lift standard %ex4 : !TZ4 -> tensor<4xi32>
+  %lx4c = mod_arith.lift standard %ex4c : !TZ4 -> tensor<4xi32>
+
+  %t1 = tensor.concat dim(0) %lx3, %lx3c : (tensor<3xi32>, tensor<3xi32>) -> tensor<6xi32>
+  %t2 = tensor.concat dim(0) %t1, %lx4 : (tensor<6xi32>, tensor<4xi32>) -> tensor<10xi32>
+  %result = tensor.concat dim(0) %t2, %lx4c : (tensor<10xi32>, tensor<4xi32>) -> tensor<14xi32>
+  return %result : tensor<14xi32>
+}

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_lift_test.cc
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_lift_test.cc
@@ -1,0 +1,54 @@
+#include <cstdint>
+#include <cstdlib>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "tests/llvm_runner/memref_types.h"
+
+extern "C" {
+void _mlir_ciface_test_lower_lift_centered(
+    StridedMemRefType<int32_t, 1>* result);
+void _mlir_ciface_test_lower_lift_standard(
+    StridedMemRefType<int32_t, 1>* result);
+}
+
+TEST(LowerLiftCenteredTest, CorrectOutput) {
+  StridedMemRefType<int32_t, 1> result;
+  _mlir_ciface_test_lower_lift_centered(&result);
+  ASSERT_EQ(result.sizes[0], 14);
+  EXPECT_EQ(result.data[0], 0);
+  EXPECT_EQ(result.data[1], 1);
+  EXPECT_EQ(result.data[2], -1);
+  EXPECT_EQ(result.data[3], 0);
+  EXPECT_EQ(result.data[4], 1);
+  EXPECT_EQ(result.data[5], -1);
+  EXPECT_EQ(result.data[6], 0);
+  EXPECT_EQ(result.data[7], 1);
+  EXPECT_EQ(result.data[8], -2);
+  EXPECT_EQ(result.data[9], -1);
+  EXPECT_EQ(result.data[10], 0);
+  EXPECT_EQ(result.data[11], 1);
+  EXPECT_EQ(result.data[12], -2);
+  EXPECT_EQ(result.data[13], -1);
+  free(result.basePtr);
+}
+
+TEST(LowerLiftStandardTest, CorrectOutput) {
+  StridedMemRefType<int32_t, 1> result;
+  _mlir_ciface_test_lower_lift_standard(&result);
+  ASSERT_EQ(result.sizes[0], 14);
+  EXPECT_EQ(result.data[0], 0);
+  EXPECT_EQ(result.data[1], 1);
+  EXPECT_EQ(result.data[2], 2);
+  EXPECT_EQ(result.data[3], 0);
+  EXPECT_EQ(result.data[4], 1);
+  EXPECT_EQ(result.data[5], 2);
+  EXPECT_EQ(result.data[6], 0);
+  EXPECT_EQ(result.data[7], 1);
+  EXPECT_EQ(result.data[8], 2);
+  EXPECT_EQ(result.data[9], 3);
+  EXPECT_EQ(result.data[10], 0);
+  EXPECT_EQ(result.data[11], 1);
+  EXPECT_EQ(result.data[12], 2);
+  EXPECT_EQ(result.data[13], 3);
+  free(result.basePtr);
+}

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mac.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mac.mlir
@@ -14,6 +14,6 @@ func.func public @test_lower_mac() -> tensor<4xi26> {
   %my = mod_arith.reduce %ey : !Zpv
   %mz = mod_arith.reduce %ez : !Zpv
   %m1 = mod_arith.mac %mx, %my, %mz : !Zpv
-  %1 = mod_arith.extract %m1 : !Zpv -> tensor<4xi26>
+  %1 = mod_arith.lift standard %m1 : !Zpv -> tensor<4xi26>
   return %1 : tensor<4xi26>
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_decompose.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_decompose.mlir
@@ -1,12 +1,11 @@
 !Zp = !mod_arith.int<3097973 : i26>
 !RNS = !rns.rns<!mod_arith.int<829 : i11>, !mod_arith.int<101 : i11>, !mod_arith.int<37 : i11>>
 
-func.func public @test_lower_mod_switch_decompose() -> tensor<3xi11> {
+func.func public @test_lower_mod_switch_decompose() -> !RNS {
   // 57543298 is -9565566
   %x = arith.constant 57543298 : i26
   %ex = mod_arith.encapsulate %x : i26 -> !Zp
   %mx = mod_arith.reduce %ex : !Zp
   %m1 = mod_arith.mod_switch %mx : !Zp to !RNS
-  %1 = mod_arith.extract %m1 : !RNS -> tensor<3xi11>
-  return %1 : tensor<3xi11>
+  return %m1 : !RNS
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_interpolate.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_interpolate.mlir
@@ -6,6 +6,6 @@ func.func public @test_lower_mod_switch_interpolate() -> i26 {
 
   %ex = mod_arith.encapsulate %x : tensor<3xi11> -> !RNS
   %m1 = mod_arith.mod_switch %ex : !RNS to !Zp
-  %1 = mod_arith.extract %m1 : !Zp -> i26
+  %1 = mod_arith.lift standard %m1 : !Zp -> i26
   return %1 : i26
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_larger_width.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_larger_width.mlir
@@ -6,6 +6,6 @@ func.func public @lower_mod_switch_larger_width() -> i32 {
   %ex = mod_arith.encapsulate %x : i26 -> !Zp
   %mx = mod_arith.reduce %ex : !Zp
   %m1 = mod_arith.mod_switch %mx : !Zp to !Zp_larger_width
-  %1 = mod_arith.extract %m1 : !Zp_larger_width -> i32
+  %1 = mod_arith.lift standard %m1 : !Zp_larger_width -> i32
   return %1 : i32
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_same_width.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_same_width.mlir
@@ -6,6 +6,6 @@ func.func public @lower_mod_switch_same_width() -> i26 {
   %ex = mod_arith.encapsulate %x : i26 -> !Zp
   %mx = mod_arith.reduce %ex : !Zp
   %m1 = mod_arith.mod_switch %mx : !Zp to !Zp_same_width
-  %1 = mod_arith.extract %m1 : !Zp_same_width -> i26
+  %1 = mod_arith.lift standard %m1 : !Zp_same_width -> i26
   return %1 : i26
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_smaller_width.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mod_switch_smaller_width.mlir
@@ -6,6 +6,6 @@ func.func public @lower_mod_switch_smaller_width() -> i10 {
   %ex = mod_arith.encapsulate %x : i26 -> !Zp
   %mx = mod_arith.reduce %ex : !Zp
   %m1 = mod_arith.mod_switch %mx : !Zp to !Zp_smaller_width
-  %1 = mod_arith.extract %m1 : !Zp_smaller_width -> i10
+  %1 = mod_arith.lift standard %m1 : !Zp_smaller_width -> i10
   return %1 : i10
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mul.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_mul.mlir
@@ -11,6 +11,6 @@ func.func public @test_lower_mul() -> tensor<4xi26> {
   %mx = mod_arith.reduce %ex : !Zpv
   %my = mod_arith.reduce %ey : !Zpv
   %m1 = mod_arith.mul %mx, %my : !Zpv
-  %1 = mod_arith.extract %m1 : !Zpv -> tensor<4xi26>
+  %1 = mod_arith.lift standard %m1 : !Zpv -> tensor<4xi26>
   return %1 : tensor<4xi26>
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_reduce.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_reduce.mlir
@@ -10,7 +10,7 @@ func.func public @test_lower_reduce_1() -> tensor<6xi26> {
   %x = arith.constant dense<[29498763, 42, 67108862, 7681, -1, 7680]> : tensor<6xi26>
   %e1 = mod_arith.encapsulate %x : tensor<6xi26> -> !Zp1v
   %m1 = mod_arith.reduce %e1 : !Zp1v
-  %1 = mod_arith.extract %m1 : !Zp1v -> tensor<6xi26>
+  %1 = mod_arith.lift standard %m1 : !Zp1v -> tensor<6xi26>
   return %1 : tensor<6xi26>
 }
 
@@ -20,6 +20,6 @@ func.func public @test_lower_reduce_2() -> tensor<6xi26> {
   // 33554431 = 2 ** 25 - 1
   %e4 = mod_arith.encapsulate %y : tensor<6xi26> -> !Zp2v
   %m4 = mod_arith.reduce %e4 : !Zp2v
-  %4 = mod_arith.extract %m4 : !Zp2v -> tensor<6xi26>
+  %4 = mod_arith.lift standard %m4 : !Zp2v -> tensor<6xi26>
   return %4 : tensor<6xi26>
 }

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_sub.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/runner/lower_sub.mlir
@@ -11,6 +11,6 @@ func.func public @test_lower_sub() -> tensor<4xi26> {
   %mx = mod_arith.reduce %ex : !Zpv
   %my = mod_arith.reduce %ey : !Zpv
   %m1 = mod_arith.sub %mx, %my : !Zpv
-  %1 = mod_arith.extract %m1 : !Zpv -> tensor<4xi26>
+  %1 = mod_arith.lift standard %m1 : !Zpv -> tensor<4xi26>
   return %1 : tensor<4xi26>
 }

--- a/tests/Dialect/ModArith/IR/invalid-ops.mlir
+++ b/tests/Dialect/ModArith/IR/invalid-ops.mlir
@@ -7,9 +7,9 @@
 
 !Zp = !mod_arith.int<255 : i32>
 
-func.func @test_bad_extract(%lhs : !Zp) -> i8 {
+func.func @test_bad_lift(%lhs : !Zp) -> i8 {
   // expected-error@+1 {{the result integer type should be of the same width as the mod arith type width, but got 8 while mod arith type width 32}}
-  %m = mod_arith.extract %lhs : !Zp -> i8
+  %m = mod_arith.lift standard %lhs : !Zp -> i8
   return %m : i8
 }
 
@@ -50,10 +50,4 @@ func.func @test_bad_encapsulate(%arg0: tensor<3x3xi10>) -> tensor<4x!rns> {
   // expected-error@+1 {{The shape of input/output type is not correct.}}
   %e = mod_arith.encapsulate %arg0 : tensor<3x3xi10> -> tensor<4x!rns>
   return %e : tensor<4x!rns>
-}
-
-func.func @test_bad_extract(%arg0: tensor<4x!rns>) -> tensor<4x5xi10> {
-  // expected-error@+1 {{The shape of input/output type is not correct.}}
-  %e = mod_arith.extract %arg0 : tensor<4x!rns> -> tensor<4x5xi10>
-  return %e : tensor<4x5xi10>
 }

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -53,14 +53,12 @@ func.func @test_arith_syntax() {
   %m_vec2 = mod_arith.reduce %e_vec2 : !Zp_vec
   %m_vec3 = mod_arith.reduce %e_vec3 : !Zp_vec
 
-  // CHECK: mod_arith.extract
-  %extract = mod_arith.extract %m4 : !Zp -> i10
-  %extract_vec = mod_arith.extract %m_vec : !Zp_vec -> tensor<4xi10>
-
   // CHECK: mod_arith.lift standard
   %standard_lift = mod_arith.lift standard %m4 : !Zp -> i10
+  %extract_vec_std = mod_arith.lift standard %m_vec : !Zp_vec -> tensor<4xi10>
   // CHECK: mod_arith.lift centered
   %centered_lift = mod_arith.lift centered %m4 : !Zp -> i10
+  %extract_vec_center = mod_arith.lift centered %m_vec : !Zp_vec -> tensor<4xi10>
 
   // CHECK: mod_arith.add
   // CHECK: mod_arith.add
@@ -112,28 +110,6 @@ func.func @test_rns_syntax(%arg0: !rns, %arg1: !rns) {
   %interpolate = mod_arith.mod_switch %add : !rns to !Zp_large
   %decompose = mod_arith.mod_switch %interpolate : !Zp_large to !rns
 
-  return
-}
-
-// CHECK: @test_rns_vec_syntax
-func.func @test_rns_vec_syntax(%arg0: !rns_vec, %arg1: !rns_vec) {
-  // CHECK: mod_arith.add
-  %add = mod_arith.add %arg0, %arg1 : !rns_vec
-
-  // CHECK: mod_arith.extract
-  // CHECK: mod_arith.encapsulate
-  %extract = mod_arith.extract %add : !rns_vec -> !int_vec
-  %encapsulate = mod_arith.encapsulate %extract : !int_vec -> !rns_vec
-
-  return
-}
-
-// CHECK: @test_rns_single_limb_shape
-func.func @test_rns_single_limb_shape(%arg0: tensor<5x1xi10>, %arg1: !rns1_vec) {
-  // CHECK: mod_arith.encapsulate
-  // CHECK: mod_arith.extract
-  %enc = mod_arith.encapsulate %arg0 : tensor<5x1xi10> -> !rns1_vec
-  %ext = mod_arith.extract %arg1 : !rns1_vec -> tensor<5x1xi10>
   return
 }
 

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_leading_term.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_leading_term.mlir
@@ -18,8 +18,7 @@ func.func @lower_leading_term() -> !coeff_ty {
   // CHECK: %[[C1023:.+]] = arith.constant 1023 : index
   // CHECK: %[[WHILE_RES:.*]] = scf.while (%[[ARG0:.*]] = %[[C1023]]) : (index) -> index {
   // CHECK:    %[[EXTRACTED:.*]] = tensor.extract %[[X]][%[[ARG0]]] : [[Tmod]]
-  // CHECK:    %[[REDUCED:.*]] = mod_arith.reduce %[[EXTRACTED]]
-  // CHECK:    %[[REDUCED_EXTRACTED:.*]] = mod_arith.extract %[[REDUCED]]
+  // CHECK:    %[[REDUCED_EXTRACTED:.*]] = mod_arith.lift standard %[[EXTRACTED]]
   // CHECK:    %[[CMP:.*]] = arith.cmpi eq, %[[REDUCED_EXTRACTED]], %[[C0]]
   // CHECK:    scf.condition(%[[CMP]]) %[[ARG0]] : index
   // CHECK: } do {

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul.mlir
@@ -56,8 +56,7 @@
 // CHECK:      %[[c2046:.*]] = arith.constant 2046 : index
 // CHECK:      %[[v1:.*]] = scf.while (%[[arg2:.*]] = %[[c2046]]) : (index) -> index {
 // CHECK:        %[[extracted_4:.*]] = tensor.extract %[[DIVIDEND]][%[[arg2]]] : [[NAIVE_POLYMUL_TENSOR_TY]]
-// CHECK:        %[[extracted_4_reduced:.*]] = mod_arith.reduce %[[extracted_4]]
-// CHECK:        %[[extracted_4_conv:.*]] = mod_arith.extract %[[extracted_4_reduced]]
+// CHECK:        %[[extracted_4_conv:.*]] = mod_arith.lift standard %[[extracted_4]]
 // CHECK:        %[[cmp1:.*]] = arith.cmpi eq, %[[extracted_4_conv]], %[[c0_i32]] : i32
 // CHECK:        scf.condition(%[[cmp1]]) %[[arg2]] : index
 // CHECK:      } do {
@@ -68,7 +67,7 @@
 // CHECK:      %[[extracted:.*]] = tensor.extract %[[DIVIDEND]][%[[v1]]] : [[NAIVE_POLYMUL_TENSOR_TY]]
 // CHECK:      %[[v2:.*]] = arith.subi %[[v1]], %[[c1024]] : index
 // CHECK:      %[[extracted_mul:.*]] = mod_arith.mul %[[extracted]], %[[c1_modarith]] : [[COEFF_TY]]
-// CHECK:      %[[extracted_mul_extracted:.*]] = mod_arith.extract %[[extracted_mul]]
+// CHECK:      %[[extracted_mul_extracted:.*]] = mod_arith.lift standard %[[extracted_mul]]
 // CHECK:      %[[splat:.*]] = tensor.splat %[[extracted_mul_extracted]] : tensor<2047xi32>
 // CHECK:      %[[splat_enc:.*]] = mod_arith.encapsulate %[[splat]]
 // CHECK:      %[[mul:.*]] = mod_arith.mul %[[DIVISOR_MODARITH]], %[[splat_enc]]

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul_scalar.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_mul_scalar.mlir
@@ -8,7 +8,7 @@
 func.func @test_lower_mul_scalar(%arg0: !poly_ty) -> !poly_ty {
   // CHECK: %[[C2:.*]] = mod_arith.constant 2
   %c2 = mod_arith.constant 2 : !coeff_ty
-  // CHECK: %[[C2EXT:.*]] = mod_arith.extract %[[C2]]
+  // CHECK: %[[C2EXT:.*]] = mod_arith.lift standard %[[C2]]
   // CHECK: %[[SPLAT:.*]] = tensor.splat %[[C2EXT]]
   // CHECK: %[[SPLAT_ENC:.*]] = mod_arith.encapsulate %[[SPLAT]]
   // CHECK: mod_arith.mul %[[ARG]], %[[SPLAT_ENC]] : [[T]]

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_to_tensor.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/lower_to_tensor.mlir
@@ -8,12 +8,12 @@
 func.func @test_lower_to_tensor() -> tensor<1024xi32> {
   // CHECK: [[COEFFS:%.+]] = arith.constant
   // CHECK: [[ENC:%.+]] = mod_arith.encapsulate [[COEFFS]]
-  // CHECK: [[EXT:%.+]] = mod_arith.extract [[ENC]]
+  // CHECK: [[EXT:%.+]] = mod_arith.lift standard [[ENC]]
   %coeffsRaw = arith.constant dense<2> : tensor<1024xi32>
   %coeffs = mod_arith.encapsulate %coeffsRaw : tensor<1024xi32> -> tensor<1024x!coeff_ty>
   %poly = polynomial.from_tensor %coeffs : tensor<1024x!coeff_ty> -> !polynomial.polynomial<ring=#ring>
   %tensorMod = polynomial.to_tensor %poly : !polynomial.polynomial<ring=#ring> -> tensor<1024x!coeff_ty>
-  %tensor = mod_arith.extract %tensorMod : tensor<1024x!coeff_ty> -> tensor<1024xi32>
+  %tensor = mod_arith.lift standard %tensorMod : tensor<1024x!coeff_ty> -> tensor<1024xi32>
   // CHECK: return [[EXT]]
   return %tensor : tensor<1024xi32>
 }
@@ -27,12 +27,12 @@ func.func @test_lower_to_tensor_small_coeffs() -> tensor<1024xi32> {
   // CHECK: [[ZERO:%.+]] = mod_arith.constant 0
   // CHECK: [[PAD:%.+]] = tensor.pad [[ENC]] low[0] high[1021]
   // CHECK:   tensor.yield [[ZERO]]
-  // CHECK: [[EXT:%.+]] = mod_arith.extract [[PAD]]
+  // CHECK: [[EXT:%.+]] = mod_arith.lift standard [[PAD]]
   // CHECK: return [[EXT]]
   %coeffsRaw = arith.constant dense<[2, 2, 5]> : tensor<3xi32>
   %coeffs = mod_arith.encapsulate %coeffsRaw : tensor<3xi32> -> tensor<3x!coeff_ty>
   %poly = polynomial.from_tensor %coeffs : tensor<3x!coeff_ty> -> !polynomial.polynomial<ring=#ring>
   %tensorMod = polynomial.to_tensor %poly : !polynomial.polynomial<ring=#ring> -> tensor<1024x!coeff_ty>
-  %tensor = mod_arith.extract %tensorMod : tensor<1024x!coeff_ty> -> tensor<1024xi32>
+  %tensor = mod_arith.lift standard %tensorMod : tensor<1024x!coeff_ty> -> tensor<1024xi32>
   return %tensor : tensor<1024xi32>
 }

--- a/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/ntt_benchmark.mlir
+++ b/tests/Dialect/Polynomial/Conversions/heir_polynomial_to_llvm/runner/ntt_benchmark.mlir
@@ -20,7 +20,7 @@ func.func @input_generation() -> !poly_ty attributes { llvm.emit_c_interface } {
 func.func @ntt(%arg0 : !poly_ty) -> tensor<65536xi32> attributes { llvm.emit_c_interface } {
   %0 = polynomial.ntt %arg0 {root=#root} : !poly_ty
   %1 = polynomial.to_tensor %0 : !ntt_poly_ty -> tensor<65536x!coeff_ty>
-  %2 = mod_arith.extract %1 : tensor<65536x!coeff_ty> -> tensor<65536xi32>
+  %2 = mod_arith.lift standard %1 : tensor<65536x!coeff_ty> -> tensor<65536xi32>
   return %2 : tensor<65536xi32>
 }
 

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/eval_monomial.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/eval_monomial.mlir
@@ -22,10 +22,8 @@ func.func @eval_constant_monomial_int(%coeff: i32) -> !poly_i32 {
 // CHECK-SAME: (%[[ARG0:.*]]: !mod_arith.int<17 : i32>)
 func.func @eval_constant_monomial_mod(%coeff: !coeff_ty) -> !poly_mod {
   %c0 = arith.constant 0 : index
-  // CHECK: %[[EXTRACTED:.*]] = mod_arith.extract %[[ARG0]] : !mod_arith.int<17 : i32> -> i32
-  // CHECK: %[[SPLAT:.*]] = tensor.splat %[[EXTRACTED]] : tensor<4xi32>
-  // CHECK: %[[ENCAPSULATED:.*]] = mod_arith.encapsulate %[[SPLAT]] : tensor<4xi32> -> tensor<4x!mod_arith.int<17 : i32>>
-  // CHECK: return %[[ENCAPSULATED]]
+  // CHECK: %[[SPLAT:.*]] = tensor.splat %[[ARG0]] : tensor<4x!mod_arith.int<17 : i32>>
+  // CHECK: return %[[SPLAT]]
   %0 = polynomial.monomial %coeff, %c0 : (!coeff_ty, index) -> !poly_mod
   return %0 : !poly_mod
 }

--- a/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/rns_mul_scalar.mlir
+++ b/tests/Dialect/Polynomial/Conversions/polynomial_to_mod_arith/rns_mul_scalar.mlir
@@ -9,11 +9,8 @@
 // CHECK: func.func @test_rns_mul_scalar
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<1024x!rns.rns<{{.*}}>>, %[[ARG1:.*]]: !rns.rns<{{.*}}>)
 func.func @test_rns_mul_scalar(%poly: !poly, %scalar: !rns) -> !poly {
-  // CHECK: %[[EXTRACTED:.*]] = mod_arith.extract %[[ARG1]] : !rns.rns<{{.*}}> -> tensor<2xi64>
-  // CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<1024x2xi64>
-  // CHECK: %[[BROADCASTED:.*]] = linalg.broadcast ins(%[[EXTRACTED]] : tensor<2xi64>) outs(%[[EMPTY]] : tensor<1024x2xi64>) dimensions = [0]
-  // CHECK: %[[ENCAPSULATED:.*]] = mod_arith.encapsulate %[[BROADCASTED]] : tensor<1024x2xi64> -> tensor<1024x!rns.rns<{{.*}}>>
-  // CHECK: %[[MUL:.*]] = mod_arith.mul %[[ARG0]], %[[ENCAPSULATED]] : tensor<1024x!rns.rns<{{.*}}>>
+  // CHECK: %[[SPLAT:.*]] = tensor.splat %[[ARG1]] : tensor<1024x!rns.rns<{{.*}}>>
+  // CHECK: %[[MUL:.*]] = mod_arith.mul %[[ARG0]], %[[SPLAT]] : tensor<1024x!rns.rns<{{.*}}>>
   // CHECK: return %[[MUL]] : tensor<1024x!rns.rns<{{.*}}>>
   %0 = polynomial.mul_scalar %poly, %scalar : !poly, !rns
   return %0 : !poly

--- a/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/lower_convert_basis_test.cc
+++ b/tests/Dialect/RNS/Conversions/heir_rns_to_llvm/runner/lower_convert_basis_test.cc
@@ -69,19 +69,18 @@ TEST(LowerConvertBasisTest, TestConvertBasis) {
     for (int64_t x = 0; x < inputModulus; x++) {
       int64_t y = x;
       // we choose to lift to the centered representative
-      // if (y > inputModulus / 2) {
-      //   y -= inputModulus;
-      // }
+      if (y > inputModulus / 2) {
+        y -= inputModulus;
+      }
       std::vector<int64_t> expectedResult;
       for (auto& q : c.dst_basis) {
-        expectedResult.push_back(y % q);
+        expectedResult.push_back(((y % q) + q) % q);
       }
-
       // compute result via MLIR
       std::vector<int64_t> residues;
       residues.reserve(c.src_basis.size());
       for (int64_t q : c.src_basis) {
-        residues.push_back(y % q);
+        residues.push_back(x % q);
       }
       StridedMemRefType<int64_t, 1> memref = StridedMemRefType<int64_t, 1>(
           residues.data(), residues.data(), 0, residues.size(), 1);

--- a/tests/Dialect/RNS/Transforms/lower_convert_basis.mlir
+++ b/tests/Dialect/RNS/Transforms/lower_convert_basis.mlir
@@ -9,22 +9,24 @@
 // CHECK: convert_basis
 func.func @convert_basis(%arg0: !src) -> !target {
   // CHECK: rns.extract_residue
-  // CHECK-NEXT: mod_arith.extract
-  // CHECK-NEXT: rns.extract_residue
-  // CHECK-NEXT: mod_arith.encapsulate
-  // CHECK-NEXT: mod_arith.reduce
-  // CHECK-NEXT: mod_arith.sub
-  // CHECK-NEXT: mod_arith.constant 2
-  // CHECK-NEXT: mod_arith.mul
-  // CHECK-NEXT: mod_arith.extract
-  // CHECK-NEXT: rns.extract_residue
-  // CHECK-NEXT: mod_arith.encapsulate
-  // CHECK-NEXT: mod_arith.reduce
-  // CHECK-NEXT: mod_arith.constant 3
-  // CHECK-NEXT: mod_arith.encapsulate
-  // CHECK-NEXT: mod_arith.reduce
-  // CHECK-NEXT: mod_arith.mac
-  // CHECK-NEXT: rns.pack
+  // CHECK: mod_arith.lift centered
+  // CHECK: rns.extract_residue
+  // CHECK: mod_arith.encapsulate
+  // CHECK: mod_arith.reduce
+  // CHECK: mod_arith.sub
+  // CHECK: mod_arith.constant 2
+  // CHECK: mod_arith.mul
+  // CHECK: mod_arith.lift centered
+  // CHECK: tensor.from_elements
+  // CHECK: rns.extract_residue
+  // CHECK: mod_arith.encapsulate
+  // CHECK: mod_arith.reduce
+  // CHECK: mod_arith.constant 3
+  // CHECK: tensor.from_elements
+  // CHECK: mod_arith.encapsulate
+  // CHECK: mod_arith.reduce
+  // CHECK: mod_arith.mac
+  // CHECK: rns.pack
   // CHECK-NOT: rns.convert_basis
   %0 = rns.convert_basis %arg0 {targetBasis = !target} : !src -> !target
   return %0 : !target

--- a/tests/Dialect/Secret/Conversions/secret_to_mod_arith/client_helpers.mlir
+++ b/tests/Dialect/Secret/Conversions/secret_to_mod_arith/client_helpers.mlir
@@ -21,7 +21,7 @@ module {
   // CHECK: @dot_product__decrypt__result0
   func.func @dot_product__decrypt__result0(%arg0: !secret.secret<tensor<1024xi16>>) -> i16 attributes {client.dec_func = {func_name = "dot_product", index = 0 : i64}} {
     %c0 = arith.constant 0 : index
-    // CHECK: mod_arith.extract
+    // CHECK: mod_arith.lift standard
     // CHECK: arith.trunci
     %0 = secret.reveal %arg0 : !secret.secret<tensor<1024xi16>> -> tensor<1024xi16>
     %extracted = tensor.extract %0[%c0] : tensor<1024xi16>


### PR DESCRIPTION
Removed `mod_arith::ExtractOp` in favor of the new `mod_arith::LiftOp`. This turned out to be more work than anticipated.

The expected changes:
- Remove references in ModArithOps.td/.cpp
- Change basis conversion to use `LiftOp` instead of `ExtractOp`
- Remove `ConvertExtract` from ModArithToArith
- Remove other occurrences of `ExtractOp`:
    - in SecretToModArith, I preserved functionality by lifting to the standard representative
- Many tests were updated to use `lift` instead of `extract`
- Updated lower_convert_basis tests, in particular the runner now expects centered representatives (converted back to standard since that's the internal representation used in ModArith).

Tangentially related changes:
- Make inner loop of `computeMixedRadixCoeffs` and lowering for `ConvertBasisOp` use scf:ForOp loops instead of C++ to reduce IR size/compile time. Note that in both cases, types change in the outer loop, so the outer loop cannot be implemented as an MLIR loop.
- I did a bit of cleanup and refactoring in the ConvertBasis lowering
- I realized the lowering for ConvertMonomial for EVAL form polynomials was unnecessarily convoluted (and used `mod_arith::ExtractOp`); it is now much simpler.
- There is no need to explicitly reduce before calling `LiftOp`; it is implicit.
    
Unexpected changes:
- `ExtractOp` is not exactly a subset of `LiftOp`. For ModArith, you could view it that way (except that ExtractOp might not have output a canonical representative, while LiftOp always does). For RNS, they have different meanings: `ExtractOp` would output the tensor of extracted ModArith coeffs. `LiftOp` doesn't support RNS for now, but if it did, it would do a CRT reconstruction on the coefficients and output a scalar. This affected a couple of tests, but mostly the lowering of `polynomial.mul_scalar`, which does some fancy unpacking and repacking of the coefficients. Since `LiftOp` doesn't support RNS, I added a special path when multiplying a polynomial by an RNS scalar that avoids it. For the non-RNS case, I changed `mod_arith::ExtractOp` to `mod_arith::LiftOp standard`; the representative doesn't matter since we immediately re-encapsulate. The representative only matters in "mathematical" code; there the "lifting" is for the compiler's benefit. The same holds in a few other places where `LiftOp` replaced `ExtractOp`.
- Convertion utils: Written by AI, but reviewed by me.
    - ConvertFromElements was tightened a bit: the main change is that the pattern fails if the input's element type doesn't lower to a tensor. (Note that with the new scf loops in basis conversion, we have to make tensors of ints and ModAriths; I don't think those had ever been tested before).
    - ConvertSplat: Add conversion for splatting a type that lowers to a tensor (e.g., RNS). The use of splat in `mul_scalar` necessitated this change.

Misc changes:
- Remove deprecated syntax in LinalgCanonicalizations.cpp

Tests:
- added runner tests for liftOp in the process of debugging basis conversion. It tests even and odd moduli with both standard and centered representatives.
- Removed test for invalid `mod_arith.extract` on RNS, since there is no analog anymore