### PR TITLE
Clean up mgmt flags in prep for orbit integration

### DIFF
--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -47,6 +47,7 @@
 #include "lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.h"
 #include "lib/Transforms/FullLoopUnroll/FullLoopUnroll.h"
 #include "lib/Transforms/GenerateParam/GenerateParam.h"
+#include "lib/Transforms/ILPBootstrapPlacement/ILPBootstrapPlacement.h"
 #include "lib/Transforms/InlineActivations/InlineActivations.h"
 #include "lib/Transforms/LayoutOptimization/LayoutOptimization.h"
 #include "lib/Transforms/LayoutPropagation/LayoutPropagation.h"
@@ -249,9 +250,67 @@ void mlirToPlaintextPipelineBuilder(OpPassManager& pm,
   polynomialToLLVMPipelineBuilder(pm);
 }
 
+static void validateCiphertextManagementOptions(
+    const MlirToRLWEPipelineOptions& options, const RLWEScheme scheme) {
+  // Check if any greedy-specific options are non-default
+  bool hasGreedyOptions = options.greedyModulusSwitchAfterMul != false ||
+                          options.greedyModulusSwitchBeforeFirstMul != false ||
+                          options.greedyLevelBudget != 10 ||
+                          options.greedyBootstrapWaterline != 10;
+
+  // Check if any orbit-specific options are non-default
+  bool hasOrbitOptions =
+      options.orbitBootstrapWaterline != 3 ||
+      options.orbitScaleWaterline != 40 || options.orbitScaleFactorBits != 51 ||
+      options.orbitBootstrapLevelLowerBound != 0 ||
+      options.orbitCostModel != "" || options.orbitBootstrapCost != 69320650 ||
+      options.orbitRescaleCost != 40988;
+
+  // Validate style exclusivity
+  if (options.ciphertextManagementStyle == CiphertextManagementStyle::greedy &&
+      hasOrbitOptions) {
+    llvm::errs() << "Error: orbit-* options cannot be used with "
+                 << "--ciphertext-management-style=greedy\n"
+                 << "Either switch to --ciphertext-management-style=orbit-ilp "
+                 << "or use greedy-* options instead.\n";
+    exit(EXIT_FAILURE);
+  }
+
+  if (options.ciphertextManagementStyle ==
+          CiphertextManagementStyle::orbitIlp &&
+      hasGreedyOptions) {
+    llvm::errs() << "Error: greedy-* options cannot be used with "
+                 << "--ciphertext-management-style=orbit-ilp\n"
+                 << "Either switch to --ciphertext-management-style=greedy "
+                 << "or use orbit-* options instead.\n";
+    exit(EXIT_FAILURE);
+  }
+
+  // Validate scheme compatibility
+  if (scheme == RLWEScheme::bfvScheme) {
+    if (options.ciphertextManagementStyle ==
+        CiphertextManagementStyle::orbitIlp) {
+      llvm::errs() << "Error: orbit-ilp ciphertext management style is not "
+                      "supported for BFV scheme\n"
+                   << "BFV does not support bootstrap operations.\n";
+      exit(EXIT_FAILURE);
+    }
+
+    if (options.greedyBootstrapWaterline != 10) {  // non-default
+      llvm::errs() << "Error: --greedy-bootstrap-waterline is not supported "
+                      "for BFV scheme\n"
+                   << "BFV does not support bootstrap operations.\n";
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+
 void mlirToRLWEPipeline(OpPassManager& pm,
                         const MlirToRLWEPipelineOptions& options,
                         const RLWEScheme scheme) {
+  // Validate ciphertext management options
+  validateCiphertextManagementOptions(options, scheme);
+
   pm.addPass(debug::createDebugValidateNames());
   if (options.enableArithmetization) {
     mlirToSecretArithmeticPipelineBuilder(pm, options);
@@ -275,31 +334,67 @@ void mlirToRLWEPipeline(OpPassManager& pm,
         secretImportExecutionResultOptions));
   }
 
-  // place mgmt.op and MgmtAttr for BGV
+  // place mgmt.op and MgmtAttr for BGV/CKKS
   // which is required for secret-to-<scheme> lowering
   switch (scheme) {
     case RLWEScheme::bgvScheme: {
-      auto secretInsertMgmtBGVOptions = SecretInsertMgmtBGVOptions{};
-      secretInsertMgmtBGVOptions.afterMul = options.modulusSwitchAfterMul;
-      secretInsertMgmtBGVOptions.beforeMulIncludeFirstMul =
-          options.modulusSwitchBeforeFirstMul;
-      pm.addPass(createSecretInsertMgmtBGV(secretInsertMgmtBGVOptions));
+      if (options.ciphertextManagementStyle ==
+          CiphertextManagementStyle::orbitIlp) {
+        // ILP-based management for BGV
+        auto ilpOptions = ILPBootstrapPlacementOptions{};
+        ilpOptions.bootstrapWaterline = options.orbitBootstrapWaterline;
+        ilpOptions.scaleWaterline = options.orbitScaleWaterline;
+        ilpOptions.scaleFactorBits = options.orbitScaleFactorBits;
+        ilpOptions.bootstrapLevelLowerBound =
+            options.orbitBootstrapLevelLowerBound;
+        ilpOptions.orbitCostModel = options.orbitCostModel;
+        ilpOptions.bootstrapCost = options.orbitBootstrapCost;
+        ilpOptions.rescaleCost = options.orbitRescaleCost;
+        pm.addPass(createILPBootstrapPlacement(ilpOptions));
+      } else {
+        // Greedy management for BGV
+        auto secretInsertMgmtBGVOptions = SecretInsertMgmtBGVOptions{};
+        secretInsertMgmtBGVOptions.afterMul =
+            options.greedyModulusSwitchAfterMul;
+        secretInsertMgmtBGVOptions.beforeMulIncludeFirstMul =
+            options.greedyModulusSwitchBeforeFirstMul;
+        secretInsertMgmtBGVOptions.levelBudget = options.greedyLevelBudget;
+        pm.addPass(createSecretInsertMgmtBGV(secretInsertMgmtBGVOptions));
+      }
       break;
     }
     case RLWEScheme::bfvScheme: {
+      // BFV doesn't use bootstrap management currently
       pm.addPass(createSecretInsertMgmtBFV());
       break;
     }
     case RLWEScheme::ckksScheme: {
-      auto secretInsertMgmtCKKSOptions = SecretInsertMgmtCKKSOptions{};
-      secretInsertMgmtCKKSOptions.afterMul = options.modulusSwitchAfterMul;
-      secretInsertMgmtCKKSOptions.beforeMulIncludeFirstMul =
-          options.modulusSwitchBeforeFirstMul;
-      secretInsertMgmtCKKSOptions.slotNumber = options.ciphertextDegree;
-      secretInsertMgmtCKKSOptions.bootstrapWaterline =
-          options.ckksBootstrapWaterline;
-      secretInsertMgmtCKKSOptions.levelBudget = options.levelBudget;
-      pm.addPass(createSecretInsertMgmtCKKS(secretInsertMgmtCKKSOptions));
+      if (options.ciphertextManagementStyle ==
+          CiphertextManagementStyle::orbitIlp) {
+        // ILP-based management for CKKS
+        auto ilpOptions = ILPBootstrapPlacementOptions{};
+        ilpOptions.bootstrapWaterline = options.orbitBootstrapWaterline;
+        ilpOptions.scaleWaterline = options.orbitScaleWaterline;
+        ilpOptions.scaleFactorBits = options.orbitScaleFactorBits;
+        ilpOptions.bootstrapLevelLowerBound =
+            options.orbitBootstrapLevelLowerBound;
+        ilpOptions.orbitCostModel = options.orbitCostModel;
+        ilpOptions.bootstrapCost = options.orbitBootstrapCost;
+        ilpOptions.rescaleCost = options.orbitRescaleCost;
+        pm.addPass(createILPBootstrapPlacement(ilpOptions));
+      } else {
+        // Greedy management for CKKS
+        auto secretInsertMgmtCKKSOptions = SecretInsertMgmtCKKSOptions{};
+        secretInsertMgmtCKKSOptions.afterMul =
+            options.greedyModulusSwitchAfterMul;
+        secretInsertMgmtCKKSOptions.beforeMulIncludeFirstMul =
+            options.greedyModulusSwitchBeforeFirstMul;
+        secretInsertMgmtCKKSOptions.slotNumber = options.ciphertextDegree;
+        secretInsertMgmtCKKSOptions.bootstrapWaterline =
+            options.greedyBootstrapWaterline;
+        secretInsertMgmtCKKSOptions.levelBudget = options.greedyLevelBudget;
+        pm.addPass(createSecretInsertMgmtCKKS(secretInsertMgmtCKKSOptions));
+      }
       break;
     }
     default:
@@ -378,7 +473,7 @@ void mlirToRLWEPipeline(OpPassManager& pm,
 
       PopulateScaleCKKSOptions populateScaleCKKSOptions;
       populateScaleCKKSOptions.beforeMulIncludeFirstMul =
-          options.modulusSwitchBeforeFirstMul;
+          options.greedyModulusSwitchBeforeFirstMul;
       pm.addPass(createPopulateScaleCKKS(populateScaleCKKSOptions));
       break;
     }
@@ -583,7 +678,7 @@ void torchLinalgToCkksBuilder(OpPassManager& manager,
 
   suboptions.enableArithmetization = true;
   suboptions.ciphertextDegree = options.ciphertextDegree;
-  suboptions.ckksBootstrapWaterline = options.ckksBootstrapWaterline;
+  suboptions.greedyBootstrapWaterline = options.greedyBootstrapWaterline;
   suboptions.scalingModBits = options.scalingModBits;
   suboptions.firstModBits = options.firstModBits;
   suboptions.enableSplitPreprocessing = options.enableSplitPreprocessing;
@@ -591,13 +686,14 @@ void torchLinalgToCkksBuilder(OpPassManager& manager,
       options.experimentalDisableLoopUnroll;
   suboptions.usePublicKey = options.usePublicKey;
   suboptions.encryptionTechniqueExtended = options.encryptionTechniqueExtended;
-  suboptions.modulusSwitchAfterMul = options.modulusSwitchAfterMul;
-  suboptions.modulusSwitchBeforeFirstMul = options.modulusSwitchBeforeFirstMul;
+  suboptions.greedyModulusSwitchAfterMul = options.greedyModulusSwitchAfterMul;
+  suboptions.greedyModulusSwitchBeforeFirstMul =
+      options.greedyModulusSwitchBeforeFirstMul;
   suboptions.plaintextModulus = options.plaintextModulus;
   suboptions.noiseModel = options.noiseModel;
   suboptions.annotateNoiseBound = options.annotateNoiseBound;
   suboptions.bfvModBits = options.bfvModBits;
-  suboptions.levelBudget = options.levelBudget;
+  suboptions.greedyLevelBudget = options.greedyLevelBudget;
   suboptions.plaintextExecutionResultFileName =
       options.plaintextExecutionResultFileName;
   suboptions.codegenStrategy = options.codegenStrategy;

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -16,6 +16,9 @@ namespace mlir::heir {
 // RLWE scheme selector
 enum RLWEScheme { ckksScheme, bgvScheme, bfvScheme };
 
+// Ciphertext management style selector
+enum CiphertextManagementStyle { greedy, orbitIlp };
+
 struct LoopOptions : public PassPipelineOptions<LoopOptions> {
   PassOptions::Option<bool> experimentalDisableLoopUnroll{
       *this, "experimental-disable-loop-unroll",
@@ -49,16 +52,6 @@ struct MlirToRLWEPipelineOptions : public LoopOptions {
       llvm::cl::desc("If true, use extended encryption technique (default to "
                      "false)"),
       llvm::cl::init(false)};
-  PassOptions::Option<bool> modulusSwitchAfterMul{
-      *this, "modulus-switch-after-mul",
-      llvm::cl::desc("Modulus switching after the first multiplication "
-                     "(default to false)"),
-      llvm::cl::init(false)};
-  PassOptions::Option<bool> modulusSwitchBeforeFirstMul{
-      *this, "modulus-switch-before-first-mul",
-      llvm::cl::desc("Modulus switching right before the first multiplication "
-                     "(default to false)"),
-      llvm::cl::init(false)};
   PassOptions::Option<int64_t> plaintextModulus{
       *this, "plaintext-modulus",
       llvm::cl::desc("Plaintext modulus for BGV scheme (default to 65537)"),
@@ -85,16 +78,6 @@ struct MlirToRLWEPipelineOptions : public LoopOptions {
       *this, "bfv-mod-bits",
       llvm::cl::desc("The number of bits for all moduli for B/FV"),
       llvm::cl::init(60)};
-  PassOptions::Option<int> ckksBootstrapWaterline{
-      *this, "ckks-bootstrap-waterline",
-      llvm::cl::desc("The number of levels to keep until bootstrapping in CKKS "
-                     "(c.f. --secret-insert-mgmt-ckks)"),
-      llvm::cl::init(10)};
-  PassOptions::Option<int> levelBudget{
-      *this, "level-budget",
-      llvm::cl::desc(
-          "The level budget excluding levels required for bootstrap"),
-      llvm::cl::init(10)};
   PassOptions::Option<bool> debug{
       *this, "debug",
       llvm::cl::desc("Insert debug ports after every secret operation."),
@@ -120,6 +103,68 @@ struct MlirToRLWEPipelineOptions : public LoopOptions {
           clEnumValN(CodegenStrategy::FOLD_WHEN_POSSIBLE, "fold-when-possible",
                      "Fold constants when possible")),
       llvm::cl::init(CodegenStrategy::AUTO)};
+
+  // Ciphertext management options
+  PassOptions::Option<CiphertextManagementStyle> ciphertextManagementStyle{
+      *this, "ciphertext-management-style",
+      llvm::cl::desc(
+          "Strategy for ciphertext management and bootstrap placement"),
+      llvm::cl::values(
+          clEnumValN(CiphertextManagementStyle::greedy, "greedy",
+                     "Greedy waterline-based management"),
+          clEnumValN(CiphertextManagementStyle::orbitIlp, "orbit-ilp",
+                     "ILP-based Orbit-style management")),
+      llvm::cl::init(CiphertextManagementStyle::greedy)};
+
+  // Greedy-specific options
+  PassOptions::Option<bool> greedyModulusSwitchAfterMul{
+      *this, "greedy-modulus-switch-after-mul",
+      llvm::cl::desc(
+          "Modulus switching after the first multiplication (greedy style)"),
+      llvm::cl::init(false)};
+  PassOptions::Option<bool> greedyModulusSwitchBeforeFirstMul{
+      *this, "greedy-modulus-switch-before-first-mul",
+      llvm::cl::desc("Modulus switching right before the first multiplication "
+                     "(greedy style)"),
+      llvm::cl::init(false)};
+  PassOptions::Option<int> greedyLevelBudget{
+      *this, "greedy-level-budget",
+      llvm::cl::desc("Maximum bound on the level for greedy management "
+                     "(excluding bootstrap levels)"),
+      llvm::cl::init(10)};
+  PassOptions::Option<int> greedyBootstrapWaterline{
+      *this, "greedy-bootstrap-waterline",
+      llvm::cl::desc("Bootstrap waterline for greedy CKKS management"),
+      llvm::cl::init(10)};
+
+  // Orbit-ILP-specific options
+  PassOptions::Option<int> orbitBootstrapWaterline{
+      *this, "orbit-bootstrap-waterline",
+      llvm::cl::desc("Bootstrap waterline (max level) for Orbit ILP"),
+      llvm::cl::init(3)};
+  PassOptions::Option<int> orbitScaleWaterline{
+      *this, "orbit-scale-waterline",
+      llvm::cl::desc("Orbit waterline/base scale bits (Sw)"),
+      llvm::cl::init(40)};
+  PassOptions::Option<int> orbitScaleFactorBits{
+      *this, "orbit-scale-factor-bits",
+      llvm::cl::desc("Orbit rescale factor bits (Sf)"), llvm::cl::init(51)};
+  PassOptions::Option<int> orbitBootstrapLevelLowerBound{
+      *this, "orbit-bootstrap-level-lower-bound",
+      llvm::cl::desc("Minimum input level for bootstrap in Orbit constraints"),
+      llvm::cl::init(0)};
+  PassOptions::Option<std::string> orbitCostModel{
+      *this, "orbit-cost-model",
+      llvm::cl::desc("Path to JSON cost model for Orbit ILP"),
+      llvm::cl::init("")};
+  PassOptions::Option<int> orbitBootstrapCost{
+      *this, "orbit-bootstrap-cost",
+      llvm::cl::desc("Cost of one bootstrap in ILP objective"),
+      llvm::cl::init(69320650)};
+  PassOptions::Option<int> orbitRescaleCost{
+      *this, "orbit-rescale-cost",
+      llvm::cl::desc("Cost of one rescale in ILP objective"),
+      llvm::cl::init(40988)};
 };
 
 struct PlaintextBackendOptions

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -147,6 +147,7 @@ cc_library(
         "@heir//lib/Transforms/ForwardInsertToExtract",
         "@heir//lib/Transforms/FullLoopUnroll",
         "@heir//lib/Transforms/GenerateParam",
+        "@heir//lib/Transforms/ILPBootstrapPlacement",
         "@heir//lib/Transforms/InlineActivations",
         "@heir//lib/Transforms/LayoutOptimization",
         "@heir//lib/Transforms/LayoutPropagation",

--- a/tests/Examples/lattigo/ckks/batch_matmul/BUILD
+++ b/tests/Examples/lattigo/ckks/batch_matmul/BUILD
@@ -7,7 +7,7 @@ heir_lattigo_lib(
     go_library_name = "batchmatmul",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--mlir-to-ckks=ciphertext-degree=4096 experimental-disable-loop-unroll=true level-budget=40 first-mod-bits=60 scaling-mod-bits=50",
+        "--mlir-to-ckks=ciphertext-degree=4096 experimental-disable-loop-unroll=true greedy-level-budget=40 first-mod-bits=60 scaling-mod-bits=50",
         "--scheme-to-lattigo",
     ],
     mlir_src = "@heir//tests/Examples/common:batch_matmul.mlir",

--- a/tests/Examples/lattigo/ckks/conv_pool_fusion/BUILD
+++ b/tests/Examples/lattigo/ckks/conv_pool_fusion/BUILD
@@ -8,7 +8,7 @@ heir_lattigo_lib(
     go_library_name = "conv_pool_fusion",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--torch-linalg-to-ckks=ciphertext-degree=4096 modulus-switch-after-mul=true experimental-disable-loop-unroll=true",
+        "--torch-linalg-to-ckks=ciphertext-degree=4096 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "conv_pool_fusion.mlir",

--- a/tests/Examples/lattigo/ckks/cross_level/BUILD
+++ b/tests/Examples/lattigo/ckks/cross_level/BUILD
@@ -18,7 +18,7 @@ heir_lattigo_lib(
     go_library_name = "main",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--mlir-to-ckks=ciphertext-degree=4 modulus-switch-before-first-mul=true first-mod-bits=59 scaling-mod-bits=45",
+        "--mlir-to-ckks=ciphertext-degree=4 greedy-modulus-switch-before-first-mul=true first-mod-bits=59 scaling-mod-bits=45",
         "--scheme-to-lattigo=insert-debug-handler-calls=true",
     ],
     mlir_src = "cross_level.mlir",

--- a/tests/Examples/lattigo/ckks/matvec_512x784/BUILD
+++ b/tests/Examples/lattigo/ckks/matvec_512x784/BUILD
@@ -8,7 +8,7 @@ heir_lattigo_lib(
     go_library_name = "matvec512x784",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--mlir-to-ckks=ciphertext-degree=1024 modulus-switch-after-mul=true experimental-disable-loop-unroll=true level-budget=40 first-mod-bits=55",
+        "--mlir-to-ckks=ciphertext-degree=1024 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true greedy-level-budget=40 first-mod-bits=55",
         "--scheme-to-lattigo",
     ],
     mlir_src = "@heir//tests/Examples/common:matvec_512x784.mlir",

--- a/tests/Examples/lattigo/ckks/matvec_square/BUILD
+++ b/tests/Examples/lattigo/ckks/matvec_square/BUILD
@@ -8,7 +8,7 @@ heir_lattigo_lib(
     go_library_name = "matvec512x512",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--mlir-to-ckks=ciphertext-degree=1024 modulus-switch-after-mul=true experimental-disable-loop-unroll=true level-budget=40 first-mod-bits=55",
+        "--mlir-to-ckks=ciphertext-degree=1024 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true greedy-level-budget=40 first-mod-bits=55",
         "--scheme-to-lattigo",
     ],
     mlir_src = "@heir//tests/Examples/common:matvec_512x512.mlir",

--- a/tests/Examples/lattigo/ckks/mnist/BUILD
+++ b/tests/Examples/lattigo/ckks/mnist/BUILD
@@ -8,7 +8,7 @@ heir_lattigo_lib(
     go_library_name = "mnist",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--torch-linalg-to-ckks=ciphertext-degree=1024 modulus-switch-after-mul=true experimental-disable-loop-unroll=true level-budget=40 first-mod-bits=55",
+        "--torch-linalg-to-ckks=ciphertext-degree=1024 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true greedy-level-budget=40 first-mod-bits=55",
         "--scheme-to-lattigo",
     ],
     mlir_src = "@heir//tests/Examples/common/mnist:mnist.mlir",

--- a/tests/Examples/openfhe/ckks/batch_matmul/BUILD
+++ b/tests/Examples/openfhe/ckks/batch_matmul/BUILD
@@ -7,7 +7,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "batch_matmul_lib.h",
     heir_opt_flags = [
         "--annotate-module=backend=openfhe scheme=ckks",
-        "--mlir-to-ckks=ciphertext-degree=4096 experimental-disable-loop-unroll=true level-budget=40 first-mod-bits=60 scaling-mod-bits=50",
+        "--mlir-to-ckks=ciphertext-degree=4096 experimental-disable-loop-unroll=true greedy-level-budget=40 first-mod-bits=60 scaling-mod-bits=50",
         "--scheme-to-openfhe",
     ],
     mlir_src = "@heir//tests/Examples/common:batch_matmul.mlir",

--- a/tests/Examples/openfhe/ckks/loop_support/BUILD
+++ b/tests/Examples/openfhe/ckks/loop_support/BUILD
@@ -8,7 +8,7 @@ openfhe_end_to_end_test(
     generated_lib_header = "loop_lib.h",
     heir_opt_flags = [
         "--annotate-module=backend=openfhe scheme=ckks",
-        "--mlir-to-ckks=ciphertext-degree=8 scaling-mod-bits=55 first-mod-bits=60 level-budget=3 modulus-switch-after-mul=true experimental-disable-loop-unroll=true",
+        "--mlir-to-ckks=ciphertext-degree=8 scaling-mod-bits=55 first-mod-bits=60 greedy-level-budget=3 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true",
         "--lwe-add-debug-port=insert-debug-after-every-op=true",
         "--scheme-to-openfhe=insert-debug-handler-calls=true",
     ],

--- a/tests/Examples/openfhe/ckks/mnist/BUILD
+++ b/tests/Examples/openfhe/ckks/mnist/BUILD
@@ -8,7 +8,7 @@ openfhe_lib(
     generated_lib_header = "mnist_openfhe_lib.inc.h",
     heir_opt_flags = [
         "--annotate-module=backend=openfhe scheme=ckks",
-        "--torch-linalg-to-ckks=ciphertext-degree=4096 ckks-bootstrap-waterline=20 level-budget=8 modulus-switch-after-mul=true experimental-disable-loop-unroll=true first-mod-bits=30 scaling-mod-bits=24",
+        "--torch-linalg-to-ckks=ciphertext-degree=4096 greedy-bootstrap-waterline=20 greedy-level-budget=8 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true first-mod-bits=30 scaling-mod-bits=24",
         "--scheme-to-openfhe=scaling-technique-fixed-manual=true",
     ],
     mlir_src = "@heir//tests/Examples/common/mnist:mnist.mlir",

--- a/tests/Examples/openfhe/ckks/rotom/mnist/BUILD
+++ b/tests/Examples/openfhe/ckks/rotom/mnist/BUILD
@@ -10,7 +10,7 @@ openfhe_lib(
     generated_lib_header = "mnist_rotom_openfhe_lib.inc.h",
     heir_opt_flags = [
         "--annotate-module=backend=openfhe scheme=ckks",
-        "--torch-linalg-to-ckks=ciphertext-degree=32768 scaling-mod-bits=45 first-mod-bits=52 ckks-bootstrap-waterline=20 level-budget=20",
+        "--torch-linalg-to-ckks=ciphertext-degree=32768 scaling-mod-bits=45 first-mod-bits=52 greedy-bootstrap-waterline=20 greedy-level-budget=20",
         "--scheme-to-openfhe",
     ],
     mlir_src = "@heir//tests/Examples/openfhe/ckks/rotom/mnist:mnist.mlir",

--- a/tests/Regression/matvec_non_power_two_crash.mlir
+++ b/tests/Regression/matvec_non_power_two_crash.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt %s --annotate-module="backend=lattigo scheme=ckks" --mlir-to-ckks="ciphertext-degree=1024 modulus-switch-after-mul=true experimental-disable-loop-unroll=true level-budget=40 first-mod-bits=55" --scheme-to-lattigo
+// RUN: heir-opt %s --annotate-module="backend=lattigo scheme=ckks" --mlir-to-ckks="ciphertext-degree=1024 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true greedy-level-budget=40 first-mod-bits=55" --scheme-to-lattigo
 
 
 module {

--- a/tests/Transforms/mlir_to_openfhe_ckks/bootstrap_waterline.mlir
+++ b/tests/Transforms/mlir_to_openfhe_ckks/bootstrap_waterline.mlir
@@ -1,4 +1,4 @@
-// RUN: heir-opt --mlir-to-ckks=ckks-bootstrap-waterline=3 --scheme-to-openfhe %s | FileCheck %s
+// RUN: heir-opt --mlir-to-ckks=greedy-bootstrap-waterline=3 --scheme-to-openfhe %s | FileCheck %s
 
 // CHECK: func.func @bootstrap_waterline
 // CHECK:   openfhe.bootstrap

--- a/tests/Transforms/rotation_analysis/large_example.mlir
+++ b/tests/Transforms/rotation_analysis/large_example.mlir
@@ -1,7 +1,7 @@
 // RUN: heir-opt --rotation-analysis --split-input-file %s | FileCheck %s
 
 // Generated with
-// heir-opt "--annotate-module=backend=lattigo scheme=ckks" "--mlir-to-ckks=ciphertext-degree=1024 level-budget=2 modulus-switch-after-mul=true experimental-disable-loop-unroll=true first-mod-bits=55" --scheme-to-lattigo --dump-pass-pipeline --mlir-print-ir-before-all --mlir-print-ir-tree-dir=/tmp/mlir $PWD/tests/Examples/common/matvec_512x784.mlir
+// heir-opt "--annotate-module=backend=lattigo scheme=ckks" "--mlir-to-ckks=ciphertext-degree=1024 greedy-level-budget=2 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true first-mod-bits=55" --scheme-to-lattigo --dump-pass-pipeline --mlir-print-ir-before-all --mlir-print-ir-tree-dir=/tmp/mlir $PWD/tests/Examples/common/matvec_512x784.mlir
 //
 // Then copied as
 // cp /tmp/mlir/builtin_module_no-symbol-name/89_lattigo-configure-crypto-context.mlir tests/Transforms/rotation_analysis/large_example.mlir


### PR DESCRIPTION
This change prepares heir-opt for a world in which there are multiple parallel ciphertext management pipelines. It adds a new `ciphertext-management-style` enum option (with `greedy` and `orbit-ilp` variants for now) and prefixes the flags specific to each style with the name (e.g., `greedy-bootstrap-waterline` vs `orbit-bootstrap-waterline`).

This change also adds validation that the subset of chosen flags are mutually exclusive across mgmt styles, so you won't accidentally set an orbit flag when trying to use greedy or vice versa.