### PR TITLE
Fixed ModDown step of lwe::keySwitchInner

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToPolynomial/LWEToPolynomial.cpp
@@ -422,6 +422,26 @@ struct ConvertRNegate : public OpConversionPattern<RNegateOp> {
   }
 };
 
+struct ConvertMulScalar : public OpConversionPattern<MulScalarOp> {
+  ConvertMulScalar(mlir::MLIRContext* context)
+      : OpConversionPattern<MulScalarOp>(context) {}
+
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      MulScalarOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getOutput().getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op,
+                                         "Result type could not be converted");
+    }
+    rewriter.replaceOpWithNewOp<polynomial::MulScalarOp>(
+        op, resultType, adaptor.getCiphertext(), adaptor.getScalar());
+    return success();
+  }
+};
+
 struct ConvertRMul : public OpConversionPattern<RMulOp> {
   ConvertRMul(mlir::MLIRContext* context)
       : OpConversionPattern<RMulOp>(context) {}
@@ -647,15 +667,15 @@ struct LWEToPolynomial : public impl::LWEToPolynomialBase<LWEToPolynomial> {
 
     RewritePatternSet patterns(context);
 
-    patterns
-        .add<ConvertRLWEDecrypt, ConvertRLWEEncrypt, ConvertRAdd, ConvertRSub,
-             ConvertRNegate, ConvertRMul, ConvertRAddPlain, ConvertRSubPlain,
-             ConvertRMulPlain, ConvertRMulRingElt, ConvertExtractCoeff,
-             ConvertFromCoeffs, ConvertExtractSlice, ConvertConvertBasis>(
-            typeConverter, context);
+    patterns.add<ConvertRLWEDecrypt, ConvertRLWEEncrypt, ConvertRAdd,
+                 ConvertRSub, ConvertRNegate, ConvertMulScalar, ConvertRMul,
+                 ConvertRAddPlain, ConvertRSubPlain, ConvertRMulPlain,
+                 ConvertRMulRingElt, ConvertExtractCoeff, ConvertFromCoeffs,
+                 ConvertExtractSlice, ConvertConvertBasis>(typeConverter,
+                                                           context);
     target.addIllegalOp<RLWEDecryptOp, RLWEEncryptOp, RAddOp, RSubOp, RNegateOp,
-                        RMulOp, RMulRingEltOp, RAddPlainOp, RSubPlainOp,
-                        RMulPlainOp, ExtractCoeffOp, FromCoeffsOp,
+                        MulScalarOp, RMulOp, RMulRingEltOp, RAddPlainOp,
+                        RSubPlainOp, RMulPlainOp, ExtractCoeffOp, FromCoeffsOp,
                         ExtractSliceOp, ConvertBasisOp>();
 
     addStructuralConversionPatterns(typeConverter, patterns, target);

--- a/lib/Dialect/LWE/IR/LWEOps.cpp
+++ b/lib/Dialect/LWE/IR/LWEOps.cpp
@@ -111,6 +111,27 @@ LogicalResult RLWEEncryptOp::verify() {
   return success();
 }
 
+LogicalResult ModDownOp::verify() {
+  // check that the target basis is a prefix of the input basis
+  auto ctType = dyn_cast<lwe::LWECiphertextType>(getInput().getType());
+  if (!ctType) return emitOpError("Expected input to be an LWECiphertextType");
+  auto eltTy = dyn_cast<rns::RNSType>(
+      ctType.getCiphertextSpace().getRing().getCoefficientType());
+  if (!eltTy) return emitOpError("Expected element type to be RNSType");
+  rns::RNSType targetBasisTy = dyn_cast<rns::RNSType>(getTargetBasis());
+  if (!targetBasisTy) return emitOpError("Expected targetBasis to be RNSType");
+
+  ArrayRef<Type> inputBasisTypes = eltTy.getBasisTypes();
+  ArrayRef<Type> targetBasisTypes = targetBasisTy.getBasisTypes();
+  bool isPrefix =
+      (targetBasisTypes.size() < inputBasisTypes.size()) &&
+      (inputBasisTypes.take_front(targetBasisTypes.size()) == targetBasisTypes);
+  if (!isPrefix) {
+    return emitOpError("Target basis is not a prefix of the input basis");
+  }
+  return success();
+}
+
 // Verify Encoding and Type match
 LogicalResult verifyEncodingAndTypeMatch(mlir::Type type,
                                          mlir::Attribute encoding) {
@@ -342,6 +363,30 @@ LogicalResult ConvertBasisOp::inferReturnTypes(
       ctx, elementType, ringAttr.getPolynomialModulus());
   lwe::LWERingEltType resultType =
       lwe::LWERingEltType::get(ctx, outputRingAttr);
+  results.push_back(resultType);
+  return success();
+}
+
+LogicalResult ModDownOp::inferReturnTypes(
+    MLIRContext* ctx, std::optional<Location>, ValueRange operands,
+    DictionaryAttr attrs, mlir::PropertyRef properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type>& results) {
+  ModDownOpAdaptor op(operands, attrs, properties, regions);
+  auto inputCtType = dyn_cast<lwe::LWECiphertextType>(op.getInput().getType());
+  if (!inputCtType) return failure();
+  lwe::CiphertextSpaceAttr inputCtSpaceAttr = inputCtType.getCiphertextSpace();
+  polynomial::RingAttr inputRingAttr = inputCtSpaceAttr.getRing();
+
+  rns::RNSType outputElementType = dyn_cast<rns::RNSType>(op.getTargetBasis());
+  if (!outputElementType) return failure();
+  auto outputRingAttr = polynomial::RingAttr::get(
+      ctx, outputElementType, inputRingAttr.getPolynomialModulus());
+  auto outputCtSpaceAttr = lwe::CiphertextSpaceAttr::get(
+      ctx, outputRingAttr, inputCtSpaceAttr.getEncryptionType(),
+      inputCtSpaceAttr.getSize());
+  auto resultType = lwe::LWECiphertextType::get(
+      ctx, inputCtType.getPlaintextSpace(), outputCtSpaceAttr,
+      inputCtType.getKey(), inputCtType.getModulusChain());
   results.push_back(resultType);
   return success();
 }

--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -176,7 +176,7 @@ def LWE_RNegateOp : LWE_Op<"rnegate", [SameOperandsAndResultType, ElementwiseMap
 def LWE_MulScalarOp : LWE_Op<"mul_scalar", [ElementwiseMappable,
     AllTypesMatch<["ciphertext", "output"]>]> {
   let summary = "Multiply an LWE ciphertext by a scalar";
-  let arguments = (ins LWECiphertextLike:$ciphertext, AnyInteger:$scalar);
+  let arguments = (ins LWECiphertextLike:$ciphertext, AnyType:$scalar);
   let results = (outs LWECiphertextLike:$output);
   let hasFolder = 1;
 }
@@ -337,6 +337,23 @@ def LWE_ConvertBasisOp : LWE_Op<"convert_basis", [Pure, DeclareOpInterfaceMethod
     LWERingElt:$output
   );
   let assemblyFormat = "$value attr-dict `:` type($value) `->` type($output)";
+}
+
+def LWE_ModDownOp : LWE_Op<"mod_down", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {
+  let summary = "Scale a plaintext by the ratio of the input and output (target) moduli.";
+  let description = [{
+    Given an encryption of `x` with ciphertext modulus `Q` and target modulus `Q'`, produces
+    an encryption of round(Q' / Q * x).
+
+    The target RNS basis must be a prefix of the input's RNS basis.
+  }];
+  let arguments = (ins
+      LWECiphertext:$input,
+      TypeAttr:$targetBasis
+  );
+  let results = (outs LWECiphertext:$output);
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
+  let hasVerifier = 1;
 }
 
 def LWE_KeySwitchInnerOp : LWE_Op<"key_switch_inner", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>]> {

--- a/lib/Dialect/LWE/Transforms/BUILD
+++ b/lib/Dialect/LWE/Transforms/BUILD
@@ -13,7 +13,7 @@ cc_library(
     ],
     deps = [
         ":AddDebugPort",
-        ":DecomposeKeySwitch",
+        ":DecomposeLWEOps",
         ":ImplementTrivialEncryptionAsAddition",
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
@@ -41,14 +41,15 @@ cc_library(
 )
 
 cc_library(
-    name = "DecomposeKeySwitch",
-    srcs = ["DecomposeKeySwitch.cpp"],
-    hdrs = ["DecomposeKeySwitch.h"],
+    name = "DecomposeLWEOps",
+    srcs = ["DecomposeLWEOps.cpp"],
+    hdrs = ["DecomposeLWEOps.h"],
     deps = [
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Dialect/ModArith/IR:Dialect",
         "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@heir//lib/Utils:APIntUtils",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",

--- a/lib/Dialect/LWE/Transforms/DecomposeLWEOps.cpp
+++ b/lib/Dialect/LWE/Transforms/DecomposeLWEOps.cpp
@@ -1,5 +1,6 @@
-#include "lib/Dialect/LWE/Transforms/DecomposeKeySwitch.h"
+#include "lib/Dialect/LWE/Transforms/DecomposeLWEOps.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <utility>
 
@@ -7,8 +8,11 @@
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Dialect/ModArith/IR/ModArithAttributes.h"
 #include "lib/Dialect/ModArith/IR/ModArithTypes.h"
+#include "lib/Dialect/RNS/IR/RNSOps.h"
 #include "lib/Dialect/RNS/IR/RNSTypes.h"
+#include "lib/Utils/APIntUtils.h"
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
@@ -20,14 +24,127 @@
 #include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
-#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace lwe {
 
-#define GEN_PASS_DEF_DECOMPOSEKEYSWITCH
+namespace {
+
+FailureOr<Value> createPInvModQConstant(
+    ModDownOp op, ImplicitLocOpBuilder& b, rns::RNSType inputRNSType,
+    ArrayRef<mod_arith::ModArithType> keySwitchPrimeTypes) {
+  SmallVector<Attribute> pInvModQResidues;
+  pInvModQResidues.reserve(inputRNSType.getBasisTypes().size());
+
+  for (Type ty : inputRNSType.getBasisTypes()) {
+    auto qiTy = dyn_cast<mod_arith::ModArithType>(ty);
+    if (!qiTy) {
+      op.emitOpError()
+          << "input basis element must be a mod_arith type to build P^-1 mod Q";
+      return failure();
+    }
+
+    APInt qi = qiTy.getModulus().getValue();
+    APInt pModQi(qi.getBitWidth(), 1);
+    for (mod_arith::ModArithType pjTy : keySwitchPrimeTypes) {
+      APInt pj = pjTy.getModulus().getValue();
+      unsigned reductionWidth = std::max(qi.getBitWidth(), pj.getBitWidth());
+      APInt pjModQi = pj.zextOrTrunc(reductionWidth)
+                          .urem(qi.zextOrTrunc(reductionWidth))
+                          .zextOrTrunc(qi.getBitWidth());
+      pModQi = modularMultiplication(pModQi, pjModQi, qi);
+    }
+
+    APInt pInvModQi = multiplicativeInverse(pModQi, qi);
+    if (pInvModQi.isZero()) {
+      op.emitOpError() << "failed to compute P^-1 modulo input limb " << qiTy;
+      return failure();
+    }
+
+    IntegerAttr pInvAttr =
+        IntegerAttr::get(qiTy.getModulus().getType(), pInvModQi);
+    pInvModQResidues.push_back(
+        mod_arith::ModArithAttr::get(op.getContext(), qiTy, pInvAttr));
+  }
+
+  auto pInvModQAttr = rns::RNSAttr::get(inputRNSType, pInvModQResidues);
+  return rns::ConstantOp::create(b, inputRNSType, pInvModQAttr).getResult();
+}
+
+}  // namespace
+
+#define GEN_PASS_DEF_DECOMPOSELWEOPS
 #include "lib/Dialect/LWE/Transforms/Passes.h.inc"
+
+LogicalResult DecomposeModDownPattern::matchAndRewrite(
+    ModDownOp op, PatternRewriter& rewriter) const {
+  ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+  lwe::LWECiphertextType ctType = op.getInput().getType();
+  auto eltTy = dyn_cast<rns::RNSType>(
+      ctType.getCiphertextSpace().getRing().getCoefficientType());
+  if (!eltTy) return op->emitOpError("Expected element type to be RNSType");
+  ArrayRef<Type> inputBasisTypes = eltTy.getBasisTypes();
+  int64_t numInputLimbs = inputBasisTypes.size();
+
+  auto targetBasisTy = dyn_cast<rns::RNSType>(op.getTargetBasis());
+  if (!targetBasisTy) return failure();
+  ArrayRef<Type> targetBasisTypes = targetBasisTy.getBasisTypes();
+  int64_t numTargetLimbs = targetBasisTypes.size();
+
+  SmallVector<mod_arith::ModArithType> keySwitchPrimeTypes;
+  for (Type ty : inputBasisTypes.drop_front(targetBasisTypes.size())) {
+    auto modArithType = dyn_cast<mod_arith::ModArithType>(ty);
+    if (!modArithType) {
+      return op->emitOpError()
+             << "key-switching prime basis element must be a mod_arith type";
+    }
+    keySwitchPrimeTypes.push_back(modArithType);
+  }
+
+  SmallVector<Value> basePrimeCoeffs;
+  SmallVector<Value> convertedKeySwitchPrimeCoeffs;
+  int64_t numCiphertextComponents = ctType.getCiphertextSpace().getSize();
+  for (int64_t i = 0; i < numCiphertextComponents; ++i) {
+    Value coeff =
+        lwe::ExtractCoeffOp::create(b, op.getInput(), b.getIndexAttr(i));
+
+    // Extract the mod-q components.
+    Value basePrimeSlice = lwe::ExtractSliceOp::create(
+        b, coeff, b.getIndexAttr(0), b.getIndexAttr(numTargetLimbs));
+    basePrimeCoeffs.push_back(basePrimeSlice);
+
+    // Extract the key-switch-prime components and basis-convert them to mod-q.
+    Value kskPrimeSlice = lwe::ExtractSliceOp::create(
+        b, coeff, b.getIndexAttr(numTargetLimbs),
+        b.getIndexAttr(numInputLimbs - numTargetLimbs));
+    Value kskSliceToBasePrimes = lwe::ConvertBasisOp::create(
+        b, kskPrimeSlice, TypeAttr::get(targetBasisTy));
+    convertedKeySwitchPrimeCoeffs.push_back(kskSliceToBasePrimes);
+  }
+
+  auto outputCtType = cast<lwe::LWECiphertextType>(op.getOutput().getType());
+  Value basePrimeCt =
+      lwe::FromCoeffsOp::create(b, outputCtType, basePrimeCoeffs);
+  Value kskPrimeCt =
+      lwe::FromCoeffsOp::create(b, outputCtType, convertedKeySwitchPrimeCoeffs);
+
+  // subtract
+  Value diffCt = lwe::RSubOp::create(b, basePrimeCt, kskPrimeCt);
+
+  // scale by a constant, which is P^{-1} mod Q,
+  // where P is the product of the special/key-switch primes and Q is the
+  // product of the input basis
+  FailureOr<Value> pInvModQ =
+      createPInvModQConstant(op, b, targetBasisTy, keySwitchPrimeTypes);
+  if (failed(pInvModQ)) return failure();
+  Value scaledCt = lwe::MulScalarOp::create(b, diffCt, pInvModQ.value());
+
+  rewriter.replaceOp(op, scaledCt);
+  return success();
+}
 
 LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
     KeySwitchInnerOp op, PatternRewriter& rewriter) const {
@@ -66,18 +183,17 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
            << "key-switching key basis must start with the input basis";
   }
 
-  SmallVector<int64_t> keySwitchPrimes;
+  SmallVector<mod_arith::ModArithType> keySwitchPrimeTypes;
   for (Type ty : keyBasis.drop_front(inputBasis.size())) {
     auto modArithType = dyn_cast<mod_arith::ModArithType>(ty);
     if (!modArithType) {
       return op->emitOpError()
              << "key-switching prime basis element must be a mod_arith type";
     }
-    keySwitchPrimes.push_back(
-        modArithType.getModulus().getValue().getSExtValue());
+    keySwitchPrimeTypes.push_back(modArithType);
   }
 
-  int64_t partSize = keySwitchPrimes.size();
+  int64_t partSize = keySwitchPrimeTypes.size();
   if (!partSize) {
     return rewriter.notifyMatchFailure(
         op, "Cannot lower key_switch_inner with empty modulus chain");
@@ -87,7 +203,7 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
   // ## Step 1: Decompose Input ##
   // #############################
 
-  int rnsLength = inputRNSType.getBasisTypes().size();
+  int rnsLength = inputBasis.size();
   int64_t numFullPartitions = rnsLength / partSize;
   int64_t extraPartStart = partSize * numFullPartitions;
   int64_t extraPartSize = rnsLength - extraPartStart;
@@ -138,9 +254,8 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
   for (auto ty : inputRNSType.getBasisTypes()) {
     extModuli.push_back(ty);
   }
-  for (auto prime : keySwitchPrimes) {
-    extModuli.push_back(mod_arith::ModArithType::get(
-        op.getContext(), b.getI64IntegerAttr(prime)));
+  for (auto primeType : keySwitchPrimeTypes) {
+    extModuli.push_back(primeType);
   }
   rns::RNSType newBasisType = rns::RNSType::get(op.getContext(), extModuli);
 
@@ -172,26 +287,28 @@ LogicalResult DecomposeKeySwitchPattern::matchAndRewrite(
   // ##########################################
   // ## Step 4: Remove the key-switch primes ##
   // ##########################################
-  Value constTerm = lwe::ExtractCoeffOp::create(b, sum, b.getIndexAttr(0));
-  Value linearTerm = lwe::ExtractCoeffOp::create(b, sum, b.getIndexAttr(1));
-  Value modDownConstTerm =
-      lwe::ConvertBasisOp::create(b, constTerm, TypeAttr::get(inputRNSType));
-  Value modDownLinearTerm =
-      lwe::ConvertBasisOp::create(b, linearTerm, TypeAttr::get(inputRNSType));
+  Value scaledCt = lwe::ModDownOp::create(b, sum, TypeAttr::get(inputRNSType));
+  Value newConstTerm =
+      lwe::ExtractCoeffOp::create(b, scaledCt, b.getIndexAttr(0));
+  Value newLinearTerm =
+      lwe::ExtractCoeffOp::create(b, scaledCt, b.getIndexAttr(1));
 
-  rewriter.replaceOp(op, {modDownConstTerm, modDownLinearTerm});
+  rewriter.replaceOp(op, {newConstTerm, newLinearTerm});
   return success();
 }
 
-struct DecomposeKeySwitch : impl::DecomposeKeySwitchBase<DecomposeKeySwitch> {
-  using DecomposeKeySwitchBase::DecomposeKeySwitchBase;
+struct DecomposeLWEOps : impl::DecomposeLWEOpsBase<DecomposeLWEOps> {
+  using DecomposeLWEOpsBase::DecomposeLWEOpsBase;
 
   void runOnOperation() override {
     MLIRContext* context = &getContext();
     RewritePatternSet patterns(context);
 
-    patterns.add<DecomposeKeySwitchPattern>(context);
-    (void)walkAndApplyPatterns(getOperation(), std::move(patterns));
+    patterns.add<DecomposeKeySwitchPattern, DecomposeModDownPattern>(context);
+    if (failed(
+            mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
   }
 };
 

--- a/lib/Dialect/LWE/Transforms/DecomposeLWEOps.h
+++ b/lib/Dialect/LWE/Transforms/DecomposeLWEOps.h
@@ -1,5 +1,5 @@
-#ifndef LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
-#define LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
+#ifndef LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_LWE_OPS_H_
+#define LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_LWE_OPS_H_
 
 #include "lib/Dialect/LWE/IR/LWEOps.h"
 #include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
@@ -14,7 +14,7 @@ namespace mlir {
 namespace heir {
 namespace lwe {
 
-#define GEN_PASS_DECL_DECOMPOSEKEYSWITCH
+#define GEN_PASS_DECL_DECOMPOSELWEOPS
 #include "lib/Dialect/LWE/Transforms/Passes.h.inc"
 
 struct DecomposeKeySwitchPattern : public OpRewritePattern<KeySwitchInnerOp> {
@@ -25,8 +25,16 @@ struct DecomposeKeySwitchPattern : public OpRewritePattern<KeySwitchInnerOp> {
                                 PatternRewriter& rewriter) const override;
 };
 
+struct DecomposeModDownPattern : public OpRewritePattern<ModDownOp> {
+  using OpRewritePattern<ModDownOp>::OpRewritePattern;
+
+ public:
+  LogicalResult matchAndRewrite(ModDownOp op,
+                                PatternRewriter& rewriter) const override;
+};
+
 }  // namespace lwe
 }  // namespace heir
 }  // namespace mlir
 
-#endif  // LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_KEYSWITCH_H_
+#endif  // LIB_DIALECT_LWE_TRANSFORMS_DECOMPOSE_LWE_OPS_H_

--- a/lib/Dialect/LWE/Transforms/Passes.h
+++ b/lib/Dialect/LWE/Transforms/Passes.h
@@ -4,7 +4,7 @@
 // IWYU pragma: begin_keep
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
-#include "lib/Dialect/LWE/Transforms/DecomposeKeySwitch.h"
+#include "lib/Dialect/LWE/Transforms/DecomposeLWEOps.h"
 #include "lib/Dialect/LWE/Transforms/ImplementTrivialEncryptionAsAddition.h"
 // IWYU pragma: end_keep
 

--- a/lib/Dialect/LWE/Transforms/Passes.td
+++ b/lib/Dialect/LWE/Transforms/Passes.td
@@ -69,10 +69,10 @@ def ImplementTrivialEncryptionAsAddition : Pass<"implement-trivial-encryption-as
   let options = [];
 }
 
-def DecomposeKeySwitch : Pass<"lwe-decompose-keyswitch"> {
-  let summary = "Decomposes lwe.key_switch_inner into primitive LWE ops";
+def DecomposeLWEOps : Pass<"lwe-decompose"> {
+  let summary = "Decomposes complex LWE ops into primitive LWE ops";
   let description = [{
-  (* example filepath=tests/Dialect/LWE/Transforms/decompose_keyswitch.mlir *)
+  (* example filepath=tests/Dialect/LWE/Transforms/DecomposeLWEOps/keyswitch.mlir *)
   }];
   let dependentDialects = [
     "mlir::arith::ArithDialect",

--- a/tests/Dialect/LWE/Conversions/lwe_to_polynomial/lower_relinearize_to_polynomial.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_polynomial/lower_relinearize_to_polynomial.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --ckks-decompose-relinearize --ckks-to-lwe --lwe-decompose-keyswitch --lwe-to-polynomial --convert-polynomial-mul-to-ntt --attach-ntt-roots --rns-lower-convert-basis %s
+// RUN: heir-opt --ckks-decompose-relinearize --ckks-to-lwe --lwe-decompose --lwe-to-polynomial --convert-polynomial-mul-to-ntt --attach-ntt-roots --rns-lower-convert-basis %s
 
 !Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
 !Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>

--- a/tests/Dialect/LWE/Conversions/lwe_to_polynomial/mul_scalar.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_polynomial/mul_scalar.mlir
@@ -1,0 +1,27 @@
+// RUN: heir-opt %s --lwe-to-polynomial | FileCheck %s
+
+!Z1032955396097_i64 = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64 = !mod_arith.int<1095233372161 : i64>
+!Z998595133441_i64 = !mod_arith.int<998595133441 : i64>
+
+!rns_L1 = !rns.rns<!Z1095233372161_i64, !Z1032955396097_i64>
+!rns_L2 = !rns.rns<!Z1095233372161_i64, !Z1032955396097_i64, !Z998595133441_i64>
+
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#ring_rns_L1_x1024 = #polynomial.ring<coefficientType = !rns_L1, polynomialModulus = <1 + x**1024>>
+#ring_rns_L2_x1024 = #polynomial.ring<coefficientType = !rns_L2, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L1 = #lwe.ciphertext_space<ring = #ring_rns_L1_x1024, encryption_type = lsb>
+
+!ct_L1 = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_rns_L2_x1024, encoding = #inverse_canonical_encoding>, ciphertext_space = #ciphertext_space_L1, key = #key>
+
+// CHECK: func.func @test_mul_scalar
+// CHECK-SAME: tensor<2x!poly
+// CHECK: polynomial.sub
+// CHECK: polynomial.mul_scalar
+// CHECK-NOT: lwe.mul_scalar
+func.func @test_mul_scalar(%lhs: !ct_L1, %rhs: !ct_L1, %scalar: !rns_L1) -> !ct_L1 {
+  %diff = lwe.rsub %lhs, %rhs : (!ct_L1, !ct_L1) -> !ct_L1
+  %scaled = lwe.mul_scalar %diff, %scalar : (!ct_L1, !rns_L1) -> !ct_L1
+  return %scaled : !ct_L1
+}

--- a/tests/Dialect/LWE/Transforms/DecomposeLWEOps/keyswitch.mlir
+++ b/tests/Dialect/LWE/Transforms/DecomposeLWEOps/keyswitch.mlir
@@ -1,7 +1,6 @@
-// RUN: heir-opt --lwe-decompose-keyswitch %s | FileCheck %s
+// RUN: heir-opt --lwe-decompose %s | FileCheck %s
 
 !Zq0 = !mod_arith.int<1095233372161 : i64>
-!Zq1 = !mod_arith.int<1032955396097 : i64>
 !Zp0 = !mod_arith.int<261405424692085787 : i64>
 
 // Input's type
@@ -35,6 +34,7 @@ module attributes {
   // CHECK-SAME: [[x:%.+]]: !ringelt,
   // CHECK-SAME: [[ksk:%.+]]: tensor<1x!ct_L1>) -> (!ringelt, !ringelt) {
   func.func @test_keyswitch(%x: !ringelt_L1, %arg0: tensor<1x!ct_L2>) -> (!ringelt_L1, !ringelt_L1) {
+    // CHECK-DAG: [[rnsConst:%.+]] = rns.constant
     // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
     // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 0 : index} : !ringelt -> !ringelt
     // !ringelt1 has the same LWERingElt type as the keyswitch key
@@ -42,10 +42,20 @@ module attributes {
     // CHECK-DAG: [[ksk0:%.+]] = tensor.extract [[ksk]][[[C0]]] : tensor<1x!ct_L1>
     // CHECK-DAG: [[dp:%.+]] = lwe.mul_ring_elt [[extPart0]], [[ksk0]] : (!ringelt1, !ct_L1) -> !ct_L1
     // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : !ct_L1
+    // CHECK-DAG: [[constTermQ:%.+]] = lwe.extract_slice [[constTerm]] {size = 1 : index, start = 0 : index} : !ringelt1 -> !ringelt
+    // CHECK-DAG: [[constTermP:%.+]] = lwe.extract_slice [[constTerm]] {size = 1 : index, start = 1 : index} : !ringelt1 -> [[kskelt:!.+]]
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTermP]] {targetBasis = [[kskBasis:!.+]]} : [[kskelt]] -> !ringelt
     // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : !ct_L1
-    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L0} : !ringelt1 -> !ringelt
-    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L0} : !ringelt1 -> !ringelt
-    // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt, !ringelt
+    // CHECK-DAG: [[linearTermQ:%.+]] = lwe.extract_slice [[linearTerm]] {size = 1 : index, start = 0 : index} : !ringelt1 -> !ringelt
+    // CHECK-DAG: [[linearTermP:%.+]] = lwe.extract_slice [[linearTerm]] {size = 1 : index, start = 1 : index} : !ringelt1 -> [[kskelt]]
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTermP]] {targetBasis = [[kskBasis]]} : [[kskelt]] -> !ringelt
+    // CHECK-DAG: [[ctQ:%.+]] = lwe.from_coeffs [[constTermQ]], [[linearTermQ]]
+    // CHECK-DAG: [[ctP:%.+]] = lwe.from_coeffs [[const_ext]], [[linear_ext]]
+    // CHECK-DAG: [[diff:%.+]] = lwe.rsub [[ctQ]], [[ctP]]
+    // CHECK-DAG: [[scaledDiff:%.+]] = lwe.mul_scalar [[diff]], [[rnsConst]]
+    // CHECK-DAG: [[newConst:%.+]] = lwe.extract_coeff [[scaledDiff]] {index = 0 : index}
+    // CHECK-DAG: [[newLinear:%.+]] = lwe.extract_coeff [[scaledDiff]] {index = 1 : index}
+    // CHECK-DAG: return [[newConst]], [[newLinear]] : !ringelt, !ringelt
     %constTerm, %linearTerm = lwe.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<1x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
     return %constTerm, %linearTerm: !ringelt_L1, !ringelt_L1
   }

--- a/tests/Dialect/LWE/Transforms/DecomposeLWEOps/keyswitch_multipart.mlir
+++ b/tests/Dialect/LWE/Transforms/DecomposeLWEOps/keyswitch_multipart.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --lwe-decompose-keyswitch %s | FileCheck %s
+// RUN: heir-opt --lwe-decompose %s | FileCheck %s
 
 !Zq0 = !mod_arith.int<1095233372161 : i64>
 !Zq1 = !mod_arith.int<1032955396097 : i64>
@@ -54,9 +54,20 @@ module attributes {
     // CHECK-DAG: [[dp:%.+]] = lwe.radd [[dp0]], [[dp1]] : (!ct_L2, !ct_L2) -> !ct_L2
     // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : !ct_L2
     // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : !ct_L2
-    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L1} : !ringelt3 -> !ringelt
-    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L1} : !ringelt3 -> !ringelt
-    // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt, !ringelt
+    // CHECK-DAG: [[constTermQ:%.+]] = lwe.extract_slice [[constTerm]] {size = 2 : index, start = 0 : index} : !ringelt3 -> !ringelt
+    // CHECK-DAG: [[linearTermQ:%.+]] = lwe.extract_slice [[linearTerm]] {size = 2 : index, start = 0 : index} : !ringelt3 -> !ringelt
+    // CHECK-DAG: [[constTermP:%.+]] = lwe.extract_slice [[constTerm]] {size = 1 : index, start = 2 : index} : !ringelt3 -> [[kskelt:!.+]]
+    // CHECK-DAG: [[linearTermP:%.+]] = lwe.extract_slice [[linearTerm]] {size = 1 : index, start = 2 : index} : !ringelt3 -> [[kskelt]]
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTermP]] {targetBasis = [[kskBasis:!.+]]} : [[kskelt]] -> !ringelt
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTermP]] {targetBasis = [[kskBasis]]} : [[kskelt]] -> !ringelt
+    // CHECK-DAG: [[ctQ:%.+]] = lwe.from_coeffs [[constTermQ]], [[linearTermQ]]
+    // CHECK-DAG: [[ctP:%.+]] = lwe.from_coeffs [[const_ext]], [[linear_ext]]
+    // CHECK-DAG: [[diff:%.+]] = lwe.rsub [[ctQ]], [[ctP]]
+    // CHECK-DAG: [[rnsConst:%.+]] = rns.constant
+    // CHECK-DAG: [[scaledDiff:%.+]] = lwe.mul_scalar [[diff]], [[rnsConst]]
+    // CHECK-DAG: [[newConst:%.+]] = lwe.extract_coeff [[scaledDiff]] {index = 0 : index}
+    // CHECK-DAG: [[newLinear:%.+]] = lwe.extract_coeff [[scaledDiff]] {index = 1 : index}
+    // CHECK-DAG: return [[newConst]], [[newLinear]] : !ringelt, !ringelt
     %constTerm, %linearTerm = lwe.key_switch_inner %x, %arg0 : (!ringelt_L1, tensor<2x!ct_L2>) -> (!ringelt_L1, !ringelt_L1)
     return %constTerm, %linearTerm: !ringelt_L1, !ringelt_L1
   }
@@ -88,31 +99,42 @@ module attributes {
 }
 {
   // CHECK: func.func @test_keyswitch_partialpart(
-  // CHECK-SAME: [[x:%.+]]: !ringelt4,
-  // CHECK-SAME: [[ksk:%.+]]: tensor<3x!ct_L6>) -> (!ringelt4, !ringelt4) {
+  // CHECK-SAME: [[x:%.+]]: [[inputRingTy:![^,]+]],
+  // CHECK-SAME: [[ksk:%.+]]: tensor<3x[[kskTy:!.+]]>) -> ([[inputRingTy]], [[inputRingTy]]) {
   func.func @test_keyswitch_partialpart(%x: !ringelt_L5, %arg0: tensor<3x!ct_L7>) -> (!ringelt_L5, !ringelt_L5) {
     // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
     // CHECK-DAG: [[C1:%.+]] = arith.constant 1 : index
     // CHECK-DAG: [[C2:%.+]] = arith.constant 2 : index
-    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 0 : index} : !ringelt4 -> !ringelt
-    // CHECK-DAG: [[part1:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 2 : index} : !ringelt4 -> !ringelt5
-    // CHECK-DAG: [[part2:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 4 : index} : !ringelt4 -> !ringelt6
-    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = !rns_L6} : !ringelt -> !ringelt7
-    // CHECK-DAG: [[extPart1:%.+]] = lwe.convert_basis [[part1]] {targetBasis = !rns_L6} : !ringelt5 -> !ringelt7
-    // CHECK-DAG: [[extPart2:%.+]] = lwe.convert_basis [[part2]] {targetBasis = !rns_L6} : !ringelt6 -> !ringelt7
-    // CHECK-DAG: [[ksk0:%.+]] = tensor.extract [[ksk]][[[C0]]] : tensor<3x!ct_L6>
-    // CHECK-DAG: [[ksk1:%.+]] = tensor.extract [[ksk]][[[C1]]] : tensor<3x!ct_L6>
-    // CHECK-DAG: [[ksk2:%.+]] = tensor.extract [[ksk]][[[C2]]] : tensor<3x!ct_L6>
-    // CHECK-DAG: [[dp0:%.+]] = lwe.mul_ring_elt [[extPart0]], [[ksk0]] : (!ringelt7, !ct_L6) -> !ct_L6
-    // CHECK-DAG: [[dp1:%.+]] = lwe.mul_ring_elt [[extPart1]], [[ksk1]] : (!ringelt7, !ct_L6) -> !ct_L6
-    // CHECK-DAG: [[dp2:%.+]] = lwe.mul_ring_elt [[extPart2]], [[ksk2]] : (!ringelt7, !ct_L6) -> !ct_L6
-    // CHECK-DAG: [[dpsum0:%.+]] = lwe.radd [[dp0]], [[dp1]] : (!ct_L6, !ct_L6) -> !ct_L6
-    // CHECK-DAG: [[dp:%.+]] = lwe.radd [[dpsum0]], [[dp2]] : (!ct_L6, !ct_L6) -> !ct_L6
-    // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : !ct_L6
-    // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : !ct_L6
-    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTerm]] {targetBasis = !rns_L4} : !ringelt7 -> !ringelt4
-    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTerm]] {targetBasis = !rns_L4} : !ringelt7 -> !ringelt4
-    // CHECK-DAG: return [[const_ext]], [[linear_ext]] : !ringelt4, !ringelt4
+    // CHECK-DAG: [[part0:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 0 : index} : [[inputRingTy]] -> [[part0Ty:!.+]]
+    // CHECK-DAG: [[part1:%.+]] = lwe.extract_slice [[x]] {size = 2 : index, start = 2 : index} : [[inputRingTy]] -> [[part1Ty:!.+]]
+    // CHECK-DAG: [[part2:%.+]] = lwe.extract_slice [[x]] {size = 1 : index, start = 4 : index} : [[inputRingTy]] -> [[part2Ty:!.+]]
+    // CHECK-DAG: [[extPart0:%.+]] = lwe.convert_basis [[part0]] {targetBasis = [[extBasis:!.+]]} : [[part0Ty]] -> [[kskRingTy:!.+]]
+    // CHECK-DAG: [[extPart1:%.+]] = lwe.convert_basis [[part1]] {targetBasis = [[extBasis]]} : [[part1Ty]] -> [[kskRingTy]]
+    // CHECK-DAG: [[extPart2:%.+]] = lwe.convert_basis [[part2]] {targetBasis = [[extBasis]]} : [[part2Ty]] -> [[kskRingTy]]
+    // CHECK-DAG: [[ksk0:%.+]] = tensor.extract [[ksk]][[[C0]]] : tensor<3x[[kskTy]]>
+    // CHECK-DAG: [[ksk1:%.+]] = tensor.extract [[ksk]][[[C1]]] : tensor<3x[[kskTy]]>
+    // CHECK-DAG: [[ksk2:%.+]] = tensor.extract [[ksk]][[[C2]]] : tensor<3x[[kskTy]]>
+    // CHECK-DAG: [[dp0:%.+]] = lwe.mul_ring_elt [[extPart0]], [[ksk0]] : ([[kskRingTy]], [[kskTy]]) -> [[kskTy]]
+    // CHECK-DAG: [[dp1:%.+]] = lwe.mul_ring_elt [[extPart1]], [[ksk1]] : ([[kskRingTy]], [[kskTy]]) -> [[kskTy]]
+    // CHECK-DAG: [[dp2:%.+]] = lwe.mul_ring_elt [[extPart2]], [[ksk2]] : ([[kskRingTy]], [[kskTy]]) -> [[kskTy]]
+    // CHECK-DAG: [[dpsum0:%.+]] = lwe.radd [[dp0]], [[dp1]] : ([[kskTy]], [[kskTy]]) -> [[kskTy]]
+    // CHECK-DAG: [[dp:%.+]] = lwe.radd [[dpsum0]], [[dp2]] : ([[kskTy]], [[kskTy]]) -> [[kskTy]]
+    // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 0 : index} : [[kskTy]]
+    // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff [[dp]] {index = 1 : index} : [[kskTy]]
+    // CHECK-DAG: [[constTermQ:%.+]] = lwe.extract_slice [[constTerm]] {size = 5 : index, start = 0 : index} : [[kskRingTy]] -> [[inputRingTy]]
+    // CHECK-DAG: [[linearTermQ:%.+]] = lwe.extract_slice [[linearTerm]] {size = 5 : index, start = 0 : index} : [[kskRingTy]] -> [[inputRingTy]]
+    // CHECK-DAG: [[constTermP:%.+]] = lwe.extract_slice [[constTerm]] {size = 2 : index, start = 5 : index} : [[kskRingTy]] -> [[kskelt:!.+]]
+    // CHECK-DAG: [[linearTermP:%.+]] = lwe.extract_slice [[linearTerm]] {size = 2 : index, start = 5 : index} : [[kskRingTy]] -> [[kskelt]]
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTermP]] {targetBasis = [[kskBasis:!.+]]} : [[kskelt]] -> [[inputRingTy]]
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTermP]] {targetBasis = [[kskBasis]]} : [[kskelt]] -> [[inputRingTy]]
+    // CHECK-DAG: [[ctQ:%.+]] = lwe.from_coeffs [[constTermQ]], [[linearTermQ]]
+    // CHECK-DAG: [[ctP:%.+]] = lwe.from_coeffs [[const_ext]], [[linear_ext]]
+    // CHECK-DAG: [[diff:%.+]] = lwe.rsub [[ctQ]], [[ctP]]
+    // CHECK-DAG: [[rnsConst:%.+]] = rns.constant
+    // CHECK-DAG: [[scaledDiff:%.+]] = lwe.mul_scalar [[diff]], [[rnsConst]]
+    // CHECK-DAG: [[newConst:%.+]] = lwe.extract_coeff [[scaledDiff]] {index = 0 : index}
+    // CHECK-DAG: [[newLinear:%.+]] = lwe.extract_coeff [[scaledDiff]] {index = 1 : index}
+    // CHECK-DAG: return [[newConst]], [[newLinear]] : [[inputRingTy]], [[inputRingTy]]
     %constTerm, %linearTerm = lwe.key_switch_inner %x, %arg0 : (!ringelt_L5, tensor<3x!ct_L7>) -> (!ringelt_L5, !ringelt_L5)
     return %constTerm, %linearTerm: !ringelt_L5, !ringelt_L5
   }

