### PR TITLE
 Rotom: Roll arguments can name a whole tensor axis

### DIFF
--- a/lib/Dialect/Rotom/IR/RotomAttributes.cpp
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.cpp
@@ -227,25 +227,40 @@ static ParseResult parseLayoutDims(AsmParser& parser,
   }
 }
 
+// One argument of a roll pair: a bare non-negative integer is a dims-list
+// position (one piece); `axis N` names the whole tensor axis N.
+static ParseResult parseRollArg(AsmParser& parser, int64_t& encoded) {
+  const bool isAxis = succeeded(parser.parseOptionalKeyword("axis"));
+  int64_t value;
+  if (parser.parseInteger(value)) return failure();
+  if (value < 0) {
+    return parser.emitError(parser.getNameLoc())
+           << (isAxis ? "an axis roll argument must name a non-negative "
+                        "tensor axis"
+                      : "a piece roll argument must be a non-negative dims "
+                        "position (spell a whole-axis argument as `axis N`)");
+  }
+  encoded = encodeRollArg({isAxis, value});
+  return success();
+}
+
 static ParseResult parseLayoutRolls(AsmParser& parser,
                                     SmallVector<int64_t>& rolls) {
   if (parser.parseLSquare()) return failure();
   if (succeeded(parser.parseOptionalRSquare())) return success();
 
+  // Each entry is one `(from, by)` pair, parenthesized -- the form the
+  // printer emits, so written and round-tripped layouts read alike.
   while (true) {
-    if (succeeded(parser.parseOptionalLParen())) {
-      int64_t from;
-      int64_t to;
-      if (parser.parseInteger(from) || parser.parseComma() ||
-          parser.parseInteger(to) || parser.parseRParen())
-        return failure();
-      rolls.push_back(from);
-      rolls.push_back(to);
-    } else {
-      int64_t value;
-      if (parser.parseInteger(value)) return failure();
-      rolls.push_back(value);
+    int64_t from;
+    int64_t by;
+    if (parser.parseLParen() || failed(parseRollArg(parser, from)) ||
+        parser.parseComma() || failed(parseRollArg(parser, by)) ||
+        parser.parseRParen()) {
+      return failure();
     }
+    rolls.push_back(from);
+    rolls.push_back(by);
 
     if (succeeded(parser.parseOptionalComma())) continue;
     return parser.parseRSquare();
@@ -255,48 +270,109 @@ static ParseResult parseLayoutRolls(AsmParser& parser,
 static LogicalResult verifyLayoutRolls(
     ArrayAttr dims, DenseI64ArrayAttr rolls,
     function_ref<InFlightDiagnostic()> emitError) {
-  if (!rolls) return success();
+  const bool noRolls = !rolls || rolls.empty();
+  if (noRolls) return success();
   ArrayRef<int64_t> r = rolls.asArrayRef();
-  if (r.empty()) return success();
   if (r.size() % 2 != 0) {
-    return emitError() << "rolls must contain an even number of integers "
-                          "(pairs of dim indices)";
+    return emitError() << "rolls must contain an even number of arguments "
+                          "(pairs)";
   }
 
+  // Traversal pieces of a tensor axis: their count decides whether an `axis`
+  // argument is legal (split axes only -- the piece spelling is canonical
+  // when the axis is one piece), and their extent product is the modulus a
+  // whole-axis rewrite reduces by.
+  auto piecesOfAxis = [&](int64_t axis) {
+    std::pair<int64_t, int64_t> countAndExtent{0, 1};
+    for (Attribute a : dims) {
+      auto d = dyn_cast<DimAttr>(a);
+      if (d && !d.isGap() && !d.isReplicate() && d.getDim() == axis) {
+        ++countAndExtent.first;
+        countAndExtent.second *= d.getSize();
+      }
+    }
+    return countAndExtent;
+  };
+
   for (size_t i = 0; i < r.size(); i += 2) {
-    const int64_t ti = r[i];
-    const int64_t tj = r[i + 1];
-    if (ti == tj) {
-      return emitError() << "each roll must use two distinct dim indices";
+    const RollArg from = decodeRollArg(r[i]);
+    const RollArg by = decodeRollArg(r[i + 1]);
+
+    // Resolve each argument: the piece it names (null for axis arguments)
+    // and the tensor axis it reads or rewrites (sentinel for gap/replication
+    // pieces).
+    DimAttr fromPiece;
+    DimAttr byPiece;
+    int64_t fromAxis = 0;
+    int64_t byAxis = 0;
+    auto checkArg = [&](const RollArg& e, DimAttr& piece,
+                        int64_t& axis) -> LogicalResult {
+      if (e.isAxis) {
+        auto [count, extent] = piecesOfAxis(e.index);
+        (void)extent;
+        if (count == 0) {
+          return emitError() << "an axis roll argument must name a tensor "
+                                "axis present in dims";
+        }
+        if (count == 1) {
+          return emitError() << "an axis roll argument requires a split "
+                                "axis; spell an unsplit axis's argument as "
+                                "its piece position";
+        }
+        axis = e.index;
+        return success();
+      }
+      if (e.index >= static_cast<int64_t>(dims.size())) {
+        return emitError() << "roll piece argument out of bounds for dims "
+                              "list";
+      }
+      piece = dyn_cast<DimAttr>(dims[e.index]);
+      if (!piece) {
+        return emitError() << "roll arguments must refer to #rotom.dim "
+                              "entries";
+      }
+      axis = piece.getDim();
+      return success();
+    };
+    if (failed(checkArg(from, fromPiece, fromAxis)) ||
+        failed(checkArg(by, byPiece, byAxis))) {
+      return failure();
     }
-    if (ti < 0 || tj < 0 || ti >= static_cast<int64_t>(dims.size()) ||
-        tj >= static_cast<int64_t>(dims.size())) {
-      return emitError() << "roll dim index out of bounds for dims list";
-    }
-    auto di = dyn_cast<DimAttr>(dims[ti]);
-    auto dj = dyn_cast<DimAttr>(dims[tj]);
-    if (!di || !dj) {
-      return emitError() << "roll indices must refer to #rotom.dim entries";
-    }
-    // The extents need not match: roll(i, j) rewrites dims[i]'s index to
-    // (i_i - i_j) mod size(dims[i]), well-defined for any partner extent (a
+
+    // The extents need not match: a roll rewrites the from index to
+    // (idx - shift) mod extent(from), well-defined for any partner extent (a
     // smaller partner covers a prefix of the rotations, a larger one wraps).
-    // The rolled (from) dim must be a traversal dim -- it is the index
-    // expression being rewritten. The roll-by (second) dim may be any kind:
-    // rolling by a replication or gap dim shifts by that dim's block index,
-    // so each block holds a distinct cyclic rotation of the rolled dim -- the
-    // layout materializes every rotation and alignment becomes block
-    // selection. (A rolled-by gap thus claims its blocks, unlike a plain gap.)
-    if (di.isGap() || di.isReplicate()) {
-      return emitError() << "the rolled dim must be a traversal dim (dim >= 0)";
+    // FROM is the index expression being rewritten, so it must be a
+    // traversal piece or a whole (traversal) axis. The by argument may be
+    // any kind: rolling by a replication or gap piece shifts by that piece's
+    // block index, so each block holds a distinct cyclic rotation of the
+    // rolled index -- the layout materializes every rotation and alignment
+    // becomes block selection. (A rolled-by gap thus claims its blocks,
+    // unlike a plain gap.)
+    if (!from.isAxis && (fromPiece.isGap() || fromPiece.isReplicate())) {
+      return emitError() << "the rolled dim must be a traversal dim (dim >= "
+                            "0)";
+    }
+    // A roll may not shift an index by itself. Piece arguments must be
+    // distinct positions (two pieces of one axis are distinct digits); an
+    // axis argument overlaps every argument on the same axis, because a
+    // whole-axis rewrite touches all of its digits.
+    if (!from.isAxis && !by.isAxis && from.index == by.index) {
+      return emitError() << "each roll must use two distinct arguments";
+    }
+    if ((from.isAxis || by.isAxis) && fromAxis == byAxis) {
+      return emitError() << "a roll may not shift an axis by one of its own "
+                            "pieces";
     }
     // A rolled-by GAP claims one ciphertext block per gap index, each holding
-    // a distinct rotation of the rolled dim. If the gap is larger than the
-    // rolled dim's extent the rotations repeat (period = the from extent),
-    // claiming blocks the conversion/kernel accounting was never audited for.
+    // a distinct rotation of the rolled index. If the gap is larger than the
+    // rolled extent the rotations repeat (period = the from extent), claiming
+    // blocks the conversion/kernel accounting was never audited for.
     // (Replication partners of larger extent are intended -- replicate-then-
     // roll -- so only gaps are bounded.)
-    if (dj.isGap() && dj.getSize() > di.getSize()) {
+    const int64_t fromExtent =
+        from.isAxis ? piecesOfAxis(fromAxis).second : fromPiece.getSize();
+    if (byPiece && byPiece.isGap() && byPiece.getSize() > fromExtent) {
       return emitError() << "a rolled-by gap dim must not exceed the rolled "
                             "dim's extent";
     }
@@ -345,10 +421,19 @@ void LayoutAttr::print(AsmPrinter& printer) const {
   DenseI64ArrayAttr rolls = getRolls();
   if (rolls && !rolls.asArrayRef().empty()) {
     ArrayRef<int64_t> values = rolls.asArrayRef();
+    auto printArg = [&](int64_t encoded) {
+      const RollArg e = decodeRollArg(encoded);
+      if (e.isAxis) printer << "axis ";
+      printer << e.index;
+    };
     printer << ", rolls = [";
     for (size_t i = 0; i < values.size(); i += 2) {
       if (i != 0) printer << ", ";
-      printer << "(" << values[i] << ", " << values[i + 1] << ")";
+      printer << "(";
+      printArg(values[i]);
+      printer << ", ";
+      printArg(values[i + 1]);
+      printer << ")";
     }
     printer << "]";
   }
@@ -436,6 +521,18 @@ Attribute LayoutAttr::parse(AsmParser& parser, Type type) {
       ArrayAttr::get(context, dims), n, DenseI64ArrayAttr::get(context, rolls));
 }
 
+SmallVector<RollSpec> getRollSpecs(LayoutAttr layout) {
+  SmallVector<RollSpec> specs;
+  DenseI64ArrayAttr rolls = layout.getRolls();
+  if (!rolls) return specs;
+  ArrayRef<int64_t> r = rolls.asArrayRef();
+
+  for (size_t i = 0; i + 1 < r.size(); i += 2) {
+    specs.push_back({decodeRollArg(r[i]), decodeRollArg(r[i + 1])});
+  }
+  return specs;
+}
+
 FailureOr<LayoutData> preprocessLayoutAttr(LayoutAttr layout) {
   return preprocessLayoutData(layout.getDims(), layout.getN(),
                               layout.getContext());
@@ -452,7 +549,9 @@ LogicalResult LayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     return emitError() << "`dims` must be an array of `#rotom.dim<...>`";
   }
 
-  if (failed(verifyLayoutRolls(dims, rolls, emitError))) return failure();
+  if (failed(verifyLayoutRolls(dims, rolls, emitError))) {
+    return failure();
+  }
 
   SmallVector<DimAttr> dimVec;
   dimVec.reserve(dims.size());
@@ -508,7 +607,8 @@ void canonicalizeLayoutDims(MLIRContext* ctx, SmallVector<DimAttr>& dims,
   if (fill <= 1) return;
   dims.insert(dims.begin() + ctLen,
               DimAttr::get(ctx, /*dim=*/-2, fill, /*stride=*/1));
-  // Roll endpoints at or past the insertion shift right.
+  // Piece arguments at or past the insertion shift right; axis arguments
+  // (encoded negative) name axes and do not move.
   for (int64_t& encoded : rolls) {
     if (encoded >= static_cast<int64_t>(ctLen)) ++encoded;
   }

--- a/lib/Dialect/Rotom/IR/RotomAttributes.cpp
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.cpp
@@ -9,6 +9,7 @@
 #include "llvm/include/llvm/ADT/DenseMap.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/DenseSet.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/ADT/Sequence.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/SmallVector.h"        // from @llvm-project
 #include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/Attributes.h"          // from @llvm-project
@@ -43,13 +44,9 @@ size_t inferCtPrefixLen(ArrayRef<DimAttr> dims, int64_t n) {
 
 // Preprocesses a layout (`dims`, slot count `n`) into the `LayoutData`
 // descriptor used to emit ciphertext addresses; also the validity check
-// behind `LayoutAttr::verify`.
-//
-// `pieces` describes the traversal dimensions, replication dimensions, and
-// gap dimensions. When lowering to ISL, a traversal piece maps to
-// `(i / divBy) mod modBy`, where i is the index of the piece's tensor axis;
-// replication and gap pieces map to their own ISL existential variables
-// instead.
+// behind `LayoutAttr::verify`. `pieces` holds the traversal, replication,
+// and gap dimensions in packing order; see `LayoutData` in the header for
+// exact field semantics.
 static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
                                                   MLIRContext* ctx) {
   LayoutData data;
@@ -108,14 +105,14 @@ static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
       piece.divBy = 1;
       piece.modBy = 0;
     } else {
-      // Split piece: digit = (i / stride) mod extent.
+      // Split piece: it reads (i / stride) mod extent of the axis index.
       const int64_t extent = piece.dim.getSize();
       const int64_t full = dimFullExtent[piece.dim.getDim()];
       piece.modBy = (piece.divBy * extent < full) ? extent : 0;
     }
   }
 
-  // Each multi-piece tensor dim must be a valid mixed-radix decomposition:
+  // Each multi-piece tensor dim must be a valid split:
   // sorted by stride, the divisors are the cumulative products of the lower
   // extents (1, e0, e0*e1, ...), and the extents multiply to the full extent.
   for (auto& [dim, count] : pieceCount) {
@@ -147,7 +144,7 @@ static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
   return data;
 }
 
-// The dim position is spelled `R` for replication and `G` for gap (the
+// The dim position is written `R` for replication and `G` for gap (the
 // readable forms, also how the printer emits them); the numeric ids -1 and
 // -2 are still accepted.
 static ParseResult parseDimTripleAfterLSquare(AsmParser& parser, int64_t& dim,
@@ -227,25 +224,40 @@ static ParseResult parseLayoutDims(AsmParser& parser,
   }
 }
 
+// One argument of a roll pair: a bare non-negative integer is a dims-list
+// position (one piece); `axis N` names the whole tensor axis N.
+static ParseResult parseRollArg(AsmParser& parser, int64_t& encoded) {
+  const bool isAxis = succeeded(parser.parseOptionalKeyword("axis"));
+  int64_t value;
+  if (parser.parseInteger(value)) return failure();
+  if (value < 0) {
+    return parser.emitError(parser.getNameLoc())
+           << (isAxis ? "an axis roll argument must name a non-negative "
+                        "tensor axis"
+                      : "a piece roll argument must be a non-negative dims "
+                        "position (write a whole-axis argument as `axis N`)");
+  }
+  encoded = encodeRollArg({isAxis, value});
+  return success();
+}
+
 static ParseResult parseLayoutRolls(AsmParser& parser,
                                     SmallVector<int64_t>& rolls) {
   if (parser.parseLSquare()) return failure();
   if (succeeded(parser.parseOptionalRSquare())) return success();
 
+  // Each entry is one `(from, by)` pair, parenthesized -- the form the
+  // printer emits, so written and round-tripped layouts read alike.
   while (true) {
-    if (succeeded(parser.parseOptionalLParen())) {
-      int64_t from;
-      int64_t to;
-      if (parser.parseInteger(from) || parser.parseComma() ||
-          parser.parseInteger(to) || parser.parseRParen())
-        return failure();
-      rolls.push_back(from);
-      rolls.push_back(to);
-    } else {
-      int64_t value;
-      if (parser.parseInteger(value)) return failure();
-      rolls.push_back(value);
+    int64_t from;
+    int64_t by;
+    if (parser.parseLParen() || failed(parseRollArg(parser, from)) ||
+        parser.parseComma() || failed(parseRollArg(parser, by)) ||
+        parser.parseRParen()) {
+      return failure();
     }
+    rolls.push_back(from);
+    rolls.push_back(by);
 
     if (succeeded(parser.parseOptionalComma())) continue;
     return parser.parseRSquare();
@@ -255,48 +267,94 @@ static ParseResult parseLayoutRolls(AsmParser& parser,
 static LogicalResult verifyLayoutRolls(
     ArrayAttr dims, DenseI64ArrayAttr rolls,
     function_ref<InFlightDiagnostic()> emitError) {
-  if (!rolls) return success();
+  const bool noRolls = !rolls || rolls.empty();
+  if (noRolls) return success();
   ArrayRef<int64_t> r = rolls.asArrayRef();
-  if (r.empty()) return success();
   if (r.size() % 2 != 0) {
-    return emitError() << "rolls must contain an even number of integers "
-                          "(pairs of dim indices)";
+    return emitError() << "rolls must contain an even number of arguments "
+                          "(pairs)";
   }
 
   for (size_t i = 0; i < r.size(); i += 2) {
-    const int64_t ti = r[i];
-    const int64_t tj = r[i + 1];
-    if (ti == tj) {
-      return emitError() << "each roll must use two distinct dim indices";
+    const RollArg from = decodeRollArg(r[i]);
+    const RollArg by = decodeRollArg(r[i + 1]);
+
+    // Resolve each argument: the piece it names (null for axis arguments)
+    // and the tensor axis it reads or rewrites (sentinel for gap/replication
+    // pieces).
+    DimAttr fromPiece;
+    DimAttr byPiece;
+    int64_t fromAxis = 0;
+    int64_t byAxis = 0;
+    auto checkArg = [&](const RollArg& e, DimAttr& piece,
+                        int64_t& axisId) -> LogicalResult {
+      if (e.isAxis) {
+        // The piece count decides how the axis may be named: an `axis`
+        // argument is legal only for a split axis.
+        const AxisPieces pieces = axisPieces(dims, e.index);
+        if (pieces.count == 0) {
+          return emitError() << "an axis roll argument must name a tensor "
+                                "axis present in dims";
+        }
+        if (!pieces.isSplit()) {
+          return emitError() << "an axis roll argument requires a split "
+                                "axis; write an unsplit axis's argument as "
+                                "its piece position";
+        }
+        axisId = e.index;
+        return success();
+      }
+      if (e.index >= static_cast<int64_t>(dims.size())) {
+        return emitError() << "roll piece argument out of bounds for dims "
+                              "list";
+      }
+      piece = dyn_cast<DimAttr>(dims[e.index]);
+      if (!piece) {
+        return emitError() << "roll arguments must refer to #rotom.dim "
+                              "entries";
+      }
+      axisId = piece.getDim();
+      return success();
+    };
+    if (failed(checkArg(from, fromPiece, fromAxis)) ||
+        failed(checkArg(by, byPiece, byAxis))) {
+      return failure();
     }
-    if (ti < 0 || tj < 0 || ti >= static_cast<int64_t>(dims.size()) ||
-        tj >= static_cast<int64_t>(dims.size())) {
-      return emitError() << "roll dim index out of bounds for dims list";
-    }
-    auto di = dyn_cast<DimAttr>(dims[ti]);
-    auto dj = dyn_cast<DimAttr>(dims[tj]);
-    if (!di || !dj) {
-      return emitError() << "roll indices must refer to #rotom.dim entries";
-    }
-    // The extents need not match: roll(i, j) rewrites dims[i]'s index to
-    // (i_i - i_j) mod size(dims[i]), well-defined for any partner extent (a
+
+    // The extents need not match: a roll rewrites the from index to
+    // (idx - shift) mod extent(from), well-defined for any partner extent (a
     // smaller partner covers a prefix of the rotations, a larger one wraps).
-    // The rolled (from) dim must be a traversal dim -- it is the index
-    // expression being rewritten. The roll-by (second) dim may be any kind:
-    // rolling by a replication or gap dim shifts by that dim's block index,
-    // so each block holds a distinct cyclic rotation of the rolled dim -- the
-    // layout materializes every rotation and alignment becomes block
-    // selection. (A rolled-by gap thus claims its blocks, unlike a plain gap.)
-    if (di.isGap() || di.isReplicate()) {
-      return emitError() << "the rolled dim must be a traversal dim (dim >= 0)";
+    // FROM is the index expression being rewritten, so it must be a
+    // traversal piece or a whole (traversal) axis. The by argument may be
+    // any kind: rolling by a replication or gap piece shifts by that piece's
+    // block index, so each block holds a distinct cyclic rotation of the
+    // rolled index -- the layout materializes every rotation and alignment
+    // becomes block selection. (A rolled-by gap thus claims its blocks,
+    // unlike a plain gap.)
+    if (!from.isAxis && (fromPiece.isGap() || fromPiece.isReplicate())) {
+      return emitError() << "the rolled dim must be a traversal dim (dim >= "
+                            "0)";
+    }
+    // A roll may not shift an index by an argument on its own axis: an axis
+    // FROM rewrites every piece of the axis, including the one the by
+    // argument reads,
+    // and a piece FROM taking a by on the same axis is a self-shear no
+    // packing needs. Gap and replication by arguments name no axis, so they
+    // never collide.
+    if (fromAxis == byAxis) {
+      return emitError()
+             << "a roll may not shift an index by an argument on the same "
+                "axis";
     }
     // A rolled-by GAP claims one ciphertext block per gap index, each holding
-    // a distinct rotation of the rolled dim. If the gap is larger than the
-    // rolled dim's extent the rotations repeat (period = the from extent),
-    // claiming blocks the conversion/kernel accounting was never audited for.
+    // a distinct rotation of the rolled index. If the gap is larger than the
+    // rolled extent the rotations repeat (period = the from extent), claiming
+    // blocks the conversion/kernel accounting was never audited for.
     // (Replication partners of larger extent are intended -- replicate-then-
     // roll -- so only gaps are bounded.)
-    if (dj.isGap() && dj.getSize() > di.getSize()) {
+    const int64_t fromExtent =
+        from.isAxis ? axisPieces(dims, fromAxis).extent : fromPiece.getSize();
+    if (byPiece && byPiece.isGap() && byPiece.getSize() > fromExtent) {
       return emitError() << "a rolled-by gap dim must not exceed the rolled "
                             "dim's extent";
     }
@@ -345,10 +403,19 @@ void LayoutAttr::print(AsmPrinter& printer) const {
   DenseI64ArrayAttr rolls = getRolls();
   if (rolls && !rolls.asArrayRef().empty()) {
     ArrayRef<int64_t> values = rolls.asArrayRef();
+    auto printArg = [&](int64_t encoded) {
+      const RollArg e = decodeRollArg(encoded);
+      if (e.isAxis) printer << "axis ";
+      printer << e.index;
+    };
     printer << ", rolls = [";
     for (size_t i = 0; i < values.size(); i += 2) {
       if (i != 0) printer << ", ";
-      printer << "(" << values[i] << ", " << values[i + 1] << ")";
+      printer << "(";
+      printArg(values[i]);
+      printer << ", ";
+      printArg(values[i + 1]);
+      printer << ")";
     }
     printer << "]";
   }
@@ -436,6 +503,39 @@ Attribute LayoutAttr::parse(AsmParser& parser, Type type) {
       ArrayAttr::get(context, dims), n, DenseI64ArrayAttr::get(context, rolls));
 }
 
+namespace {
+template <typename RangeT>
+AxisPieces accumulateAxisPieces(RangeT&& dims, int64_t axis) {
+  AxisPieces pieces;
+  for (DimAttr d : dims) {
+    if (d.isGap() || d.isReplicate() || d.getDim() != axis) continue;
+    ++pieces.count;
+    pieces.extent *= d.getSize();
+  }
+  return pieces;
+}
+}  // namespace
+
+AxisPieces axisPieces(ArrayRef<DimAttr> dims, int64_t axis) {
+  return accumulateAxisPieces(dims, axis);
+}
+
+AxisPieces axisPieces(ArrayAttr dims, int64_t axis) {
+  return accumulateAxisPieces(dims.getAsRange<DimAttr>(), axis);
+}
+
+SmallVector<RollSpec> getRollSpecs(LayoutAttr layout) {
+  SmallVector<RollSpec> specs;
+  DenseI64ArrayAttr rolls = layout.getRolls();
+  if (!rolls) return specs;
+  ArrayRef<int64_t> r = rolls.asArrayRef();
+
+  for (size_t i = 0; i + 1 < r.size(); i += 2) {
+    specs.push_back({decodeRollArg(r[i]), decodeRollArg(r[i + 1])});
+  }
+  return specs;
+}
+
 FailureOr<LayoutData> preprocessLayoutAttr(LayoutAttr layout) {
   return preprocessLayoutData(layout.getDims(), layout.getN(),
                               layout.getContext());
@@ -452,7 +552,9 @@ LogicalResult LayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     return emitError() << "`dims` must be an array of `#rotom.dim<...>`";
   }
 
-  if (failed(verifyLayoutRolls(dims, rolls, emitError))) return failure();
+  if (failed(verifyLayoutRolls(dims, rolls, emitError))) {
+    return failure();
+  }
 
   SmallVector<DimAttr> dimVec;
   dimVec.reserve(dims.size());
@@ -478,7 +580,7 @@ LogicalResult LayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     return emitError() << "slot dims must fill the ciphertext exactly (slot "
                           "extent "
                        << slotExtent << " vs n = " << n
-                       << "); spell unused capacity as an explicit gap piece";
+                       << "); state unused capacity as an explicit gap piece";
   }
 
   return success();
@@ -500,6 +602,83 @@ LogicalResult SeedAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 
 void canonicalizeLayoutDims(MLIRContext* ctx, SmallVector<DimAttr>& dims,
                             int64_t n, SmallVector<int64_t>& rolls) {
+  // A unit axis -- one whose whole extent is one -- places no data: its index
+  // has a single value, so it contributes nothing to any address, and a
+  // factor of one changes no other piece's offset. Its position was therefore
+  // free, which is what let one packing have several forms and made every
+  // consumer walk past unit pieces. Pin it to the tail in axis order, where
+  // addUnitAxisPieces already puts the pieces it creates and where
+  // inferCtPrefixLen's trailing trim already assumes they live. The piece
+  // stays: the relation the layout lowers to needs one domain variable per
+  // tensor axis. This rewrites the form, never the packing.
+  {
+    llvm::DenseMap<int64_t, int64_t> extentOfAxis;
+    for (DimAttr d : dims) {
+      if (d.isGap() || d.isReplicate()) continue;
+      auto it = extentOfAxis.find(d.getDim());
+      extentOfAxis[d.getDim()] =
+          it == extentOfAxis.end() ? d.getSize() : it->second * d.getSize();
+    }
+    auto isUnitAxisPiece = [&](DimAttr d) {
+      if (d.isGap() || d.isReplicate()) return false;
+      auto it = extentOfAxis.find(d.getDim());
+      return it != extentOfAxis.end() && it->second == 1;
+    };
+    // Extent-one replication and gaps are NOT dropped: alignment pairs two
+    // layouts by piece count (pieceMovements requires the counts to match),
+    // so a piece like [R:1:1] is a positional placeholder even though it
+    // places no data. Dropping it loses the matmul kernel entirely.
+    auto isInert = [](DimAttr d) {
+      (void)d;
+      return false;
+    };
+    SmallVector<DimAttr> rest, units;
+    SmallVector<int64_t> restOld, unitOld;
+    bool dropped = false;
+    for (auto [p, d] : llvm::enumerate(dims)) {
+      if (isInert(d)) {
+        dropped = true;
+      } else if (isUnitAxisPiece(d)) {
+        units.push_back(d);
+        unitOld.push_back(static_cast<int64_t>(p));
+      } else {
+        rest.push_back(d);
+        restOld.push_back(static_cast<int64_t>(p));
+      }
+    }
+    const bool moved =
+        !units.empty() && unitOld.front() != static_cast<int64_t>(rest.size());
+    if (dropped || moved) {
+      SmallVector<int64_t> order(unitOld.size());
+      for (size_t i = 0; i < order.size(); ++i) {
+        order[i] = static_cast<int64_t>(i);
+      }
+      llvm::stable_sort(order, [&](int64_t x, int64_t y) {
+        return units[x].getDim() < units[y].getDim();
+      });
+      SmallVector<int64_t> newPos(dims.size(), -1);
+      SmallVector<DimAttr> out;
+      for (auto [i, oldIdx] : llvm::enumerate(restOld)) {
+        newPos[oldIdx] = static_cast<int64_t>(out.size());
+        out.push_back(rest[i]);
+      }
+      for (int64_t i : order) {
+        newPos[unitOld[i]] = static_cast<int64_t>(out.size());
+        out.push_back(units[i]);
+      }
+      SmallVector<int64_t> keptRolls;
+      for (size_t i = 0; i + 1 < rolls.size(); i += 2) {
+        const int64_t from = rolls[i], by = rolls[i + 1];
+        const bool fromGone = from >= 0 && newPos[from] < 0;
+        const bool byGone = by >= 0 && newPos[by] < 0;
+        if (fromGone || byGone) continue;
+        keptRolls.push_back(from >= 0 ? newPos[from] : from);
+        keptRolls.push_back(by >= 0 ? newPos[by] : by);
+      }
+      dims = std::move(out);
+      rolls = std::move(keptRolls);
+    }
+  }
   const size_t ctLen = inferCtPrefixLen(dims, n);
   int64_t slotExtent = 1;
   for (size_t p = ctLen; p < dims.size(); ++p) slotExtent *= dims[p].getSize();
@@ -508,7 +687,7 @@ void canonicalizeLayoutDims(MLIRContext* ctx, SmallVector<DimAttr>& dims,
   if (fill <= 1) return;
   dims.insert(dims.begin() + ctLen,
               DimAttr::get(ctx, /*dim=*/-2, fill, /*stride=*/1));
-  // Roll endpoints at or past the insertion shift right.
+  // Piece arguments at or past the insertion shift right.
   for (int64_t& encoded : rolls) {
     if (encoded >= static_cast<int64_t>(ctLen)) ++encoded;
   }

--- a/lib/Dialect/Rotom/IR/RotomAttributes.h
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.h
@@ -15,6 +15,37 @@
 
 namespace mlir::heir::rotom {
 
+// One argument of a roll: either one piece of the layout (a position in its
+// dims list) or a whole tensor axis (spelled `axis N`; legal only when the
+// axis is packed as more than one piece).
+struct RollArg {
+  bool isAxis;
+  int64_t index;  // Dims-list position, or the tensor axis id when isAxis.
+  bool operator==(const RollArg& other) const {
+    return isAxis == other.isAxis && index == other.index;
+  }
+};
+
+// Argument encoding in the flat rolls storage: a piece argument is its
+// non-negative dims-list position, an axis argument is -(axis + 1).
+inline int64_t encodeRollArg(RollArg e) {
+  return e.isAxis ? -(e.index + 1) : e.index;
+}
+inline RollArg decodeRollArg(int64_t encoded) {
+  return encoded < 0 ? RollArg{true, -encoded - 1} : RollArg{false, encoded};
+}
+
+// One roll of a layout: FROM's index is rewritten to
+// (idx_from - shift(by)) mod extent(from), where a piece FROM rewrites only
+// its own mixed-radix digit and an axis FROM rewrites the whole axis index.
+struct RollSpec {
+  RollArg from;
+  RollArg by;
+};
+
+// The layout's rolls with both arguments decoded.
+llvm::SmallVector<RollSpec> getRollSpecs(LayoutAttr layout);
+
 enum class LayoutPieceKind { Traversal, Replication, Gap };
 
 struct LayoutPiece {

--- a/lib/Dialect/Rotom/IR/RotomAttributes.h
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.h
@@ -15,6 +15,54 @@
 
 namespace mlir::heir::rotom {
 
+// One argument of a roll: either one piece of the layout (a position in its
+// dims list) or a whole tensor axis (written `axis N`; legal only when the
+// axis is packed as more than one piece).
+struct RollArg {
+  bool isAxis;
+  int64_t index;  // Dims-list position, or the tensor axis id when isAxis.
+  bool operator==(const RollArg& other) const {
+    return isAxis == other.isAxis && index == other.index;
+  }
+};
+
+// Argument encoding in the flat rolls storage: a piece argument is its
+// non-negative dims-list position, an axis argument is -(axis + 1).
+inline int64_t encodeRollArg(RollArg e) {
+  return e.isAxis ? -(e.index + 1) : e.index;
+}
+inline RollArg decodeRollArg(int64_t encoded) {
+  return encoded < 0 ? RollArg{true, -encoded - 1} : RollArg{false, encoded};
+}
+
+// One roll of a layout: FROM's index is rewritten to
+// (idx_from - shift(by)) mod extent(from), where a piece FROM rewrites only
+// the part of the axis index that piece reads, and an axis FROM rewrites the
+// whole axis index.
+struct RollSpec {
+  RollArg from;
+  RollArg by;
+};
+
+// The layout's rolls with both arguments decoded.
+llvm::SmallVector<RollSpec> getRollSpecs(LayoutAttr layout);
+
+// The traversal pieces one tensor axis occupies in a dims list: how many
+// there are, and the product of their extents -- the axis's full logical
+// extent, since a split factors it across pieces. Gap and
+// replication pieces name no tensor axis and are skipped.
+struct AxisPieces {
+  int64_t count = 0;
+  int64_t extent = 1;
+  // Whether a roll must name this axis with an `axis` argument: with a single
+  // piece, rolling the axis and rolling that piece are the same rewrite, and
+  // the piece form is canonical.
+  bool isSplit() const { return count > 1; }
+};
+
+AxisPieces axisPieces(llvm::ArrayRef<DimAttr> dims, int64_t axis);
+AxisPieces axisPieces(ArrayAttr dims, int64_t axis);
+
 enum class LayoutPieceKind { Traversal, Replication, Gap };
 
 struct LayoutPiece {
@@ -23,15 +71,15 @@ struct LayoutPiece {
   // axisIndex, divBy, and modBy lower a traversal piece into its term of the
   // ISL relation. The emitter builds an address `[i0, i1, ...] -> [ct, slot]`
   // with one variable per axis (LayoutData::axes); each piece contributes a
-  // term reading one mixed-radix digit of its axis's variable.
+  // term reading one part of its axis's variable.
   //
   // axisIndex picks the variable: an index into LayoutData::axes, emitted as
   // `i{axisIndex}`.
   int64_t axisIndex = -1;
-  // divBy and modBy pick which digit of that variable the piece reads, as
-  // (i / divBy) mod modBy. divBy is the digit's place value: the piece's
-  // stride when the axis is split across pieces, else 1. modBy is the digit's
-  // extent or 0 to drop the modulus on the most-significant digit.
+  // divBy and modBy pick which part of that variable the piece reads, as
+  // (i / divBy) mod modBy. divBy is that part's offset: the piece's
+  // stride when the axis is split across pieces, else 1. modBy is the piece's
+  // extent, or 0 to drop the modulus on the highest part.
   int64_t divBy = 1;
   int64_t modBy = 0;
 };

--- a/lib/Dialect/Rotom/IR/RotomAttributes.td
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.td
@@ -24,7 +24,7 @@ def Rotom_DimAttr : Rotom_Attr<"Dim", "dim"> {
     * `-2`: gap (padding / unused slots; constrained to zero in materialization)
 
     Non-negative `dim` values index into the logical tensor shape. In the
-    assembly form the sentinels are spelled `R` (replication) and `G` (gap),
+    assembly form the sentinels are written `R` (replication) and `G` (gap),
     e.g. `[R:4:1]`; the numeric ids are also accepted on input.
   }];
 
@@ -55,11 +55,57 @@ def Rotom_LayoutAttr : Rotom_Attr<"Layout", "layout"> {
     with an explicit gap piece (e.g. `[G:4:1]`).
     See [Section 4.2 of the Rotom paper](https://eprint.iacr.org/2025/1319.pdf).
 
-    Optional **rolls** encode a `roll(i,j)` metadata object: each pair `(i, j)`
-    indexes into the `dims` array (the flattened `ct_dims + slot_dims` list) and
-    rewrites `dims[i]`'s index to `(idx_i - idx_j) mod size(dims[i])`. The two
-    extents need not match: the shift reduces modulo the rolled dim's extent, so
-    a smaller partner covers a prefix of the rotations and a larger one wraps.
+    Optional **rolls** encode `roll(from, by)` metadata objects, applied left
+    to right. Each argument is either a *piece* -- a position in the `dims`
+    list, written as a bare integer -- or a whole tensor *axis*, written
+    `axis N` (legal only when axis `N` is packed as more than one piece; the
+    piece form is canonical for an unsplit axis, where the two coincide).
+
+    ```mlir
+    // Halevi-Shoup diagonal of a 4x4 matrix: slot j of ciphertext i holds
+    // A[i, (j + i) mod 4]. Argument 1 (the axis-1 piece) is rolled by
+    // argument 0 (the axis-0 piece).
+    #diag = #rotom.layout<n = 4, rolls = [(1, 0)], dims = [[0:4:1] | [1:4:1]]>
+
+    // Axis 1 is split across two pieces, so a whole-axis roll names its
+    // argument `axis 1` rather than a piece position.
+    #split = #rotom.layout<n = 16, rolls = [(axis 1, 2)],
+                           dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+    ```
+
+    When an axis is split, each piece reads one part of that axis's index:
+    the piece of stride `s` and extent `e` reads `(i / s) mod e`, the way one
+    digit of a number reads one part of its value. A piece FROM rewrites that
+    part in place, `part(from) <- (part(from) - shift(by)) mod extent(from)`,
+    leaving the axis's other pieces untouched. An `axis` FROM instead rewrites
+    the whole axis index modulo its full extent and redistributes it over the
+    pieces, so the subtraction can carry from one piece into the next.
+
+    For example, axis 0 of extent 4 split across two pieces of extent 2 and
+    replicated twice, so replica `d` supplies the shift `d`:
+
+    ```mlir
+    // `[0:2:2]` carries the high part of axis 0's index and `[0:2:1]` the low
+    // part, so a replica's four slots hold elements 0, 1, 2, 3 in order. The
+    // two layouts differ only in whether the roll names the axis or the piece
+    // holding the low part.
+    #by_axis = #rotom.layout<n = 8, rolls = [(axis 0, 0)],
+                             dims = [[R:2:1], [0:2:2], [0:2:1]]>
+    #by_piece = #rotom.layout<n = 8, rolls = [(2, 0)],
+                              dims = [[R:2:1], [0:2:2], [0:2:1]]>
+    ```
+
+    Replica 0 shifts by 0, so both layouts hold `0, 1, 2, 3`. Replica 1 shifts
+    by 1, and there they differ: `#by_axis` holds `1, 2, 3, 0`, the whole axis
+    rotated by one, while `#by_piece` holds `1, 0, 3, 2`, each pair of slots
+    rotated inside itself.
+
+    The shift is the by argument's index: a
+    traversal piece's part of its axis index (the whole index when the axis is
+    unsplit), a whole axis's index via `axis`, a replication piece's replica
+    index, or a gap piece's block index. The two extents need not match: the shift
+    reduces modulo the rolled extent, so a smaller partner covers a prefix of
+    the rotations and a larger one wraps.
   }];
 
   let parameters = (ins

--- a/lib/Dialect/Rotom/IR/RotomAttributes.td
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.td
@@ -55,11 +55,54 @@ def Rotom_LayoutAttr : Rotom_Attr<"Layout", "layout"> {
     with an explicit gap piece (e.g. `[G:4:1]`).
     See [Section 4.2 of the Rotom paper](https://eprint.iacr.org/2025/1319.pdf).
 
-    Optional **rolls** encode a `roll(i,j)` metadata object: each pair `(i, j)`
-    indexes into the `dims` array (the flattened `ct_dims + slot_dims` list) and
-    rewrites `dims[i]`'s index to `(idx_i - idx_j) mod size(dims[i])`. The two
-    extents need not match: the shift reduces modulo the rolled dim's extent, so
-    a smaller partner covers a prefix of the rotations and a larger one wraps.
+    Optional **rolls** encode `roll(from, by)` metadata objects, applied left
+    to right. Each argument is either a *piece* -- a position in the `dims`
+    list, spelled as a bare integer -- or a whole tensor *axis*, spelled
+    `axis N` (legal only when axis `N` is packed as more than one piece; the
+    piece spelling is canonical for an unsplit axis, where the two coincide).
+
+    ```mlir
+    // Halevi-Shoup diagonal of a 4x4 matrix: slot j of ciphertext i holds
+    // A[i, (j - i) mod 4]. Argument 1 (the axis-1 piece) is rolled by
+    // argument 0 (the axis-0 piece).
+    #diag = #rotom.layout<n = 4, rolls = [(1, 0)], dims = [[0:4:1] | [1:4:1]]>
+
+    // Axis 1 is split across two pieces, so a whole-axis roll spells its
+    // argument `axis 1` rather than a piece position.
+    #split = #rotom.layout<n = 16, rolls = [(axis 1, 2)],
+                           dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+    ```
+
+    A piece FROM rewrites that piece's own mixed-radix digit in place,
+    `digit(from) <- (digit(from) - shift(by)) mod extent(from)`, leaving
+    the axis's other digits untouched. An `axis` FROM rewrites the whole axis
+    index modulo its full extent, and each piece then takes its digit of the
+    rolled index -- the shift borrows across digits, which no combination of
+    piece rolls can express:
+
+    ```mlir
+    // Axis 0 has extent 4, split into digits [0:2:2] (high) and [0:2:1]
+    // (low), and is rolled by a replication argument of extent 2. Writing
+    // the index as (high, low), replica d holds:
+    //
+    //   axis roll, `(axis 0, 0)`:   index (i - d) mod 4, so replica 1 maps
+    //                               (0,0) <- (0,1) <- (1,0) <- (1,1): the
+    //                               subtraction borrows out of the low
+    //                               digit into the high one.
+    //   piece roll, `(1, 0)`:       only the high digit moves, so replica 1
+    //                               maps (0,0) <- (1,0) and (0,1) <- (1,1);
+    //                               the low digit never carries.
+    //
+    // Rolling BOTH pieces by the same argument is still not the axis roll:
+    // each digit wraps inside itself, so (0,0) <- (1,1), not (1,1) <- (0,0).
+    ```
+
+    The shift is the by argument's index: a
+    traversal piece's digit (its whole index when the axis is unsplit), a
+    whole axis's index via `axis`, a replication piece's replica index, or a
+    gap piece's block index. The two extents need not match: the shift
+    reduces modulo the rolled extent, so a smaller partner covers a prefix of
+    the rotations and a larger one wraps.
   }];
 
   let parameters = (ins

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
@@ -18,18 +18,36 @@
 namespace mlir::heir::rotom {
 namespace {
 
-/// Maps a `#rotom.dim` from the layout's `dims` list to its iterator index `i*`
-/// after preprocessing (match logical axis, size, and stride).
-static FailureOr<int64_t> varIndexForRotomDim(const SmallVector<DimAttr>& axes,
-                                              DimAttr want) {
+/// Maps a tensor axis id to its iterator index `i*` after preprocessing.
+/// Preprocessing dedupes traversal pieces per logical axis (a mixed-radix
+/// split contributes one variable), so the axis id identifies the variable.
+static FailureOr<int64_t> varIndexForAxis(const SmallVector<DimAttr>& axes,
+                                          int64_t axis) {
   for (int64_t i = 0; i < static_cast<int64_t>(axes.size()); ++i) {
-    if (axes[i].getDim() == want.getDim() &&
-        axes[i].getSize() == want.getSize() &&
-        axes[i].getStride() == want.getStride()) {
-      return i;
-    }
+    if (axes[i].getDim() == axis) return i;
   }
   return failure();
+}
+
+/// Product of the extents of `dim`'s pieces in the layout's dims list (the
+/// logical axis extent; a single whole-dim piece gives its own size).
+static int64_t fullExtentOfDim(ArrayAttr rotomDims, int64_t dim) {
+  int64_t extent = 1;
+  for (auto d : rotomDims.getAsRange<DimAttr>()) {
+    if (!d.isGap() && !d.isReplicate() && d.getDim() == dim) {
+      extent *= d.getSize();
+    }
+  }
+  return extent;
+}
+
+/// Whether `dim` is packed as more than one mixed-radix piece.
+static bool isSplitDim(ArrayAttr rotomDims, int64_t dim) {
+  int64_t count = 0;
+  for (auto d : rotomDims.getAsRange<DimAttr>()) {
+    if (!d.isGap() && !d.isReplicate() && d.getDim() == dim) ++count;
+  }
+  return count > 1;
 }
 
 static std::string modExpr(llvm::StringRef expr, int64_t mod) {
@@ -156,51 +174,105 @@ static LogicalResult emitSegmentAddress(
     axisExprs.push_back("i" + std::to_string(i));
   }
 
-  // Apply roll(a,b) transforms left-to-right:
-  // t_a <- (t_a - t_b) mod extent(a).
+  // Apply rolls left-to-right. A piece FROM rewrites that piece's own
+  // mixed-radix digit in place, (digit - shift) mod extent(piece),
+  // leaving its axis's other digits untouched; an `axis` FROM rewrites the
+  // whole axis index mod its full extent, so the shift borrows across digits
+  // (each piece then takes its digit of the rolled index). The shift is the
+  // by argument's index: a traversal piece's digit (its whole index when the
+  // axis is unsplit), a whole axis via `axis`, a slot replication's replica
+  // index, or a gap's block index.
   //
-  // The rewrite lands wherever the FROM dimension sits -- the ciphertext
-  // address, the slot address, or both when it straddles the boundary. BY is
-  // another traversal dimension on either axis, or a slot replication/gap
-  // block index, so a roll diagonalizes a ciphertext dimension against a slot
-  // one (one ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup
-  // slot diagonal); a roll within the ciphertext axis is a free ciphertext
+  // The rewrite lands wherever the FROM pieces sit -- the ciphertext
+  // address, the slot address, or both when the axis straddles the boundary.
+  // A roll diagonalizes a ciphertext dimension against a slot one (one
+  // ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup slot
+  // diagonal); a roll within the ciphertext axis is a free ciphertext
   // relabeling that enumeration never generates.
   if (!rolls.empty()) {
     if (!rotomDims || rolls.size() % 2 != 0) return failure();
     for (size_t i = 0; i < rolls.size(); i += 2) {
-      const int64_t fromIdx = rolls[i];
-      const int64_t toIdx = rolls[i + 1];
-      if (fromIdx < 0 || toIdx < 0 ||
-          fromIdx >= static_cast<int64_t>(rotomDims.size()) ||
-          toIdx >= static_cast<int64_t>(rotomDims.size())) {
+      const RollArg from = decodeRollArg(rolls[i]);
+      const RollArg by = decodeRollArg(rolls[i + 1]);
+      if (!from.isAxis && from.index >= static_cast<int64_t>(rotomDims.size()))
         return failure();
-      }
-      auto fromDim = cast<DimAttr>(rotomDims[fromIdx]);
-      auto toDim = cast<DimAttr>(rotomDims[toIdx]);
-      FailureOr<int64_t> maybeFromVar = varIndexForRotomDim(axes, fromDim);
+      if (!by.isAxis && by.index >= static_cast<int64_t>(rotomDims.size()))
+        return failure();
+      DimAttr fromPiece =
+          from.isAxis ? DimAttr() : dyn_cast<DimAttr>(rotomDims[from.index]);
+      if (!from.isAxis && !fromPiece) return failure();
+      const int64_t fromAxis = from.isAxis ? from.index : fromPiece.getDim();
+      FailureOr<int64_t> maybeFromVar = varIndexForAxis(axes, fromAxis);
       if (failed(maybeFromVar)) return failure();
       const int64_t fromVar = *maybeFromVar;
+
       std::string toExpr;
-      if (toDim.isGap()) {
-        // Rolling by a gap dim: the shift is the gap's existential block
-        // index, so block g holds the rolled dim cyclically shifted by g.
-        toExpr = "g" + std::to_string(gapIndexForPosition(rotomDims, toIdx));
-      } else if (toDim.isReplicate()) {
-        // Rolling by a replication dim: the shift is the replica index, whose
-        // existential variable is named after the piece's replication slot.
-        int64_t replicationIndex = 0;
-        for (int64_t k = 0; k < toIdx; ++k) {
-          if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
-        }
-        toExpr = "d" + std::to_string(numAxes + replicationIndex);
-      } else {
-        FailureOr<int64_t> maybeToVar = varIndexForRotomDim(axes, toDim);
+      if (by.isAxis) {
+        // Rolling by a whole axis: the shift is the axis's (possibly
+        // already-rolled) index expression.
+        FailureOr<int64_t> maybeToVar = varIndexForAxis(axes, by.index);
         if (failed(maybeToVar)) return failure();
         toExpr = axisExprs[*maybeToVar];
+      } else {
+        auto toDim = dyn_cast<DimAttr>(rotomDims[by.index]);
+        if (!toDim) return failure();
+        if (toDim.isGap()) {
+          // Rolling by a gap dim: the shift is the gap's existential block
+          // index, so block g holds the rolled index cyclically shifted by g.
+          toExpr =
+              "g" + std::to_string(gapIndexForPosition(rotomDims, by.index));
+        } else if (toDim.isReplicate()) {
+          // Rolling by a replication dim: the shift is the replica index,
+          // whose existential variable is named after the piece's replication
+          // slot.
+          int64_t replicationIndex = 0;
+          for (int64_t k = 0; k < by.index; ++k) {
+            if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
+          }
+          toExpr = "d" + std::to_string(numAxes + replicationIndex);
+        } else {
+          FailureOr<int64_t> maybeToVar = varIndexForAxis(axes, toDim.getDim());
+          if (failed(maybeToVar)) return failure();
+          toExpr = axisExprs[*maybeToVar];
+          if (isSplitDim(rotomDims, toDim.getDim())) {
+            // The by piece's digit: (i / stride) mod extent, with the modulus
+            // redundant on the most-significant digit.
+            const int64_t fullTo = fullExtentOfDim(rotomDims, toDim.getDim());
+            if (toDim.getStride() > 1) {
+              toExpr = floorDivExpr(toExpr, toDim.getStride());
+            }
+            if (toDim.getStride() * toDim.getSize() < fullTo) {
+              toExpr = modExpr(toExpr, toDim.getSize());
+            }
+          }
+        }
       }
-      std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
-      axisExprs[fromVar] = modExpr(diffExpr, fromDim.getSize());
+
+      if (from.isAxis || !isSplitDim(rotomDims, fromAxis)) {
+        // Whole-axis rewrite (the piece spelling of an unsplit axis is the
+        // same operation: its one piece's digit is the axis index).
+        std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
+        axisExprs[fromVar] =
+            modExpr(diffExpr, fullExtentOfDim(rotomDims, fromAxis));
+      } else {
+        // Piece rewrite on a split axis: replace this piece's digit with
+        // (digit - shift) mod extent(piece), i.e. add
+        // stride * (newDigit - digit) to the axis index. No borrow crosses
+        // into the other digits.
+        const int64_t stride = fromPiece.getStride();
+        const int64_t extent = fromPiece.getSize();
+        const std::string axisExpr = axisExprs[fromVar];
+        std::string digit = axisExpr;
+        if (stride > 1) digit = floorDivExpr(digit, stride);
+        if (stride * extent < fullExtentOfDim(rotomDims, fromAxis)) {
+          digit = modExpr(digit, extent);
+        }
+        const std::string newDigit =
+            modExpr("(" + digit + " - " + toExpr + ")", extent);
+        axisExprs[fromVar] = "(" + axisExpr + " + " + std::to_string(stride) +
+                             " * (" + newDigit + ") - " +
+                             std::to_string(stride) + " * (" + digit + "))";
+      }
     }
   }
 

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
@@ -18,16 +18,13 @@
 namespace mlir::heir::rotom {
 namespace {
 
-/// Maps a `#rotom.dim` from the layout's `dims` list to its iterator index `i*`
-/// after preprocessing (match logical axis, size, and stride).
-static FailureOr<int64_t> varIndexForRotomDim(const SmallVector<DimAttr>& axes,
-                                              DimAttr want) {
+/// Maps a tensor axis id to its iterator index `i*` after preprocessing.
+/// Preprocessing dedupes traversal pieces per logical axis (a
+/// split contributes one variable), so the axis id identifies the variable.
+static FailureOr<int64_t> varIndexForAxis(const SmallVector<DimAttr>& axes,
+                                          int64_t axis) {
   for (int64_t i = 0; i < static_cast<int64_t>(axes.size()); ++i) {
-    if (axes[i].getDim() == want.getDim() &&
-        axes[i].getSize() == want.getSize() &&
-        axes[i].getStride() == want.getStride()) {
-      return i;
-    }
+    if (axes[i].getDim() == axis) return i;
   }
   return failure();
 }
@@ -89,9 +86,10 @@ static LogicalResult emitSegmentAddress(
     const SmallVector<DimAttr>& axes, int64_t numAxes, size_t segStart,
     size_t segEnd, const llvm::DenseSet<int64_t>& rolledGapIndices,
     ArrayRef<int64_t> rolls, ArrayAttr rotomDims) {
-  // Effective extent of a piece = the range of its mixed-radix digit, which
+  // Effective extent of a piece = the range of the axis-index part it reads,
+  // which
   // is the piece's own extent: a lone piece reads the whole axis index, and
-  // for a valid mixed-radix split each digit ranges over its piece's extent.
+  // for a valid split each part ranges over its piece's extent.
   llvm::SmallVector<int64_t> suffixCoeff(pieces.size(), 0);
   int64_t suffix = 1;
   for (size_t p = segEnd; p > segStart;) {
@@ -133,20 +131,21 @@ static LogicalResult emitSegmentAddress(
     }
   }
 
-  // A tensor dim can contribute several pieces to one segment (a mixed-radix
-  // split places more than one digit of the same index on the same axis), so
-  // collect a list of (coeff, digit descriptor) per dim rather than one entry.
-  struct AxisDigit {
+  // A tensor dim can contribute several pieces to one segment (a split places
+  // more than one part of the same index on the same axis), so collect a list
+  // of terms per dim rather than one entry. Each term reads the part
+  // (i / divBy) mod modBy of the axis variable and scales it by coeff.
+  struct AxisTerm {
     int64_t coeff;
     int64_t divBy;
     int64_t modBy;
   };
-  llvm::DenseMap<int64_t, llvm::SmallVector<AxisDigit>> digitsByAxis;
+  llvm::DenseMap<int64_t, llvm::SmallVector<AxisTerm>> termsByAxis;
   for (size_t p = segStart; p < segEnd; ++p) {
     if (pieces[p].kind != LayoutPieceKind::Traversal) continue;
     const int64_t ti = pieces[p].axisIndex;
     if (axes[ti].getSize() == 1) continue;
-    digitsByAxis[ti].push_back(
+    termsByAxis[ti].push_back(
         {suffixCoeff[p], pieces[p].divBy, pieces[p].modBy});
   }
 
@@ -156,61 +155,118 @@ static LogicalResult emitSegmentAddress(
     axisExprs.push_back("i" + std::to_string(i));
   }
 
-  // Apply roll(a,b) transforms left-to-right:
-  // t_a <- (t_a - t_b) mod extent(a).
+  // Apply rolls left-to-right. A piece FROM rewrites that piece's own
+  // part of the axis index in place, (part - shift) mod extent(piece),
+  // leaving its axis's other pieces untouched; an `axis` FROM rewrites the
+  // whole axis index mod its full extent, so the shift can carry from one
+  // piece into the next (each piece then reads its part of the rolled index).
+  // The shift is the by argument's index: a traversal piece's part (its whole
+  // index when the
+  // axis is unsplit), a whole axis via `axis`, a slot replication's replica
+  // index, or a gap's block index.
   //
-  // The rewrite lands wherever the FROM dimension sits -- the ciphertext
-  // address, the slot address, or both when it straddles the boundary. BY is
-  // another traversal dimension on either axis, or a slot replication/gap
-  // block index, so a roll diagonalizes a ciphertext dimension against a slot
-  // one (one ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup
-  // slot diagonal); a roll within the ciphertext axis is a free ciphertext
+  // The rewrite lands wherever the FROM pieces sit -- the ciphertext
+  // address, the slot address, or both when the axis straddles the boundary.
+  // A roll diagonalizes a ciphertext dimension against a slot one (one
+  // ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup slot
+  // diagonal); a roll within the ciphertext axis is a free ciphertext
   // relabeling that enumeration never generates.
   if (!rolls.empty()) {
     if (!rotomDims || rolls.size() % 2 != 0) return failure();
     for (size_t i = 0; i < rolls.size(); i += 2) {
-      const int64_t fromIdx = rolls[i];
-      const int64_t toIdx = rolls[i + 1];
-      if (fromIdx < 0 || toIdx < 0 ||
-          fromIdx >= static_cast<int64_t>(rotomDims.size()) ||
-          toIdx >= static_cast<int64_t>(rotomDims.size())) {
+      const RollArg from = decodeRollArg(rolls[i]);
+      const RollArg by = decodeRollArg(rolls[i + 1]);
+      if (!from.isAxis && from.index >= static_cast<int64_t>(rotomDims.size()))
         return failure();
-      }
-      auto fromDim = cast<DimAttr>(rotomDims[fromIdx]);
-      auto toDim = cast<DimAttr>(rotomDims[toIdx]);
-      FailureOr<int64_t> maybeFromVar = varIndexForRotomDim(axes, fromDim);
+      if (!by.isAxis && by.index >= static_cast<int64_t>(rotomDims.size()))
+        return failure();
+      DimAttr fromPiece =
+          from.isAxis ? DimAttr() : dyn_cast<DimAttr>(rotomDims[from.index]);
+      if (!from.isAxis && !fromPiece) return failure();
+      const int64_t fromAxis = from.isAxis ? from.index : fromPiece.getDim();
+      FailureOr<int64_t> maybeFromVar = varIndexForAxis(axes, fromAxis);
       if (failed(maybeFromVar)) return failure();
       const int64_t fromVar = *maybeFromVar;
+
       std::string toExpr;
-      if (toDim.isGap()) {
-        // Rolling by a gap dim: the shift is the gap's existential block
-        // index, so block g holds the rolled dim cyclically shifted by g.
-        toExpr = "g" + std::to_string(gapIndexForPosition(rotomDims, toIdx));
-      } else if (toDim.isReplicate()) {
-        // Rolling by a replication dim: the shift is the replica index, whose
-        // existential variable is named after the piece's replication slot.
-        int64_t replicationIndex = 0;
-        for (int64_t k = 0; k < toIdx; ++k) {
-          if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
-        }
-        toExpr = "d" + std::to_string(numAxes + replicationIndex);
-      } else {
-        FailureOr<int64_t> maybeToVar = varIndexForRotomDim(axes, toDim);
+      if (by.isAxis) {
+        // Rolling by a whole axis: the shift is the axis's (possibly
+        // already-rolled) index expression.
+        FailureOr<int64_t> maybeToVar = varIndexForAxis(axes, by.index);
         if (failed(maybeToVar)) return failure();
         toExpr = axisExprs[*maybeToVar];
+      } else {
+        auto toDim = dyn_cast<DimAttr>(rotomDims[by.index]);
+        if (!toDim) return failure();
+        if (toDim.isGap()) {
+          // Rolling by a gap dim: the shift is the gap's existential block
+          // index, so block g holds the rolled index cyclically shifted by g.
+          toExpr =
+              "g" + std::to_string(gapIndexForPosition(rotomDims, by.index));
+        } else if (toDim.isReplicate()) {
+          // Rolling by a replication dim: the shift is the replica index,
+          // whose existential variable is named after the piece's replication
+          // slot.
+          int64_t replicationIndex = 0;
+          for (int64_t k = 0; k < by.index; ++k) {
+            if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
+          }
+          toExpr = "d" + std::to_string(numAxes + replicationIndex);
+        } else {
+          FailureOr<int64_t> maybeToVar = varIndexForAxis(axes, toDim.getDim());
+          if (failed(maybeToVar)) return failure();
+          toExpr = axisExprs[*maybeToVar];
+          const AxisPieces toAxis = axisPieces(rotomDims, toDim.getDim());
+          if (toAxis.isSplit()) {
+            // The part the by piece reads: (i / stride) mod extent, with the
+            // modulus redundant on the highest part.
+            const int64_t fullTo = toAxis.extent;
+            if (toDim.getStride() > 1) {
+              toExpr = floorDivExpr(toExpr, toDim.getStride());
+            }
+            if (toDim.getStride() * toDim.getSize() < fullTo) {
+              toExpr = modExpr(toExpr, toDim.getSize());
+            }
+          }
+        }
       }
-      std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
-      axisExprs[fromVar] = modExpr(diffExpr, fromDim.getSize());
+
+      const AxisPieces fromAxisPieces = axisPieces(rotomDims, fromAxis);
+      if (from.isAxis || !fromAxisPieces.isSplit()) {
+        // Whole-axis rewrite (the piece form of an unsplit axis is the
+        // same operation: its one piece reads the whole axis index).
+        std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
+        axisExprs[fromVar] = modExpr(diffExpr, fromAxisPieces.extent);
+      } else {
+        // Piece rewrite on a split axis: replace the part this piece reads
+        // with (part - shift) mod extent(piece), i.e. add
+        // stride * (rolled - part) to the axis index. Nothing carries into
+        // the other pieces.
+        const int64_t stride = fromPiece.getStride();
+        const int64_t extent = fromPiece.getSize();
+        const std::string axisExpr = axisExprs[fromVar];
+        std::string part = axisExpr;
+        if (stride > 1) part = floorDivExpr(part, stride);
+        if (stride * extent < fromAxisPieces.extent) {
+          part = modExpr(part, extent);
+        }
+        const std::string rolled =
+            modExpr("(" + part + " - " + toExpr + ")", extent);
+        axisExprs[fromVar] = "(" + axisExpr + " + " + std::to_string(stride) +
+                             " * (" + rolled + ") - " + std::to_string(stride) +
+                             " * (" + part + "))";
+      }
     }
   }
 
   for (int64_t oldIdx = 0; oldIdx < static_cast<int64_t>(axes.size());
        ++oldIdx) {
     if (axes[oldIdx].getSize() == 1) continue;
-    auto it = digitsByAxis.find(oldIdx);
-    if (it == digitsByAxis.end()) continue;
-    for (const AxisDigit& tp : it->second) {
-      // Mixed-radix digit: (i / divBy) mod modBy (modBy 0 => no modulus). A
+    auto it = termsByAxis.find(oldIdx);
+    if (it == termsByAxis.end()) continue;
+    for (const AxisTerm& tp : it->second) {
+      // The part this piece reads: (i / divBy) mod modBy (modBy 0 => no
+      // modulus). A
       // whole-dim piece (divBy 1, modBy 0) leaves the index untouched.
       std::string expr = axisExprs[oldIdx];
       if (tp.divBy > 1) expr = floorDivExpr(expr, tp.divBy);

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.h
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.h
@@ -11,7 +11,10 @@ namespace heir {
 namespace rotom {
 
 /// Lowers a Rotom `#rotom.layout` to the ISL map text used by
-/// `tensor_ext.layout` (domain `i*`, range `ct`, `slot`).
+/// `tensor_ext.layout` (domain `i*`, range `ct`, `slot`). The layout is the
+/// whole story: a value's packed bytes are exactly what its layout says, so
+/// kernel schedules (e.g. a baby-step/giant-step shift) are emitted as
+/// rotations by the kernel, never folded into a value's packing.
 struct RotomTensorExtLayoutLowering {
   static FailureOr<std::string> lowerToTensorExtIsl(LayoutAttr layout);
 };

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
@@ -113,7 +113,7 @@ TEST(RotomTensorExtLayoutLoweringTest, TiledRowMajor4x4Evaluate) {
       {9, 10, 11, 12},
       {13, 14, 15, 16},
   };
-  // dim ids 0 and 1 are each split mixed-radix into two pieces, so the relation
+  // dim ids 0 and 1 are each split into two pieces, so the relation
   // has one domain variable per tensor axis: i0 = row, i1 = col -- the pieces
   // of an axis share its variable rather than each binding their own. The
   // packing itself is plain 2x2-tiled row-major.
@@ -414,6 +414,147 @@ TEST(RotomTensorExtLayoutLoweringTest, UnequalExtentRollReducesModFromSize) {
   EXPECT_EQ(packed, expected);
 }
 
+// An `axis` FROM argument rewrites the whole dim's index, and each piece
+// takes its part of the rolled index: ciphertext (g, b) at slot a holds the
+// iteration point k = (a + 4g + b) mod 16 -- the diagonal index split across
+// two ciphertext pieces (the carry between pieces is what a piece FROM
+// cannot express).
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollOnSplitDim) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr kHi = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/4);
+  DimAttr kLo = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/1);
+  DimAttr i = DimAttr::get(&context, /*dim=*/0, /*size=*/16, /*stride=*/1);
+  // rolls (axis 1, 2): the whole k index is rewritten to (k - i) mod 16;
+  // k_hi emits its floor part, k_lo its mod part.
+  LayoutAttr layout = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {kHi, kLo, i}), /*n=*/16,
+      DenseI64ArrayAttr::get(
+          &context,
+          ArrayRef<int64_t>{rotom::encodeRollArg({/*isAxis=*/true, 1}), 2}));
+
+  FailureOr<std::string> isl =
+      RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+  ASSERT_TRUE(succeeded(isl));
+  auto relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+
+  std::vector<std::vector<int>> packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        // f(i, k) = 16*i + k, distinct per iteration point.
+        return 16 * static_cast<int>(domainPoint[0]) +
+               static_cast<int>(domainPoint[1]);
+      });
+  ASSERT_EQ(packed.size(), 16u);
+  for (int g = 0; g < 4; ++g) {
+    for (int b = 0; b < 4; ++b) {
+      for (int a = 0; a < 16; ++a) {
+        const int k = (a + 4 * g + b) % 16;
+        EXPECT_EQ(packed[4 * g + b][a], 16 * a + k)
+            << "ct (" << g << ", " << b << ") slot " << a;
+      }
+    }
+  }
+}
+
+// A piece FROM on a split dim rewrites only that piece's part of the index --
+// nothing carries into the other pieces. Rolling the high piece shifts the
+// axis in strides of 4; rolling the low piece rotates within each block of 4.
+TEST(RotomTensorExtLayoutLoweringTest, PieceRollOnSplitDimRotatesOnePiece) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr d0Hi = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/4);
+  DimAttr d0Lo = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, d0Hi, d0Lo});
+  std::vector<int> vec(16);
+  for (int i = 0; i < 16; ++i) vec[i] = i + 1;
+  auto evaluate = [&](LayoutAttr layout) {
+    FailureOr<std::string> isl =
+        RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+    EXPECT_TRUE(succeeded(isl));
+    auto relation = getIntegerRelationFromIslStr(*isl);
+    EXPECT_TRUE(succeeded(relation));
+    return evaluateLayout<int>(
+        relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+          return vec[domainPoint[0]];
+        });
+  };
+
+  // roll(1, 0): the high piece shifts by the replica index, so replica d
+  // holds the vector rotated by 4d whole (the low bits ride along
+  // untouched, so no borrow is observable here).
+  LayoutAttr hiRolled = LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+  std::vector<std::vector<int>> packed = evaluate(hiRolled);
+  ASSERT_EQ(packed.size(), 1u);
+  ASSERT_EQ(packed[0].size(), 64u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      EXPECT_EQ(packed[0][16 * d + a], vec[(a + 4 * d) % 16])
+          << "hi-rolled replica " << d << " slot " << a;
+    }
+  }
+
+  // roll(2, 0): the LOW piece shifts by the replica index -- each block of
+  // 4 rotates independently, with no carry into the high piece (the
+  // whole-axis roll, written `axis 0`, would borrow).
+  LayoutAttr loRolled = LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{2, 0}));
+  packed = evaluate(loRolled);
+  ASSERT_EQ(packed.size(), 1u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      const int block = a / 4;
+      const int within = (a % 4 + d) % 4;
+      EXPECT_EQ(packed[0][16 * d + a], vec[4 * block + within])
+          << "lo-rolled replica " << d << " slot " << a;
+    }
+  }
+}
+
+// Axis arguments: legal only on a split axis (the piece form is
+// canonical when the axis is one piece), and a roll may not shift an axis by
+// one of its own pieces.
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollArgVerifierRules) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr kHi = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/4);
+  DimAttr kLo = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/1);
+  DimAttr i = DimAttr::get(&context, /*dim=*/0, /*size=*/16, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {kHi, kLo, i});
+  ScopedDiagnosticHandler silence(&context,
+                                  [](Diagnostic&) { return success(); });
+  auto swallow =
+      mlir::detail::getDefaultDiagnosticEmitFn(UnknownLoc::get(&context));
+  const int64_t axisK = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  const int64_t axisI = rotom::encodeRollArg({/*isAxis=*/true, 0});
+  const int64_t axisMissing = rotom::encodeRollArg({/*isAxis=*/true, 5});
+
+  // FROM the split axis, BY the unsplit i piece: legal.
+  EXPECT_TRUE(succeeded(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisK, 2}))));
+  // An axis argument on an unsplit axis must use the piece form.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisI, 0}))));
+  // An axis argument must name an axis present in dims.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisMissing, 2}))));
+  // An axis may not be shifted by one of its own pieces.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisK, 0}))));
+  // ... nor may a piece be shifted by its own whole axis.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{0, axisK}))));
+}
+
 TEST(RotomTensorExtLayoutLoweringTest, RollVerifierDimKindRules) {
   MLIRContext context;
   context.loadDialect<RotomDialect>();
@@ -472,6 +613,94 @@ TEST(RotomTensorExtLayoutLoweringTest, RollByGapMaterializesRotations) {
   std::vector<std::vector<int>> expected = {
       {1, 2, 3, 4, 2, 3, 4, 1, 3, 4, 1, 2, 4, 1, 2, 3}};
   EXPECT_EQ(packed, expected);
+}
+
+// The axis argument is not sugar for rolling every piece: rolling both
+// pieces of a split axis by the same partner wraps each piece
+// INDEPENDENTLY, while the axis form rewrites the whole index so the shift
+// carries across pieces. No combination of piece rolls expresses the latter,
+// which is the reason `axis N` exists.
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollDiffersFromRollingEveryPiece) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr hi = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/4);
+  DimAttr lo = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, hi, lo});
+  std::vector<int> vec(16);
+  for (int i = 0; i < 16; ++i) vec[i] = i;
+  auto evaluate = [&](LayoutAttr layout) {
+    FailureOr<std::string> isl =
+        RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+    EXPECT_TRUE(succeeded(isl));
+    auto relation = getIntegerRelationFromIslStr(*isl);
+    EXPECT_TRUE(succeeded(relation));
+    return evaluateLayout<int>(
+        relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+          return vec[domainPoint[0]];
+        });
+  };
+
+  // Whole-axis roll by the replica index: replica d holds (a + d) mod 16.
+  std::vector<std::vector<int>> axisRolled = evaluate(LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(
+          &context,
+          ArrayRef<int64_t>{rotom::encodeRollArg({/*isAxis=*/true, 0}), 0})));
+  // Both pieces rolled by the same replica index.
+  std::vector<std::vector<int>> pieceRolled = evaluate(LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0, 2, 0})));
+
+  ASSERT_EQ(axisRolled.size(), 1u);
+  ASSERT_EQ(pieceRolled.size(), 1u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      EXPECT_EQ(axisRolled[0][16 * d + a], (a + d) % 16)
+          << "axis-rolled replica " << d << " slot " << a;
+      // Per-piece wrapping: the high piece takes no carry out of the low.
+      EXPECT_EQ(pieceRolled[0][16 * d + a],
+                4 * ((a / 4 + d) % 4) + (a % 4 + d) % 4)
+          << "piece-rolled replica " << d << " slot " << a;
+    }
+  }
+  // Concretely different maps, not just different forms.
+  EXPECT_NE(axisRolled[0], pieceRolled[0]);
+}
+
+// Canonicalization inserts the front gap that fills the slot side, which
+// shifts PIECE arguments at or past the insertion; an axis argument names an
+// axis and must not move. Writing the gap explicitly (with the argument
+// already shifted) must therefore produce the very same attribute.
+TEST(RotomTensorExtLayoutLoweringTest, GapInsertionShiftsOnlyPieceArgs) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  // Slot side holds 16 of 32 slots, so canonicalization inserts [G:2:1].
+  SmallVector<DimAttr> dims = {
+      DimAttr::get(&context, /*dim=*/1, /*size=*/2, /*stride=*/2),
+      DimAttr::get(&context, /*dim=*/1, /*size=*/2, /*stride=*/1),
+      DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1)};
+  const int64_t axisK = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  // roll(axis 1, 2): the whole split k rolled by the i piece at position 2.
+  LayoutAttr inserted = LayoutAttr::getCanonical(&context, dims, /*n=*/32,
+                                                 ArrayRef<int64_t>{axisK, 2});
+  ASSERT_TRUE(inserted);
+
+  SmallVector<DimAttr> withUnitAxis = {
+      DimAttr::get(&context, /*dim=*/-2, /*size=*/2, /*stride=*/1)};
+  withUnitAxis.append(dims.begin(), dims.end());
+  // Same packing written out: the gap is explicit and the piece argument
+  // already accounts for it, while the axis argument is unchanged.
+  LayoutAttr explicitGap = LayoutAttr::getCanonical(
+      &context, withUnitAxis, /*n=*/32, ArrayRef<int64_t>{axisK, 3});
+  ASSERT_TRUE(explicitGap);
+
+  EXPECT_EQ(inserted, explicitGap);
+  ArrayRef<int64_t> rolls = inserted.getRolls().asArrayRef();
+  ASSERT_EQ(rolls.size(), 2u);
+  EXPECT_TRUE(rotom::decodeRollArg(rolls[0]).isAxis);
+  EXPECT_EQ(rotom::decodeRollArg(rolls[0]).index, 1);
+  EXPECT_EQ(rolls[1], 3);
 }
 
 }  // namespace

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
@@ -414,6 +414,147 @@ TEST(RotomTensorExtLayoutLoweringTest, UnequalExtentRollReducesModFromSize) {
   EXPECT_EQ(packed, expected);
 }
 
+// An `axis` FROM argument rewrites the whole dim's index, and each piece
+// takes its digit of the rolled index: ciphertext (g, b) at slot a holds the
+// iteration point k = (a + 4g + b) mod 16 -- the diagonal index split across
+// two ciphertext digits (the borrow between digits is what a piece FROM
+// cannot express).
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollOnSplitDim) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr kHi = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/4);
+  DimAttr kLo = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/1);
+  DimAttr i = DimAttr::get(&context, /*dim=*/0, /*size=*/16, /*stride=*/1);
+  // rolls (axis 1, 2): the whole k index is rewritten to (k - i) mod 16;
+  // k_hi emits its floor digit, k_lo its mod digit.
+  LayoutAttr layout = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {kHi, kLo, i}), /*n=*/16,
+      DenseI64ArrayAttr::get(
+          &context,
+          ArrayRef<int64_t>{rotom::encodeRollArg({/*isAxis=*/true, 1}), 2}));
+
+  FailureOr<std::string> isl =
+      RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+  ASSERT_TRUE(succeeded(isl));
+  auto relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+
+  std::vector<std::vector<int>> packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        // f(i, k) = 16*i + k, distinct per iteration point.
+        return 16 * static_cast<int>(domainPoint[0]) +
+               static_cast<int>(domainPoint[1]);
+      });
+  ASSERT_EQ(packed.size(), 16u);
+  for (int g = 0; g < 4; ++g) {
+    for (int b = 0; b < 4; ++b) {
+      for (int a = 0; a < 16; ++a) {
+        const int k = (a + 4 * g + b) % 16;
+        EXPECT_EQ(packed[4 * g + b][a], 16 * a + k)
+            << "ct (" << g << ", " << b << ") slot " << a;
+      }
+    }
+  }
+}
+
+// A piece FROM on a split dim rewrites only that piece's digit -- no borrow
+// crosses into the other digits. Rolling the high digit shifts the axis in
+// strides of 4; rolling the low digit rotates within each block of 4.
+TEST(RotomTensorExtLayoutLoweringTest, PieceRollOnSplitDimRotatesOneDigit) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr d0Hi = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/4);
+  DimAttr d0Lo = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, d0Hi, d0Lo});
+  std::vector<int> vec(16);
+  for (int i = 0; i < 16; ++i) vec[i] = i + 1;
+  auto evaluate = [&](LayoutAttr layout) {
+    FailureOr<std::string> isl =
+        RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+    EXPECT_TRUE(succeeded(isl));
+    auto relation = getIntegerRelationFromIslStr(*isl);
+    EXPECT_TRUE(succeeded(relation));
+    return evaluateLayout<int>(
+        relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+          return vec[domainPoint[0]];
+        });
+  };
+
+  // roll(1, 0): the high digit shifts by the replica index, so replica d
+  // holds the vector rotated by 4d whole (the low bits ride along
+  // untouched, so no borrow is observable here).
+  LayoutAttr hiRolled = LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+  std::vector<std::vector<int>> packed = evaluate(hiRolled);
+  ASSERT_EQ(packed.size(), 1u);
+  ASSERT_EQ(packed[0].size(), 64u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      EXPECT_EQ(packed[0][16 * d + a], vec[(a + 4 * d) % 16])
+          << "hi-rolled replica " << d << " slot " << a;
+    }
+  }
+
+  // roll(2, 0): the LOW digit shifts by the replica index -- each block of
+  // 4 rotates independently, with no borrow into the high digit (the
+  // whole-axis roll, spelled `axis 0`, would borrow).
+  LayoutAttr loRolled = LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{2, 0}));
+  packed = evaluate(loRolled);
+  ASSERT_EQ(packed.size(), 1u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      const int block = a / 4;
+      const int within = (a % 4 + d) % 4;
+      EXPECT_EQ(packed[0][16 * d + a], vec[4 * block + within])
+          << "lo-rolled replica " << d << " slot " << a;
+    }
+  }
+}
+
+// Axis arguments: legal only on a split axis (the piece spelling is
+// canonical when the axis is one piece), and a roll may not shift an axis by
+// one of its own pieces.
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollArgVerifierRules) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr kHi = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/4);
+  DimAttr kLo = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/1);
+  DimAttr i = DimAttr::get(&context, /*dim=*/0, /*size=*/16, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {kHi, kLo, i});
+  ScopedDiagnosticHandler silence(&context,
+                                  [](Diagnostic&) { return success(); });
+  auto swallow =
+      mlir::detail::getDefaultDiagnosticEmitFn(UnknownLoc::get(&context));
+  const int64_t axisK = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  const int64_t axisI = rotom::encodeRollArg({/*isAxis=*/true, 0});
+  const int64_t axisMissing = rotom::encodeRollArg({/*isAxis=*/true, 5});
+
+  // FROM the split axis, BY the unsplit i piece: legal.
+  EXPECT_TRUE(succeeded(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisK, 2}))));
+  // An axis argument on an unsplit axis must use the piece spelling.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisI, 0}))));
+  // An axis argument must name an axis present in dims.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisMissing, 2}))));
+  // An axis may not be shifted by one of its own pieces.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisK, 0}))));
+  // ... nor may a piece be shifted by its own whole axis.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{0, axisK}))));
+}
+
 TEST(RotomTensorExtLayoutLoweringTest, RollVerifierDimKindRules) {
   MLIRContext context;
   context.loadDialect<RotomDialect>();
@@ -472,6 +613,94 @@ TEST(RotomTensorExtLayoutLoweringTest, RollByGapMaterializesRotations) {
   std::vector<std::vector<int>> expected = {
       {1, 2, 3, 4, 2, 3, 4, 1, 3, 4, 1, 2, 4, 1, 2, 3}};
   EXPECT_EQ(packed, expected);
+}
+
+// The axis argument is not sugar for rolling every piece: rolling both
+// digits of a split axis by the same partner wraps each digit
+// INDEPENDENTLY, while the axis form rewrites the whole index so the shift
+// borrows across digits. No combination of piece rolls expresses the latter,
+// which is the reason `axis N` exists.
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollDiffersFromRollingEveryPiece) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr hi = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/4);
+  DimAttr lo = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, hi, lo});
+  std::vector<int> vec(16);
+  for (int i = 0; i < 16; ++i) vec[i] = i;
+  auto evaluate = [&](LayoutAttr layout) {
+    FailureOr<std::string> isl =
+        RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+    EXPECT_TRUE(succeeded(isl));
+    auto relation = getIntegerRelationFromIslStr(*isl);
+    EXPECT_TRUE(succeeded(relation));
+    return evaluateLayout<int>(
+        relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+          return vec[domainPoint[0]];
+        });
+  };
+
+  // Whole-axis roll by the replica index: replica d holds (a + d) mod 16.
+  std::vector<std::vector<int>> axisRolled = evaluate(LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(
+          &context,
+          ArrayRef<int64_t>{rotom::encodeRollArg({/*isAxis=*/true, 0}), 0})));
+  // Both digits rolled by the same replica index.
+  std::vector<std::vector<int>> pieceRolled = evaluate(LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0, 2, 0})));
+
+  ASSERT_EQ(axisRolled.size(), 1u);
+  ASSERT_EQ(pieceRolled.size(), 1u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      EXPECT_EQ(axisRolled[0][16 * d + a], (a + d) % 16)
+          << "axis-rolled replica " << d << " slot " << a;
+      // Per-digit wrapping: the high digit carries no borrow out of the low.
+      EXPECT_EQ(pieceRolled[0][16 * d + a],
+                4 * ((a / 4 + d) % 4) + (a % 4 + d) % 4)
+          << "piece-rolled replica " << d << " slot " << a;
+    }
+  }
+  // Concretely different maps, not just different spellings.
+  EXPECT_NE(axisRolled[0], pieceRolled[0]);
+}
+
+// Canonicalization inserts the front gap that fills the slot side, which
+// shifts PIECE arguments at or past the insertion; an axis argument names an
+// axis and must not move. Writing the gap explicitly (with the argument
+// already shifted) must therefore produce the very same attribute.
+TEST(RotomTensorExtLayoutLoweringTest, GapInsertionShiftsOnlyPieceArgs) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  // Slot side holds 16 of 32 slots, so canonicalization inserts [G:2:1].
+  SmallVector<DimAttr> dims = {
+      DimAttr::get(&context, /*dim=*/1, /*size=*/2, /*stride=*/2),
+      DimAttr::get(&context, /*dim=*/1, /*size=*/2, /*stride=*/1),
+      DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1)};
+  const int64_t axisK = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  // roll(axis 1, 2): the whole split k rolled by the i piece at position 2.
+  LayoutAttr inserted = LayoutAttr::getCanonical(&context, dims, /*n=*/32,
+                                                 ArrayRef<int64_t>{axisK, 2});
+  ASSERT_TRUE(inserted);
+
+  SmallVector<DimAttr> spelled = {
+      DimAttr::get(&context, /*dim=*/-2, /*size=*/2, /*stride=*/1)};
+  spelled.append(dims.begin(), dims.end());
+  // Same packing written out: the gap is explicit and the piece argument
+  // already accounts for it, while the axis argument is unchanged.
+  LayoutAttr explicitGap = LayoutAttr::getCanonical(
+      &context, spelled, /*n=*/32, ArrayRef<int64_t>{axisK, 3});
+  ASSERT_TRUE(explicitGap);
+
+  EXPECT_EQ(inserted, explicitGap);
+  ArrayRef<int64_t> rolls = inserted.getRolls().asArrayRef();
+  ASSERT_EQ(rolls.size(), 2u);
+  EXPECT_TRUE(rotom::decodeRollArg(rolls[0]).isAxis);
+  EXPECT_EQ(rotom::decodeRollArg(rolls[0]).index, 1);
+  EXPECT_EQ(rolls[1], 3);
 }
 
 }  // namespace

