### PR TITLE
Fold vector permutation into matrix layout

### DIFF
--- a/lib/Transforms/LayoutOptimization/BUILD
+++ b/lib/Transforms/LayoutOptimization/BUILD
@@ -85,12 +85,16 @@ cc_library(
     srcs = ["Patterns.cpp"],
     hdrs = ["Patterns.h"],
     deps = [
+        "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:SecretPatterns",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Kernel",
         "@heir//lib/Utils:AttributeUtils",
+        "@heir//lib/Utils/Layout:Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
+++ b/lib/Transforms/LayoutOptimization/LayoutOptimization.cpp
@@ -109,6 +109,14 @@ void LayoutOptimization::runOnOperation() {
   auto* ctx = &getContext();
   IRRewriter builder(ctx);
 
+  RewritePatternSet preprocessingPatterns(ctx);
+  preprocessingPatterns.add<FoldMatvecInputConversionIntoPlaintext>(ctx);
+  if (failed(applyPatternsGreedily(getOperation(),
+                                   std::move(preprocessingPatterns)))) {
+    signalPassFailure();
+    return;
+  }
+
   DataFlowSolver solver;
   dataflow::loadBaselineAnalyses(solver);
   solver.load<LayoutIsFreeAnalysis>();

--- a/lib/Transforms/LayoutOptimization/Patterns.cpp
+++ b/lib/Transforms/LayoutOptimization/Patterns.cpp
@@ -2,10 +2,14 @@
 
 #include <optional>
 
+#include "lib/Dialect/Secret/IR/SecretAttributes.h"
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Kernel/KernelName.h"
 #include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/Layout/Utils.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"            // from @llvm-project
 #include "llvm/include/llvm/ADT/SmallVector.h"          // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
@@ -82,6 +86,66 @@ LogicalResult FoldLayoutConversions::matchAndRewrite(
   }
 
   return result;
+}
+
+LogicalResult FoldMatvecInputConversionIntoPlaintext::matchAndRewrite(
+    linalg::MatvecOp op, PatternRewriter& rewriter) const {
+  auto conversion = op.getInputs()[1].getDefiningOp<ConvertLayoutOp>();
+  auto matrixAssignment = op.getInputs()[0].getDefiningOp<AssignLayoutOp>();
+  // Don't fold into atomic or complex (ArrayAttr) assignments to prevent
+  // performance regressions.
+  if (!conversion || !matrixAssignment ||
+      isa<ArrayAttr>(matrixAssignment.getLayout())) {
+    return failure();
+  }
+
+  auto fromLayout =
+      dyn_cast<tensor_ext::LayoutAttr>(conversion.getFromLayout());
+  auto toLayout = dyn_cast<tensor_ext::LayoutAttr>(conversion.getToLayout());
+  auto matrixLayout =
+      dyn_cast<tensor_ext::LayoutAttr>(matrixAssignment.getLayout());
+  auto vectorType = dyn_cast<RankedTensorType>(conversion.getType());
+  auto matrixType = dyn_cast<RankedTensorType>(matrixAssignment.getType());
+  if (!fromLayout || !toLayout || !matrixLayout || !vectorType || !matrixType) {
+    return failure();
+  }
+
+  auto kernel = op->getAttrOfType<secret::KernelAttr>(
+      secret::SecretDialect::kKernelAttrName);
+  if (!kernel || kernel.getName() != KernelName::MatvecDiagonal)
+    return failure();
+
+  const auto& toRelation = toLayout.getIntegerRelation();
+  auto ciphertextSize = toRelation.getConstantBoundOnDimSize64(
+      toRelation.getVarKindOffset(presburger::VarKind::Range) + 1);
+  if (!ciphertextSize ||
+      !isRelationRowMajor(vectorType, *ciphertextSize, toRelation) ||
+      !isRelationSquatDiagonal(matrixType, *ciphertextSize,
+                               matrixLayout.getIntegerRelation()) ||
+      !isOneToOneSingleCiphertextPacking(fromLayout.getIntegerRelation())) {
+    return failure();
+  }
+
+  auto newMatrixLayout = tensor_ext::LayoutAttr::getFromIntegerRelation(
+      op.getContext(),
+      foldVectorPermutationIntoMatrixLayout(fromLayout.getIntegerRelation(),
+                                            matrixLayout.getIntegerRelation()));
+
+  // Emit the repacked (plaintext) weights where the original assignment lived,
+  // rather than inside the secret.generic that contains the matvec.
+  rewriter.setInsertionPoint(matrixAssignment);
+  auto newMatrix = AssignLayoutOp::create(
+      rewriter, op.getLoc(), matrixAssignment.getValue(), newMatrixLayout,
+      matrixAssignment.getDomainScheduleAttr());
+  newMatrix->setAttr(kLayoutAttrName, newMatrixLayout);
+
+  rewriter.modifyOpInPlace(op, [&] {
+    op->setOperand(0, newMatrix);
+    op->setOperand(1, conversion.getValue());
+  });
+  if (conversion->use_empty()) rewriter.eraseOp(conversion);
+  if (matrixAssignment->use_empty()) rewriter.eraseOp(matrixAssignment);
+  return success();
 }
 
 LogicalResult HoistArgLayouts::matchAndRewrite(

--- a/lib/Transforms/LayoutOptimization/Patterns.h
+++ b/lib/Transforms/LayoutOptimization/Patterns.h
@@ -2,9 +2,10 @@
 #define LIB_TRANSFORMS_LAYOUTOPTIMIZATION_LAYOUTPATTERNS_H_
 
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
-#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"          // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -20,6 +21,14 @@ struct FoldLayoutConversions
 
  public:
   LogicalResult matchAndRewrite(tensor_ext::ConvertLayoutOp op,
+                                PatternRewriter& rewriter) const override;
+};
+
+struct FoldMatvecInputConversionIntoPlaintext
+    : public OpRewritePattern<linalg::MatvecOp> {
+  using OpRewritePattern<linalg::MatvecOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::MatvecOp op,
                                 PatternRewriter& rewriter) const override;
 };
 

--- a/lib/Utils/Layout/Hoisting.cpp
+++ b/lib/Utils/Layout/Hoisting.cpp
@@ -58,42 +58,13 @@ presburger::IntegerRelation hoistConversionThroughMatvec(
 
   // At this stage, fromClone models the re-packing relation on the vector
   // (slots) -> (slots). Put the ct dim back in with bounds from the matrix
-  // layout, and equality between the domain ct var and the range ct var.
-  fromClone.insertVar(VarKind::Domain, 0, 1);
-  fromClone.insertVar(VarKind::Range, 0, 1);
+  // layout, and equality between the domain ct var and the range ct var (so
+  // slots can only be rotated within a single ciphertext).
   std::optional<int64_t> ctUb = matrixLayout.getConstantBound64(
       BoundType::UB, matrixLayout.getVarKindOffset(VarKind::Range));
   std::optional<int64_t> ctLb = matrixLayout.getConstantBound64(
       BoundType::LB, matrixLayout.getVarKindOffset(VarKind::Range));
-
-  if (ctUb.has_value()) {
-    fromClone.addBound(BoundType::UB,
-                       fromClone.getVarKindOffset(VarKind::Domain),
-                       ctUb.value());
-    fromClone.addBound(BoundType::UB,
-                       fromClone.getVarKindOffset(VarKind::Range),
-                       ctUb.value());
-  }
-  if (ctLb.has_value()) {
-    fromClone.addBound(BoundType::LB,
-                       fromClone.getVarKindOffset(VarKind::Domain),
-                       ctLb.value());
-    fromClone.addBound(BoundType::LB,
-                       fromClone.getVarKindOffset(VarKind::Range),
-                       ctLb.value());
-  }
-
-  // Still need to ensure the input and output ciphertext
-  // are the same (i.e., slots can only be rotated within one ct).
-  // Order of variables in the constraint are:
-  //
-  //    0,    1,  2,    3,        4
-  //   ct, slot, ct, slot, constant
-  //
-  SmallVector<int64_t> ciphertextEq(fromClone.getNumCols(), 0);
-  ciphertextEq[0] = 1;
-  ciphertextEq[2] = -1;
-  fromClone.addEquality(ciphertextEq);
+  prependPassthroughDim(fromClone, ctLb, ctUb);
 
   // At this point the re-packing relation should look something like
   //

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -554,6 +554,75 @@ bool isRelationRowMajor(RankedTensorType vectorType, int64_t numSlots,
   return relation.isEqual(rowMajorRelation);
 }
 
+bool isOneToOneSingleCiphertextPacking(
+    const presburger::IntegerRelation& relation) {
+  if (relation.getNumDomainVars() != 1 || relation.getNumRangeVars() != 2)
+    return false;
+
+  isl_ctx* ctx = isl_ctx_alloc();
+  isl_basic_map* map = convertRelationToBasicMap(relation, ctx);
+  if (!map) {
+    isl_ctx_free(ctx);
+    return false;
+  }
+
+  isl_val* ct =
+      isl_basic_map_plain_get_val_if_fixed(map, isl_dim_out, /*pos=*/0);
+  bool singleCiphertext = ct && isl_val_is_zero(ct) == isl_bool_true;
+  isl_val_free(ct);
+
+  isl_basic_map* slots = isl_basic_map_project_out(
+      isl_basic_map_copy(map), isl_dim_out, /*first=*/0, /*n=*/1);
+  isl_map* slotMap = isl_map_from_basic_map(slots);
+  isl_bool oneToOne = isl_map_is_bijective(slotMap);
+  isl_map_free(slotMap);
+  isl_basic_map_free(map);
+  isl_ctx_free(ctx);
+  return singleCiphertext && oneToOne == isl_bool_true;
+}
+
+void prependPassthroughDim(IntegerRelation& relation, std::optional<int64_t> lb,
+                           std::optional<int64_t> ub) {
+  relation.insertVar(VarKind::Domain, 0, 1);
+  relation.insertVar(VarKind::Range, 0, 1);
+  int64_t domainDim = relation.getVarKindOffset(VarKind::Domain);
+  int64_t rangeDim = relation.getVarKindOffset(VarKind::Range);
+  // The new domain var equals the new range var, so it is carried through.
+  addConstraint(relation, {{domainDim, 1}, {rangeDim, -1}}, /*equality=*/true);
+  if (lb.has_value()) {
+    relation.addBound(BoundType::LB, domainDim, lb.value());
+    relation.addBound(BoundType::LB, rangeDim, lb.value());
+  }
+  if (ub.has_value()) {
+    relation.addBound(BoundType::UB, domainDim, ub.value());
+    relation.addBound(BoundType::UB, rangeDim, ub.value());
+  }
+}
+
+IntegerRelation foldVectorPermutationIntoMatrixLayout(
+    const IntegerRelation& vectorPermutation,
+    const IntegerRelation& matrixLayout) {
+  // vectorPermutation maps a vector index [col] -> [ct, slot] as a
+  // single-ciphertext permutation (ct is fixed to zero). Drop the constant ct
+  // output, leaving the pure index-to-slot permutation [col] -> [slot].
+  IntegerRelation result(vectorPermutation);
+  result.projectOut(result.getVarKindOffset(VarKind::Range), 1);
+
+  // Lift the permutation to a matrix domain by prepending a passthrough row
+  // dimension to both sides (row_in == row_out), giving
+  // [row, col] -> [row, slot].
+  prependPassthroughDim(result);
+
+  // Compose with the matrix layout (result;matrixLayout): the permutation's
+  // [row, slot] output feeds the matrix layout's [row, col] input, so the
+  // vector permutation is absorbed into the matrix's column indexing, yielding
+  // the folded matrix layout [row, col] -> [ct, slot].
+  result.compose(matrixLayout);
+  result.removeRedundantConstraints();
+  result.simplify();
+  return result;
+}
+
 bool isRelationPerRow(RankedTensorType matrixType, int64_t ciphertextSize,
                       presburger::IntegerRelation relation) {
   IntegerRelation perRowRelation =

--- a/lib/Utils/Layout/Utils.h
+++ b/lib/Utils/Layout/Utils.h
@@ -30,6 +30,15 @@ void addConstraint(presburger::IntegerRelation& result,
 void addBounds(presburger::IntegerRelation& result, int64_t pos, int64_t lower,
                std::optional<int64_t> upper = std::nullopt);
 
+// Lifts a relation R : [a...] -> [b...] to [p, a...] -> [p, b...] by prepending
+// a "passthrough" dimension as the new leading variable of both the domain and
+// range, constrained so the new domain variable equals the new range variable
+// (i.e. p is carried through unchanged). When `lb`/`ub` are provided, the
+// passthrough dimension is additionally bounded to [lb, ub].
+void prependPassthroughDim(presburger::IntegerRelation& relation,
+                           std::optional<int64_t> lb = std::nullopt,
+                           std::optional<int64_t> ub = std::nullopt);
+
 // Adds a new local variable q to the relation that represents expr % modulus.
 // Returns the index of the new local variable in the relation.
 unsigned int addModConstraint(presburger::IntegerRelation& result,
@@ -103,6 +112,20 @@ bool isRelationSquatDiagonal(RankedTensorType matrixType,
 // vector type and slot size.
 bool isRelationRowMajor(RankedTensorType vectorType, int64_t numSlots,
                         const presburger::IntegerRelation& relation);
+
+// Returns true if the relation packs a vector into ciphertext zero with each
+// vector element occupying exactly one distinct slot.
+bool isOneToOneSingleCiphertextPacking(
+    const presburger::IntegerRelation& relation);
+
+// Folds a single-ciphertext vector permutation (as accepted by
+// isOneToOneSingleCiphertextPacking) into a matrix layout, returning the matrix
+// layout that lets a diagonal matvec consume the un-permuted vector directly.
+// `vectorPermutation` maps [col] -> [ct, slot]; `matrixLayout` maps
+// [row, col] -> [ct, slot].
+presburger::IntegerRelation foldVectorPermutationIntoMatrixLayout(
+    const presburger::IntegerRelation& vectorPermutation,
+    const presburger::IntegerRelation& matrixLayout);
 
 // Returns true if the given relation is a per-row layout
 // for the given matrix type and ciphertext semantic shape.

--- a/lib/Utils/Layout/UtilsTest.cpp
+++ b/lib/Utils/Layout/UtilsTest.cpp
@@ -678,6 +678,53 @@ TEST(UtilsTest, TestGetCtComplementPoolingLayer) {
   EXPECT_EQ(collector.points.size(), 1994);
 }
 
+TEST(UtilsTest, TestIsOneToOneSingleCiphertextPacking) {
+  auto permutation = getIntegerRelationFromIslStr(
+                         "{ [i] -> [ct, slot] : ct = 0 and (slot - 3i) mod 8 "
+                         "= 0 and 0 <= i <= 7 and 0 <= slot <= 7 }")
+                         .value();
+  EXPECT_TRUE(isOneToOneSingleCiphertextPacking(permutation));
+
+  auto replicated = getIntegerRelationFromIslStr(
+                        "{ [i] -> [ct, slot] : ct = 0 and (slot - i) mod 8 = "
+                        "0 and 0 <= i <= 7 and 0 <= slot <= 15 }")
+                        .value();
+  EXPECT_FALSE(isOneToOneSingleCiphertextPacking(replicated));
+
+  auto multipleCiphertexts = getIntegerRelationFromIslStr(
+                                 "{ [i] -> [ct, slot] : i = 4ct + slot and 0 "
+                                 "<= i <= 7 and 0 <= ct <= 1 and 0 <= slot <= "
+                                 "3 }")
+                                 .value();
+  EXPECT_FALSE(isOneToOneSingleCiphertextPacking(multipleCiphertexts));
+}
+
+TEST(UtilsTest, TestFoldVectorPermutationIntoMatrixLayout) {
+  // The vector's slot = 3i permutation is folded into the matrix's column
+  // indexing (col -> 3col), so a diagonal matvec can consume the un-permuted
+  // ciphertext directly.
+  auto vectorPermutation = getIntegerRelationFromIslStr(
+                               "{ [i] -> [ct, slot] : ct = 0 and (slot - 3i) "
+                               "mod 8 = 0 and 0 <= i <= 7 and 0 <= slot <= 7 }")
+                               .value();
+  auto matrixLayout =
+      getIntegerRelationFromIslStr(
+          "{ [row, col] -> [ct, slot] : (row - col + ct) mod 4 = 0 and (-col + "
+          "ct + slot) mod 8 = 0 and 0 <= row <= 3 and 0 <= col <= 7 and 0 <= "
+          "ct <= 3 and 0 <= slot <= 7 }")
+          .value();
+  auto expected =
+      getIntegerRelationFromIslStr(
+          "{ [i0, i1] -> [ct, slot] : (i0 + i1 + ct) mod 4 = 0 and (-3i1 + ct "
+          "+ slot) mod 8 = 0 and 0 <= i0 <= 3 and 0 <= i1 <= 7 and 0 <= ct <= "
+          "3 and 0 <= slot <= 7 }")
+          .value();
+
+  auto folded =
+      foldVectorPermutationIntoMatrixLayout(vectorPermutation, matrixLayout);
+  EXPECT_TRUE(folded.isEqual(expected));
+}
+
 TEST(UtilsTest, TestIsDenseLayout_Dense) {
   MLIRContext context;
   RankedTensorType type =

--- a/tests/Transforms/layout_optimization/fold_matvec_input_conversion_into_plaintext.mlir
+++ b/tests/Transforms/layout_optimization/fold_matvec_input_conversion_into_plaintext.mlir
@@ -1,0 +1,33 @@
+// RUN: heir-opt --layout-optimization --canonicalize %s | FileCheck %s
+
+#permuted = #tensor_ext.layout<"{ [i] -> [ct, slot] : ct = 0 and (slot - 3i) mod 8 = 0 and 0 <= i <= 7 and 0 <= slot <= 7 }">
+#row_major = #tensor_ext.layout<"{ [i] -> [ct, slot] : ct = 0 and (slot - i) mod 8 = 0 and 0 <= i <= 7 and 0 <= slot <= 7 }">
+#result = #tensor_ext.layout<"{ [i] -> [ct, slot] : ct = 0 and (slot - i) mod 4 = 0 and 0 <= i <= 3 and 0 <= slot <= 7 }">
+#matrix = #tensor_ext.layout<"{ [row, col] -> [ct, slot] : (row - col + ct) mod 4 = 0 and (-col + ct + slot) mod 8 = 0 and 0 <= row <= 3 and 0 <= col <= 7 and 0 <= ct <= 3 and 0 <= slot <= 7 }">
+
+// CHECK: #[[MATRIX:layout[0-9]*]] = #tensor_ext.layout<"{ [i0, i1] -> [ct, slot] : (i0 + i1 + ct) mod 4 = 0 and (-3i1 + ct + slot) mod 8 = 0 and 0 <= i0 <= 3 and 0 <= i1 <= 7 and 0 <= ct <= 3 and 0 <= slot <= 7 }">
+// CHECK: func.func @fold_matvec_input_conversion_into_plaintext(%[[WEIGHTS:arg[0-9]+]]:
+func.func @fold_matvec_input_conversion_into_plaintext(
+    %weights: tensor<4x8xf32>,
+    %input: !secret.secret<tensor<8xf32>> {tensor_ext.layout = #permuted})
+    -> (!secret.secret<tensor<4xf32>> {tensor_ext.layout = #result}) {
+  %empty = tensor.empty() : tensor<4xf32>
+  %init = tensor_ext.assign_layout %empty {layout = #result, tensor_ext.layout = #result} : tensor<4xf32>
+  %matrix = tensor_ext.assign_layout %weights {layout = #matrix, tensor_ext.layout = #matrix} : tensor<4x8xf32>
+  %0 = secret.generic(
+      %input: !secret.secret<tensor<8xf32>> {tensor_ext.layout = #permuted}) {
+  ^body(%arg0: tensor<8xf32>):
+    // CHECK: %[[PACKED_WEIGHTS:.*]] = tensor_ext.assign_layout %[[WEIGHTS]]
+    // CHECK-SAME: layout = #[[MATRIX]]
+    // CHECK: ^body(%[[INPUT:.*]]: tensor<8xf32>)
+    // CHECK-NOT: tensor_ext.convert_layout
+    // CHECK: linalg.matvec
+    // CHECK-SAME: ins(%[[PACKED_WEIGHTS]], %[[INPUT]]
+    %converted = tensor_ext.convert_layout %arg0 {from_layout = #permuted, tensor_ext.layout = #row_major, to_layout = #row_major} : tensor<8xf32>
+    %result = linalg.matvec {secret.kernel = #secret.kernel<name="MatvecDiagonal", force=false>, tensor_ext.layout = #result}
+        ins(%matrix, %converted : tensor<4x8xf32>, tensor<8xf32>)
+        outs(%init : tensor<4xf32>) -> tensor<4xf32>
+    secret.yield %result : tensor<4xf32>
+  } -> !secret.secret<tensor<4xf32>> {tensor_ext.layout = #result}
+  return %0 : !secret.secret<tensor<4xf32>>
+}


### PR DESCRIPTION
Also unifies it with the hoisting operation through a small helper. Unfortunately, they are not quite the same operation (hoisting composes on the slots, while folding composes on the matrix columns), so I was not able to completely unify these two operations

I can squash the two commits if you agree with the changes, but felt it was easier to review with two distinct commits to see the refactoring more clearly