--- a/tests/Dialect/LWE/Transforms/DecomposeLWEOps/moddown.mlir
+++ b/tests/Dialect/LWE/Transforms/DecomposeLWEOps/moddown.mlir
@@ -1,0 +1,54 @@
+// RUN: heir-opt --lwe-decompose %s | FileCheck %s
+
+!Zq0 = !mod_arith.int<1095233372161 : i64>
+!Zp0 = !mod_arith.int<261405424692085787 : i64>
+
+#key = #lwe.key<>
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 0>
+
+// Output type
+#ring_L1x1024 = #polynomial.ring<coefficientType = !rns.rns<!Zq0>, polynomialModulus = <1 + x**1024>>
+!ringelt_L1 = !lwe.lwe_ring_elt<ring = #ring_L1x1024>
+#ciphertext_space_L1 = #lwe.ciphertext_space<ring = #ring_L1x1024, encryption_type = lsb, size = 2>
+!ct_L1 = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_L1x1024, encoding = #inverse_canonical_encoding>,
+                             ciphertext_space = #ciphertext_space_L1,
+                             key = #key>
+
+// KSK type
+!rns_L2 = !rns.rns<!Zq0, !Zp0>
+#ring_L2x1024 = #polynomial.ring<coefficientType = !rns_L2, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L2 = #lwe.ciphertext_space<ring = #ring_L2x1024, encryption_type = lsb, size = 2>
+!ct_L2 = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_L1x1024, encoding = #inverse_canonical_encoding>,
+                             ciphertext_space = #ciphertext_space_L2,
+                             key = #key>
+
+module attributes {
+    ckks.schemeParam = #ckks.scheme_param<
+      logN = 10,
+      Q = [1095233372161, 1032955396097],
+      P = [261405424692085787],
+      logDefaultScale = 45
+    >
+}
+{
+  // CHECK: func.func @test_moddown(
+  // CHECK-SAME: [[x:%.+]]: [[kskTy:!.+]]) -> [[outTy:!.+]] {
+  func.func @test_moddown(%x: !ct_L2) -> !ct_L1 {
+    // CHECK-DAG: [[rnsConst:%.+]] = rns.constant <[#mod_arith.value<60017030419 : !Z1095233372161_i64> : !Z1095233372161_i64]> : !rns_L0
+    // CHECK-DAG: [[constTerm:%.+]] = lwe.extract_coeff %ct {index = 0 : index} : [[kskTy]]
+    // CHECK-DAG: [[constTermQ:%.+]] = lwe.extract_slice [[constTerm]] {size = 1 : index, start = 0 : index} : [[kskrng:!.+]] -> [[qrng:!.+]]
+    // CHECK-DAG: [[constTermP:%.+]] = lwe.extract_slice [[constTerm]] {size = 1 : index, start = 1 : index} : [[kskrng]] -> [[prng:!.+]]
+    // CHECK-DAG: [[const_ext:%.+]] = lwe.convert_basis [[constTermP]] {targetBasis = !rns_L0} : [[prng]] -> [[qrng]]
+    // CHECK-DAG: [[linearTerm:%.+]] = lwe.extract_coeff %ct {index = 1 : index} : [[kskTy]]
+    // CHECK-DAG: [[linearTermQ:%.+]] = lwe.extract_slice [[linearTerm]] {size = 1 : index, start = 0 : index} : [[kskrng]] -> [[qrng]]
+    // CHECK-DAG: [[linearTermP:%.+]] = lwe.extract_slice [[linearTerm]] {size = 1 : index, start = 1 : index} : [[kskrng]] -> [[prng]]
+    // CHECK-DAG: [[linear_ext:%.+]] = lwe.convert_basis [[linearTermP]] {targetBasis = !rns_L0} : [[prng]] -> [[qrng]]
+    // CHECK-DAG: [[ctq:%.+]] = lwe.from_coeffs [[constTermQ]], [[linearTermQ]] : ([[qrng]], [[qrng]]) -> [[outTy]]
+    // CHECK-DAG: [[ctp:%.+]] = lwe.from_coeffs [[const_ext]], [[linear_ext]] : ([[qrng]], [[qrng]]) -> [[outTy]]
+    // CHECK-DAG: [[diff:%.+]] = lwe.rsub [[ctq]], [[ctp]] : ([[outTy]], [[outTy]]) -> [[outTy]]
+    // CHECK-DAG: [[result:%.+]] = lwe.mul_scalar [[diff]], [[rnsConst]] : ([[outTy]], !rns_L0) -> [[outTy]]
+    // CHECK-DAG: return [[result]] : [[outTy]]
+    %result = lwe.mod_down %x {targetBasis = !rns.rns<!Zq0>} : !ct_L2 -> !ct_L1
+    return %result: !ct_L1
+  }
+}