--- a/tests/Dialect/Rotom/IR/layout.mlir
+++ b/tests/Dialect/Rotom/IR/layout.mlir
@@ -24,7 +24,7 @@ func.func private @split_ok(tensor<16xi32> {foo.bar = #split_ok})
 
 // The slot side must fill the ciphertext exactly; a written layout may not
 // leave capacity implicit.
-#underfilled = #rotom.layout<n = 8, dims = [[0:4:1]]> // expected-error {{slot dims must fill the ciphertext exactly (slot extent 4 vs n = 8); spell unused capacity as an explicit gap piece}}
+#underfilled = #rotom.layout<n = 8, dims = [[0:4:1]]> // expected-error {{slot dims must fill the ciphertext exactly (slot extent 4 vs n = 8); state unused capacity as an explicit gap piece}}
 func.func private @underfilled(tensor<16xi32> {foo.bar = #underfilled})
 
 // -----
@@ -61,3 +61,23 @@ func.func private @uneven_roll(tensor<16xi32> {foo.bar = #uneven_roll})
 // blocks would repeat rotations the accounting was not audited for.
 #big_gap_roll = #rotom.layout<n = 8, rolls = [(0, 1)], dims = [#t | #g]> // expected-error {{a rolled-by gap dim must not exceed the rolled dim's extent}}
 func.func private @big_gap_roll(tensor<32xi32> {foo.bar = #big_gap_roll})
+
+// -----
+
+// An `axis` argument rolls the whole split axis: legal when the axis has
+// more than one piece.
+#axis_roll = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+func.func private @axis_roll(tensor<16x16xi32> {foo.bar = #axis_roll})
+
+// -----
+
+// The piece form is canonical for an unsplit axis: the axis form is
+// rejected there.
+#axis_unsplit = #rotom.layout<n = 16, rolls = [(axis 0, 1)], dims = [[0:4:1], [1:4:1]]> // expected-error {{an axis roll argument requires a split axis; write an unsplit axis's argument as its piece position}}
+func.func private @axis_unsplit(tensor<16xi32> {foo.bar = #axis_unsplit})
+
+// -----
+
+// An axis may not be shifted by one of its own pieces.
+#axis_self = #rotom.layout<n = 16, rolls = [(axis 1, 0)], dims = [[1:4:4], [1:4:1] | [0:16:1]]> // expected-error {{a roll may not shift an index by an argument on the same axis}}
+func.func private @axis_self(tensor<16x16xi32> {foo.bar = #axis_self})

--- a/tests/Dialect/Rotom/IR/layout.mlir
+++ b/tests/Dialect/Rotom/IR/layout.mlir
@@ -61,3 +61,24 @@ func.func private @uneven_roll(tensor<16xi32> {foo.bar = #uneven_roll})
 // blocks would repeat rotations the accounting was not audited for.
 #big_gap_roll = #rotom.layout<n = 8, rolls = [(0, 1)], dims = [#t | #g]> // expected-error {{a rolled-by gap dim must not exceed the rolled dim's extent}}
 func.func private @big_gap_roll(tensor<32xi32> {foo.bar = #big_gap_roll})
+
+// -----
+
+// An `axis` argument rolls the whole split axis: legal when the axis has
+// more than one piece.
+#axis_roll = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+func.func private @axis_roll(tensor<16x16xi32> {foo.bar = #axis_roll})
+
+// -----
+
+// The piece spelling is canonical for an unsplit axis: the axis form is
+// rejected there.
+#axis_unsplit = #rotom.layout<n = 16, rolls = [(axis 0, 1)], dims = [[0:4:1], [1:4:1]]> // expected-error {{an axis roll argument requires a split axis; spell an unsplit axis's argument as its piece position}}
+func.func private @axis_unsplit(tensor<16xi32> {foo.bar = #axis_unsplit})
+
+// -----
+
+// An axis may not be shifted by one of its own pieces (the axis FROM
+// rewrites every digit, including the by piece's).
+#axis_self = #rotom.layout<n = 16, rolls = [(axis 1, 0)], dims = [[1:4:4], [1:4:1] | [0:16:1]]> // expected-error {{a roll may not shift an axis by one of its own pieces}}
+func.func private @axis_self(tensor<16x16xi32> {foo.bar = #axis_self})

--- a/tests/Dialect/Rotom/IR/syntax.mlir
+++ b/tests/Dialect/Rotom/IR/syntax.mlir
@@ -2,7 +2,7 @@
 
 #d0 = #rotom.dim<[0:4:1]>
 #d1 = #rotom.dim<[1:4:1]>
-// Unused slot capacity is spelled as an explicit gap piece (the builders
+// Unused slot capacity is written as an explicit gap piece (the builders
 // insert it; written layouts must show it).
 #plain = #rotom.layout<n = 8, dims = [[G:2:1], [0:4:1]]>
 #rolled = #rotom.layout<n = 16, rolls = [(0, 1)], dims = [#d0, #d1]>
@@ -10,27 +10,41 @@
 // accepted on input and round-trip to the letter forms.
 #repl_gap = #rotom.layout<n = 16, dims = [[R:2:1], [-2:2:1], [0:4:1]]>
 // The `|` separates ciphertext dims from slot dims (omitted when every dim
-// is a slot dim): here each of the 8 elements sits in its own ciphertext,
-// and the slot side is all gap.
+// is a slot dim): both k pieces index ciphertexts here, i addresses slots.
+// A roll argument is a dims-list position (bare integer, one piece) or a
+// whole tensor axis (`axis N`, legal only when the axis is split): the axis
+// FROM rewrites the whole split-k index and each piece takes its digit.
+#axis = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+// Each roll is a parenthesized `(from, by)` pair; several apply left to
+// right.
+#mixed = #rotom.layout<n = 16, rolls = [(0, 1), (2, 3)], dims = [[0:2:1], [1:2:1], [2:2:1], [3:2:1]]>
+// An oversized dim spans ciphertexts entirely (ct = i0): here each of the 8
+// elements sits in its own ciphertext, and the slot side is all gap.
 #split = #rotom.layout<n = 4, dims = [[0:8:1] | [G:4:1]]>
 
 // CHECK: #dim = #rotom.dim<[2:8:4]>
-// CHECK: #layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
-// CHECK: #layout1 = #rotom.layout<n = 16, dims = {{\[\[R:2:1\], \[G:2:1\], \[0:4:1\]\]}}>
-// CHECK: #layout2 = #rotom.layout<n = 16, rolls = [(0, 1)], dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
-// CHECK: #layout3 = #rotom.layout<n = 4, dims = {{\[\[0:8:1\] \| \[G:4:1\]\]}}>
+// CHECK: #layout = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = {{\[\[1:4:4\], \[1:4:1\] \| \[0:16:1\]\]}}>
+// CHECK: #layout1 = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
+// CHECK: #layout2 = #rotom.layout<n = 16, dims = {{\[\[R:2:1\], \[G:2:1\], \[0:4:1\]\]}}>
+// CHECK: #layout3 = #rotom.layout<n = 16, rolls = [(0, 1)], dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+// CHECK: #layout4 = #rotom.layout<n = 4, dims = {{\[\[0:8:1\] \| \[G:4:1\]\]}}>
+// CHECK: #layout5 = #rotom.layout<n = 16, rolls = [(0, 1), (2, 3)], dims = {{\[\[0:2:1\], \[1:2:1\], \[2:2:1\], \[3:2:1\]\]}}>
 // CHECK: module attributes
+// CHECK-SAME: rotom.axis_layout = #layout
 // CHECK-SAME: rotom.dim_attr = #dim
-// CHECK-SAME: rotom.plain_layout = #layout
-// CHECK-SAME: rotom.repl_gap_layout = #layout1
-// CHECK-SAME: rotom.rolled_layout = #layout2
-// CHECK-SAME: rotom.split_layout = #layout3
+// CHECK-SAME: rotom.plain_layout = #layout1
+// CHECK-SAME: rotom.repl_gap_layout = #layout2
+// CHECK-SAME: rotom.rolled_layout = #layout3
+// CHECK-SAME: rotom.split_layout = #layout4
+// CHECK-SAME: rotom.zmixed_layout = #layout5
 module attributes {
   rotom.dim_attr = #rotom.dim<[2:8:4]>,
   rotom.plain_layout = #plain,
   rotom.repl_gap_layout = #repl_gap,
   rotom.rolled_layout = #rolled,
-  rotom.split_layout = #split
+  rotom.axis_layout = #axis,
+  rotom.split_layout = #split,
+  rotom.zmixed_layout = #mixed
 } {
   func.func @f(%arg0: tensor<4x4xf32>) {
     return

--- a/tests/Dialect/Rotom/IR/syntax.mlir
+++ b/tests/Dialect/Rotom/IR/syntax.mlir
@@ -10,27 +10,41 @@
 // accepted on input and round-trip to the letter forms.
 #repl_gap = #rotom.layout<n = 16, dims = [[R:2:1], [-2:2:1], [0:4:1]]>
 // The `|` separates ciphertext dims from slot dims (omitted when every dim
-// is a slot dim): here each of the 8 elements sits in its own ciphertext,
-// and the slot side is all gap.
+// is a slot dim): both k digits index ciphertexts here, i addresses slots.
+// A roll argument is a dims-list position (bare integer, one piece) or a
+// whole tensor axis (`axis N`, legal only when the axis is split): the axis
+// FROM rewrites the whole split-k index and each piece takes its digit.
+#axis = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+// Each roll is a parenthesized `(from, by)` pair; several apply left to
+// right.
+#mixed = #rotom.layout<n = 16, rolls = [(0, 1), (2, 3)], dims = [[0:2:1], [1:2:1], [2:2:1], [3:2:1]]>
+// An oversized dim spans ciphertexts entirely (ct = i0): here each of the 8
+// elements sits in its own ciphertext, and the slot side is all gap.
 #split = #rotom.layout<n = 4, dims = [[0:8:1] | [G:4:1]]>
 
 // CHECK: #dim = #rotom.dim<[2:8:4]>
-// CHECK: #layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
-// CHECK: #layout1 = #rotom.layout<n = 16, dims = {{\[\[R:2:1\], \[G:2:1\], \[0:4:1\]\]}}>
-// CHECK: #layout2 = #rotom.layout<n = 16, rolls = [(0, 1)], dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
-// CHECK: #layout3 = #rotom.layout<n = 4, dims = {{\[\[0:8:1\] \| \[G:4:1\]\]}}>
+// CHECK: #layout = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = {{\[\[1:4:4\], \[1:4:1\] \| \[0:16:1\]\]}}>
+// CHECK: #layout1 = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
+// CHECK: #layout2 = #rotom.layout<n = 16, dims = {{\[\[R:2:1\], \[G:2:1\], \[0:4:1\]\]}}>
+// CHECK: #layout3 = #rotom.layout<n = 16, rolls = [(0, 1)], dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+// CHECK: #layout4 = #rotom.layout<n = 4, dims = {{\[\[0:8:1\] \| \[G:4:1\]\]}}>
+// CHECK: #layout5 = #rotom.layout<n = 16, rolls = [(0, 1), (2, 3)], dims = {{\[\[0:2:1\], \[1:2:1\], \[2:2:1\], \[3:2:1\]\]}}>
 // CHECK: module attributes
+// CHECK-SAME: rotom.axis_layout = #layout
 // CHECK-SAME: rotom.dim_attr = #dim
-// CHECK-SAME: rotom.plain_layout = #layout
-// CHECK-SAME: rotom.repl_gap_layout = #layout1
-// CHECK-SAME: rotom.rolled_layout = #layout2
-// CHECK-SAME: rotom.split_layout = #layout3
+// CHECK-SAME: rotom.plain_layout = #layout1
+// CHECK-SAME: rotom.repl_gap_layout = #layout2
+// CHECK-SAME: rotom.rolled_layout = #layout3
+// CHECK-SAME: rotom.split_layout = #layout4
+// CHECK-SAME: rotom.zmixed_layout = #layout5
 module attributes {
   rotom.dim_attr = #rotom.dim<[2:8:4]>,
   rotom.plain_layout = #plain,
   rotom.repl_gap_layout = #repl_gap,
   rotom.rolled_layout = #rolled,
-  rotom.split_layout = #split
+  rotom.axis_layout = #axis,
+  rotom.split_layout = #split,
+  rotom.zmixed_layout = #mixed
 } {
   func.func @f(%arg0: tensor<4x4xf32>) {
     return


### PR DESCRIPTION
Part 3 of https://github.com/google/heir/pull/2980 and stacked on https://github.com/google/heir/pull/3170

A Rotom roll decorates a layout: `roll(from, by)` rewrites the `from` index by subtracting the `by` argument's index. Until now a roll argument could only be a **piece**, a position in the `dims` list. This PR lets it also be a whole tensor **axis**, spelled `axis N` and stored as `-(axis+1)` in the flat rolls array.

```mlir
// Piece arguments: Halevi-Shoup diagonal of a 4x4 matrix, slot j of
// ciphertext i holds A[i, (j - i) mod 4].
#diag  = #rotom.layout<n = 4, rolls = [(1, 0)], dims = [[0:4:1] | [1:4:1]]>

// Axis 1 is split across two pieces, so the whole-axis roll names it.
// How to read this: `axis 1` refers to `[1:4:4], [1:4:1]` and `2` refers to piece 2 or `[0:16:1]`
#split = #rotom.layout<n = 16, rolls = [(axis 1, 2)],
                       dims = [[1:4:4], [1:4:1] | [0:16:1]]>
```
- Piece FROM rewrites only that piece's mixed-radix digit, leaving the axis's other digits untouched. This is the original per-piece reading, now materialized correctly on split axes (no borrow leaks across digits).
- Axis FROM rewrites the whole axis index modulo its full extent; each piece then takes its digit of the rolled index, so the shift borrows across digits.