### PR TITLE
layout: Support arbitrary layout permutation for rank-2 tensors

### DIFF
--- a/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
@@ -134,7 +134,7 @@ static FailureOr<Value> implementUnpackOpStep(
 
 static FailureOr<Value> implementAssignLayoutPermutation(
     Value input, DenseIntElementsAttr permutation, Type targetTypeTy,
-    int64_t ciphertextSize, ImplicitLocOpBuilder& builder,
+    ImplicitLocOpBuilder& builder,
     const std::function<void(Operation*)>& createdOpCallback) {
   auto tensorType = dyn_cast<RankedTensorType>(input.getType());
   if (!tensorType)
@@ -152,7 +152,7 @@ static FailureOr<Value> implementAssignLayoutPermutation(
 
   int64_t ctBound = (tensorType.getRank() == 2) ? tensorType.getDimSize(0) : 1;
   int64_t srcSlotBound = tensorType.getDimSize(tensorType.getRank() - 1);
-  int64_t dstSlotBound = ciphertextSize;
+  int64_t dstSlotBound = targetType.getDimSize(targetType.getRank() - 1);
 
   for (auto it = permutation.value_begin<APInt>();
        it != permutation.value_end<APInt>();) {
@@ -432,8 +432,7 @@ FailureOr<Value> implementAssignLayout(
     Type targetType = materializePermutationLayout(input.getType(), elementAttr,
                                                    ciphertextSize);
     return implementAssignLayoutPermutation(input, elementAttr, targetType,
-                                            ciphertextSize, builder,
-                                            createdOpCallback);
+                                            builder, createdOpCallback);
   }
   return builder.emitError() << "Unsupported layout attribute type: " << layout;
 }

--- a/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
@@ -133,63 +133,67 @@ static FailureOr<Value> implementUnpackOpStep(
 }
 
 static FailureOr<Value> implementAssignLayoutPermutation(
-    Value input, DenseIntElementsAttr permutation, int64_t ciphertextSize,
-    ImplicitLocOpBuilder& builder,
+    Value input, DenseIntElementsAttr permutation, Type targetTypeTy,
+    int64_t ciphertextSize, ImplicitLocOpBuilder& builder,
     const std::function<void(Operation*)>& createdOpCallback) {
-  auto elementType = getElementTypeOrSelf(input.getType());
   auto tensorType = dyn_cast<RankedTensorType>(input.getType());
-  // TODO(#2666): This logic assumes ctxt = 0, this can be extended to handle a
-  // more general case. permutation is <N x 4 x i64>: each row is [src_ct,
-  // src_slot, dst_ct, dst_slot]. src_ct and dst_ct are always 0 (single
-  // ciphertext), so treat as 1D: extract from input[0][src_slot] and insert
-  // into result[0][dst_slot].
-  auto ciphertextType = RankedTensorType::get({1, ciphertextSize}, elementType);
-  auto zeroCtxt = arith::ConstantOp::create(
-      builder, ciphertextType, builder.getZeroAttr(ciphertextType));
+  if (!tensorType)
+    return builder.emitError() << "Permutation layout requires tensor input";
+
+  if (tensorType.getRank() > 2)
+    return builder.emitError() << "Arbitrary permutation layout only "
+                                  "supports up to 2D tensors for now";
+
+  RankedTensorType targetType = cast<RankedTensorType>(targetTypeTy);
+  auto zeroCtxt = arith::ConstantOp::create(builder, targetType,
+                                            builder.getZeroAttr(targetType));
   createdOpCallback(zeroCtxt);
   Value result = zeroCtxt.getResult();
-  auto ctIdxOp = arith::ConstantIndexOp::create(builder, 0);
-  createdOpCallback(ctIdxOp);
-  Value ctIdx = ctIdxOp.getResult();
+
+  int64_t ctBound = (tensorType.getRank() == 2) ? tensorType.getDimSize(0) : 1;
+  int64_t srcSlotBound = tensorType.getDimSize(tensorType.getRank() - 1);
+  int64_t dstSlotBound = ciphertextSize;
 
   for (auto it = permutation.value_begin<APInt>();
        it != permutation.value_end<APInt>();) {
-    // skip src_ct (always 0)
-    ++it;
+    int64_t srcCt = (*it++).getSExtValue();
     int64_t srcSlot = (*it++).getSExtValue();
-    // skip dst_ct (always 0)
-    ++it;
+    int64_t dstCt = (*it++).getSExtValue();
     int64_t dstSlot = (*it++).getSExtValue();
 
-    if (tensorType.getRank() > 2)
-      return builder.emitError() << "Arbitrary permutation layout only "
-                                    "supports up to 2D tensors for now";
-
-    // TODO(#2666): Update this to check the dimensions of src ctxt and dst ctxt
-    // when we support more general layouts. we want to check srcSlot against
-    // the last dimension of the tensor
-    if (srcSlot >= tensorType.getDimSize(tensorType.getRank() - 1) ||
-        dstSlot >= ciphertextSize) {
+    if (srcCt >= ctBound || srcSlot >= srcSlotBound || dstCt >= ctBound ||
+        dstSlot >= dstSlotBound) {
       return builder.emitError()
-             << "Permutation index out of bounds: src_slot=" << srcSlot
-             << ", dst_slot=" << dstSlot;
+             << "Permutation index out of bounds: " << "src_ct=" << srcCt
+             << ", src_slot=" << srcSlot << " (input bounds: ct < " << ctBound
+             << ", slot < " << srcSlotBound << "); " << "dst_ct=" << dstCt
+             << ", dst_slot=" << dstSlot << " (target bounds: ct < " << ctBound
+             << ", slot < " << dstSlotBound << ")";
     }
-    // TODO(#2666): This logic assumes src_ct and dst_ct are always 0
-    // we can have input tensors of type <1xNxType> or just <NxType>
-    // We need to handle both cases when extracting the elements
-    SmallVector<Value> extractIndices;
-    if (tensorType.getRank() == 2) extractIndices.push_back(ctIdx);
 
-    auto srcSlotIdx = arith::ConstantIndexOp::create(builder, srcSlot);
-    createdOpCallback(srcSlotIdx);
-    extractIndices.push_back(srcSlotIdx);
+    SmallVector<Value> extractIndices;
+
+    if (tensorType.getRank() == 2) {
+      auto srcCtIdxOp = arith::ConstantIndexOp::create(builder, srcCt);
+      createdOpCallback(srcCtIdxOp);
+      Value srcCtIdx = srcCtIdxOp.getResult();
+      extractIndices.push_back(srcCtIdx);
+    }
+    auto srcSlotIdxOp = arith::ConstantIndexOp::create(builder, srcSlot);
+    createdOpCallback(srcSlotIdxOp);
+    extractIndices.push_back(srcSlotIdxOp.getResult());
     auto extracted = tensor::ExtractOp::create(builder, input, extractIndices);
     createdOpCallback(extracted);
-    auto dstSlotIdx = arith::ConstantIndexOp::create(builder, dstSlot);
-    createdOpCallback(dstSlotIdx);
+
+    auto dstCtIdxOp = arith::ConstantIndexOp::create(builder, dstCt);
+    createdOpCallback(dstCtIdxOp);
+    auto dstSlotIdxOp = arith::ConstantIndexOp::create(builder, dstSlot);
+    createdOpCallback(dstSlotIdxOp);
     auto insertOp = tensor::InsertOp::create(
-        builder, extracted.getResult(), result, ValueRange{ctIdx, dstSlotIdx});
+        builder, extracted.getResult(), result,
+        ValueRange{dstCtIdxOp.getResult(), dstSlotIdxOp.getResult()});
     createdOpCallback(insertOp);
+
     result = insertOp.getResult();
   }
 
@@ -425,8 +429,11 @@ FailureOr<Value> implementAssignLayout(
                                      domainSchedule);
   } else if (DenseIntElementsAttr elementAttr =
                  dyn_cast<DenseIntElementsAttr>(layout)) {
-    return implementAssignLayoutPermutation(input, elementAttr, ciphertextSize,
-                                            builder, createdOpCallback);
+    Type targetType = materializePermutationLayout(input.getType(), elementAttr,
+                                                   ciphertextSize);
+    return implementAssignLayoutPermutation(input, elementAttr, targetType,
+                                            ciphertextSize, builder,
+                                            createdOpCallback);
   }
   return builder.emitError() << "Unsupported layout attribute type: " << layout;
 }

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -216,14 +216,16 @@ struct LayoutMaterializationTypeConverter
         });
     addConversion([this](secret::SecretType type,
                          DenseIntElementsAttr attr) -> std::optional<Type> {
-      return secret::SecretType::get(materializePermutationLayout(
-          getElementTypeOrSelf(type.getValueType()), attr,
-          getCiphertextSize()));
+      auto innerType = type.getValueType();
+
+      FailureOr<Type> convertedInnerType =
+          materializePermutationLayout(innerType, attr, getCiphertextSize());
+      if (failed(convertedInnerType)) return std::nullopt;
+      return secret::SecretType::get(convertedInnerType.value());
     });
     addConversion([this](RankedTensorType type,
                          DenseIntElementsAttr attr) -> std::optional<Type> {
-      return materializePermutationLayout(getElementTypeOrSelf(type), attr,
-                                          getCiphertextSize());
+      return materializePermutationLayout(type, attr, getCiphertextSize());
     });
   }
 

