### PR TITLE
Improved batchnorm fusing

### DIFF
--- a/lib/Transforms/LinalgFuseLinearOps/BUILD
+++ b/lib/Transforms/LinalgFuseLinearOps/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:DestinationStyleOpInterface",
+        "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/lib/Transforms/LinalgFuseLinearOps/LinalgFuseLinearOps.cpp
+++ b/lib/Transforms/LinalgFuseLinearOps/LinalgFuseLinearOps.cpp
@@ -12,6 +12,7 @@
 #include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"    // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Traits.h"              // from @llvm-project
 #include "mlir/include/mlir/Dialect/Utils/StructuredOpsUtils.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/AffineExpr.h"    // from @llvm-project
 #include "mlir/include/mlir/IR/AffineMap.h"     // from @llvm-project
@@ -36,30 +37,159 @@ namespace heir {
 
 namespace {
 
+bool accumulatesIntoOuts(Operation* linearOp) {
+  if (isa<linalg::BatchMatmulOp, linalg::BatchMatvecOp, linalg::BatchMmt4DOp,
+          linalg::BatchReduceMatmulOp, linalg::BatchVecmatOp,
+          linalg::ContractOp, linalg::Conv1DNcwFcwOp, linalg::Conv1DNwcWcfOp,
+          linalg::Conv1DOp, linalg::Conv2DNchwFchwOp, linalg::Conv2DNchwFchwQOp,
+          linalg::Conv2DNgchwFgchwOp, linalg::Conv2DNgchwGfchwOp,
+          linalg::Conv2DNgchwGfchwQOp, linalg::Conv2DNhwcFhwcOp,
+          linalg::Conv2DNhwcFhwcQOp, linalg::Conv2DNhwcHwcfOp,
+          linalg::Conv2DNhwcHwcfQOp, linalg::Conv2DNhwgcGfhwcOp,
+          linalg::Conv2DNhwgcGfhwcQOp, linalg::Conv2DOp,
+          linalg::Conv3DNcdhwFcdhwOp, linalg::Conv3DNdhwcDhwcfOp,
+          linalg::Conv3DNdhwcDhwcfQOp, linalg::Conv3DOp,
+          linalg::DepthwiseConv1DNcwCwOp, linalg::DepthwiseConv1DNwcWcOp,
+          linalg::DepthwiseConv1DNwcWcmOp, linalg::DepthwiseConv2DNchwChwOp,
+          linalg::DepthwiseConv2DNhwcHwcOp, linalg::DepthwiseConv2DNhwcHwcQOp,
+          linalg::DepthwiseConv2DNhwcHwcmOp, linalg::DepthwiseConv2DNhwcHwcmQOp,
+          linalg::DepthwiseConv3DNcdhwCdhwOp,
+          linalg::DepthwiseConv3DNdhwcDhwcOp,
+          linalg::DepthwiseConv3DNdhwcDhwcmOp, linalg::DotOp, linalg::MatmulOp,
+          linalg::MatvecOp, linalg::Mmt4DOp, linalg::PoolingNchwMaxOp,
+          linalg::PoolingNchwSumOp, linalg::PoolingNcwMaxOp,
+          linalg::PoolingNcwSumOp, linalg::PoolingNdhwcMaxOp,
+          linalg::PoolingNdhwcMinOp, linalg::PoolingNdhwcSumOp,
+          linalg::PoolingNhwcMaxOp, linalg::PoolingNhwcMaxUnsignedOp,
+          linalg::PoolingNhwcMinOp, linalg::PoolingNhwcMinUnsignedOp,
+          linalg::PoolingNhwcSumOp, linalg::PoolingNwcMaxOp,
+          linalg::PoolingNwcMaxUnsignedOp, linalg::PoolingNwcMinOp,
+          linalg::PoolingNwcMinUnsignedOp, linalg::PoolingNwcSumOp,
+          linalg::QuantizedBatchMatmulOp, linalg::QuantizedMatmulOp,
+          linalg::ReduceOp, linalg::VecmatOp>(linearOp)) {
+    return true;
+  }
+
+  // Check if a generic op uses addi or addf on the outs's corresponding block
+  // argument just before yielding it.
+  if (auto generic = dyn_cast<linalg::GenericOp>(linearOp)) {
+    if (generic.getNumDpsInits() != 1) return false;
+    Block* body = generic.getBody();
+    auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
+    Value yieldedValue = yieldOp.getOperand(0);
+    auto addOp = yieldedValue.getDefiningOp();
+    if (!addOp) return false;
+    if (isa<arith::AddFOp, arith::AddIOp>(addOp)) {
+      Value lhs = addOp->getOperand(0);
+      Value rhs = addOp->getOperand(1);
+      Value outBlockArg = body->getArgument(generic.getNumDpsInputs());
+      if (lhs == outBlockArg || rhs == outBlockArg) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+// Given an op (add, sub, div, mul), try to find a linalg op whose op result is
+// used by this op, populate `linearOp` with that result, and populate
+// `rawOperand` with the other operand of `op`. Fail if no such linalg op can be
+// found.
 template <typename OpTy>
 LogicalResult findLinearOpAndOperand(OpTy op, Operation*& linearOp,
                                      Value& rawOperand) {
   Value lhs = op.getLhs();
   Value rhs = op.getRhs();
 
-  auto defOp = lhs.getDefiningOp();
-  Value other = rhs;
-  if (!defOp || !isa<linalg::LinalgOp>(defOp)) {
-    defOp = rhs.getDefiningOp();
-    other = lhs;
-  }
-  if (!defOp || !isa<linalg::LinalgOp>(defOp)) return failure();
+  auto isLinearOp = [](Operation* defOp) {
+    return defOp && isa<linalg::LinalgOp>(defOp) &&
+           !isa<linalg::BroadcastOp, linalg::FillOp, linalg::TransposeOp>(
+               defOp);
+  };
 
-  linearOp = defOp;
-  rawOperand = other;
-  if (Operation* broadcastOp = other.getDefiningOp()) {
-    if (broadcastOp->getName().getStringRef() == "linalg.broadcast") {
-      rawOperand = broadcastOp->getOperand(0);
-    }
+  auto* lhsOp = lhs.getDefiningOp();
+  auto* rhsOp = rhs.getDefiningOp();
+
+  if (isLinearOp(lhsOp)) {
+    linearOp = lhsOp;
+    rawOperand = rhs;
+    return success();
   }
-  return success();
+  if (isLinearOp(rhsOp)) {
+    linearOp = rhsOp;
+    rawOperand = lhs;
+    return success();
+  }
+  return failure();
 }
 
+static void moveSliceBefore(Operation* op, Operation* target) {
+  if (!op) return;
+  if (op->getBlock() != target->getBlock() || op->isBeforeInBlock(target))
+    return;
+  for (Value operand : op->getOperands()) {
+    moveSliceBefore(operand.getDefiningOp(), target);
+  }
+  op->moveBefore(target);
+}
+
+// Given a value, walk the use-def chain backwards to try to find a scalar SSA
+// value, passing through ops that only splat/reshape a scalar as a dense
+// tensor. Alternatively, if the end of the chain is a tensor type, check
+// to see if it can be broadcast to a given weightsType.
+FailureOr<OpFoldResult> findOriginalScalar(Value scaleVal, Type weightsType) {
+  Value val = scaleVal;
+  Operation* definingOp = nullptr;
+  while (val.getDefiningOp() && isa<ShapedType>(val.getType())) {
+    definingOp = val.getDefiningOp();
+
+    // We hit a block argument
+    if (!definingOp) break;
+
+    if (!isa<linalg::BroadcastOp, tensor::ExpandShapeOp, tensor::SplatOp,
+             arith::ConstantOp>(*definingOp))
+      return failure();
+
+    // For the supported ops, the input to traverse is always the first operand,
+    // or else a constant op (with no operands) at which point we break.
+    if (definingOp->getNumOperands() == 0) break;
+
+    val = definingOp->getOperand(0);
+  }
+
+  // Case 1: we stopped at an SSA value that is already a scalar
+  if (!isa<ShapedType>(val.getType())) return OpFoldResult(val);
+
+  // Case 2: we stopped at an SSA value defined by a splatted arith.constant
+  if (definingOp) {
+    if (auto constantOp = dyn_cast<arith::ConstantOp>(definingOp)) {
+      Attribute valueAttr = constantOp.getValue();
+      if (DenseElementsAttr denseElementsAttr =
+              dyn_cast<DenseElementsAttr>(valueAttr)) {
+        if (denseElementsAttr.isSplat()) {
+          return OpFoldResult(denseElementsAttr);
+        }
+      }
+    }
+  }
+
+  // Case 3: we stopped at an SSA value that is a 1D tensor. This is checked
+  // for broadcast compatibility by the caller.
+  if (auto shapedTy = dyn_cast<ShapedType>(val.getType())) {
+    if (shapedTy.getRank() == 1) return OpFoldResult(val);
+  }
+
+  return failure();
+}
+
+// If `op` has a preceding LinalgOp with a compatible structure, fuse `op`
+// by multiplying or dividing it by the initializer and using that as the new
+// initializer.
+//
+// In this routine, we support fusing only a scalar multiplication or division,
+// though we also support constants that are broadcast, expand-shaped, or
+// dense-splatted to match the `outs` shape.
 template <typename OpTy>
 LogicalResult fuseScaleOrDivIntoLinearOp(PatternRewriter& rewriter, OpTy op,
                                          DataFlowSolver& solver) {
@@ -75,14 +205,18 @@ LogicalResult fuseScaleOrDivIntoLinearOp(PatternRewriter& rewriter, OpTy op,
   int64_t weightOperandIdx = -1;
   int64_t matchDim = -1;
 
+  // Opt-in only specific ops where the `addend` can be fused into the
+  // corresponding cleartext weights matrix.
   llvm::TypeSwitch<Operation*>(linearOp)
       .template Case<linalg::MatmulOp, linalg::VecmatOp>([&](auto op) {
         weights = op.getOperand(1);
         weightOperandIdx = 1;
+        matchDim = 1;
       })
       .template Case<linalg::MatvecOp>([&](auto op) {
         weights = op.getOperand(0);
         weightOperandIdx = 0;
+        matchDim = 0;
       })
       .template Case<linalg::Conv2DNchwFchwOp, linalg::Conv2DNhwcFhwcOp,
                      linalg::Conv1DNcwFcwOp>([&](auto op) {
@@ -103,49 +237,78 @@ LogicalResult fuseScaleOrDivIntoLinearOp(PatternRewriter& rewriter, OpTy op,
       .Default([](auto) {});
 
   if (!weights) return failure();
+  if (isSecret(weights, &solver)) {
+    return failure();
+  }
 
   auto weightsType = cast<RankedTensorType>(weights.getType());
-  auto scaleValType = cast<RankedTensorType>(scaleVal.getType());
 
-  if (scaleValType.getRank() != 1) return failure();
+  // In this pattern, we support fusing only a scalar multiplication or
+  // division. So the `scaleVal` may need to be traced back through broadcasts
+  // until a dense constant or scalar SSA value is identified.
+  FailureOr<OpFoldResult> maybeScaleOfr =
+      findOriginalScalar(scaleVal, weightsType);
+  if (failed(maybeScaleOfr)) return failure();
+  OpFoldResult scaleOfr = *maybeScaleOfr;
 
-  // Determine which dimension of the weight matrix we need to broadcast the
-  // scalar along.
-  if (matchDim == -1) {
-    for (int i = 0; i < weightsType.getRank(); ++i) {
-      if (weightsType.getDimSize(i) == scaleValType.getDimSize(0)) {
-        matchDim = i;
-        break;
+  if (auto origVal = dyn_cast<Value>(scaleOfr)) {
+    moveSliceBefore(origVal.getDefiningOp(), linearOp);
+  }
+  moveSliceBefore(scaleVal.getDefiningOp(), linearOp);
+  rewriter.setInsertionPoint(linearOp);
+
+  // Next we need to materialize the scalar as a constant, with shape matching
+  // the weights we want to fuse it to.
+
+  Value newScaleVal;
+  if (auto attr = dyn_cast<Attribute>(scaleOfr)) {
+    auto newDenseAttr = DenseElementsAttr::get(
+        weightsType, cast<DenseElementsAttr>(attr).getSplatValue<Attribute>());
+    auto newConstantOp =
+        arith::ConstantOp::create(rewriter, linearOp->getLoc(), newDenseAttr);
+    newScaleVal = newConstantOp.getResult();
+  } else {
+    Value origVal = cast<Value>(scaleOfr);
+    auto origType = cast<ShapedType>(origVal.getType());
+    if (origType == weightsType) {
+      newScaleVal = origVal;
+    } else if (origType.getRank() == 1) {
+      // The added type is not broadcast compatible with the weights tensor.
+      if (weightsType.getDimSize(matchDim) != origType.getDimSize(0)) {
+        return failure();
       }
+
+      SmallVector<int64_t> addedDims;
+      for (int i = 0; i < weightsType.getRank(); ++i) {
+        if (i != matchDim) {
+          addedDims.push_back(i);
+        }
+      }
+      auto emptyOp = tensor::EmptyOp::create(rewriter, linearOp->getLoc(),
+                                             weightsType.getShape(),
+                                             weightsType.getElementType());
+      auto broadcastOp =
+          linalg::BroadcastOp::create(rewriter, linearOp->getLoc(), origVal,
+                                      emptyOp.getResult(), addedDims);
+      newScaleVal = broadcastOp.getResults()[0];
+    } else {
+      return failure();
     }
   }
-  if (matchDim == -1) return failure();
 
-  SmallVector<int64_t> addedDims;
-  for (int i = 0; i < weightsType.getRank(); ++i) {
-    if (i != matchDim) {
-      addedDims.push_back(i);
-    }
-  }
+  Value scaledWeights =
+      rewriter.createOrFold<OpTy>(op.getLoc(), weights, newScaleVal);
 
-  auto emptyOp = tensor::EmptyOp::create(rewriter, linearOp->getLoc(),
-                                         weightsType.getShape(),
-                                         weightsType.getElementType());
-
-  auto broadcastOp = linalg::BroadcastOp::create(
-      rewriter, linearOp->getLoc(), scaleVal, emptyOp.getResult(), addedDims);
-
-  auto scaledWeights =
-      OpTy::create(rewriter, op.getLoc(), weights, broadcastOp.getResults()[0]);
-
-  IRMapping bvm;
-  Operation* newLinearOp = rewriter.clone(*linearOp, bvm);
-  newLinearOp->setOperand(weightOperandIdx, scaledWeights);
-
-  rewriter.replaceOp(op, newLinearOp->getResults());
+  rewriter.modifyOpInPlace(linearOp, [&]() {
+    linearOp->setOperand(weightOperandIdx, scaledWeights);
+  });
+  rewriter.replaceOp(op, linearOp->getResults());
   return success();
 }
 
+// If `op` has a preceding LinalgOp with a single `outs` initializer, fuse `op`
+// by adding or subtracting it by the initializer and using that as the new
+// initializer.
 template <typename OpTy>
 LogicalResult fuseAddOrSubIntoLinearOp(PatternRewriter& rewriter, OpTy op,
                                        DataFlowSolver& solver) {
@@ -160,59 +323,35 @@ LogicalResult fuseAddOrSubIntoLinearOp(PatternRewriter& rewriter, OpTy op,
   auto destStyleOp = dyn_cast<DestinationStyleOpInterface>(linearOp);
   if (!destStyleOp) return failure();
 
+  if (!accumulatesIntoOuts(linearOp)) return failure();
+
   if (destStyleOp.getNumDpsInits() != 1) return failure();
 
-  auto outputType =
-      cast<RankedTensorType>(destStyleOp.getDpsInitOperand(0)->get().getType());
+  auto previousOuts = destStyleOp.getDpsInitOperand(0)->get();
+  auto outputType = cast<RankedTensorType>(previousOuts.getType());
   auto addendType = cast<RankedTensorType>(addend.getType());
 
-  if (addendType.getRank() != 1) return failure();
+  // The addend and output type must match by construction: they were originally
+  // added or sub'ed together by `op` which is assumed to verify.
+  assert(outputType == addendType &&
+         "mismatching types for fuseAddOrSubIntoLinearOp");
 
-  int64_t matchDimAddend = -1;
-  for (int i = 0; i < outputType.getRank(); ++i) {
-    if (outputType.getDimSize(i) == addendType.getDimSize(0)) {
-      matchDimAddend = i;
-      break;
-    }
-  }
-  if (matchDimAddend == -1) return failure();
-
-  SmallVector<int64_t> addedDimsAddend;
-  for (int i = 0; i < outputType.getRank(); ++i) {
-    if (i != matchDimAddend) {
-      addedDimsAddend.push_back(i);
-    }
-  }
-
-  auto emptyOutputOp = tensor::EmptyOp::create(rewriter, linearOp->getLoc(),
-                                               outputType.getShape(),
-                                               outputType.getElementType());
-
-  auto broadcastAddendOp =
-      linalg::BroadcastOp::create(rewriter, linearOp->getLoc(), addend,
-                                  emptyOutputOp.getResult(), addedDimsAddend);
-
-  Value existingOuts = destStyleOp.getDpsInitOperand(0)->get();
+  moveSliceBefore(addend.getDefiningOp(), linearOp);
+  rewriter.setInsertionPoint(linearOp);
   Value newOuts;
-  if (existingOuts.getDefiningOp<tensor::EmptyOp>()) {
+  if (previousOuts.getDefiningOp<tensor::EmptyOp>()) {
     if constexpr (std::is_same_v<OpTy, arith::SubFOp>) {
-      newOuts = arith::NegFOp::create(rewriter, op.getLoc(),
-                                      broadcastAddendOp.getResults()[0]);
+      newOuts = rewriter.createOrFold<arith::NegFOp>(op.getLoc(), addend);
     } else {
-      newOuts = broadcastAddendOp.getResults()[0];
+      newOuts = addend;
     }
   } else {
-    newOuts = OpTy::create(rewriter, op.getLoc(), existingOuts,
-                           broadcastAddendOp.getResults()[0]);
+    newOuts = rewriter.createOrFold<OpTy>(op.getLoc(), previousOuts, addend);
   }
 
-  IRMapping bvm;
-  Operation* newLinearOp = rewriter.clone(*linearOp, bvm);
-  unsigned initOperandIdx =
-      destStyleOp.getDpsInitOperand(0)->getOperandNumber();
-  newLinearOp->setOperand(initOperandIdx, newOuts);
-
-  rewriter.replaceOp(op, newLinearOp->getResults());
+  rewriter.modifyOpInPlace(
+      destStyleOp, [&]() { destStyleOp.setDpsInitOperand(0, newOuts); });
+  rewriter.replaceOp(op, destStyleOp->getResults());
   return success();
 }
 

--- a/tests/Transforms/linalg_fuse_linear_ops/batch_norm.mlir
+++ b/tests/Transforms/linalg_fuse_linear_ops/batch_norm.mlir
@@ -1,0 +1,76 @@
+// RUN: heir-opt --inline-activations --activation-canonicalizations --linalg-canonicalizations --linalg-fuse-linear-ops --canonicalize %s | FileCheck %s
+
+// This test verifies that the preprocessing + canonicalization + fusion
+// pipeline can successfully fold and fuse a raw BatchNorm sequence exported
+// from torch-mlir when using standard `dense` constants.
+
+// CHECK: func.func @reproducer_raw
+// CHECK: arith.constant
+// CHECK-NEXT: arith.constant
+// CHECK-NEXT: linalg.matmul
+// CHECK-NEXT: return
+func.func @reproducer_raw(%arg0: tensor<1x8xf32>) -> tensor<1x16xf32> {
+  %cst_w = arith.constant dense<2.000000e+00> : tensor<16x8xf32> // Use 2.0 to prevent folding to identity
+  %cst_b = arith.constant dense<2.000000e+00> : tensor<16xf32>
+
+  // BatchNorm parameters
+  %cst_mean = arith.constant dense<3.000000e+00> : tensor<16xf32>
+  %cst_var = arith.constant dense<4.000000e+00> : tensor<16xf32>
+  %cst_gamma = arith.constant dense<5.000000e+00> : tensor<16xf32>
+  %cst_beta = arith.constant dense<6.000000e+00> : tensor<16xf32>
+  %cst_eps = arith.constant 1.000000e-05 : f32
+
+  %cst_zero = arith.constant dense<0.000000e+00> : tensor<1x16xf32>
+  %cst_one = arith.constant 1.000000e+00 : f32
+
+  %0 = tensor.empty() : tensor<8x16xf32>
+  %transposed = linalg.transpose ins(%cst_w : tensor<16x8xf32>) outs(%0 : tensor<8x16xf32>) permutation = [1, 0]
+
+  // MatMul
+  %1 = linalg.matmul ins(%arg0, %transposed : tensor<1x8xf32>, tensor<8x16xf32>) outs(%cst_zero : tensor<1x16xf32>) -> tensor<1x16xf32>
+
+  // Bias Add
+  %expanded_b = tensor.expand_shape %cst_b [[0, 1]] output_shape [1, 16] : tensor<16xf32> into tensor<1x16xf32>
+  %2 = arith.addf %1, %expanded_b : tensor<1x16xf32>
+
+  // BatchNorm Step 1: Compute reciprocal standard deviation: 1 / sqrt(var + eps)
+  %empty_16 = tensor.empty() : tensor<16xf32>
+  %eps_filled = linalg.fill ins(%cst_eps : f32) outs(%empty_16 : tensor<16xf32>) -> tensor<16xf32>
+  %var_plus_eps = arith.addf %cst_var, %eps_filled : tensor<16xf32>
+
+  %std = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%var_plus_eps : tensor<16xf32>) outs(%empty_16 : tensor<16xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %sqrt = math.sqrt %in : f32
+    linalg.yield %sqrt : f32
+  } -> tensor<16xf32>
+
+  %reciprocal_std = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%std : tensor<16xf32>) outs(%empty_16 : tensor<16xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %div = arith.divf %cst_one, %in : f32
+    linalg.yield %div : f32
+  } -> tensor<16xf32>
+
+  // BatchNorm Step 2: Subtract Mean
+  %expanded_mean = tensor.expand_shape %cst_mean [[0, 1]] output_shape [1, 16] : tensor<16xf32> into tensor<1x16xf32>
+  %3 = arith.subf %2, %expanded_mean : tensor<1x16xf32>
+
+  // BatchNorm Step 3: Multiply by reciprocal std
+  %expanded_rstd = tensor.expand_shape %reciprocal_std [[0, 1]] output_shape [1, 16] : tensor<16xf32> into tensor<1x16xf32>
+  %4 = arith.mulf %3, %expanded_rstd : tensor<1x16xf32>
+
+  // BatchNorm Step 4: Multiply by gamma
+  %expanded_gamma = tensor.expand_shape %cst_gamma [[0, 1]] output_shape [1, 16] : tensor<16xf32> into tensor<1x16xf32>
+  %5 = arith.mulf %4, %expanded_gamma : tensor<1x16xf32>
+
+  // BatchNorm Step 5: Add beta
+  %expanded_beta = tensor.expand_shape %cst_beta [[0, 1]] output_shape [1, 16] : tensor<16xf32> into tensor<1x16xf32>
+  %6 = arith.addf %5, %expanded_beta : tensor<1x16xf32>
+
+  return %6 : tensor<1x16xf32>
+}

--- a/tests/Transforms/linalg_fuse_linear_ops/linalg_fuse_linear_ops.mlir
+++ b/tests/Transforms/linalg_fuse_linear_ops/linalg_fuse_linear_ops.mlir
@@ -26,9 +26,7 @@ func.func @fuse_matmul(%arg0: tensor<2x3xf32>, %arg1: tensor<3x4xf32>, %arg2: te
 // CHECK: %[[EMPTY_W:.*]] = tensor.empty() : tensor<2x3xf32>
 // CHECK: %[[BROADCAST_W:.*]] = linalg.broadcast ins(%arg2 : tensor<2xf32>) outs(%[[EMPTY_W]] : tensor<2x3xf32>) dimensions = [1]
 // CHECK: %[[SCALED_W:.*]] = arith.mulf %arg0, %[[BROADCAST_W]] : tensor<2x3xf32>
-// CHECK: %[[EMPTY_OUT:.*]] = tensor.empty() : tensor<2xf32>
-// CHECK: %[[BROADCAST_OUT:.*]] = linalg.broadcast ins(%arg3 : tensor<2xf32>) outs(%[[EMPTY_OUT]] : tensor<2xf32>) dimensions = []
-// CHECK: %[[RESULT:.*]] = linalg.matvec ins(%[[SCALED_W]], %arg1 : tensor<2x3xf32>, tensor<3xf32>) outs(%[[BROADCAST_OUT]] : tensor<2xf32>)
+// CHECK: %[[RESULT:.*]] = linalg.matvec ins(%[[SCALED_W]], %arg1 : tensor<2x3xf32>, tensor<3xf32>) outs(%arg3 : tensor<2xf32>)
 // CHECK: return %[[RESULT]]
 func.func @fuse_matvec(%arg0: tensor<2x3xf32>, %arg1: tensor<3xf32>, %arg2: tensor<2xf32>, %arg3: tensor<2xf32>) -> tensor<2xf32> {
   %0 = tensor.empty() : tensor<2xf32>
@@ -44,9 +42,7 @@ func.func @fuse_matvec(%arg0: tensor<2x3xf32>, %arg1: tensor<3xf32>, %arg2: tens
 // CHECK: %[[EMPTY_W:.*]] = tensor.empty() : tensor<3x4xf32>
 // CHECK: %[[BROADCAST_W:.*]] = linalg.broadcast ins(%arg2 : tensor<4xf32>) outs(%[[EMPTY_W]] : tensor<3x4xf32>) dimensions = [0]
 // CHECK: %[[SCALED_W:.*]] = arith.mulf %arg1, %[[BROADCAST_W]] : tensor<3x4xf32>
-// CHECK: %[[EMPTY_OUT:.*]] = tensor.empty() : tensor<4xf32>
-// CHECK: %[[BROADCAST_OUT:.*]] = linalg.broadcast ins(%arg3 : tensor<4xf32>) outs(%[[EMPTY_OUT]] : tensor<4xf32>) dimensions = []
-// CHECK: %[[RESULT:.*]] = linalg.vecmat ins(%arg0, %[[SCALED_W]] : tensor<3xf32>, tensor<3x4xf32>) outs(%[[BROADCAST_OUT]] : tensor<4xf32>)
+// CHECK: %[[RESULT:.*]] = linalg.vecmat ins(%arg0, %[[SCALED_W]] : tensor<3xf32>, tensor<3x4xf32>) outs(%arg3 : tensor<4xf32>)
 // CHECK: return %[[RESULT]]
 func.func @fuse_vecmat(%arg0: tensor<3xf32>, %arg1: tensor<3x4xf32>, %arg2: tensor<4xf32>, %arg3: tensor<4xf32>) -> tensor<4xf32> {
   %0 = tensor.empty() : tensor<4xf32>
@@ -140,4 +136,59 @@ func.func @no_fuse_secret_bias(%arg0: tensor<2x3xf32>, %arg1: tensor<3xf32>, %ar
   %1 = linalg.matvec ins(%arg0, %arg1 : tensor<2x3xf32>, tensor<3xf32>) outs(%0 : tensor<2xf32>) -> tensor<2xf32>
   %2 = arith.addf %1, %arg2 : tensor<2xf32>
   return %2 : tensor<2xf32>
+}
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK: func.func @fuse_generic
+// CHECK-SAME: %[[arg0:[a-zA-Z0-9_]+]]: tensor<2x3xf32>
+// CHECK-SAME: %[[arg1:[a-zA-Z0-9_]+]]: tensor<3x4xf32>
+// CHECK-SAME: %[[arg2:[a-zA-Z0-9_]+]]: tensor<2x4xf32>
+// CHECK-SAME: %[[bias:[a-zA-Z0-9_]+]]: tensor<2x4xf32>
+// CHECK: %[[NEW_OUTS:.*]] = arith.addf %[[arg2]], %[[bias]] : tensor<2x4xf32>
+// CHECK: %[[RESULT:.*]] = linalg.generic
+// CHECK-SAME: outs(%[[NEW_OUTS]] : tensor<2x4xf32>)
+// CHECK: return %[[RESULT]]
+func.func @fuse_generic(%arg0: tensor<2x3xf32>, %arg1: tensor<3x4xf32>, %arg2: tensor<2x4xf32>, %bias: tensor<2x4xf32>) -> tensor<2x4xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<2x3xf32>, tensor<3x4xf32>) outs(%arg2 : tensor<2x4xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %1 = arith.mulf %in, %in_0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<2x4xf32>
+  %1 = arith.addf %0, %bias : tensor<2x4xf32>
+  return %1 : tensor<2x4xf32>
+}
+
+// -----
+
+// CHECK: func.func @fuse_matmul_splat_constant
+// CHECK: %[[CONST_W:.*]] = arith.constant dense<6.000000e+00> : tensor<3x4xf32>
+// CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<2x4xf32>
+// CHECK: %[[RESULT:.*]] = linalg.matmul ins(%arg0, %[[CONST_W]] : tensor<2x3xf32>, tensor<3x4xf32>) outs(%[[EMPTY]] : tensor<2x4xf32>)
+// CHECK: return %[[RESULT]]
+func.func @fuse_matmul_splat_constant(%arg0: tensor<2x3xf32>) -> tensor<2x4xf32> {
+  %weights = arith.constant dense<2.000000e+00> : tensor<3x4xf32>
+  %scale = arith.constant dense<3.000000e+00> : tensor<2x4xf32>
+  %0 = tensor.empty() : tensor<2x4xf32>
+  %1 = linalg.matmul ins(%arg0, %weights : tensor<2x3xf32>, tensor<3x4xf32>) outs(%0 : tensor<2x4xf32>) -> tensor<2x4xf32>
+  %2 = arith.mulf %1, %scale : tensor<2x4xf32>
+  return %2 : tensor<2x4xf32>
+}
+
+// -----
+
+// CHECK: func.func @fuse_matmul_sub_empty_constant
+// CHECK: %[[CONST_NEG:.*]] = arith.constant dense<-3.000000e+00> : tensor<2x4xf32>
+// CHECK: %[[RESULT:.*]] = linalg.matmul ins(%arg0, %arg1 : tensor<2x3xf32>, tensor<3x4xf32>) outs(%[[CONST_NEG]] : tensor<2x4xf32>)
+// CHECK: return %[[RESULT]]
+func.func @fuse_matmul_sub_empty_constant(%arg0: tensor<2x3xf32>, %arg1: tensor<3x4xf32>) -> tensor<2x4xf32> {
+  %0 = tensor.empty() : tensor<2x4xf32>
+  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<2x3xf32>, tensor<3x4xf32>) outs(%0 : tensor<2x4xf32>) -> tensor<2x4xf32>
+  %scale = arith.constant dense<3.000000e+00> : tensor<2x4xf32>
+  %2 = arith.subf %1, %scale : tensor<2x4xf32>
+  return %2 : tensor<2x4xf32>
 }

--- a/tests/Transforms/linalg_fuse_linear_ops/preexisting_bias.mlir
+++ b/tests/Transforms/linalg_fuse_linear_ops/preexisting_bias.mlir
@@ -1,0 +1,20 @@
+// RUN: heir-opt --linalg-fuse-linear-ops %s | FileCheck %s
+
+// Tests that fusing a multiplication (scale) into a linalg.matmul updates the
+// pre-existing outs accumulator appropriately.
+
+// CHECK: func.func @matmul_preexisting_bias
+// CHECK-SAME: %[[arg1:[a-zA-Z0-9_]+]]: tensor<3x4xf32>
+// CHECK-SAME: %[[arg3:[a-zA-Z0-9_]+]]: tensor<4xf32>
+// CHECK: %[[EMPTY_W:.*]] = tensor.empty() : tensor<3x4xf32>
+// CHECK: %[[BROADCAST_W:.*]] = linalg.broadcast ins(%[[arg3]] : tensor<4xf32>) outs(%[[EMPTY_W]] : tensor<3x4xf32>) dimensions = [0]
+// CHECK: %[[SCALED_W:.*]] = arith.mulf %[[arg1]], %[[BROADCAST_W]] : tensor<3x4xf32>
+// CHECK: %[[RESULT:.*]] = linalg.matmul ins(%arg0, %[[SCALED_W]] : tensor<2x3xf32>, tensor<3x4xf32>) outs(%arg2 : tensor<2x4xf32>)
+// CHECK: return %[[RESULT]]
+func.func @matmul_preexisting_bias(%arg0: tensor<2x3xf32>, %arg1: tensor<3x4xf32>, %arg2: tensor<2x4xf32>, %arg3: tensor<4xf32>) -> tensor<2x4xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<2x3xf32>, tensor<3x4xf32>) outs(%arg2 : tensor<2x4xf32>) -> tensor<2x4xf32>
+  %1 = tensor.empty() : tensor<2x4xf32>
+  %broadcasted = linalg.broadcast ins(%arg3 : tensor<4xf32>) outs(%1 : tensor<2x4xf32>) dimensions = [0]
+  %2 = arith.mulf %0, %broadcasted : tensor<2x4xf32>
+  return %2 : tensor<2x4xf32>
+}


### PR DESCRIPTION
This PR improves the support for fusing batch norm into matmul or other prior linalg ops. I found a few cases where it wasn't properly fusing (involving broadcasts between the dense constant and the mul op). I also noticed that the `outs` accumulator was being overridden, and even though we don't typically have nonempty/nonzero `outs`, this PR adds support for that case.