### PR TITLE
ci: fix flag passing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,13 +39,15 @@ jobs:
       # Bazel tests
       - name: "Run `bazel build`"
         run: |
-          bazel build -c opt "$BAZEL_CONFIG_FLAG" \
+          read -r -a BAZEL_CONFIGS <<< "$BAZEL_CONFIG_FLAG"
+          bazel build -c opt "${BAZEL_CONFIGS[@]}" \
             --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
             //...
 
       - name: "Run `bazel test`"
         run: |
-          bazel test -c opt "$BAZEL_CONFIG_FLAG" \
+          read -r -a BAZEL_CONFIGS <<< "$BAZEL_CONFIG_FLAG"
+          bazel test -c opt "${BAZEL_CONFIGS[@]}" \
             --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
             //...
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,17 +45,19 @@ jobs:
       # disk.
       - name: "Build markdown files from tblgen sources"
         run: |
+          read -r -a BAZEL_CONFIGS <<< "$BAZEL_CONFIG_FLAG"
           bazel query "filter('_filegroup', siblings(kind('gentbl_rule', @heir//...)))" | \
-            xargs bazel build -c opt "$BAZEL_CONFIG_FLAG" \
+            xargs bazel build -c opt "${BAZEL_CONFIGS[@]}" \
               --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
               "$@"
 
       - name: "Copy markdown files to docs/"
         run: |
+          read -r -a BAZEL_CONFIGS <<< "$BAZEL_CONFIG_FLAG"
           python -m pip install --upgrade pip
           python -m pip install pyyaml==6.0.2 fire==0.7.0
           # heir-opt is needed to generate the doctest examples
-          bazel build -c opt "$BAZEL_CONFIG_FLAG" \
+          bazel build -c opt "${BAZEL_CONFIGS[@]}" \
               --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
               //tools:heir-opt
           python -m scripts.docs.copy_tblgen_files


### PR DESCRIPTION
Previous error was:

```
Run bazel build -c opt "$BAZEL_CONFIG_FLAG" \
  bazel build -c opt "$BAZEL_CONFIG_FLAG" \
    --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY" \
    //...
  shell: /usr/bin/bash -e {0}
  env:
    BUILDBUDDY_API_KEY: ***
    BAZEL_CONFIG_FLAG: --config=ci --config=remote
2026/06/23 18:21:30 Downloading https://releases.bazel.build/8.4.0/release/bazel-8.4.0-linux-x86_64...
Starting local Bazel server (8.4.0) and connecting to it...
ERROR: Config value 'ci --config=remote' is not defined in any .rc file
INFO: Invocation ID: af845015-d465-48d7-b824-bfd96830719f
INFO: Streaming build results to: https://heir.buildbuddy.io/invocation/af845015-d465-48d7-b824-bfd96830719f
Error: Process completed with exit code 2.
```

So the quoting of the env var was making bazel treat `ci --config=remote` as a single config name. Use a workaround to still quote but also allow multiple args.