### PR TITLE
skip first_interaction.yml for copybara bot

### DIFF
--- a/.github/workflows/first_interaction.yml
+++ b/.github/workflows/first_interaction.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    if: github.actor != 'copybara-service[bot]'
     steps:
       - name: Welcome new contributor
         uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0


### PR DESCRIPTION
Poor @copybara-service constantly gets asked to please meet a contributor in a non-textual format, which feels very discriminatory against a bot that exists purely in a textual medium 😉 

Also, maybe a googler could add <noreply​@google.com> to the CLA list, so the CLA bot doesn't feel the need to chime in constantly, either?
<img width="394" height="93" alt="image" src="https://github.com/user-attachments/assets/6cb3ccfa-d076-4500-a0d4-dcce5411ded5" />