### PR TITLE
restore python3.10 compatibility

### DIFF
--- a/frontend/heir/mlir/types.py
+++ b/frontend/heir/mlir/types.py
@@ -1,11 +1,17 @@
 """Defines Python type annotations for MLIR types."""
 
 from abc import ABC, abstractmethod
+import sys
 from typing import Generic, Optional, TypeVar, get_args, get_origin
-from typing import TypeVarTuple, Unpack
 from numba.core.types import boolean, float32, float64, int16, int32, int64, int8
 from numba.core.types import Type as NumbaType
 from numba.extending import type_callable
+
+if sys.version_info >= (3, 11):
+  from typing import TypeVarTuple, Unpack
+else:
+  # TypeVarTuple/Unpack landed in typing in 3.11; use the backport on 3.10.
+  from typing_extensions import TypeVarTuple, Unpack
 
 T = TypeVar("T")
 Ts = TypeVarTuple("Ts")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "The HEIR compiler"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 classifiers = [
   "Topic :: Security :: Cryptography",
   "Intended Audience :: Developers",
@@ -62,7 +62,7 @@ dev = [
   # For ML integration tests
   "torch>=2.8.0",
   "setuptools>=80.9.0",
-  "cibuildwheel>=4.0.0",
+  "cibuildwheel>=4.0.0 ; python_version >= '3.11'",
   "pytest",
 ]
 
@@ -87,9 +87,9 @@ zip-safe = false
 where = ["frontend"]
 
 [tool.cibuildwheel]
-build = "cp311-* cp312-* cp313-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 build-frontend = "build[uv]"
-skip = "*-musllinux_* pp-*"
+skip = "*musllinux* *android* *ios* *pyodide*"
 # The test must be run in an isolated directory so that python uses the wheel
 # when running `import heir` instead of the local source files. cibuildwheel
 # creates an isolated directory for this purpose, and cd's to it before running


### PR DESCRIPTION
This change restores python3.10 compatibility and adds python3.10 and python3.14 to the cibuildwheel target builds.