### PR TITLE
Parse ModArith constants as modulus's bit-width

### DIFF
--- a/lib/Dialect/ModArith/IR/ModArithOps.cpp
+++ b/lib/Dialect/ModArith/IR/ModArithOps.cpp
@@ -223,7 +223,23 @@ LogicalResult BarrettReduceOp::verify() {
 }
 
 ParseResult ConstantOp::parse(OpAsmParser& parser, OperationState& result) {
-  unsigned minBitwidth = 4;  // bitwidth assigned by parser to integer `1`
+  auto normalizeInteger = [&](APInt& parsedInt,
+                              unsigned storageWidth) -> ParseResult {
+    if (parsedInt.isNegative()) {
+      if (parsedInt.getSignificantBits() > storageWidth)
+        return parser.emitError(parser.getNameLoc(),
+                                "constant value does not fit in storage type"),
+               failure();
+      parsedInt = parsedInt.sextOrTrunc(storageWidth);
+      return success();
+    }
+    if (parsedInt.getActiveBits() > storageWidth)
+      return parser.emitError(parser.getNameLoc(),
+                              "constant value does not fit in storage type"),
+             failure();
+    parsedInt = parsedInt.zextOrTrunc(storageWidth);
+    return success();
+  };
   Type parsedType;
   if (parser.parseOptionalKeyword("dense").succeeded()) {
     // Dense case
@@ -251,18 +267,19 @@ ParseResult ConstantOp::parse(OpAsmParser& parser, OperationState& result) {
       return parser.emitError(parser.getNameLoc(),
                               "expected at least one integer in dense list.");
 
-    unsigned maxWidth = 0;
+    auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(parsedType));
+    if (!modType)
+      return parser.emitError(parser.getNameLoc(),
+                              "expected mod_arith-like result type"),
+             failure();
+    auto storageType = modType.getModulus().getType();
+    unsigned storageWidth = storageType.getIntOrFloatBitWidth();
     for (auto& parsedInt : parsedInts) {
-      // zero becomes `i64` when parsed, so truncate back down to minBitwidth
-      parsedInt = parsedInt.isZero() ? parsedInt.trunc(minBitwidth) : parsedInt;
-      maxWidth = std::max(maxWidth, parsedInt.getBitWidth());
-    }
-    for (auto& parsedInt : parsedInts) {
-      parsedInt = parsedInt.zextOrTrunc(maxWidth);
+      if (failed(normalizeInteger(parsedInt, storageWidth))) return failure();
     }
     auto attr = DenseIntElementsAttr::get(
         RankedTensorType::get({static_cast<int64_t>(parsedInts.size())},
-                              IntegerType::get(parser.getContext(), maxWidth)),
+                              storageType),
         parsedInts);
     result.addAttribute("value", attr);
   } else {
@@ -272,12 +289,16 @@ ParseResult ConstantOp::parse(OpAsmParser& parser, OperationState& result) {
       return parser.emitError(parser.getNameLoc(),
                               "failed to parse scalar constant"),
              failure();
-    // zero becomes `i64` when parsed, so truncate back down to minBitwidth
-    if (parsedInt.isZero()) parsedInt = parsedInt.trunc(minBitwidth);
-    result.addAttribute(
-        "value", IntegerAttr::get(IntegerType::get(parser.getContext(),
-                                                   parsedInt.getBitWidth()),
-                                  parsedInt));
+    // Convert the scalar to the modulus's width
+    auto modType = dyn_cast<ModArithType>(getElementTypeOrSelf(parsedType));
+    if (!modType)
+      return parser.emitError(parser.getNameLoc(),
+                              "expected mod_arith-like result type"),
+             failure();
+    auto storageType = modType.getModulus().getType();
+    unsigned storageWidth = storageType.getIntOrFloatBitWidth();
+    if (failed(normalizeInteger(parsedInt, storageWidth))) return failure();
+    result.addAttribute("value", IntegerAttr::get(storageType, parsedInt));
   }
   result.addTypes(parsedType);
   return success();
@@ -301,7 +322,7 @@ LogicalResult ConstantOp::verify() {
   if (intAttr) {
     if (intAttr.getValue().getBitWidth() > modBW)
       return emitOpError(
-          "value's bitwidth must not be larger than underlying type.");
+          "value's bitwidth must not be larger than underlying type");
     return success();
   }
 

--- a/tests/Dialect/ModArith/IR/invalid-ops.mlir
+++ b/tests/Dialect/ModArith/IR/invalid-ops.mlir
@@ -34,7 +34,7 @@ func.func @test_barrett_neg_mod_err(%arg : i8) -> i8 {
 
 // -----
 func.func @test_constant_bad_width() {
-  // expected-error@+1 {{value's bitwidth must not be larger than underlying type.}}
+  // expected-error@+1 {{custom op 'mod_arith.constant' constant value does not fit in storage type}}
   %c = mod_arith.constant 512 : !mod_arith.int<17 : i8>
   return
 }

--- a/tests/Dialect/ModArith/IR/syntax.mlir
+++ b/tests/Dialect/ModArith/IR/syntax.mlir
@@ -11,6 +11,8 @@
 !int_vec = tensor<5x6x3xi10>
 !rns1_vec = tensor<5x!rns1>
 !Zp_large = !mod_arith.int<2223821 : i32>
+!Zp_i64 = !mod_arith.int<14604445665681409 : i64>
+!Zp_i64_vec = tensor<2x!Zp_i64>
 
 // CHECK: @test_arith_syntax
 func.func @test_arith_syntax() {
@@ -97,6 +99,15 @@ func.func @test_arith_syntax() {
   %mod_switch_same_width = mod_arith.mod_switch %e6 : !Zp to !mod_arith.int<31 : i10>
   %mod_switch_larger = mod_arith.mod_switch %e6 : !Zp to !mod_arith.int<18446744069414584321 : i65>
 
+  return
+}
+
+// CHECK: @test_large_decimal_constant_syntax
+func.func @test_large_decimal_constant_syntax() {
+  // CHECK: mod_arith.constant 12535824225335233 : !mod_arith.int<14604445665681409 : i64>
+  %scalar = mod_arith.constant 12535824225335233 : !Zp_i64
+  // CHECK: mod_arith.constant dense<[12535824225335233, 0]> : tensor<2x!mod_arith.int<14604445665681409 : i64>>
+  %dense = mod_arith.constant dense<[12535824225335233, 0]> : !Zp_i64_vec
   return
 }
 


### PR DESCRIPTION
This simple test fails on both lines, for different reasons.
```
func.func @test_large_decimal_constant_syntax() {
  %scalar = mod_arith.constant 12535824225335233 : !Zp_i64
  %dense = mod_arith.constant dense<[12535824225335233, 0]> : !Zp_i64_vec
  return
}
```

For the first line, 12535824225335233 is a 53-bit constant, but it triggers an error in the ConstantOp verifier that the constant is too big to fit in the modulus. For some reason, MLIR's int parser makes it a 68-bit value.

For the second line, existing code in the ConstantOp parser sets 0 to 4 bits, but this is incompatible with a non-zero constant (of any size other than 4 bits).

This PR fixes these issues by forcing all ModArith constants to have the same bit-width as the modulus (after checking that it in fact fits).

Assisted by AI.