### PR TITLE
Made ConversionUtils more robust and cover more of the tensor dialect

### DIFF
--- a/lib/Utils/ConversionUtils.cpp
+++ b/lib/Utils/ConversionUtils.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 
 #include "mlir/include/mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
@@ -12,6 +13,7 @@
 #include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/IRMapping.h"              // from @llvm-project
@@ -32,6 +34,27 @@ namespace heir {
 using ::mlir::func::CallOp;
 using ::mlir::func::FuncOp;
 using ::mlir::func::ReturnOp;
+
+static bool isDynamicOrUnshapedType(Type t) {
+  if (!t) return false;
+  auto shaped = mlir::dyn_cast<ShapedType>(t);
+  return shaped && !shaped.hasStaticShape();
+}
+
+static bool hasAnyDynamicOrUnrankedShape(Operation* op,
+                                         const TypeConverter* typeConverter) {
+  for (Type t : op->getOperandTypes()) {
+    if (isDynamicOrUnshapedType(t) ||
+        isDynamicOrUnshapedType(typeConverter->convertType(t)))
+      return true;
+  }
+  for (Type t : op->getResultTypes()) {
+    if (isDynamicOrUnshapedType(t) ||
+        isDynamicOrUnshapedType(typeConverter->convertType(t)))
+      return true;
+  }
+  return false;
+}
 
 FailureOr<Operation*> convertAnyOperand(const TypeConverter* typeConverter,
                                         Operation* op, ArrayRef<Value> operands,
@@ -80,6 +103,8 @@ struct ConvertExtract : public OpConversionPattern<tensor::ExtractOp> {
   LogicalResult matchAndRewrite(
       tensor::ExtractOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
+    if (hasAnyDynamicOrUnrankedShape(op, getTypeConverter())) return failure();
+
     auto convertedType =
         getTypeConverter()->convertType(op.getResult().getType());
     auto resultType = mlir::dyn_cast<RankedTensorType>(convertedType);
@@ -136,6 +161,8 @@ struct ConvertInsert : public OpConversionPattern<tensor::InsertOp> {
   LogicalResult matchAndRewrite(
       tensor::InsertOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
+    if (hasAnyDynamicOrUnrankedShape(op, getTypeConverter())) return failure();
+
     auto convertedType =
         getTypeConverter()->convertType(op.getScalar().getType());
     auto resultType = mlir::dyn_cast<RankedTensorType>(convertedType);
@@ -192,6 +219,8 @@ struct ConvertFromElements
   LogicalResult matchAndRewrite(
       tensor::FromElementsOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
+    if (hasAnyDynamicOrUnrankedShape(op, getTypeConverter())) return failure();
+
     auto resultType = dyn_cast<RankedTensorType>(
         getTypeConverter()->convertType(op.getResult().getType()));
     if (!resultType) {
@@ -230,9 +259,105 @@ struct ConvertFromElements
           shapeOp);
       newOperands.push_back(reshapeOp);
     }
-    // Create the final tensor.concat operation
-    rewriter.replaceOpWithNewOp<tensor::ConcatOp>(op, 0, newOperands);
+    // Create the final tensor.concat operation, then restore the original
+    // tensor shape with the converted element shape appended.
+    auto concatOp =
+        tensor::ConcatOp::create(rewriter, op.getLoc(), 0, newOperands);
+    Value result = concatOp.getResult();
+    // This block fires if, e.g., we are calling `from_elements` on four inputs
+    // and producing a 2x2xT tensor instead of a 4xT tensor.
+    if (result.getType() != resultType) {
+      auto shapeOp = mlir::arith::ConstantOp::create(
+          rewriter, op.getLoc(),
+          RankedTensorType::get(resultType.getRank(), rewriter.getIndexType()),
+          rewriter.getIndexTensorAttr(resultType.getShape()));
+      result = tensor::ReshapeOp::create(rewriter, op.getLoc(), resultType,
+                                         result, shapeOp);
+    }
+    rewriter.replaceOp(op, result);
 
+    return success();
+  }
+};
+
+template <typename Op>
+struct ConvertOffsetSizeStrideOp : public OpConversionPattern<Op> {
+  ConvertOffsetSizeStrideOp(TypeConverter& typeConverter,
+                            mlir::MLIRContext* context)
+      : OpConversionPattern<Op>(typeConverter, context, /*benefit=*/2) {}
+
+  // Convert a tensor.extract_slice on tensor<...xSourceType> when SourceType
+  // type-converts to tensor<...>. The slice metadata is extended with the full
+  // converted element shape so the result keeps the original slice dimensions
+  // and appends the converted element dimensions.
+  LogicalResult matchAndRewrite(
+      Op op, OpConversionPattern<Op>::OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    if (hasAnyDynamicOrUnrankedShape(op, this->getTypeConverter()))
+      return failure();
+
+    auto originalResultType =
+        dyn_cast<RankedTensorType>(op.getResult().getType());
+    if (!originalResultType) return failure();
+    auto convertedType =
+        this->getTypeConverter()->convertType(originalResultType);
+    auto resultType = dyn_cast<RankedTensorType>(convertedType);
+    if (!resultType) return failure();
+
+    int64_t extraRank = resultType.getRank() - originalResultType.getRank();
+    if (extraRank <= 0) return failure();
+
+    SmallVector<OpFoldResult> offsets = op.getMixedOffsets();
+    SmallVector<OpFoldResult> sizes = op.getMixedSizes();
+    SmallVector<OpFoldResult> strides = op.getMixedStrides();
+
+    ArrayRef<int64_t> extraShape = resultType.getShape().take_back(extraRank);
+    for (int64_t dim : extraShape) {
+      if (ShapedType::isDynamic(dim)) return failure();
+      offsets.push_back(rewriter.getIndexAttr(0));
+      sizes.push_back(rewriter.getIndexAttr(dim));
+      strides.push_back(rewriter.getIndexAttr(1));
+    }
+
+    Value source = adaptor.getSource();
+    if constexpr (std::is_same_v<Op, tensor::ExtractSliceOp>) {
+      rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
+          op, resultType, source, offsets, sizes, strides);
+    } else if constexpr (std::is_same_v<Op, tensor::InsertSliceOp>) {
+      rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
+          op, source, adaptor.getDest(), offsets, sizes, strides);
+    } else {
+      return failure();
+    }
+    return success();
+  }
+};
+
+struct ConvertReshape : public OpConversionPattern<tensor::ReshapeOp> {
+  ConvertReshape(mlir::MLIRContext* context)
+      : OpConversionPattern<tensor::ReshapeOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      tensor::ReshapeOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    if (hasAnyDynamicOrUnrankedShape(op, getTypeConverter())) return failure();
+
+    auto convertedType = dyn_cast<RankedTensorType>(
+        getTypeConverter()->convertType(op.getResult().getType()));
+    if (!convertedType) return failure();
+    if (convertedType == op.getResult().getType()) return failure();
+    for (int64_t dim : convertedType.getShape()) {
+      if (ShapedType::isDynamic(dim)) return failure();
+    }
+
+    auto shapeOp = arith::ConstantOp::create(
+        rewriter, op.getLoc(),
+        RankedTensorType::get(convertedType.getRank(), rewriter.getIndexType()),
+        rewriter.getIndexTensorAttr(convertedType.getShape()));
+    rewriter.replaceOpWithNewOp<tensor::ReshapeOp>(
+        op, convertedType, adaptor.getSource(), shapeOp);
     return success();
   }
 };
@@ -246,6 +371,8 @@ struct ConvertSplat : public OpConversionPattern<tensor::SplatOp> {
   LogicalResult matchAndRewrite(
       tensor::SplatOp op, OpAdaptor adaptor,
       ConversionPatternRewriter& rewriter) const override {
+    if (hasAnyDynamicOrUnrankedShape(op, getTypeConverter())) return failure();
+
     auto resultType = dyn_cast<RankedTensorType>(
         getTypeConverter()->convertType(op.getResult().getType()));
     auto inputType = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
@@ -279,11 +406,15 @@ void addTensorOfTensorConversionPatterns(TypeConverter& typeConverter,
       [&](Operation* op) { return typeConverter.isLegal(op); });
 
   typeConverter.addConversion([&](TensorType type) -> std::optional<Type> {
+    if (isDynamicOrUnshapedType(type)) return std::nullopt;
+
     if (!typeConverter.isLegal(type.getElementType())) {
       if (auto convertedType =
               typeConverter.convertType(type.getElementType())) {
         if (auto castConvertedType =
                 mlir::dyn_cast<RankedTensorType>(convertedType)) {
+          if (isDynamicOrUnshapedType(castConvertedType)) return std::nullopt;
+
           //  Create the combined shape
           auto polyShape = castConvertedType.getShape();
           auto tensorShape = type.getShape();
@@ -302,9 +433,11 @@ void addTensorOfTensorConversionPatterns(TypeConverter& typeConverter,
   target.addDynamicallyLegalDialect<affine::AffineDialect>(
       [&](Operation* op) { return typeConverter.isLegal(op); });
 
-  patterns
-      .add<ConvertExtract, ConvertInsert, ConvertFromElements, ConvertSplat>(
-          typeConverter, patterns.getContext());
+  patterns.add<ConvertAny<tensor::EmptyOp>, ConvertExtract, ConvertInsert,
+               ConvertSplat, ConvertFromElements, ConvertReshape,
+               ConvertOffsetSizeStrideOp<tensor::ExtractSliceOp>,
+               ConvertOffsetSizeStrideOp<tensor::InsertSliceOp>>(
+      typeConverter, patterns.getContext());
 }
 
 void addStructuralConversionPatterns(TypeConverter& typeConverter,

--- a/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
+++ b/tests/Dialect/ModArith/Conversions/mod_arith_to_arith/mod-arith-to-arith.mlir
@@ -314,6 +314,48 @@ func.func @test_lower_tensor_rns_extract_slice(%arg : tensor<4x!RNS>) -> tensor<
   return %res : tensor<4x!RNS_slice>
 }
 
+// CHECK: @test_lower_rns_reshape
+// CHECK-SAME: (%[[ARG:.*]]: tensor<3x3xi11>) -> tensor<1x3x3xi11>
+func.func @test_lower_rns_reshape(%arg : tensor<3x!RNS>) -> tensor<1x3x!RNS> {
+  // CHECK: %[[SHAPE:.*]] = arith.constant dense<[1, 3, 3]>
+  %shape = arith.constant dense<[1, 3]> : tensor<2xindex>
+  // CHECK: %[[RESHAPE:.*]] = tensor.reshape %[[ARG]](%[[SHAPE]]) : (tensor<3x3xi11>, tensor<3xindex>) -> tensor<1x3x3xi11>
+  %res = tensor.reshape %arg(%shape) : (tensor<3x!RNS>, tensor<2xindex>) -> tensor<1x3x!RNS>
+  // CHECK: return %[[RESHAPE]]
+  return %res : tensor<1x3x!RNS>
+}
+
+// CHECK: @test_lower_rns_insert_slice
+// CHECK-SAME: (%[[SRC:.*]]: tensor<4096x2xi11>, %[[DEST:.*]]: tensor<2x1x4096x2xi11>
+func.func @test_lower_rns_insert_slice(%src : tensor<4096x!RNS_slice>, %dest : tensor<2x1x4096x!RNS_slice>, %i : index, %j : index) -> tensor<2x1x4096x!RNS_slice> {
+  // CHECK: tensor.insert_slice %[[SRC]] into %[[DEST]]
+  // CHECK-SAME: [{{.*}}, {{.*}}, 0, 0] [1, 1, 4096, 2] [1, 1, 1, 1]
+  %res = tensor.insert_slice %src into %dest[%i, %j, 0] [1, 1, 4096] [1, 1, 1] : tensor<4096x!RNS_slice> into tensor<2x1x4096x!RNS_slice>
+  return %res : tensor<2x1x4096x!RNS_slice>
+}
+
+// CHECK: @test_lower_extract_slice_tensor
+// CHECK-SAME: (%[[ARG:.*]]: tensor<2x2x3xi11>) -> tensor<2x3xi11>
+func.func @test_lower_extract_slice_tensor(%arg0: tensor<2x2x!RNS>) -> tensor<2x!RNS> {
+  // CHECK: %[[SLICE:.*]] = tensor.extract_slice %[[ARG]][1, 0, 0] [1, 2, 3] [1, 1, 1] : tensor<2x2x3xi11> to tensor<2x3xi11>
+  %slice = tensor.extract_slice %arg0[1, 0] [1, 2] [1, 1] : tensor<2x2x!RNS> to tensor<2x!RNS>
+  // CHECK: return %[[SLICE]] : tensor<2x3xi11>
+  return %slice : tensor<2x!RNS>
+}
+
+// CHECK: @test_lower_from_elements_2d
+// CHECK-SAME: (%[[A:.*]]: tensor<3xi11>, %[[B:.*]]: tensor<3xi11>) -> tensor<2x1x3xi11>
+func.func @test_lower_from_elements_2d(%a: !RNS, %b: !RNS) -> tensor<2x1x!RNS> {
+  // CHECK: %[[CONCAT:.*]] = tensor.concat
+  // CHECK-SAME: -> tensor<2x3xi11>
+  // CHECK: %[[SHAPE:.*]] = arith.constant dense<[2, 1, 3]>
+  // CHECK: %[[RESHAPE:.*]] = tensor.reshape %[[CONCAT]](%[[SHAPE]])
+  // CHECK-SAME: -> tensor<2x1x3xi11>
+  %result = tensor.from_elements %a, %b : tensor<2x1x!RNS>
+  // CHECK: return %[[RESHAPE]] : tensor<2x1x3xi11>
+  return %result : tensor<2x1x!RNS>
+}
+
 // CHECK: @test_lower_mod_switch_decompose
 // CHECK-SAME: (%[[ARG:.*]]: [[INT_TYPE:.*]]) -> [[TENSOR_TYPE:.*]] {
 func.func @test_lower_mod_switch_decompose(%arg : !Zp) -> !RNS {


### PR DESCRIPTION
- Added explicit uniform checks for unshaped tensors or tensors with a dynamic shape to robustly limit the coverage of these conversions. Note that `ConvertAny` still supports dynamic shapes, but it is the only one that does.
- Added support for `tensor.from_elements` where the output shape is multi-dimensional; previously it only handled the case of a 1D output. Added a test for this case.
- Added support for `tensor.extract_slice` via `ConvertOffsetSizeStrideOp`
- Added support for `tensor.insert_slice` via `ConvertOffsetSizeStrideOp`
- Added support for `tensor.reshape`