### PR TITLE
Avoid dense check when assigning layout

### DIFF
--- a/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
@@ -270,24 +270,25 @@ static FailureOr<Value> implementAssignLayoutStep(
   }
 
   // The result can be simplified if the layout is dense in the ciphertext type,
-  // and if the input is a scalar or a constant splat.
-  if (isDenseLayout(rel, targetType)) {
+  // and the input is a scalar or a constant splat.
+  SplatElementsAttr splatAttr;
+  bool inputIsScalar = !dataSemanticType;
+  bool inputIsSplatConstant = matchPattern(input, m_Constant(&splatAttr));
+  if ((inputIsScalar || inputIsSplatConstant) &&
+      isDenseLayout(rel, targetType)) {
     // Regardless of being constant or not, a scalar can be splat into the
     // ciphertext tensor.
-    if (!dataSemanticType) {
+    if (inputIsScalar) {
       auto splatOp = tensor::SplatOp::create(builder, targetType, input);
       createdOpCallback(splatOp);
       return splatOp.getResult();
     }
-    SplatElementsAttr splatAttr;
-    if (matchPattern(input, m_Constant(&splatAttr))) {
-      auto constantOp = arith::ConstantOp::create(
-          builder, targetType,
-          SplatElementsAttr::get(targetType,
-                                 splatAttr.getSplatValue<TypedAttr>()));
-      createdOpCallback(constantOp);
-      return constantOp.getResult();
-    }
+    auto constantOp = arith::ConstantOp::create(
+        builder, targetType,
+        SplatElementsAttr::get(targetType,
+                               splatAttr.getSplatValue<TypedAttr>()));
+    createdOpCallback(constantOp);
+    return constantOp.getResult();
   }
 
   // If the input is a dense/splat constant, evaluate the relation on its


### PR DESCRIPTION
This particular check was very expensive. I inverted the logic to avoid it.

FYI: this is the ISL that was generated for my convolutional network

===== isDenseLayout call #8 =====
range/type dims: [2048, 4096]
num relation vars: 7, num constraints (eq+ineq): 20
imageSet := { [i0, i1] : exists (e0, e1, e2, e3: 0 <= i0 <= 2047 and 0 <= i1 <= 4095 and 2048e0 <= -2048 + i1 and 0 <= e1 <= 63 and 0 <= e2 <= 63 and -2077 + i1 - 2048e0 <= 30e2 <= -2048 + i1 - 2048e0 and -2 + i0 - 32e1 + 30e2 <= 2048e3 <= i0 - 32e1 + 30e2) }
denseSet := { [i0, i1] : 0 <= i0 <= 2047 and 0 <= i1 <= 4095 }
--- calling isl_set_is_equal(imageSet, denseSet) ---


