### PR TITLE
buildbuddy: add metadata (repo/branch/commit)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,7 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 # BuildBuddy
 build --bes_results_url=https://heir.buildbuddy.io/invocation/
 build --bes_backend=grpcs://heir.buildbuddy.io
+build --workspace_status_command=./scripts/workspace_status.sh
 common --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
 common --remote_cache=grpcs://heir.buildbuddy.io
 common --remote_cache_compression

--- a/scripts/workspace_status.sh
+++ b/scripts/workspace_status.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Used to map BuildBuddy invocations to a repo/branch/commit.
+# See https://www.buildbuddy.io/docs/guide-metadata/
+echo "COMMIT_SHA $(git rev-parse HEAD)"
+
+# Branch is a bit tricky, since on GitHub Actions the checkout is a detached HEAD,
+# so `git rev-parse --abbrev-ref HEAD` is just "HEAD", but we can check for ENV variables
+# such as GITHUB_HEAD_REF (PR source branch) or GITHUB_REF_NAME (branch on push).
+# NB: the workspace-status key is GIT_BRANCH, not BRANCH_NAME. BRANCH_NAME is the
+# --build_metadata flag name; workspace-status ingestion uses GIT_BRANCH (see
+# buildbuddy-io/buildbuddy:workspace_status.sh). Don't "fix" this to BRANCH_NAME.
+echo "GIT_BRANCH ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}}"
+
+# Repo is even trickier, since a checkout might have multiple (or no) remotes.
+# We once again read it from ENV for GitHub actions,
+if [ -n "$GITHUB_REPOSITORY" ]; then
+  repo_url="${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY"
+else
+  # otherwise try:
+  # 1.) current branch's configured remote
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  remote=$(git config --get "branch.$branch.remote")
+  # 2.) remote.pushDefault setting if it is set
+  [ -z "$remote" ] && remote=$(git config --get remote.pushDefault)
+  # 3.) the first remote, if it exists
+  [ -z "$remote" ] && remote=$(git remote | head -n1)
+  # Normalize ssh to https: git@host:owner/repo(.git) -> https://host/owner/repo
+  repo_url=$(git remote get-url "$remote" 2>/dev/null | sed -E -e 's#^git@([^:]+):#https://\1/#' -e 's#\.git$##')
+fi
+if [ -n "$repo_url" ]; then echo "REPO_URL $repo_url"; fi


### PR DESCRIPTION
Adds some metadata on repo, branch and commit to buildbuddy invocations:
See https://heir.buildbuddy.io/invocation/2e68f2dd-7013-4e8d-ba80-85f4e95c3b2a for an example

This already happened automatically for Github Actions because they have environment variables for this, but for locally triggered builds, these would be missing.