### PR TITLE
Rotom: Rolled Layout Representation

### DIFF
--- a/lib/Dialect/Rotom/IR/RotomAttributes.cpp
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.cpp
@@ -278,15 +278,27 @@ static LogicalResult verifyLayoutRolls(
     if (!di || !dj) {
       return emitError() << "roll indices must refer to #rotom.dim entries";
     }
-    // The two dims of a roll must have equal extents: roll(i, j) shifts dims[i]
-    // by dims[j]'s index modulo their shared extent, which is well-defined only
-    // when the extents match.
-    if (di.getSize() != dj.getSize()) {
-      return emitError() << "rolled dims must have the same extent (size)";
+    // The extents need not match: roll(i, j) rewrites dims[i]'s index to
+    // (i_i - i_j) mod size(dims[i]), well-defined for any partner extent (a
+    // smaller partner covers a prefix of the rotations, a larger one wraps).
+    // The rolled (from) dim must be a traversal dim -- it is the index
+    // expression being rewritten. The roll-by (second) dim may be any kind:
+    // rolling by a replication or gap dim shifts by that dim's block index,
+    // so each block holds a distinct cyclic rotation of the rolled dim -- the
+    // layout materializes every rotation and alignment becomes block
+    // selection. (A rolled-by gap thus claims its blocks, unlike a plain gap.)
+    if (di.isGap() || di.isReplicate()) {
+      return emitError() << "the rolled dim must be a traversal dim (dim >= 0)";
     }
-    if (di.isGap() || dj.isGap() || di.isReplicate() || dj.isReplicate()) {
-      return emitError() << "rolls may only reference non-sentinel traversal "
-                            "dims (dim >= 0)";
+    // A rolled-by GAP claims one ciphertext block per gap index, each holding
+    // a distinct rotation of the rolled dim. If the gap is larger than the
+    // rolled dim's extent the rotations repeat (period = the from extent),
+    // claiming blocks the conversion/kernel accounting was never audited for.
+    // (Replication partners of larger extent are intended -- replicate-then-
+    // roll -- so only gaps are bounded.)
+    if (dj.isGap() && dj.getSize() > di.getSize()) {
+      return emitError() << "a rolled-by gap dim must not exceed the rolled "
+                            "dim's extent";
     }
   }
   return success();

--- a/lib/Dialect/Rotom/IR/RotomAttributes.td
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.td
@@ -57,8 +57,9 @@ def Rotom_LayoutAttr : Rotom_Attr<"Layout", "layout"> {
 
     Optional **rolls** encode a `roll(i,j)` metadata object: each pair `(i, j)`
     indexes into the `dims` array (the flattened `ct_dims + slot_dims` list) and
-    uses modular addition to modify the indices of  `dims[i]` by the indices of
-    `dims[j]`.
+    rewrites `dims[i]`'s index to `(idx_i - idx_j) mod size(dims[i])`. The two
+    extents need not match: the shift reduces modulo the rolled dim's extent, so
+    a smaller partner covers a prefix of the rotations and a larger one wraps.
   }];
 
   let parameters = (ins

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
@@ -47,8 +47,17 @@ static std::string floorDivExpr(llvm::StringRef expr, int64_t d) {
   return out;
 }
 
-/// Ordinal of pieces[p] among the pieces of its kind.
-/// Used to name the existential variables for replication and gap pieces.
+/// Index of the gap piece at position `idx` of the layout's dims list within
+/// the per-kind gap dim list (gaps are collected in order of appearance).
+static int64_t gapIndexForPosition(ArrayAttr rotomDims, int64_t idx) {
+  return llvm::count_if(
+      rotomDims.getValue().take_front(idx),
+      [](Attribute attr) { return cast<DimAttr>(attr).isGap(); });
+}
+
+/// Ordinal of pieces[p] among the pieces of its kind. Used to name the
+/// existential variables for replication and gap pieces, and matches the
+/// dims-list ordinals the roll machinery computes.
 static int64_t kindOrdinal(ArrayRef<LayoutPiece> pieces, size_t p) {
   int64_t ordinal = 0;
   for (size_t q = 0; q < p; ++q) {
@@ -57,13 +66,32 @@ static int64_t kindOrdinal(ArrayRef<LayoutPiece> pieces, size_t p) {
   return ordinal;
 }
 
-static LogicalResult emitSegmentAddress(llvm::raw_ostream& os, bool& firstTerm,
-                                        ArrayRef<LayoutPiece> pieces,
-                                        const SmallVector<DimAttr>& axes,
-                                        int64_t numAxes, size_t segStart,
-                                        size_t segEnd, bool foldGapVarsToZero,
-                                        ArrayRef<int64_t> rolls,
-                                        ArrayAttr rotomDims) {
+/// Gap dims referenced in the roll-by position, as indices into the gap dim
+/// list. A rolled-by gap claims its blocks (each holds a distinct rotation of
+/// the rolled dim), so it gets an existential variable instead of folding to
+/// zero.
+static llvm::DenseSet<int64_t> rolledGapIndexSet(ArrayRef<int64_t> rolls,
+                                                 ArrayAttr rotomDims) {
+  llvm::DenseSet<int64_t> rolled;
+  if (!rotomDims) return rolled;
+  for (size_t i = 0; i + 1 < rolls.size(); i += 2) {
+    const int64_t toIdx = rolls[i + 1];
+    if (toIdx < 0 || toIdx >= static_cast<int64_t>(rotomDims.size())) continue;
+    if (cast<DimAttr>(rotomDims[toIdx]).isGap()) {
+      rolled.insert(gapIndexForPosition(rotomDims, toIdx));
+    }
+  }
+  return rolled;
+}
+
+static LogicalResult emitSegmentAddress(
+    llvm::raw_ostream& os, bool& firstTerm, ArrayRef<LayoutPiece> pieces,
+    const SmallVector<DimAttr>& axes, int64_t numAxes, size_t segStart,
+    size_t segEnd, const llvm::DenseSet<int64_t>& rolledGapIndices,
+    ArrayRef<int64_t> rolls, ArrayAttr rotomDims) {
+  // Effective extent of a piece = the range of its mixed-radix digit, which
+  // is the piece's own extent: a lone piece reads the whole axis index, and
+  // for a valid mixed-radix split each digit ranges over its piece's extent.
   llvm::SmallVector<int64_t> suffixCoeff(pieces.size(), 0);
   int64_t suffix = 1;
   for (size_t p = segEnd; p > segStart;) {
@@ -94,8 +122,12 @@ static LogicalResult emitSegmentAddress(llvm::raw_ostream& os, bool& firstTerm,
   for (size_t p = segStart; p < segEnd; ++p) {
     const int64_t coeff = suffixCoeff[p];
     if (pieces[p].kind == LayoutPieceKind::Gap) {
-      if (foldGapVarsToZero) continue;
-      gapCoeff[kindOrdinal(pieces, p)] = coeff;
+      // Only a rolled-by gap contributes an address term (its blocks hold the
+      // rotations of the rolled dim); other gaps fold to zero, leaving their
+      // blocks unclaimed.
+      const int64_t ordinal = kindOrdinal(pieces, p);
+      if (!rolledGapIndices.contains(ordinal)) continue;
+      gapCoeff[ordinal] = coeff;
     } else if (pieces[p].kind == LayoutPieceKind::Replication) {
       replicationCoeff[kindOrdinal(pieces, p)] = coeff;
     }
@@ -129,11 +161,11 @@ static LogicalResult emitSegmentAddress(llvm::raw_ostream& os, bool& firstTerm,
   //
   // The rewrite lands wherever the FROM dimension sits -- the ciphertext
   // address, the slot address, or both when it straddles the boundary. BY is
-  // another traversal dimension on either axis, so a roll diagonalizes a
-  // ciphertext dimension against a slot one (one ciphertext per diagonal) or
-  // two slot dimensions (a Halevi-Shoup slot diagonal); a roll within the
-  // ciphertext axis is a free ciphertext relabeling that enumeration never
-  // generates.
+  // another traversal dimension on either axis, or a slot replication/gap
+  // block index, so a roll diagonalizes a ciphertext dimension against a slot
+  // one (one ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup
+  // slot diagonal); a roll within the ciphertext axis is a free ciphertext
+  // relabeling that enumeration never generates.
   if (!rolls.empty()) {
     if (!rotomDims || rolls.size() % 2 != 0) return failure();
     for (size_t i = 0; i < rolls.size(); i += 2) {
@@ -144,16 +176,30 @@ static LogicalResult emitSegmentAddress(llvm::raw_ostream& os, bool& firstTerm,
           toIdx >= static_cast<int64_t>(rotomDims.size())) {
         return failure();
       }
-      auto fromDim = dyn_cast<DimAttr>(rotomDims[fromIdx]);
-      auto toDim = dyn_cast<DimAttr>(rotomDims[toIdx]);
-      if (!fromDim || !toDim) return failure();
+      auto fromDim = cast<DimAttr>(rotomDims[fromIdx]);
+      auto toDim = cast<DimAttr>(rotomDims[toIdx]);
       FailureOr<int64_t> maybeFromVar = varIndexForRotomDim(axes, fromDim);
-      FailureOr<int64_t> maybeToVar = varIndexForRotomDim(axes, toDim);
-      if (failed(maybeFromVar) || failed(maybeToVar)) return failure();
+      if (failed(maybeFromVar)) return failure();
       const int64_t fromVar = *maybeFromVar;
-      const int64_t toVar = *maybeToVar;
-      std::string diffExpr =
-          "(" + axisExprs[fromVar] + " - " + axisExprs[toVar] + ")";
+      std::string toExpr;
+      if (toDim.isGap()) {
+        // Rolling by a gap dim: the shift is the gap's existential block
+        // index, so block g holds the rolled dim cyclically shifted by g.
+        toExpr = "g" + std::to_string(gapIndexForPosition(rotomDims, toIdx));
+      } else if (toDim.isReplicate()) {
+        // Rolling by a replication dim: the shift is the replica index, whose
+        // existential variable is named after the piece's replication slot.
+        int64_t replicationIndex = 0;
+        for (int64_t k = 0; k < toIdx; ++k) {
+          if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
+        }
+        toExpr = "d" + std::to_string(numAxes + replicationIndex);
+      } else {
+        FailureOr<int64_t> maybeToVar = varIndexForRotomDim(axes, toDim);
+        if (failed(maybeToVar)) return failure();
+        toExpr = axisExprs[*maybeToVar];
+      }
+      std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
       axisExprs[fromVar] = modExpr(diffExpr, fromDim.getSize());
     }
   }
@@ -196,17 +242,23 @@ static FailureOr<std::string> emitSplitCtSlotIsl(
 
   const int64_t numAxes = static_cast<int64_t>(axes.size());
   int64_t numReplication = 0;
-  int64_t numGap = 0;
   for (const LayoutPiece& piece : pieces) {
     if (piece.kind == LayoutPieceKind::Replication) ++numReplication;
-    if (piece.kind == LayoutPieceKind::Gap) ++numGap;
   }
+
+  const llvm::DenseSet<int64_t> rolledGapIndices =
+      rolledGapIndexSet(rolls, rotomDims);
 
   int64_t numCt = 1;
   for (size_t p = 0; p < prefix; ++p) {
-    if (pieces[p].kind == LayoutPieceKind::Traversal ||
-        pieces[p].kind == LayoutPieceKind::Replication) {
-      numCt *= pieces[p].dim.getSize();
+    const LayoutPiece& piece = pieces[p];
+    if (piece.kind == LayoutPieceKind::Traversal ||
+        piece.kind == LayoutPieceKind::Replication) {
+      numCt *= piece.dim.getSize();
+    } else if (piece.kind == LayoutPieceKind::Gap &&
+               rolledGapIndices.contains(kindOrdinal(pieces, p))) {
+      // A rolled-by gap claims its blocks (one rotation per block index).
+      numCt *= piece.dim.getSize();
     }
   }
   if (numCt < 1) numCt = 1;
@@ -238,8 +290,8 @@ static FailureOr<std::string> emitSplitCtSlotIsl(
   emitAnd();
   os << "0 <= slot <= " << (n - 1);
 
-  const bool foldGapVarsToZero = numGap > 0;
-  const int64_t numLocalVars = numReplication;
+  const int64_t numLocalVars =
+      numReplication + static_cast<int64_t>(rolledGapIndices.size());
 
   if (numLocalVars > 0) {
     os << " and exists ";
@@ -249,6 +301,11 @@ static FailureOr<std::string> emitSplitCtSlotIsl(
         if (!firstVar) os << ", ";
         firstVar = false;
         os << "d" << (numAxes + kindOrdinal(pieces, p));
+      } else if (pieces[p].kind == LayoutPieceKind::Gap &&
+                 rolledGapIndices.contains(kindOrdinal(pieces, p))) {
+        if (!firstVar) os << ", ";
+        firstVar = false;
+        os << "g" << kindOrdinal(pieces, p);
       }
     }
     os << " : ";
@@ -259,7 +316,7 @@ static FailureOr<std::string> emitSplitCtSlotIsl(
   bool firstTerm = true;
   os << "ct = ";
   if (failed(emitSegmentAddress(os, firstTerm, pieces, axes, numAxes, 0, prefix,
-                                foldGapVarsToZero, rolls, rotomDims)))
+                                rolledGapIndices, rolls, rotomDims)))
     return failure();
   if (firstTerm) os << "0";
 
@@ -267,7 +324,7 @@ static FailureOr<std::string> emitSplitCtSlotIsl(
   firstTerm = true;
   os << "slot = ";
   if (failed(emitSegmentAddress(os, firstTerm, pieces, axes, numAxes, prefix,
-                                pieces.size(), foldGapVarsToZero, rolls,
+                                pieces.size(), rolledGapIndices, rolls,
                                 rotomDims)))
     return failure();
   if (firstTerm) os << "0";
@@ -278,6 +335,13 @@ static FailureOr<std::string> emitSplitCtSlotIsl(
       emitAnd();
       os << "0 <= d" << (numAxes + kindOrdinal(pieces, p))
          << " <= " << (pieces[p].dim.getSize() - 1);
+    }
+    for (size_t p = 0; p < pieces.size(); ++p) {
+      if (pieces[p].kind != LayoutPieceKind::Gap) continue;
+      const int64_t g = kindOrdinal(pieces, p);
+      if (!rolledGapIndices.contains(g)) continue;
+      emitAnd();
+      os << "0 <= g" << g << " <= " << (pieces[p].dim.getSize() - 1);
     }
   }
 

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
@@ -11,6 +11,7 @@
 #include "lib/Utils/Layout/Utils.h"
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"         // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 
@@ -334,6 +335,143 @@ TEST(RotomTensorExtLayoutLoweringTest, RolledInternalRowMajor4x4Evaluate) {
   };
   EXPECT_EQ(packed, expected);
   EXPECT_EQ(unpackLayoutToMatrix(relation.value(), packed, {4, 4}), matrix);
+}
+
+// roll(1, 0) with piece 0 a replication dim: dim 0's index is shifted by the
+// replica index, so replica d holds the vector rotated left by d -- the
+// layout materializes every cyclic rotation, making downstream alignment a
+// replica selection.
+TEST(RotomTensorExtLayoutLoweringTest, RollByReplicationMaterializesRotations) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr d0 = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, d0});
+  LayoutAttr layout = LayoutAttr::get(
+      &context, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+
+  FailureOr<std::string> isl =
+      RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+  ASSERT_TRUE(succeeded(isl));
+  auto relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+
+  std::vector<int> vec = {1, 2, 3, 4};
+  std::vector<std::vector<int>> packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        return vec[domainPoint[0]];
+      });
+  std::vector<std::vector<int>> expected = {
+      {1, 2, 3, 4, 2, 3, 4, 1, 3, 4, 1, 2, 4, 1, 2, 3}};
+  EXPECT_EQ(packed, expected);
+}
+
+// Unequal roll extents: the shift reduces modulo the rolled dim's extent.
+// A smaller partner materializes a prefix of the rotations; a larger one
+// wraps around.
+TEST(RotomTensorExtLayoutLoweringTest, UnequalExtentRollReducesModFromSize) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+
+  // roll(1, 0) [R:2][0:8]: replica d of two holds the 8-vector rotated
+  // left by d.
+  DimAttr repl2 = DimAttr::get(&context, /*dim=*/-1, /*size=*/2, /*stride=*/1);
+  DimAttr d0Of8 = DimAttr::get(&context, /*dim=*/0, /*size=*/8, /*stride=*/1);
+  LayoutAttr prefix = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {repl2, d0Of8}), /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+  FailureOr<std::string> isl =
+      RotomTensorExtLayoutLowering::lowerToTensorExtIsl(prefix);
+  ASSERT_TRUE(succeeded(isl));
+  auto relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+  std::vector<int> vec = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<std::vector<int>> packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        return vec[domainPoint[0]];
+      });
+  std::vector<std::vector<int>> expected = {
+      {1, 2, 3, 4, 5, 6, 7, 8, 2, 3, 4, 5, 6, 7, 8, 1}};
+  EXPECT_EQ(packed, expected);
+
+  // roll(1, 0) [R:4][0:2]: shifts 2 and 3 wrap to 0 and 1.
+  DimAttr repl4 = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr d0Of2 = DimAttr::get(&context, /*dim=*/0, /*size=*/2, /*stride=*/1);
+  LayoutAttr wrap = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {repl4, d0Of2}), /*n=*/8,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+  isl = RotomTensorExtLayoutLowering::lowerToTensorExtIsl(wrap);
+  ASSERT_TRUE(succeeded(isl));
+  relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+  std::vector<int> pair = {1, 2};
+  packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        return pair[domainPoint[0]];
+      });
+  expected = {{1, 2, 2, 1, 1, 2, 2, 1}};
+  EXPECT_EQ(packed, expected);
+}
+
+TEST(RotomTensorExtLayoutLoweringTest, RollVerifierDimKindRules) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr gap = DimAttr::get(&context, /*dim=*/-2, /*size=*/4, /*stride=*/1);
+  DimAttr d0 = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ScopedDiagnosticHandler silence(&context,
+                                  [](Diagnostic&) { return success(); });
+  auto swallow =
+      mlir::detail::getDefaultDiagnosticEmitFn(UnknownLoc::get(&context));
+
+  // Rolling a traversal dim BY a replication dim of equal extent is allowed.
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, d0});
+  EXPECT_TRUE(succeeded(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}))));
+  // Rolling FROM a replication dim stays rejected (no index to rewrite).
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{0, 1}))));
+  // Rolling BY a gap dim of equal extent is allowed; rolling FROM a gap dim
+  // stays rejected.
+  ArrayAttr gapDims = ArrayAttr::get(&context, {gap, d0});
+  EXPECT_TRUE(succeeded(LayoutAttr::verify(
+      swallow, gapDims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}))));
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, gapDims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{0, 1}))));
+}
+
+// roll(1, 0) with piece 0 a gap dim: the gap's block index is the shift, so
+// block g holds the vector rotated left by g -- a rolled-by gap claims its
+// blocks with the rotations (a plain gap would leave them unclaimed).
+TEST(RotomTensorExtLayoutLoweringTest, RollByGapMaterializesRotations) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr gap = DimAttr::get(&context, /*dim=*/-2, /*size=*/4, /*stride=*/1);
+  DimAttr d0 = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {gap, d0});
+  LayoutAttr layout = LayoutAttr::get(
+      &context, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+
+  FailureOr<std::string> isl =
+      RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+  ASSERT_TRUE(succeeded(isl));
+  auto relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+
+  std::vector<int> vec = {1, 2, 3, 4};
+  std::vector<std::vector<int>> packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        return vec[domainPoint[0]];
+      });
+  std::vector<std::vector<int>> expected = {
+      {1, 2, 3, 4, 2, 3, 4, 1, 3, 4, 1, 2, 4, 1, 2, 3}};
+  EXPECT_EQ(packed, expected);
 }
 
 }  // namespace