### PR DESCRIPTION
This should fix #2987.

In short, the final step of keyswitch should be a "mod down", which means
- pull off the special-prime RNS components of the dot product result
- basis-convert them to the input RNS type
- subtract the previous result from the input-basis-components of the dot-product result

Architecture questions:
- It's annoying to have to repack the ring elements into a ciphertext just to do two ops (subtract and mul_scalar) and then unpack them again. However, LWE doesn't have ops that work on individual ring elements. Should it? If so, we could either add new ops that work specifically on ring elements, or make the existing ops work on ring elements. Note that I need this functionality for some other stuff I'm working on, so this isn't a one-off need.
- I would really have *liked* to make an `lwe::ModDown` op. But it would have been annoying to use: DecomposeKeySwitch would product an `lwe::ModDown` op, which would then need to be decomposed *again* (via a separate transform) into smaller LWE ops. It seems weird to make yet-another transform to decompose a single op in the LWE pipeline; I feel like I must be missing some convenient technique for this. One option is to make the LWeToPolynomial conversion pass iterative instead of single-pass. Then we could dispense with the existing DecomposeKeySwitch op and have KeySwitchInner lower to other LWE ops (including ModDown), ModDown would lower to yet more LWE ops, and finally, those could be lowered directly to Polynomial. Is that better? Unclear.

Also note that there still aren't end-to-end tests for keyswitch, which are still needed.
