### PR TITLE
buildbuddy: ensure autogenerated tablegen headers are downloaded

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,10 @@ common --remote_cache_compression
 common --remote_header=x-buildbuddy-api-key=IqGGzfrvMgDJh927qtrw
 common --remote_timeout=10m
 
+# Force downloading of TableGen-generated files (.inc) for local debugging and
+# IDE autocompletion support.
+build --remote_download_regex=".*\.inc$"
+
 # This enables remote build execution and writing to the remote cache, which
 # dramatically speeds up builds. Add a .bazelrc.user file with:
 #


### PR DESCRIPTION
When using buildbuddy with RBE, the code generated by tablegen is not downloaded to the user's machine by default, unless the dialect targets are explicitly requested to be built. This change to bazelrc should opt-in to always downloading `.inc` files to the local system from the remote build farm.