### PR TITLE
Enable buildbuddy in CI workflows build_and_test.yml and docs.yml

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,17 +22,26 @@ common --@rules_python//python/config_settings:bootstrap_impl=script
 # default in bazel 9
 startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 
-# buildbuddy
-# for remote execution of the build. Add `common --config=remote` to
-# .bazelrc.user
-common:remote --bes_backend=grpcs://heir.buildbuddy.io
-common:remote --bes_results_url=https://heir.buildbuddy.io/invocation/
-common:remote --remote_cache=grpcs://heir.buildbuddy.io
-common:remote --remote_cache_compression
-common:remote --remote_timeout=10m
+# BuildBuddy
+build --bes_results_url=https://heir.buildbuddy.io/invocation/
+build --bes_backend=grpcs://heir.buildbuddy.io
+common --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
+common --remote_cache=grpcs://heir.buildbuddy.io
+common --remote_cache_compression
+common --remote_header=x-buildbuddy-api-key=IqGGzfrvMgDJh927qtrw
+common --remote_timeout=10m
+
+# This enables remote build execution and writing to the remote cache, which
+# dramatically speeds up builds. Add a .bazelrc.user file with:
+#
+#     common --remote_header=x-buildbuddy-api-key=<YOUR_API_KEY>
+#     common --config=remote
+#
+# Note this requires a buildbuddy.io account and API key. The default
+# API key used above is read-only.
 common:remote --extra_execution_platforms=@llvm//:rbe_platform
 common:remote --jobs=500
-common:remote --remote_executor=grpcs://heir.buildbuddy.io
+common:remote --remote_executor=grpcs://remote.buildbuddy.io
 
 # CI executions are always remote, and have extra build metadata
 common:ci --build_metadata=ROLE=CI

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on:
       labels: ubuntu-24.04-64core
     env:
-      BUILDBUDDY_API_KEY: ${{ github.event_name != 'pull_request' && secrets.BUILDBUDDY_API_KEY || vars.BUILDBUDDY_READ_ONLY_API_KEY }}
+      BUILDBUDDY_API_KEY: ${{ github.event_name != 'pull_request' && secrets.BUILDBUDDY_API_KEY || '7eYz4UY70YSrT55wmjWV' }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
@@ -38,11 +38,17 @@ jobs:
       # Bazel tests
       - name: "Run `bazel build`"
         run: |
-          bazel build -c opt //...
+          bazel build -c opt \
+            --config=ci \
+            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
+            //...
 
       - name: "Run `bazel test`"
         run: |
-          bazel test -c opt //...
+          bazel test -c opt \
+            --config=ci \
+            --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
+            //...
 
       # Frontend tests
       - name: Build OpenFHE

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     env:
-      BUILDBUDDY_API_KEY: ${{ github.event_name != 'pull_request' && secrets.BUILDBUDDY_API_KEY || vars.BUILDBUDDY_READ_ONLY_API_KEY }}
+      BUILDBUDDY_API_KEY: ${{ github.event_name != 'pull_request' && secrets.BUILDBUDDY_API_KEY || '7eYz4UY70YSrT55wmjWV' }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
@@ -45,14 +45,20 @@ jobs:
       - name: "Build markdown files from tblgen sources"
         run: |
           bazel query "filter('_filegroup', siblings(kind('gentbl_rule', @heir//...)))" | \
-            xargs bazel build --//:enable_openmp=0 -c opt "$@"
+            xargs bazel build -c opt \
+              --config=ci \
+              --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
+              "$@"
 
       - name: "Copy markdown files to docs/"
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml==6.0.2 fire==0.7.0
           # heir-opt is needed to generate the doctest examples
-          bazel build --//:enable_openmp=0 -c opt //tools:heir-opt
+          bazel build -c opt \
+              --config=ci \
+              --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
+              //tools:heir-opt
           python -m scripts.docs.copy_tblgen_files
 
       # Please update the local install instructions at docs/README.md if

--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ encrypt-run-decrypt flow for ease of testing.
 
 ## Building from source
 
-HEIR requires a recent C compiler (see
-[clang_matrix](https://github.com/google/heir/actions/workflows/clang_matrix.yml)
-for version-specific support, recent GCCs also tend to work), and some backends
-like OpenFHE require `libomp-dev`.
-
-HEIR depends on LLVM (from source) so a clean build may take 15-30 minutes
-depending on your machine.
-
 This project uses `bazel` for its build system. Install
 [bazelisk](https://github.com/bazelbuild/bazelisk) to manage the bazel version
 automatically. Then, with `bazel` on your path (pointing to `bazelisk`), run the
@@ -77,6 +69,18 @@ Or run an end-to-end test like
 ```bash
 bazel test //tests/Examples/openfhe/ckks/halevi_shoup_matvec:all
 ```
+
+HEIR depends on LLVM (from source) so a clean build may take 30 minutes
+depending on your machine. For faster builds, use
+[BuildBuddy](https://www.buildbuddy.io/). Sign up for an account, create an API
+key, and add the following to `.bazelrc.user` in the root of the HEIR workspace:
+
+```
+common --remote_header=x-buildbuddy-api-key=<YOUR_API_KEY>
+common --config=remote
+```
+
+This should reduce a clean build time to about 5 minutes.
 
 See the [bazel tips](https://heir.dev/docs/development/bazel/) page for more
 example commands and tips on using bazel.


### PR DESCRIPTION
This change adds support for buildbuddy in the CI workflows.

However, due to GitHub's security isolation, we can't directly load the buildbuddy API key used for remote builds from a GH pull request. So we have a (public) read-only key that at least allows one to pull in cached build artifacts.

The configuration here also (hopefully) sets up the build_and_test workflow that runs on main to use RBE, which I can't test until this is merged. But once that workflow runs, then the Content addressable storage cache should reflect in faster pull_request builds with the read-only key.

https://heir.buildbuddy.io/invocation/4dd62bd8-bb88-4049-8f0a-2988d008d655

Includes instructions on using buildbuddy as a developer in the README.