### PR TITLE
Don't install clang in cibuildwheel anymore

### DIFF
--- a/.github/install_cibuildwheel_deps.sh
+++ b/.github/install_cibuildwheel_deps.sh
@@ -12,23 +12,3 @@ if ! bazel version; then
   curl -L -o $HOME/bin/bazel --create-dirs "https://github.com/bazelbuild/bazel/releases/download/${bazel_version}/bazel-${bazel_version}-linux-${arch}"
   chmod +x $HOME/bin/bazel
 fi
-
-manylinux-install-clang -v v20.1.8.0
-
-# Install OpenMP development headers using the CRB repository
-dnf install -y --enablerepo=crb libomp-devel
-
-# Symlink OpenMP headers from system Clang to static Clang's include directory
-for system_clang_dir in /usr/lib/clang/* /usr/lib64/clang/*; do
-  [ -d "$system_clang_dir/include" ] || continue
-  for f in "$system_clang_dir/include"/omp*.h; do
-    [ -f "$f" ] || continue
-    for static_clang_include in /opt/clang/lib/clang/*/include; do
-      [ -d "$static_clang_include" ] || continue
-      target="$static_clang_include/$(basename "$f")"
-      if [ ! -e "$target" ]; then
-        ln -sf "$f" "$target"
-      fi
-    done
-  done
-done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: pip install requests
+
       - name: Get version
         id: get-version
         shell: bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -113,7 +113,6 @@ Build a single wheel (recommended for local testing):
 
 ```bash
 cibuildwheel --only cp312-macosx_arm64      # macOS Apple Silicon
-cibuildwheel --only cp312-macosx_x86_64     # macOS Intel
 cibuildwheel --only cp312-manylinux_x86_64  # Linux x86_64
 cibuildwheel --only cp312-manylinux_aarch64 # Linux arm64
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,16 +102,16 @@ test-extras = ["python"]
 
 [tool.cibuildwheel.linux]
 archs = "auto64"
-manylinux-x86_64-image = "manylinux_2_34"
-manylinux-aarch64-image = "manylinux_2_34"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 before-all = "bash .github/install_cibuildwheel_deps.sh"
 # Use the rootless Bazel installation inside the container.
 environment = { PATH = "$PATH:$HOME/bin" }
-# Force the repaired wheel to use the manylinux_2_34 platform tag.
+# Force the repaired wheel to use the manylinux_2_28 platform tag.
 # By default, auditwheel may analyze the wheel's actual symbol requirements
 # and choose or add a lower compatible manylinux_x_y tag such as 2_28
 # which PyPi might reject (they only accept a few specific tags).
-repair-wheel-command = "auditwheel repair --plat manylinux_2_34_$(uname -m) --only-plat -w {dest_dir} {wheel}"
+repair-wheel-command = "auditwheel repair --plat manylinux_2_28_$(uname -m) --only-plat -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.windows]
 archs = "auto64"


### PR DESCRIPTION
Now that the C++ toolchain is managed fully by bazel, we don't need clang in the cibuildwheel container anymore. We can remove it. Also, now that we don't bundle openfhe anymore, we can easily extend glibc support back to 2.28 again.

Also, note this should fix the currently broken nightly build (https://github.com/google/heir/actions/runs/28209911846/job/83568751709 which fails with `.github/install_cibuildwheel_deps.sh: line 16: manylinux-install-clang: command not found`)