### PR TITLE
[FoldConstantTensors] Set insertion point after last operation to erase

### DIFF
--- a/lib/Transforms/FoldConstantTensors/FoldConstantTensors.cpp
+++ b/lib/Transforms/FoldConstantTensors/FoldConstantTensors.cpp
@@ -172,6 +172,7 @@ class InsertIntoFromElements final : public OpRewritePattern<tensor::InsertOp> {
       }
     }
 
+    rewriter.setInsertionPointAfter(opsToErase.back());
     rewriter.replaceAllUsesWith(
         opsToErase.back()->getResult(0),
         tensor::FromElementsOp::create(rewriter, insertOp.getLoc(), destType,


### PR DESCRIPTION
InsertIntoFromElements rewrite pattern emits the new FromElementsOp after the first InsertOp. This creates dominance issues if there are SSA values defined after the first InsertOp. The following snippet depicts the issue with the current implementation. This patch sets an insertion point after the last InsertOp to fix the dominance issue.

```
%ext0 = tensor.extract %input[idx0]
%ins1 = tensor.insert %ext0 into %zero[...]
%ext2 = tensor.extract %input[idx2]
%ins3 = tensor.insert %ext2 into %ins1[...]
```

```
/local/scratch/a/heir/kernel-mm4.mlir:12:12: note: operand defined here (op in the same block)
/local/scratch/a/heir/kernel-mm4.mlir:11:12: error: operand #8 does not dominate this use
```