--- a/tests/Dialect/Rotom/IR/layout.mlir
+++ b/tests/Dialect/Rotom/IR/layout.mlir
@@ -47,6 +47,17 @@ func.func private @n0_ok(tensor<16xi32> {foo.bar = #n0_ok})
 #d0 = #rotom.dim<[0:4:1]>
 #d1 = #rotom.dim<[1:2:1]>
 
-// Mismatched extents for a roll pair.
-#bad_roll = #rotom.layout<n = 8, rolls = [(0, 1)], dims = [#d0, #d1]> // expected-error {{rolled dims must have the same extent (size)}}
-func.func private @bad_roll(tensor<16xi32> {foo.bar = #bad_roll})
+// Mismatched extents for a roll pair are legal: the shift reduces modulo the
+// rolled dim's extent (a smaller partner covers a prefix of the rotations).
+#uneven_roll = #rotom.layout<n = 8, rolls = [(0, 1)], dims = [#d0, #d1]>
+func.func private @uneven_roll(tensor<16xi32> {foo.bar = #uneven_roll})
+
+// -----
+
+#t = #rotom.dim<[0:4:1]>
+#g = #rotom.dim<[-2:8:1]>
+
+// A rolled-by gap larger than the rolled dim's extent is rejected: its extra
+// blocks would repeat rotations the accounting was not audited for.
+#big_gap_roll = #rotom.layout<n = 8, rolls = [(0, 1)], dims = [#t | #g]> // expected-error {{a rolled-by gap dim must not exceed the rolled dim's extent}}
+func.func private @big_gap_roll(tensor<32xi32> {foo.bar = #big_gap_roll})


### PR DESCRIPTION
Part 2 of https://github.com/google/heir/pull/2980  and stacked on https://github.com/google/heir/pull/3169 

Two extensions to roll(from, by) semantics that make diagonal packings expressible beyond the square, equal-extent case.

1. Roll partners may be replication or gap dims. Previously both roll operands had to be traversal dims. Now the by (second) dim may also be a replication or gap dim.

2. Roll extents need not match (mod-from). roll(i, j) now rewrites dims[i]'s index to (idx_i  - idx_j) mod extent(dims[i]), well-defined for any partner extent - a smaller partner covers a prefix of the rotations, a larger one wraps. This unlocks rolled placements for rectangular (non-square-k) contractions.

3. Rolled-by-gap bound. A rolled-by gap partner is bounded to the rolled dim's extent.