### PR TITLE
Convolution speedup

### DIFF
--- a/lib/Transforms/ApplyFolders/ApplyFolders.cpp
+++ b/lib/Transforms/ApplyFolders/ApplyFolders.cpp
@@ -1,11 +1,14 @@
 #include "lib/Transforms/ApplyFolders/ApplyFolders.h"
 
+#include <cstdint>
 #include <utility>
 
 #include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Tensor/Transforms/Transforms.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"       // from @llvm-project
 #include "mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
 
 // required for generated patterns
@@ -30,8 +33,20 @@ struct ApplyFolders : impl::ApplyFoldersBase<ApplyFolders> {
   void runOnOperation() override {
     MLIRContext* context = &getContext();
     RewritePatternSet patterns(context);
+    // Folding tensor.extract_slice of a constant materializes a new constant by
+    // reading the source element-by-element. Skip it for large tensors. See
+    // TODO(#1221).
+    constexpr int64_t kMaxConstantFoldElements = 1 << 16;
     tensor::ControlConstantExtractSliceFusionFn controlFn =
-        [](tensor::ExtractSliceOp op) { return true; };
+        [](tensor::ExtractSliceOp op) {
+          DenseElementsAttr cst;
+          if (matchPattern(op.getSource(), m_Constant(&cst))) {
+            if (auto shaped = dyn_cast<ShapedType>(cst.getType()))
+              if (shaped.getNumElements() > kMaxConstantFoldElements)
+                return false;
+          }
+          return true;
+        };
     tensor::populateFoldConstantExtractSlicePatterns(patterns, controlFn);
     tensor::populateFoldTensorSubsetOpPatterns(patterns);
     tensor::populateDecomposeTensorConcatPatterns(patterns);

--- a/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/AssignLayout.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <string>
 #include <vector>
@@ -368,35 +369,70 @@ static FailureOr<Value> implementAssignLayoutStep(
       isLast) {
     LLVM_DEBUG(llvm::dbgs() << "Detected constant input, evaluating layout\n");
     int64_t numTargetElements = targetType.getNumElements();
-    Attribute zeroAttr = builder.getZeroAttr(elementType);
-    SmallVector<Attribute> packedValues(numTargetElements, zeroAttr);
 
     PointPairCollector collector(dataSemanticType.getRank(),
                                  /*rangeDims=*/targetType.getRank());
     enumeratePoints(rel, collector);
 
-    for (const auto& pointPair : collector.points) {
-      const auto& domainPoint = pointPair.first;
-      const auto& rangePoint = pointPair.second;
+    // Row-major strides let us flatten a multi-dimensional point with plain
+    // integer math, avoiding per-element getFlattenedIndex() interface lookups
+    auto rowMajorStrides = [](ArrayRef<int64_t> shape) {
+      SmallVector<int64_t> strides(shape.size(), 1);
+      for (int i = static_cast<int>(shape.size()) - 2; i >= 0; --i)
+        strides[i] = strides[i + 1] * shape[i + 1];
+      return strides;
+    };
+    SmallVector<int64_t> srcStrides =
+        rowMajorStrides(dataSemanticType.getShape());
+    SmallVector<int64_t> dstStrides = rowMajorStrides(targetType.getShape());
+    auto flatten = [](ArrayRef<int64_t> point, ArrayRef<int64_t> strides) {
+      int64_t flat = 0;
+      for (size_t i = 0; i < point.size(); ++i) flat += point[i] * strides[i];
+      return flat;
+    };
+    bool srcIsSplat = constantAttr.isSplat();
 
-      Attribute valAttr;
-      if (constantAttr.isSplat()) {
-        valAttr = constantAttr.getSplatValue<Attribute>();
-      } else {
-        SmallVector<uint64_t> coord;
-        coord.reserve(domainPoint.size());
-        for (int64_t val : domainPoint) {
-          coord.push_back(static_cast<uint64_t>(val));
-        }
-        valAttr =
-            constantAttr
-                .getValues<Attribute>()[mlir::ElementsAttr::getFlattenedIndex(
-                    constantAttr.getType(), coord)];
+    // Fast path: for byte-aligned int/float element types, pack directly into a
+    // raw byte buffer rather than building an N-element SmallVector<Attribute>
+    // and re-encoding it via DenseElementsAttr::get().
+    if (elementType.isIntOrFloat() &&
+        elementType.getIntOrFloatBitWidth() % 8 == 0) {
+      unsigned byteWidth = elementType.getIntOrFloatBitWidth() / 8;
+      ArrayRef<char> srcRaw = constantAttr.getRawData();
+      std::vector<char> rawBuffer(
+          static_cast<size_t>(numTargetElements) * byteWidth, 0);
+
+      for (const auto& [domainPoint, rangePoint] : collector.points) {
+        int64_t dstFlat = flatten(rangePoint, dstStrides);
+        if (dstFlat < 0 || dstFlat >= numTargetElements) continue;
+        int64_t srcFlat = srcIsSplat ? 0 : flatten(domainPoint, srcStrides);
+        std::memcpy(rawBuffer.data() + static_cast<size_t>(dstFlat) * byteWidth,
+                    srcRaw.data() + static_cast<size_t>(srcFlat) * byteWidth,
+                    byteWidth);
       }
-      auto flatIdx = getFlattenedIndex(targetType, llvm::to_vector(rangePoint));
-      if (flatIdx >= 0 && flatIdx < numTargetElements) {
-        packedValues[flatIdx] = valAttr;
-      }
+
+      auto packedConstantAttr = DenseElementsAttr::getFromRawBuffer(
+          targetType, ArrayRef<char>(rawBuffer.data(), rawBuffer.size()));
+      auto constantOp = arith::ConstantOp::create(builder, builder.getLoc(),
+                                                  packedConstantAttr);
+      createdOpCallback(constantOp);
+      return constantOp.getResult();
+    }
+
+    // Fallback for sub-byte element types (e.g. i1): build the packed constant
+    // from boxed Attributes.
+    Attribute zeroAttr = builder.getZeroAttr(elementType);
+    SmallVector<Attribute> packedValues(numTargetElements, zeroAttr);
+    Attribute splatValue =
+        srcIsSplat ? constantAttr.getSplatValue<Attribute>() : Attribute();
+    auto srcValues = constantAttr.getValues<Attribute>();
+    for (const auto& [domainPoint, rangePoint] : collector.points) {
+      int64_t dstFlat = flatten(rangePoint, dstStrides);
+      if (dstFlat < 0 || dstFlat >= numTargetElements) continue;
+      packedValues[dstFlat] = srcIsSplat
+                                  ? splatValue
+                                  : srcValues[static_cast<size_t>(
+                                        flatten(domainPoint, srcStrides))];
     }
 
     auto packedConstantAttr =

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -709,9 +709,6 @@ void getRangePoints(const presburger::IntegerRelation& relation,
 isl_stat pointPairCallback(__isl_take isl_point* pnt, void* user) {
   PointPairCollector* collector = static_cast<PointPairCollector*>(user);
 
-  isl_space* space = isl_point_get_space(pnt);
-  isl_space_free(space);
-
   std::vector<int64_t> domainPoint(collector->domainDims);
   std::vector<int64_t> rangePoint(collector->rangeDims);
 
@@ -785,18 +782,20 @@ void getCtComplementPoints(const presburger::IntegerRelation& relation,
 
   int64_t numCts = outputType.getDimSize(0);
 
-  // Enumerate the full, un-projected (ct, slot) relation, collect the distinct
-  // ct coordinates, then take the complement against [0, numCts) in plain C++.
-  PointPairCollector present(relation.getNumDomainVars(),
-                             relation.getNumRangeVars());
-  enumeratePoints(relation, present);
+  // We only need the distinct ct indices (range var 0) in the relation's image.
+  // Projecting out the slot dimension first lets us enumerate at most numCts
+  // points instead of the full (ct, slot) grid.
+  PointCollector ctPoints;
+  isl_basic_map* bmap = convertRelationToBasicMap(relation, ctPoints.ctx);
+  isl_set* ctSet = isl_set_from_basic_set(isl_basic_map_range(bmap));
+  ctSet = isl_set_project_out(ctSet, isl_dim_set, /*first=*/1, /*n=*/1);
+  isl_set_foreach_point(ctSet, &pointCallback, &ctPoints);
+  isl_set_free(ctSet);
 
   std::vector<bool> seen(numCts, false);
-  for (const auto& point : present.points) {
-    int64_t ct = point.second[0];  // range var 0 == ct
-    if (ct >= 0 && ct < numCts) {
-      seen[ct] = true;
-    }
+  for (const std::vector<int64_t>& point : ctPoints.points) {
+    int64_t ct = point[0];
+    if (ct >= 0 && ct < numCts) seen[ct] = true;
   }
 
   // The complement is every ct index in [0, numCts) that never appeared,


### PR DESCRIPTION
Three small improvements/special cases for improving compile time for convolution networks:

- project out dimension in getCtComplementPoints

- avoid folding large extract_slice

- pack constant tensors using memcpy 