### PR TITLE
Add Poulpy exit dialect types and ops

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -217,5 +217,13 @@ crate.spec(
     package = "tfhe",
     version = "1.5.0",
 )
+crate.spec(
+    package = "poulpy-ckks",
+    version = "0.7.0",
+)
+crate.spec(
+    package = "poulpy-cpu-ref",
+    version = "0.7.0",
+)
 crate.from_specs()
 use_repo(crate, "crates")

--- a/lib/Dialect/Poulpy/IR/BUILD
+++ b/lib/Dialect/Poulpy/IR/BUILD
@@ -1,0 +1,136 @@
+# Poulpy dialect implementation.
+
+load("@heir//lib/Dialect:dialect.bzl", "add_heir_dialect_library")
+load("@llvm-project//mlir:tblgen.bzl", "td_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Dialect",
+    srcs = [
+        "PoulpyDialect.cpp",
+    ],
+    hdrs = [
+        "PoulpyDialect.h",
+        "PoulpyOps.h",
+        "PoulpyTypes.h",
+    ],
+    deps = [
+        ":Enums",
+        ":PoulpyOps",
+        ":PoulpyTypes",
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        ":types_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "Enums",
+    srcs = ["PoulpyEnums.cpp"],
+    hdrs = ["PoulpyEnums.h"],
+    deps = [
+        ":enums_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "PoulpyTypes",
+    srcs = [
+        "PoulpyTypes.cpp",
+    ],
+    hdrs = [
+        "PoulpyDialect.h",
+        "PoulpyTypes.h",
+    ],
+    deps = [
+        ":Enums",
+        ":dialect_inc_gen",
+        ":types_inc_gen",
+        "@heir//lib/Dialect:HEIRInterfaces",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+cc_library(
+    name = "PoulpyOps",
+    srcs = [
+        "PoulpyOps.cpp",
+    ],
+    hdrs = [
+        "PoulpyDialect.h",
+        "PoulpyOps.h",
+        "PoulpyTypes.h",
+    ],
+    deps = [
+        ":PoulpyTypes",
+        ":dialect_inc_gen",
+        ":ops_inc_gen",
+        ":types_inc_gen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+td_library(
+    name = "td_files",
+    srcs = [
+        "PoulpyDialect.td",
+        "PoulpyEnums.td",
+        "PoulpyOps.td",
+        "PoulpyTypes.td",
+    ],
+    # include from the heir-root to enable fully-qualified include-paths
+    includes = ["../../../.."],
+    deps = [
+        "@heir//lib/Dialect:td_files",
+        "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "dialect_inc_gen",
+    dialect = "Poulpy",
+    kind = "dialect",
+    td_file = "PoulpyDialect.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "enums_inc_gen",
+    dialect = "Poulpy",
+    kind = "enum",
+    td_file = "PoulpyEnums.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "types_inc_gen",
+    dialect = "Poulpy",
+    kind = "type",
+    td_file = "PoulpyTypes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "Poulpy",
+    kind = "op",
+    td_file = "PoulpyOps.td",
+    deps = [
+        ":td_files",
+    ],
+)

--- a/lib/Dialect/Poulpy/IR/PoulpyDialect.cpp
+++ b/lib/Dialect/Poulpy/IR/PoulpyDialect.cpp
@@ -1,0 +1,35 @@
+#include "lib/Dialect/Poulpy/IR/PoulpyDialect.h"
+
+#include "lib/Dialect/Poulpy/IR/PoulpyOps.h"
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
+
+// Generated definitions
+#include "lib/Dialect/Poulpy/IR/PoulpyDialect.cpp.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/Poulpy/IR/PoulpyOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace poulpy {
+
+void PoulpyDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.cpp.inc"
+      >();
+
+  addOperations<
+#define GET_OP_LIST
+#include "lib/Dialect/Poulpy/IR/PoulpyOps.cpp.inc"
+      >();
+}
+
+}  // namespace poulpy
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Poulpy/IR/PoulpyDialect.h
+++ b/lib/Dialect/Poulpy/IR/PoulpyDialect.h
@@ -1,0 +1,10 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYDIALECT_H_
+#define LIB_DIALECT_POULPY_IR_POULPYDIALECT_H_
+
+#include "mlir/include/mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Dialect.h"   // from @llvm-project
+
+// Generated headers (block clang-format from messing up order)
+#include "lib/Dialect/Poulpy/IR/PoulpyDialect.h.inc"
+
+#endif  // LIB_DIALECT_POULPY_IR_POULPYDIALECT_H_

--- a/lib/Dialect/Poulpy/IR/PoulpyDialect.td
+++ b/lib/Dialect/Poulpy/IR/PoulpyDialect.td
@@ -1,0 +1,21 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYDIALECT_TD_
+#define LIB_DIALECT_POULPY_IR_POULPYDIALECT_TD_
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/OpBase.td"
+
+def Poulpy_Dialect : Dialect {
+  let name = "poulpy";
+  let description = [{
+  The `poulpy` dialect is an exit dialect for generating Rust code against the Poulpy library API.
+
+  See https://github.com/poulpy-fhe/poulpy
+  }];
+
+  let cppNamespace = "::mlir::heir::poulpy";
+
+  let useDefaultTypePrinterParser = 1;
+  // let useDefaultAttributePrinterParser = 1;
+}
+
+#endif  // LIB_DIALECT_POULPY_IR_POULPYDIALECT_TD_

--- a/lib/Dialect/Poulpy/IR/PoulpyEnums.cpp
+++ b/lib/Dialect/Poulpy/IR/PoulpyEnums.cpp
@@ -1,0 +1,7 @@
+#include "lib/Dialect/Poulpy/IR/PoulpyEnums.h"
+
+// IWYU_pragma: begin_keep
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+// IWYU_pragma: end_keep
+
+#include "lib/Dialect/Poulpy/IR/PoulpyEnums.cpp.inc"

--- a/lib/Dialect/Poulpy/IR/PoulpyEnums.h
+++ b/lib/Dialect/Poulpy/IR/PoulpyEnums.h
@@ -1,0 +1,11 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYENUMS_H_
+#define LIB_DIALECT_POULPY_IR_POULPYENUMS_H_
+
+// IWYU pragma: begin_keep
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+// Guard against clang-format
+#include "lib/Dialect/Poulpy/IR/PoulpyEnums.h.inc"
+
+#endif  // LIB_DIALECT_POULPY_IR_POULPYENUMS_H_

--- a/lib/Dialect/Poulpy/IR/PoulpyEnums.td
+++ b/lib/Dialect/Poulpy/IR/PoulpyEnums.td
@@ -1,0 +1,14 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYENUMS_TD_
+#define LIB_DIALECT_POULPY_IR_POULPYENUMS_TD_
+
+include "mlir/IR/EnumAttr.td"
+include "lib/Dialect/Poulpy/IR/PoulpyDialect.td"
+
+def Poulpy_BackendEnum : I32EnumAttr<"PoulpyBackend", "An enum attribute representing a module's backend-specific handle", [
+  I32EnumAttrCase<"FFT64Ref", 0, "fft64_ref">, // f64 FFT backend
+  I32EnumAttrCase<"NTT4x30Ref", 1, "ntt4x30_ref"> // Q120 NTT backend (CRT over four ~30-bit primes)
+]> {
+    let cppNamespace = "::mlir::heir::poulpy";
+}
+
+#endif // LIB_DIALECT_POULPY_IR_POULPYENUMS_TD_

--- a/lib/Dialect/Poulpy/IR/PoulpyOps.cpp
+++ b/lib/Dialect/Poulpy/IR/PoulpyOps.cpp
@@ -1,0 +1,9 @@
+#include "lib/Dialect/Poulpy/IR/PoulpyOps.h"
+
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.h"
+
+namespace mlir {
+namespace heir {
+namespace poulpy {}  // namespace poulpy
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Poulpy/IR/PoulpyOps.h
+++ b/lib/Dialect/Poulpy/IR/PoulpyOps.h
@@ -1,0 +1,11 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYOPS_H_
+#define LIB_DIALECT_POULPY_IR_POULPYOPS_H_
+
+#include "lib/Dialect/Poulpy/IR/PoulpyDialect.h"
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/Poulpy/IR/PoulpyOps.h.inc"
+
+#endif  // LIB_DIALECT_POULPY_IR_POULPYOPS_H_

--- a/lib/Dialect/Poulpy/IR/PoulpyOps.td
+++ b/lib/Dialect/Poulpy/IR/PoulpyOps.td
@@ -1,0 +1,307 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYOPS_TD_
+#define LIB_DIALECT_POULPY_IR_POULPYOPS_TD_
+
+include "PoulpyDialect.td"
+include "PoulpyTypes.td"
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class Poulpy_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Poulpy_Dialect, mnemonic, traits> {
+  let assemblyFormat = [{
+    operands attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+def Poulpy_CiphertextMemRef : MemRefOf<[Poulpy_CiphertextType]>;
+def Poulpy_UnnormalizedCiphertextMemRef : MemRefOf<[Poulpy_UnnormalizedCiphertextType]>;
+def Poulpy_PlaintextMemRef : MemRefOf<[Poulpy_PlaintextType]>;
+
+// maps to ModuleNew::<BE>::new(n)
+def Poulpy_ModuleCreateOp : Poulpy_Op<"module_create", [Pure]> {
+  let summary = "Create a new poulpy module";
+  let description = [{
+    See https://docs.rs/poulpy-hal/latest/poulpy_hal/layouts/struct.Module.html
+  }];
+  let arguments = (ins I64Attr:$N);
+  let results = (outs Poulpy_ModuleType:$module);
+}
+
+// maps to ScratchOwned::<BE>::alloc(size)
+def Poulpy_ScratchAllocOp : Poulpy_Op<"scratch_alloc", [Pure]> {
+  let summary = "Allocate a scratch arena of the given byte size";
+  let description = [{
+    See https://docs.rs/poulpy-hal/latest/poulpy_hal/layouts/struct.ScratchOwned.html
+  }];
+  let arguments = (ins I64Attr:$size);
+  let results = (outs Poulpy_ScratchType:$scratch);
+}
+
+// maps to host_module.ckks_pt_vec_alloc + pt.set_meta + encoder.encode_reim
+def Poulpy_EncodeOp : Poulpy_Op<"encode"> {
+  let summary = "Encode real and imaginary slot vectors into a plaintext";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/encoding/reim/struct.Encoder.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_PlaintextMemRef:$plaintext,
+    AnyMemRef:$real,
+    AnyMemRef:$imag,
+    I64Attr:$logDelta,
+    I64Attr:$logBudget
+  );
+}
+
+// maps to encoder.decode_reim
+def Poulpy_DecodeOp : Poulpy_Op<"decode"> {
+  let summary = "Decode a plaintext into real and imaginary slot vectors";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/encoding/reim/struct.Encoder.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    AnyMemRef:$real,
+    AnyMemRef:$imag,
+    Poulpy_PlaintextMemRef:$plaintext
+  );
+}
+
+// maps to ckks_encrypt_sk
+def Poulpy_EncryptOp : Poulpy_Op<"encrypt"> {
+  let summary = "Secret-key encryption of a CKKS plaintext";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSEncrypt.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$ciphertext,
+    Poulpy_PlaintextMemRef:$plaintext,
+    Poulpy_SecretKeyType:$secret_key,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_decrypt
+def Poulpy_DecryptOp : Poulpy_Op<"decrypt"> {
+  let summary = "Secret-key decryption of a CKKS ciphertext";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSDecrypt.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_PlaintextMemRef:$plaintext,
+    Poulpy_CiphertextMemRef:$ciphertext,
+    Poulpy_SecretKeyType:$secret_key,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_add_into
+def Poulpy_AddOp : Poulpy_Op<"add"> {
+  let summary = "Computes `dst = a + b`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSAddOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_CiphertextMemRef:$b,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_add_assign
+def Poulpy_AddAssignOp : Poulpy_Op<"add_assign"> {
+  let summary = "Computes `dst += a`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSAddOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_add_into_unnormalized
+def Poulpy_AddUnnormalizedOp : Poulpy_Op<"add_unnormalized"> {
+  let summary = "Computes `dst = a + b` without normalizing `dst`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSAddOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_UnnormalizedCiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_CiphertextMemRef:$b,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_sub_into
+def Poulpy_SubOp : Poulpy_Op<"sub"> {
+  let summary = "Computes `dst = a - b`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSSubOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_CiphertextMemRef:$b,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_sub_assign
+def Poulpy_SubAssignOp : Poulpy_Op<"sub_assign"> {
+  let summary = "Computes `dst -= a`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSSubOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_sub_into_unnormalized
+def Poulpy_SubUnnormalizedOp : Poulpy_Op<"sub_unnormalized"> {
+  let summary = "Computes `dst = a - b` without normalizing `dst`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSSubOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_UnnormalizedCiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_CiphertextMemRef:$b,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_mul_into
+def Poulpy_MulOp : Poulpy_Op<"mul"> {
+  let summary = "Computes `dst = a * b` using tensor-product keyswitching via `tsk`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSMulOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_CiphertextMemRef:$b,
+    Poulpy_TensorKeyType:$tsk,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_mul_assign
+def Poulpy_MulAssignOp : Poulpy_Op<"mul_assign"> {
+  let summary = "Computes `dst *= a` in-place using tensor-product keyswitching via `tsk`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSMulOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$a,
+    Poulpy_TensorKeyType:$tsk,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_rotate_into
+def Poulpy_RotateOp : Poulpy_Op<"rotate"> {
+  let summary = "Computes `dst = rotate(src, k)`: shifts all complex slots by `k` positions.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSRotateOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$src,
+    I64Attr:$k,
+    Poulpy_AutomorphismKeyMapType:$keys,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_rotate_assign
+def Poulpy_RotateAssignOp : Poulpy_Op<"rotate_assign"> {
+  let summary = "Computes `dst = rotate(dst, k)` in-place. Metadata is unchanged.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSRotateOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    I64Attr:$k,
+    Poulpy_AutomorphismKeyMapType:$keys,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_div_pow2_into
+def Poulpy_RescaleOp : Poulpy_Op<"rescale"> {
+  let summary = "Computes `dst = src / 2^bits`.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSPow2Ops.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$src,
+    I64Attr:$bits,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_div_pow2_assign
+def Poulpy_RescaleAssignOp : Poulpy_Op<"rescale_assign"> {
+  let summary = "Computes `dst /= 2^bits` in-place.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSPow2Ops.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    I64Attr:$bits,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to glwe_normalize
+def Poulpy_NormalizeOp : Poulpy_Op<"normalize"> {
+  let summary = "Propagate carries in an unnormalized ciphertext, producing a normalized result.";
+  let description = [{
+    See https://docs.rs/poulpy-core/latest/poulpy_core/api/trait.GLWENormalize.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$res,
+    Poulpy_UnnormalizedCiphertextMemRef:$a,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+// maps to ckks_copy
+def Poulpy_CompactLimbsOp : Poulpy_Op<"compact_limbs"> {
+  let summary = "Level-aware ciphertext copy that compacts src into a smaller dst.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/api/trait.CKKSCopyOps.html
+  }];
+  let arguments = (ins
+    Poulpy_ModuleType:$module,
+    Poulpy_CiphertextMemRef:$dst,
+    Poulpy_CiphertextMemRef:$src,
+    Poulpy_ScratchType:$scratch
+  );
+}
+
+#endif // LIB_DIALECT_POULPY_IR_POULPYOPS_TD_

--- a/lib/Dialect/Poulpy/IR/PoulpyTypes.cpp
+++ b/lib/Dialect/Poulpy/IR/PoulpyTypes.cpp
@@ -1,0 +1,7 @@
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.h"
+
+namespace mlir {
+namespace heir {
+namespace poulpy {}  // namespace poulpy
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Poulpy/IR/PoulpyTypes.h
+++ b/lib/Dialect/Poulpy/IR/PoulpyTypes.h
@@ -1,0 +1,11 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYTYPES_H_
+#define LIB_DIALECT_POULPY_IR_POULPYTYPES_H_
+
+#include "lib/Dialect/HEIRInterfaces.h"
+#include "lib/Dialect/Poulpy/IR/PoulpyDialect.h"
+#include "lib/Dialect/Poulpy/IR/PoulpyEnums.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "lib/Dialect/Poulpy/IR/PoulpyTypes.h.inc"
+
+#endif  // LIB_DIALECT_POULPY_IR_POULPYTYPES_H_

--- a/lib/Dialect/Poulpy/IR/PoulpyTypes.td
+++ b/lib/Dialect/Poulpy/IR/PoulpyTypes.td
@@ -1,0 +1,107 @@
+#ifndef LIB_DIALECT_POULPY_IR_POULPYTYPES_TD_
+#define LIB_DIALECT_POULPY_IR_POULPYTYPES_TD_
+
+include "PoulpyDialect.td"
+include "PoulpyEnums.td"
+
+include "mlir/IR/DialectBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/EnumAttr.td"
+include "lib/Dialect/HEIRInterfaces.td"
+
+class Poulpy_Type<string name, string typeMnemonic, list<Trait> traits = []>
+  : TypeDef<Poulpy_Dialect, name, traits> {
+      let mnemonic = typeMnemonic;
+  }
+
+// maps to Module<BE>
+def Poulpy_ModuleType : Poulpy_Type<"Module", "module"> {
+  let summary = "An evaluator context for the poulpy backend";
+  let description = [{
+    See https://docs.rs/poulpy-hal/latest/poulpy_hal/layouts/struct.Module.html
+  }];
+  let parameters = (ins
+    DefaultValuedParameter<"::mlir::heir::poulpy::PoulpyBackend",
+    "::mlir::heir::poulpy::PoulpyBackend::FFT64Ref">:$backend
+  );
+  let assemblyFormat = "`<` $backend `>`";
+}
+
+// maps to CKKSCiphertext<D, Normalized>
+def Poulpy_CiphertextType : Poulpy_Type<"Ciphertext", "ciphertext",
+  [MemRefElementTypeInterface, SecretTypeInterface]> {
+  let summary = "CKKS ciphertext storage plus semantic precision metadata.";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/layouts/ciphertext/struct.CKKSCiphertext.html
+  }];
+}
+
+// maps to CKKSCiphertext<D, Unnormalized>
+// pub type UnnormalizedCKKSCiphertext<D> = CKKSCiphertext<D, Unnormalized>;
+def Poulpy_UnnormalizedCiphertextType : Poulpy_Type<"UnnormalizedCiphertext", "unnormalized_ciphertext",
+  [MemRefElementTypeInterface, SecretTypeInterface]> {
+  let summary = "A CKKS ciphertext produced by an unnormalized linear operation";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/layouts/ciphertext/type.UnnormalizedCKKSCiphertext.html
+  }];
+}
+
+// maps to CKKSPlaintext<D>
+def Poulpy_PlaintextType : Poulpy_Type<"Plaintext", "plaintext",
+  [MemRefElementTypeInterface, PlaintextTypeInterface]> {
+  let summary = "A plaintext in the ZNX (torus) domain in the poulpy backend";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/layouts/plaintext/struct.CKKSPlaintext.html
+  }];
+}
+
+// maps to ScratchOwned<BE>
+def Poulpy_ScratchType : Poulpy_Type<"Scratch", "scratch", [MemRefElementTypeInterface]> {
+  let summary = "Owned scratch buffer for temporary workspace during polynomial operations.";
+  let description = [{
+    See https://docs.rs/poulpy-hal/latest/poulpy_hal/layouts/struct.ScratchOwned.html
+  }];
+}
+
+// maps to GLWESecretPrepared<BE::OwnedBuf, BE>
+def Poulpy_SecretKeyType : Poulpy_Type<"SecretKey", "secret_key", [MemRefElementTypeInterface]> {
+  let summary = "A DFT-domain prepared GLWE secret key";
+  let description = [{
+    See https://docs.rs/poulpy-core/latest/poulpy_core/layouts/prepared/struct.GLWESecretPrepared.html
+  }];
+}
+
+// maps to GLWETensorKeyPrepared<BE::OwnedBuf, BE>
+def Poulpy_TensorKeyType : Poulpy_Type<"TensorKey", "tensor_key", [MemRefElementTypeInterface]> {
+  let summary = "DFT-domain (prepared) variant of a GLWE tensor key.";
+  let description = [{
+    See https://docs.rs/poulpy-core/latest/poulpy_core/layouts/prepared/struct.GLWETensorKeyPrepared.html
+  }];
+}
+
+// maps to HashMap<i64, GLWEAutomorphismKeyPrepared<D, BE>> (implements GLWEAutomorphismKeyHelper)
+def Poulpy_AutomorphismKeyMapType : Poulpy_Type<"AutomorphismKeyMap", "automorphism_key_map", [MemRefElementTypeInterface]> {
+  let summary = "Map of prepared automorphism keys keyed by Galois element";
+  let description = [{
+    See https://docs.rs/poulpy-core/latest/poulpy_core/layouts/struct.GLWEAutomorphismKey.html
+  }];
+}
+
+// maps to BootstrappingContext<BE, F>
+def Poulpy_BootstrappingContextType : Poulpy_Type<"BootstrappingContext", "bootstrapping_context", [MemRefElementTypeInterface]> {
+  let summary = "Compiled bootstrapping context with resident DFT matrices";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/layouts/bootstrapping/struct.BootstrappingContext.html
+  }];
+}
+
+// maps to BootstrappingKeysPrepared<BE::OwnedBuf, BE>
+def Poulpy_BootstrappingKeysType : Poulpy_Type<"BootstrappingKeys", "bootstrapping_keys", [MemRefElementTypeInterface]> {
+  let summary = "Prepared bundle of bootstrapping evaluation keys";
+  let description = [{
+    See https://docs.rs/poulpy-ckks/latest/poulpy_ckks/layouts/bootstrapping_keys/struct.BootstrappingKeysPrepared.html
+  }];
+}
+
+#endif // LIB_DIALECT_POULPY_IR_POULPYTYPES_TD_

--- a/tests/Dialect/Poulpy/IR/BUILD
+++ b/tests/Dialect/Poulpy/IR/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Poulpy/IR/ops.mlir
+++ b/tests/Dialect/Poulpy/IR/ops.mlir
@@ -1,0 +1,172 @@
+// RUN: heir-opt %s | FileCheck %s
+
+// This simply tests for syntax.
+
+!module    = !poulpy.module<fft64_ref>
+!ct        = !poulpy.ciphertext
+!unnorm_ct = !poulpy.unnormalized_ciphertext
+!pt        = !poulpy.plaintext
+!scratch   = !poulpy.scratch
+!sk        = !poulpy.secret_key
+!tk        = !poulpy.tensor_key
+!akm       = !poulpy.automorphism_key_map
+!bsk       = !poulpy.bootstrapping_keys
+!bctx      = !poulpy.bootstrapping_context
+
+module {
+  // CHECK: func @test_module_create
+  func.func @test_module_create() {
+    // CHECK: poulpy.module_create
+    %mod = poulpy.module_create {N = 64 : i64} : () -> !module
+    return
+  }
+
+  // CHECK: func @test_scratch_alloc
+  func.func @test_scratch_alloc() {
+    // CHECK: poulpy.scratch_alloc
+    %scratch = poulpy.scratch_alloc {size = 1024 : i64} : () -> !scratch
+    return
+  }
+
+  // CHECK: func @test_types
+  // Exercises MemRefElementTypeInterface on ciphertext, unnormalized_ciphertext, and plaintext.
+  func.func @test_types(
+    %ct_buf: memref<!ct>,
+    %unnorm_buf: memref<!unnorm_ct>,
+    %pt_buf: memref<!pt>,
+    %scratch: !scratch,
+    %sk: !sk,
+    %tk: !tk,
+    %akm: !akm,
+    %bsk: !bsk,
+    %bctx: !bctx
+  ) {
+    return
+  }
+
+  // CHECK: func @test_encode
+  func.func @test_encode(%mod: !module, %pt: memref<!pt>, %re: memref<f64>, %im: memref<f64>) {
+    // CHECK: poulpy.encode
+    poulpy.encode %mod, %pt, %re, %im {logDelta = 40 : i64, logBudget = 20 : i64} : (!module, memref<!pt>, memref<f64>, memref<f64>) -> ()
+    return
+  }
+
+  // CHECK: func @test_decode
+  func.func @test_decode(%mod: !module, %re: memref<f64>, %im: memref<f64>, %pt: memref<!pt>) {
+    // CHECK: poulpy.decode
+    poulpy.decode %mod, %re, %im, %pt : (!module, memref<f64>, memref<f64>, memref<!pt>) -> ()
+    return
+  }
+
+  // CHECK: func @test_encrypt
+  func.func @test_encrypt(%mod: !module, %ct: memref<!ct>, %pt: memref<!pt>, %sk: !sk, %scratch: !scratch) {
+    // CHECK: poulpy.encrypt
+    poulpy.encrypt %mod, %ct, %pt, %sk, %scratch : (!module, memref<!ct>, memref<!pt>, !sk, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_decrypt
+  func.func @test_decrypt(%mod: !module, %pt: memref<!pt>, %ct: memref<!ct>, %sk: !sk, %scratch: !scratch) {
+    // CHECK: poulpy.decrypt
+    poulpy.decrypt %mod, %pt, %ct, %sk, %scratch : (!module, memref<!pt>, memref<!ct>, !sk, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_add
+  func.func @test_add(%mod: !module, %dst: memref<!ct>, %a: memref<!ct>, %b: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.add
+    poulpy.add %mod, %dst, %a, %b, %scratch : (!module, memref<!ct>, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_add_assign
+  func.func @test_add_assign(%mod: !module, %dst: memref<!ct>, %a: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.add_assign
+    poulpy.add_assign %mod, %dst, %a, %scratch : (!module, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_add_unnormalized
+  func.func @test_add_unnormalized(%mod: !module, %dst: memref<!unnorm_ct>, %a: memref<!ct>, %b: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.add_unnormalized
+    poulpy.add_unnormalized %mod, %dst, %a, %b, %scratch : (!module, memref<!unnorm_ct>, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_sub
+  func.func @test_sub(%mod: !module, %dst: memref<!ct>, %a: memref<!ct>, %b: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.sub
+    poulpy.sub %mod, %dst, %a, %b, %scratch : (!module, memref<!ct>, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_sub_assign
+  func.func @test_sub_assign(%mod: !module, %dst: memref<!ct>, %a: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.sub_assign
+    poulpy.sub_assign %mod, %dst, %a, %scratch : (!module, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_sub_unnormalized
+  func.func @test_sub_unnormalized(%mod: !module, %dst: memref<!unnorm_ct>, %a: memref<!ct>, %b: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.sub_unnormalized
+    poulpy.sub_unnormalized %mod, %dst, %a, %b, %scratch : (!module, memref<!unnorm_ct>, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_mul
+  func.func @test_mul(%mod: !module, %dst: memref<!ct>, %a: memref<!ct>, %b: memref<!ct>, %tk: !tk, %scratch: !scratch) {
+    // CHECK: poulpy.mul
+    poulpy.mul %mod, %dst, %a, %b, %tk, %scratch : (!module, memref<!ct>, memref<!ct>, memref<!ct>, !tk, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_mul_assign
+  func.func @test_mul_assign(%mod: !module, %dst: memref<!ct>, %a: memref<!ct>, %tk: !tk, %scratch: !scratch) {
+    // CHECK: poulpy.mul_assign
+    poulpy.mul_assign %mod, %dst, %a, %tk, %scratch : (!module, memref<!ct>, memref<!ct>, !tk, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_rotate
+  func.func @test_rotate(%mod: !module, %dst: memref<!ct>, %src: memref<!ct>, %akm: !akm, %scratch: !scratch) {
+    // CHECK: poulpy.rotate
+    poulpy.rotate %mod, %dst, %src, %akm, %scratch {k = 1 : i64} : (!module, memref<!ct>, memref<!ct>, !akm, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_rotate_assign
+  func.func @test_rotate_assign(%mod: !module, %dst: memref<!ct>, %akm: !akm, %scratch: !scratch) {
+    // CHECK: poulpy.rotate_assign
+    poulpy.rotate_assign %mod, %dst, %akm, %scratch {k = 1 : i64} : (!module, memref<!ct>, !akm, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_rescale
+  func.func @test_rescale(%mod: !module, %dst: memref<!ct>, %src: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.rescale
+    poulpy.rescale %mod, %dst, %src, %scratch {bits = 40 : i64} : (!module, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_rescale_assign
+  func.func @test_rescale_assign(%mod: !module, %dst: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.rescale_assign
+    poulpy.rescale_assign %mod, %dst, %scratch {bits = 40 : i64} : (!module, memref<!ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_normalize
+  func.func @test_normalize(%mod: !module, %dst: memref<!ct>, %src: memref<!unnorm_ct>, %scratch: !scratch) {
+    // CHECK: poulpy.normalize
+    poulpy.normalize %mod, %dst, %src, %scratch : (!module, memref<!ct>, memref<!unnorm_ct>, !scratch) -> ()
+    return
+  }
+
+  // CHECK: func @test_compact_limbs
+  func.func @test_compact_limbs(%mod: !module, %dst: memref<!ct>, %src: memref<!ct>, %scratch: !scratch) {
+    // CHECK: poulpy.compact_limbs
+    poulpy.compact_limbs %mod, %dst, %src, %scratch : (!module, memref<!ct>, memref<!ct>, !scratch) -> ()
+    return
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -93,6 +93,7 @@ cc_binary(
         "@heir//lib/Dialect/Polynomial/Conversions/PolynomialToModArith",
         "@heir//lib/Dialect/Polynomial/IR:Dialect",
         "@heir//lib/Dialect/Polynomial/Transforms",
+        "@heir//lib/Dialect/Poulpy/IR:Dialect",
         "@heir//lib/Dialect/Preprocessing/Conversions/PreprocessingToLattigo",
         "@heir//lib/Dialect/Preprocessing/Conversions/PreprocessingToMemref",
         "@heir//lib/Dialect/Preprocessing/Conversions/PreprocessingToOpenfhe",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -47,6 +47,7 @@
 #include "lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
 #include "lib/Dialect/Polynomial/Transforms/Passes.h"
+#include "lib/Dialect/Poulpy/IR/PoulpyDialect.h"
 #include "lib/Dialect/Preprocessing/Conversions/PreprocessingToLattigo/PreprocessingToLattigo.h"
 #include "lib/Dialect/Preprocessing/Conversions/PreprocessingToMemref/PreprocessingToMemref.h"
 #include "lib/Dialect/Preprocessing/Conversions/PreprocessingToOpenfhe/PreprocessingToOpenfhe.h"
@@ -259,6 +260,7 @@ int main(int argc, char** argv) {
   registry.insert<random::RandomDialect>();
   registry.insert<orion::OrionDialect>();
   registry.insert<openfhe::OpenfheDialect>();
+  registry.insert<poulpy::PoulpyDialect>();
   registry.insert<preprocessing::PreprocessingDialect>();
   registry.insert<rns::RNSDialect>();
   registry.insert<rotom::RotomDialect>();


### PR DESCRIPTION
Implements step 1 and 2 (Add Poulpy as a Bazel Dependency and Define the poulpy Exit Dialect) from #3096.

- Adds types: `module`, `ciphertext`, `unnormalized_ciphertext`,
  `plaintext`, `scratch`, `secret_key`, `tensor_key`,
  `automorphism_key_map`, `bootstrapping_keys`, `bootstrapping_context`
- Adds ops: `module_create`, `scratch_alloc`, `encode`, `decode`,
  `encrypt`, `decrypt`, `add`, `sub`, `mul`, `rotate`, `rescale` and
  their in-place assign variants, `add_unnormalized`, `sub_unnormalized`,
  `normalize`, `compact_limbs`
- All ciphertext/plaintext operands use memrefs as described in the issue ("The poulpy exit dialect should be designed to work with memrefs")
- Adds syntax tests in `tests/Dialect/Poulpy/IR/ops.mlir`

Not in scope for this PR:
PoulpyEmitter (step 3), configure-crypto-context pass (step 4),
parameter selection (step 5), SecretToPoulpy lowering (step 6),
management passes (step 7), end-to-end tests (step 8).

Assisted-by: Claude