### PR TITLE
change the default build mode to fastbuild

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ common --enable_platform_specific_config
 
 # compilation_mode options below are `dbg` (debug symbols) `fastbuild`
 # (build as quickly as possible), and `opt` (turn on all optimizations)
-common -c dbg
+common -c fastbuild
 common --enable_bzlmod
 
 # prevents changes to PATH from causing a full rebuild


### PR DESCRIPTION
I think this should improve linker run time by stripping unused symbols.