--- a/lib/Transforms/ConvertToCiphertextSemantics/TypeConversion.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/TypeConversion.cpp
@@ -7,9 +7,10 @@
 #include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Types.h"         // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/TypeUtilities.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"          // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"      // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -41,12 +42,21 @@ Type materializeScalarLayout(Type type, LayoutAttr attr, int ciphertextSize) {
   return RankedTensorType::get({1, ciphertextSize}, type);
 }
 
-Type materializePermutationLayout(Type elementType,
-                                  DenseIntElementsAttr permutation,
+Type materializePermutationLayout(Type type, DenseIntElementsAttr permutation,
                                   int ciphertextSize) {
-  // TODO(#2666): Extend to a more general case where src_ct and dst_ct != 0
-  // src_ct and dst_ct are always 0; output is always a single ciphertext.
-  return RankedTensorType::get({1, ciphertextSize}, elementType);
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+
+  assert(tensorType &&
+         "Permutation layout attributes on non-tensor args are not supported");
+  assert(tensorType.getShape().size() <= 2 &&
+         "Permutation layouts only supports tensor args of max dim-2");
+
+  auto inShape = tensorType.getShape();
+  if (inShape.size() == 2)
+    return RankedTensorType::get({inShape[0], ciphertextSize},
+                                 getElementTypeOrSelf(type));
+
+  return RankedTensorType::get({1, ciphertextSize}, getElementTypeOrSelf(type));
 }
 
 }  // namespace heir

