### PR TITLE
Use simple bounding boxes when available

### DIFF
--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -5,6 +5,7 @@
 #include <climits>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -13,7 +14,9 @@
 
 #include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/MathUtils.h"
-#include "llvm/include/llvm/ADT/STLExtras.h"  // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/ErrorHandling.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Arith/Utils/Utils.h"  // from @llvm-project
@@ -707,42 +710,187 @@ void getRangePoints(const presburger::IntegerRelation& relation,
   isl_set_free(set);
 }
 
-isl_stat pointPairCallback(__isl_take isl_point* pnt, void* user) {
-  PointPairCollector* collector = static_cast<PointPairCollector*>(user);
-
-  std::vector<int64_t> domainPoint(collector->domainDims);
-  std::vector<int64_t> rangePoint(collector->rangeDims);
-
-  // Extract domain coordinates
-  for (int i = 0; i < collector->domainDims; i++) {
+namespace {
+// Extract the first `n` set coordinates of `pnt` into `out`.
+void extractCoords(__isl_keep isl_point* pnt, int n,
+                   std::vector<int64_t>& out) {
+  for (int i = 0; i < n; i++) {
     isl_val* coord = isl_point_get_coordinate_val(pnt, isl_dim_set, i);
     if (isl_val_is_int(coord)) {
-      domainPoint[i] = isl_val_get_num_si(coord);
+      out[i] = isl_val_get_num_si(coord);
     }
     isl_val_free(coord);
   }
+}
 
-  // Extract range coordinates
-  for (int i = 0; i < collector->rangeDims; i++) {
-    isl_val* coord = isl_point_get_coordinate_val(pnt, isl_dim_set,
-                                                  collector->domainDims + i);
-    if (isl_val_is_int(coord)) {
-      rangePoint[i] = isl_val_get_num_si(coord);
+// Computes each domain variable's box bounds [lb, ub].
+//
+// It first tries a quick scan for single-variable equality/inequality rows of
+// `rel` (e.g. `c = 0`, `f >= 0`, `7 - f >= 0`), which the layout construction
+// adds for the data-tensor index space. This avoids
+// IntegerRelation::getConstantBound64, which derives bounds via Fourier-Motzkin
+// elimination over every other variable and blows up on the relation's
+// mod/floordiv existentials. For any bound the quick scan cannot determine, it
+// falls back to getConstantBound64 for that single bound.
+void getDomainBox(const presburger::IntegerRelation& rel,
+                  SmallVector<int64_t>& lb, SmallVector<int64_t>& ub) {
+  unsigned numDomain = rel.getNumDomainVars();
+  unsigned numVars = rel.getNumVars();
+  unsigned constCol = rel.getNumCols() - 1;
+  unsigned numIneqs = rel.getNumInequalities();
+  lb.assign(numDomain, std::numeric_limits<int64_t>::min());
+  ub.assign(numDomain, std::numeric_limits<int64_t>::max());
+
+  // Single pass over every constraint (inequalities then equalities, per
+  // atConstraint64's indexing). A constraint bounds a domain variable only if
+  // it has exactly one nonzero variable coefficient and that variable is a
+  // domain variable. Inequalities (coeff*v + c >= 0) give one bound by sign;
+  // equalities (coeff*v + c = 0) pin both bounds.
+  for (unsigned r = 0, e = rel.getNumConstraints(); r < e; ++r) {
+    unsigned v = 0, nonzeros = 0;
+    for (unsigned j = 0; j < numVars; ++j) {
+      if (rel.atConstraint64(r, j) == 0) continue;
+      v = j;
+      if (++nonzeros > 1) break;
     }
-    isl_val_free(coord);
+    if (nonzeros != 1 || v >= numDomain) continue;
+
+    int64_t coeff = rel.atConstraint64(r, v);
+    int64_t c = rel.atConstraint64(r, constCol);
+    if (r < numIneqs) {
+      if (coeff > 0) {
+        // v >= ceil(-c/coeff)
+        lb[v] = std::max(lb[v], llvm::divideCeilSigned(-c, coeff));
+      } else {
+        // v <= floor(c/-coeff)
+        ub[v] = std::min(ub[v], llvm::divideFloorSigned(c, -coeff));
+      }
+    } else {
+      // A single-variable equality coeff*v + c = 0 has an integer solution
+      // only if coeff divides c; otherwise the relation is infeasible.
+      assert((-c) % coeff == 0 && "non-integer single-variable equality bound");
+      int64_t val = -c / coeff;
+      lb[v] = std::max(lb[v], val);
+      ub[v] = std::min(ub[v], val);
+    }
   }
 
-  collector->points.emplace_back(domainPoint, rangePoint);
+  // Fall back to the general (but expensive) constant-bound computation for any
+  // domain variable the quick single-variable scan left undetermined. This uses
+  // Fourier-Motzkin elimination over the other variables, so we only reach it
+  // when the cheap method is insufficient.
+  auto resolve = [&](BoundType type, int64_t sentinel, int64_t& slot,
+                     unsigned i, const char* err) {
+    if (slot != sentinel) return;
+    std::optional<int64_t> b = rel.getConstantBound64(type, i);
+    if (!b) llvm::report_fatal_error(err);
+    slot = *b;
+  };
+  for (unsigned i = 0; i < numDomain; ++i) {
+    resolve(BoundType::LB, std::numeric_limits<int64_t>::min(), lb[i], i,
+            "getDomainBox: domain variable has no constant lower bound");
+    resolve(BoundType::UB, std::numeric_limits<int64_t>::max(), ub[i], i,
+            "getDomainBox: domain variable has no constant upper bound");
+  }
+}
+
+// isl_set_foreach_point takes a plain C callback and a void* cookie. This
+// bridges that callback back to a richer llvm::function_ref, carrying along the
+// domain point currently being imaged, and frees the (owned) point afterwards.
+struct ImageCtx {
+  llvm::function_ref<void(ArrayRef<int64_t>, __isl_keep isl_point*)>
+      onImagePoint;
+  ArrayRef<int64_t> domainPoint;
+};
+isl_stat imagePointTrampoline(__isl_take isl_point* pnt, void* user) {
+  auto* imageCtx = static_cast<ImageCtx*>(user);
+  imageCtx->onImagePoint(imageCtx->domainPoint, pnt);
   isl_point_free(pnt);
   return isl_stat_ok;
 }
 
+// Mutate `point` to hold the next point of a multi-dimensional coordinate grid
+// over the bounding box [lbs, ubs]. Returns false once the space is fully
+// traversed.
+bool nextGridPoint(SmallVectorImpl<int64_t>& point, ArrayRef<int64_t> lbs,
+                   ArrayRef<int64_t> ubs) {
+  for (int d = static_cast<int>(point.size()) - 1; d >= 0; --d) {
+    if (++point[d] <= ubs[d]) return true;
+    point[d] = lbs[d];
+  }
+  return false;
+}
+
+// Enumerates the domain box [lb, ub] explicitly and, for each concrete domain
+// point, invokes `onImagePoint(domainPoint, imagePoint)` for every point of
+// that domain point's image. `imagePoint` is borrowed (freed by this function).
+// Between domain points `shouldStop` is polled (when non-null); returning true
+// halts enumeration early.
+//
+// Fixing the domain to concrete integers collapses the relation's mod/floordiv
+// existentials into a non-parametric feasibility problem that isl resolves
+// cheaply. We deliberately do NOT ask isl to enumerate the domain set
+// (isl_set_foreach_point over isl_basic_map_domain): projecting the range out
+// leaves those existentials in the domain set, making that scan itself an
+// expensive parametric-ILP solve -- the very cost we are avoiding.
+void forEachDomainImagePoint(
+    __isl_keep isl_basic_map* bmap, ArrayRef<int64_t> lb, ArrayRef<int64_t> ub,
+    llvm::function_ref<void(ArrayRef<int64_t>, __isl_keep isl_point*)>
+        onImagePoint,
+    llvm::function_ref<bool()> shouldStop = nullptr) {
+  isl_ctx* ctx = isl_basic_map_get_ctx(bmap);
+  unsigned numDomain = lb.size();
+
+  // Fix the domain to `point`, then invoke onImagePoint for every point of the
+  // resulting (now fully concrete) range.
+  auto processImageOfPoint = [&](ArrayRef<int64_t> point) {
+    isl_basic_map* fixed = isl_basic_map_copy(bmap);
+    for (unsigned i = 0; i < numDomain; ++i) {
+      fixed = isl_basic_map_fix_val(fixed, isl_dim_in, i,
+                                    isl_val_int_from_si(ctx, point[i]));
+    }
+    isl_set* image = isl_set_from_basic_set(isl_basic_map_range(fixed));
+    ImageCtx imageCtx{onImagePoint, point};
+    isl_set_foreach_point(image, imagePointTrampoline, &imageCtx);
+    isl_set_free(image);
+  };
+
+  // An empty box (some lb > ub) contains no points.
+  for (unsigned i = 0; i < numDomain; ++i)
+    if (lb[i] > ub[i]) return;
+
+  SmallVector<int64_t> point(lb.begin(), lb.end());
+  do {
+    processImageOfPoint(point);
+    if (shouldStop && shouldStop()) break;
+  } while (nextGridPoint(point, lb, ub));
+}
+}  // namespace
+
 void enumeratePoints(const presburger::IntegerRelation& relation,
                      PointPairCollector& collector) {
-  auto* bmap = convertRelationToBasicMap(relation, collector.ctx);
-  isl_set* set = isl_set_from_basic_set(isl_basic_map_wrap(bmap));
-  isl_set_foreach_point(set, &pointPairCallback, &collector);
-  isl_set_free(set);
+  assert(relation.getNumDomainVars() ==
+             static_cast<unsigned>(collector.domainDims) &&
+         "collector domainDims must match the relation's domain rank");
+  assert(relation.getNumRangeVars() ==
+             static_cast<unsigned>(collector.rangeDims) &&
+         "collector rangeDims must match the relation's range rank");
+  isl_basic_map* bmap = convertRelationToBasicMap(relation, collector.ctx);
+
+  SmallVector<int64_t> lb, ub;
+  getDomainBox(relation, lb, ub);
+
+  forEachDomainImagePoint(
+      bmap, lb, ub,
+      [&](ArrayRef<int64_t> domainPoint, __isl_keep isl_point* imagePoint) {
+        std::vector<int64_t> rangePoint(collector.rangeDims);
+        extractCoords(imagePoint, collector.rangeDims, rangePoint);
+        collector.points.emplace_back(
+            std::vector<int64_t>(domainPoint.begin(), domainPoint.end()),
+            std::move(rangePoint));
+      });
+
+  isl_basic_map_free(bmap);
 }
 
 std::vector<int64_t> anyRangePoint(
@@ -783,23 +931,34 @@ void getCtComplementPoints(const presburger::IntegerRelation& relation,
 
   int64_t numCts = outputType.getDimSize(0);
 
-  isl_ctx* ctx = isl_ctx_alloc();
-  isl_basic_map* bmap = convertRelationToBasicMap(relation, ctx);
+  SmallVector<int64_t> lb, ub;
+  getDomainBox(relation, lb, ub);
 
+  isl_basic_map* bmap = convertRelationToBasicMap(relation, collector.ctx);
+
+  // Mark which ct indices (range var 0) actually appear in the range. See
+  // forEachDomainImagePoint for why we enumerate the domain rather than probe
+  // each ct with isl_basic_map_is_empty. Once every ct is accounted for we can
+  // stop early instead of scanning the rest of a large domain.
   std::vector<bool> seen(numCts, false);
-  for (int64_t ct = 0; ct < numCts; ++ct) {
-    isl_val* v = isl_val_int_from_si(ctx, ct);
-    // Copy bmap because fix_val consumes it.
-    isl_basic_map* fixedBmap =
-        isl_basic_map_fix_val(isl_basic_map_copy(bmap), isl_dim_out, 0, v);
-    isl_bool isEmpty = isl_basic_map_is_empty(fixedBmap);
-    isl_basic_map_free(fixedBmap);
-    if (isEmpty == isl_bool_false) {
-      seen[ct] = true;
-    }
-  }
+  int64_t seenCount = 0;
+  forEachDomainImagePoint(
+      bmap, lb, ub,
+      [&](ArrayRef<int64_t> /*domainPoint*/, __isl_keep isl_point* imagePoint) {
+        isl_val* coord =
+            isl_point_get_coordinate_val(imagePoint, isl_dim_set, 0);
+        if (isl_val_is_int(coord)) {
+          int64_t ct = isl_val_get_num_si(coord);
+          if (ct >= 0 && ct < numCts && !seen[ct]) {
+            seen[ct] = true;
+            ++seenCount;
+          }
+        }
+        isl_val_free(coord);
+      },
+      /*shouldStop=*/[&]() { return seenCount == numCts; });
+
   isl_basic_map_free(bmap);
-  isl_ctx_free(ctx);
 
   // The complement is every ct index in [0, numCts) that never appeared,
   // emitted in ascending order.


### PR DESCRIPTION
When iterating over large domains, we iterate over all points instead of solving a large ILP. We also scan the ISL for easy to gather bounding boxes.

The enumerate_points benchmark gets slower, but the get_ct_complements benchmarks is generally positive

#### get_ct_complement

| Layout   | Before (s) | After (s) | Speedup        |
|----------|-----------:|----------:|---------------:|
| Pooling1 |      0.459 |     0.035 | 13.1×          |
| Layout19 |      1.34  |     0.243 | 5.5×           |
| Layout24 |      2.00  |     0.995 | 2.0×           |
| Layout13 |      2.52  |     1.34  | 1.9×           |
| Layout29 |      0.934 |     0.563 | 1.7×           |
| Layout4  |      0.353 |     0.214 | 1.65×          |
| Layout8  |      0.229 |     0.155 | 1.5×           |
| Layout34 |      1.71  |     1.17  | 1.5×           |
| Layout27 |      0.149 |     0.107 | 1.4×           |
| Layout39 |      0.004 |     0.003 | 1.3×           |
| Layout17 |      0.346 |     0.538 | 0.64× (slower) |
| Layout37 |      0.125 |     0.202 | 0.62× (slower) |

#### enumerate_points

| Relation  | Before (s) | After (s) | Speedup            |
|-----------|-----------:|----------:|-------------------:|
| Relation1 |      0.008 |     0.020 | 0.40× (2.5× slower)|
| Relation2 |      0.050 |     0.061 | 0.82× (1.2× slower)|
| Relation3 |      1.31  |     2.09  | 0.63× (1.6× slower)|


The gain is for large instances where the ILP gets pathologically slow (Lola)