### PR TITLE
Updated use of deprecated APIs

### DIFF
--- a/lib/Transforms/Halo/Patterns.cpp
+++ b/lib/Transforms/Halo/Patterns.cpp
@@ -198,16 +198,6 @@ FailureOr<SmallVector<Value>> isLoopStructuredForHaloUnroll(
   return secretIterArgs;
 }
 
-// Inject an scf::ForOp overload of this function, which exists upstream for
-// affine already.
-FailureOr<int64_t> getConstantTripCount(scf::ForOp forOp) {
-  std::optional<APInt> maybeTripCount = forOp.getStaticTripCount();
-  if (!maybeTripCount.has_value()) {
-    return failure();
-  }
-  return maybeTripCount->getSExtValue();
-}
-
 template <typename ForOp>
 LogicalResult doPartialUnroll(ForOp forOp, PatternRewriter& rewriter,
                               int forceMaxLevel, DataFlowSolver* solver) {
@@ -221,12 +211,12 @@ LogicalResult doPartialUnroll(ForOp forOp, PatternRewriter& rewriter,
   LDBG(2) << "Loop is structured for Halo-style unroll";
   SmallVector<Value> secretIterArgs = secretIterArgsResult.value();
 
-  std::optional<uint64_t> maybeTripCount = getConstantTripCount(forOp);
+  std::optional<APInt> maybeTripCount = forOp.getStaticTripCount();
   if (!maybeTripCount.has_value()) {
     LDBG(2) << "Could not infer trip count";
     return failure();
   }
-  int64_t tripCount = maybeTripCount.value();
+  int64_t tripCount = maybeTripCount->getSExtValue();
   LDBG(2) << "Inferred trip count=" << tripCount;
 
   // Now we need to compute how many loop iterations we can unroll.

--- a/lib/Transforms/MemrefToArith/ExtractLoopBody.cpp
+++ b/lib/Transforms/MemrefToArith/ExtractLoopBody.cpp
@@ -74,9 +74,9 @@ static bool checkUsedForLoad(Operation* op, bool exclusive) {
 std::optional<uint64_t> getLoopSize(SmallVector<AffineForOp> forOps) {
   uint64_t size = 1;
   for (auto forOp : forOps) {
-    auto tripCount = affine::getConstantTripCount(forOp);
+    auto tripCount = forOp.getStaticTripCount();
     if (!tripCount.has_value()) return std::nullopt;
-    size *= tripCount.value();
+    size *= tripCount.value().getSExtValue();
   }
   return size;
 }

--- a/lib/Transforms/MemrefToArith/UnrollAndForward.cpp
+++ b/lib/Transforms/MemrefToArith/UnrollAndForward.cpp
@@ -364,17 +364,26 @@ void UnrollAndForwardPass::runOnOperation() {
     mlir::affine::getPerfectlyNestedLoops(nestedLoops, root);
     nestedLoops[0].getBody(0)->walk<WalkOrder::PostOrder>(
         [&](AffineForOp forOp) {
-          auto unrollFactor =
-              mlir::affine::getConstantTripCount(forOp).value_or(
-                  std::numeric_limits<int>::max());
+          auto tripCount = forOp.getStaticTripCount();
+          int64_t unrollFactor;
+          if (tripCount.has_value()) {
+            unrollFactor = tripCount->getSExtValue();
+          } else {
+            unrollFactor = std::numeric_limits<int>::max();
+          }
           if (failed(loopUnrollUpToFactor(forOp, unrollFactor))) {
             return WalkResult::skip();
           }
           return WalkResult::advance();
         });
 
-    auto unrollFactor = mlir::affine::getConstantTripCount(root).value_or(
-        std::numeric_limits<int>::max());
+    auto rootTripCount = root.getStaticTripCount();
+    int64_t unrollFactor;
+    if (rootTripCount.has_value()) {
+      unrollFactor = rootTripCount->getSExtValue();
+    } else {
+      unrollFactor = std::numeric_limits<int>::max();
+    }
     if (failed(loopUnrollUpToFactor(root, unrollFactor))) {
       return signalPassFailure();
     }


### PR DESCRIPTION
MLIR appears to have deprecated `getConstantTripCount` for `AffineForOp` and `scf::ForOp`. This PR switches to the recommended `getStaticTripCount` API to reduce warnings.