--- a/tests/Transforms/convert_to_ciphertext_semantics/assign_layout.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/assign_layout.mlir
@@ -169,6 +169,95 @@ module {
 
 // -----
 
+// Test that a tensor<2x8xi16> input preserves its leading ct dim when emitted
+// into a ciphertext-semantic tensor<2x32xi16>, and that permutation entries
+// can stay within their own ciphertext.
+
+// CHECK: func.func private @_assign_layout_{{[0-9]+}}
+// CHECK-SAME: %[[ARG0:.*]]: tensor<2x8xi16>) -> tensor<2x32xi16>
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG: %[[C5:.*]] = arith.constant 5 : index
+// CHECK-DAG: %[[C7:.*]] = arith.constant 7 : index
+// CHECK-DAG: %[[C10:.*]] = arith.constant 10 : index
+// CHECK-DAG: %[[ZERO:.*]] = arith.constant dense<0> : tensor<2x32xi16>
+// CHECK-DAG: %[[E0:.*]] = tensor.extract %arg0[%[[C0]], %[[C0]]] : tensor<2x8xi16>
+// CHECK-DAG: %[[I0:.*]] = tensor.insert %[[E0]] into %[[ZERO]][%[[C0]], %[[C7]]] : tensor<2x32xi16>
+// CHECK-DAG: %[[E1:.*]] = tensor.extract %arg0[%[[C0]], %[[C2]]] : tensor<2x8xi16>
+// CHECK-DAG: %[[I1:.*]] = tensor.insert %[[E1]] into %[[I0]][%[[C0]], %[[C10]]] : tensor<2x32xi16>
+// CHECK-DAG: %[[E2:.*]] = tensor.extract %arg0[%[[C1]], %[[C1]]] : tensor<2x8xi16>
+// CHECK-DAG: %[[I2:.*]] = tensor.insert %[[E2]] into %[[I1]][%[[C1]], %[[C5]]] : tensor<2x32xi16>
+// CHECK-DAG: %[[E3:.*]] = tensor.extract %arg0[%[[C1]], %[[C5]]] : tensor<2x8xi16>
+// CHECK-DAG: %[[I3:.*]] = tensor.insert %[[E3]] into %[[I2]][%[[C1]], %[[C0]]] : tensor<2x32xi16>
+// CHECK: return %[[I3]] : tensor<2x32xi16>
+
+// CHECK: @permutate_within_ct
+#layout_within = dense<[
+  [0, 0, 0, 7],
+  [0, 2, 0, 10],
+  [1, 1, 1, 5],
+  [1, 5, 1, 0]
+]> : tensor<4x4xi64>
+module {
+  func.func @permutate_within_ct() {
+    %cst = arith.constant dense<1> : tensor<2x8xi16>
+    // CHECK: %[[cst:.*]] = arith.constant dense<1> : tensor<2x8xi16>
+    // CHECK: func.call @_assign_layout_{{[0-9]+}}(%[[cst]])
+    %0 = secret.generic() {
+      %1 = tensor_ext.assign_layout %cst {layout = #layout_within, tensor_ext.layout = #layout_within} : tensor<2x8xi16>
+      secret.yield %1 : tensor<2x8xi16>
+    } -> (!secret.secret<tensor<2x8xi16>> {tensor_ext.layout = #layout_within})
+    return
+  }
+}
+
+// -----
+
+// Test that a multi-ciphertext input can have data moved BETWEEN ciphertexts:
+// some src_ct=0 entries go to dst_ct=1 and vice versa.
+
+// CHECK: func.func private @_assign_layout_{{[0-9]+}}
+// CHECK-SAME: %[[ARG0:.*]]: tensor<2x16xi16>) -> tensor<2x32xi16>
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[C5:.*]] = arith.constant 5 : index
+// CHECK-DAG: %[[C7:.*]] = arith.constant 7 : index
+// CHECK-DAG: %[[ZERO:.*]] = arith.constant dense<0> : tensor<2x32xi16>
+// CHECK-DAG: %[[E0:.*]] = tensor.extract %arg0[%[[C0]], %[[C0]]] : tensor<2x16xi16>
+// CHECK-DAG: %[[I0:.*]] = tensor.insert %[[E0]] into %[[ZERO]][%[[C1]], %[[C5]]] : tensor<2x32xi16>
+// CHECK-DAG: %[[E1:.*]] = tensor.extract %arg0[%[[C0]], %[[C3]]] : tensor<2x16xi16>
+// CHECK-DAG: %[[I1:.*]] = tensor.insert %[[E1]] into %[[I0]][%[[C0]], %[[C7]]] : tensor<2x32xi16>
+// CHECK-DAG: %[[E2:.*]] = tensor.extract %arg0[%[[C1]], %[[C0]]] : tensor<2x16xi16>
+// CHECK-DAG: %[[I2:.*]] = tensor.insert %[[E2]] into %[[I1]][%[[C0]], %[[C4]]] : tensor<2x32xi16>
+// CHECK-DAG: %[[E3:.*]] = tensor.extract %arg0[%[[C1]], %[[C7]]] : tensor<2x16xi16>
+// CHECK-DAG: %[[I3:.*]] = tensor.insert %[[E3]] into %[[I2]][%[[C1]], %[[C0]]] : tensor<2x32xi16>
+// CHECK: return %[[I3]] : tensor<2x32xi16>
+
+// CHECK: @permutate_cross_ct
+#layout_cross = dense<[
+  [0, 0, 1, 5],
+  [0, 3, 0, 7],
+  [1, 0, 0, 4],
+  [1, 7, 1, 0]
+]> : tensor<4x4xi64>
+module {
+  func.func @permutate_cross_ct() {
+    %cst = arith.constant dense<1> : tensor<2x16xi16>
+    // CHECK: %[[cst:.*]] = arith.constant dense<1> : tensor<2x16xi16>
+    // CHECK: func.call @_assign_layout_{{[0-9]+}}(%[[cst]])
+    %0 = secret.generic() {
+      %1 = tensor_ext.assign_layout %cst {layout = #layout_cross, tensor_ext.layout = #layout_cross} : tensor<2x16xi16>
+      secret.yield %1 : tensor<2x16xi16>
+    } -> (!secret.secret<tensor<2x16xi16>> {tensor_ext.layout = #layout_cross})
+    return
+  }
+}
+
+// -----
+
 // CHECK: func.func @fold_4d_constant
 #layout3 = #tensor_ext.layout<"{ [f, c, fh, fw] -> [ct, slot] : ct = 0 and 0 <= f < 2 and 0 <= c < 1 and 0 <= fh < 2 and 0 <= fw < 2 and slot = 8 * f + c + 2 * fh + fw }">
 module {

--- a/tests/Transforms/convert_to_ciphertext_semantics/assign_layout_failure.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/assign_layout_failure.mlir
@@ -5,7 +5,7 @@ module {
   func.func @permutate_vector_error() {
     %cst = arith.constant dense<1> : tensor<16xi16>
     %0 = secret.generic() {
-      // expected-error@+2 {{Permutation index out of bounds: src_slot=18, dst_slot=2}}
+      // expected-error@+2 {{Permutation index out of bounds: src_ct=0, src_slot=18 (input bounds: ct < 1, slot < 16); dst_ct=0, dst_slot=2 (target bounds: ct < 1, slot < 32)}}
       // expected-error@+1 {{'tensor_ext.assign_layout' op failed to verify that all of {value, output} have same type}}
       %1 = tensor_ext.assign_layout %cst {layout = #layout3, tensor_ext.layout = #layout3} : tensor<16xi16>
       secret.yield %1 : tensor<16xi16>


### PR DESCRIPTION
Permutation layout attributes can be used to assign random permutations of scalar values to ciphertext slots. This patch adds support for adding permutations to rank-2 tensors.

Fixes #2666