### PR TITLE
cheddar: switch to DPS

### DIFF
--- a/lib/Dialect/Cheddar/IR/BUILD
+++ b/lib/Dialect/Cheddar/IR/BUILD
@@ -27,8 +27,10 @@ cc_library(
         ":types_inc_gen",
         "@heir//lib/Dialect:HEIRInterfaces",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )
 
@@ -67,6 +69,7 @@ cc_library(
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Utils",
         "@heir//lib/Utils:RotationUtils",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",
@@ -85,6 +88,7 @@ td_library(
     deps = [
         "@heir//lib/Dialect:td_files",
         "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
     ],

--- a/lib/Dialect/Cheddar/IR/CheddarOps.cpp
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.cpp
@@ -1,5 +1,7 @@
 #include "lib/Dialect/Cheddar/IR/CheddarOps.h"
 
+#include <algorithm>
+
 #include "lib/Dialect/Cheddar/IR/CheddarTypes.h"
 #include "lib/Utils/RotationUtils.h"
 #include "lib/Utils/Utils.h"
@@ -27,11 +29,10 @@ LogicalResult HRotOp::verify() {
 
 ::llvm::SmallVector<::mlir::OpFoldResult>
 LinearTransformOp::getRotationIndices() {
-  auto diagonalsType = cast<RankedTensorType>(getDiagonals().getType());
+  auto diagonalsType = cast<ShapedType>(getDiagonals().getType());
   int64_t slots = diagonalsType.getShape()[1];
-  int64_t logBSGS = getLogBabyStepGiantStepRatio().getInt();
-  auto rotations = lintransRotationIndices(
-      getDiagonalIndicesAttr().asArrayRef(), slots, logBSGS);
+  auto rotations = lintransRotationIndicesWithBabyStep(
+      getDiagonalIndicesAttr().asArrayRef(), slots, getBs().getInt());
   SmallVector<OpFoldResult> result;
   result.reserve(rotations.size());
   auto* mlirCtx = (*this)->getContext();

--- a/lib/Dialect/Cheddar/IR/CheddarOps.h
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.h
@@ -6,6 +6,7 @@
 #include "lib/Dialect/Cheddar/IR/CheddarTypes.h"
 #include "lib/Dialect/HEIRInterfaces.h"
 #include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 // IWYU pragma: end_keep
 

--- a/lib/Dialect/Cheddar/IR/CheddarOps.td
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.td
@@ -5,7 +5,9 @@ include "CheddarDialect.td"
 include "CheddarTypes.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/BuiltinAttributes.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "lib/Dialect/HEIRInterfaces.td"
 
 class Cheddar_Op<string mnemonic, list<Trait> traits = []> :
@@ -15,40 +17,183 @@ class Cheddar_Op<string mnemonic, list<Trait> traits = []> :
   }];
 }
 
+// The CHEDDAR payload types are move-only and the C++ API is destination-passing
+// (`ctx->Add(out, a, b)`). To match that, every payload-producing op is modeled
+// as a destination-passing-style (DPS) op on builtin tensors: a scalar payload
+// is a rank-0 `tensor<!cheddar.X>`, the trailing `$output` operand is the
+// destination (init), and the result is tied 1:1 to it. The op is valid both
+// in tensor form (one result, pre-bufferization) and in buffer form (operands
+// are `memref<!cheddar.X>`, zero results, post one-shot-bufferize). The shared
+// `getDpsInitsMutable` points at the init operand named by `initName` (the
+// `$output` of most ops; `decode` writes `$value`, `mad_unsafe` its
+// `$accumulator` for a true in-place update).
+class Cheddar_DpsOp<string mnemonic, list<Trait> traits = [],
+                    string initName = "Output"> :
+        Cheddar_Op<mnemonic, traits # [DestinationStyleOpInterface,
+            DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let extraClassDeclaration = [{
+    // The single init operand as a (length-1) MutableOperandRange.
+    ::mlir::MutableOperandRange getDpsInitsMutable() {
+      return ::mlir::MutableOperandRange(
+          getOperation(), get}] # initName # [{Mutable().getOperandNumber(), 1);
+    }
+  }];
+  // Operand-aware memory effects (linalg-style): only memref operands carry
+  // effects, so the tensor form stays value-semantics/side-effect-free (and
+  // DCE/CSE-able) while the bufferized memref form reports read/write. The DPS
+  // init memref is written; other memref operands are read. This lets the stock
+  // ownership-based buffer-deallocation analyze the bufferized cheddar ops and
+  // free intermediate GPU buffers at their last use. (Defined out-of-line: the
+  // declaration comes from DeclareOpInterfaceMethods<MemoryEffectsOpInterface>.)
+  let extraClassDefinition = [{
+    void $cppClass::getEffects(::llvm::SmallVectorImpl<
+        ::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>>
+            &effects) {
+      for (::mlir::OpOperand &operand : getOperation()->getOpOperands()) {
+        if (!::llvm::isa<::mlir::MemRefType>(operand.get().getType()))
+          continue;
+        if (isDpsInit(&operand))
+          effects.emplace_back(::mlir::MemoryEffects::Write::get(), &operand,
+                               ::mlir::SideEffects::DefaultResource::get());
+        else
+          effects.emplace_back(::mlir::MemoryEffects::Read::get(), &operand,
+                               ::mlir::SideEffects::DefaultResource::get());
+      }
+    }
+  }];
+}
+
+// Payload operands and results are constrained by their cheddar element type.
+// `*Like` accepts a tensor or memref (valid pre- and post-bufferization);
+// `*Result` is a variadic ranked tensor (present in tensor form, absent in
+// buffer form).
+def Cheddar_CtLike : TensorOrMemRef<[Cheddar_Ciphertext]>;
+def Cheddar_PtLike : TensorOrMemRef<[Cheddar_Plaintext]>;
+def Cheddar_ConstLike : TensorOrMemRef<[Cheddar_Constant]>;
+def Cheddar_FloatLike : TensorOrMemRef<[AnyFloat, AnyComplex]>;
+
+def Cheddar_CtResult : Variadic<RankedTensorOf<[Cheddar_Ciphertext]>>;
+def Cheddar_PtResult : Variadic<RankedTensorOf<[Cheddar_Plaintext]>>;
+def Cheddar_ConstResult : Variadic<RankedTensorOf<[Cheddar_Constant]>>;
+
+// Owning setup-handle destinations. The `create_*` setup ops are
+// destination-passing like the payload ops: in tensor form they produce an SSA
+// result (the owning context / user_interface, consumed downstream) and carry a
+// trailing `$output` init operand that is the bufferization destination hint.
+// After one-shot-bufferize + buffer-results-to-out-params the result becomes a
+// `memref<!cheddar.{context,user_interface}>` out-param, which
+// `cheddar-emitc-boundary` re-types to the owning C++ smart-pointer references
+// (`std::shared_ptr<Context<word>>&` / `std::unique_ptr<UserInterface<word>>&`),
+// distinguishing them from the borrowed raw-pointer handles the
+// compute/encrypt/decrypt funcs take.
+def Cheddar_ContextLike : TensorOrMemRef<[Cheddar_Context]>;
+def Cheddar_UserInterfaceLike : TensorOrMemRef<[Cheddar_UserInterface]>;
+def Cheddar_ContextResult : Variadic<RankedTensorOf<[Cheddar_Context]>>;
+def Cheddar_UserInterfaceResult : Variadic<RankedTensorOf<[Cheddar_UserInterface]>>;
+
+// A BootContext is an owning setup handle just like Context (it lowers to
+// `std::shared_ptr<BootContext<word>>`); bootstrapping programs create one of
+// these instead of a plain Context. `AnyOwningContextLike` accepts either, used
+// by ops (e.g. create_user_interface) that work off whichever context the
+// program selected.
+def Cheddar_BootContextLike : TensorOrMemRef<[Cheddar_BootContext]>;
+def Cheddar_BootContextResult : Variadic<RankedTensorOf<[Cheddar_BootContext]>>;
+def Cheddar_AnyOwningContextLike :
+    TensorOrMemRef<[Cheddar_Context, Cheddar_BootContext]>;
+
 //===----------------------------------------------------------------------===//
 // Setup operations
 //===----------------------------------------------------------------------===//
 
-def Cheddar_CreateContextOp : Cheddar_Op<"create_context"> {
+def Cheddar_CreateContextOp : Cheddar_DpsOp<"create_context"> {
   let summary = "Create a CHEDDAR context from parameters";
   let description = [{
-    Creates a CHEDDAR Context<word> from a Parameter object.
-    The context is the main server-side computation engine.
+    Creates a CHEDDAR Context<word> from a Parameter object (DPS). The result is
+    the owning context (the main server-side computation engine); `$output` is
+    the destination buffer hint. After bufferization the destination is a
+    `memref<!cheddar.context>` re-typed to `std::shared_ptr<Context<word>>&` at
+    the emitc boundary, so a generated `__configure` hands the context back
+    through an out-param: `ctx_out = Context<word>::Create(params)`.
   }];
-  let arguments = (ins Cheddar_Parameter:$params);
-  let results = (outs Cheddar_Context:$ctx);
+  let arguments = (ins Cheddar_Parameter:$params, Cheddar_ContextLike:$output);
+  let results = (outs Cheddar_ContextResult:$result);
 }
 
-def Cheddar_CreateUserInterfaceOp : Cheddar_Op<"create_user_interface"> {
+def Cheddar_CreateUserInterfaceOp : Cheddar_DpsOp<"create_user_interface"> {
   let summary = "Create a CHEDDAR UserInterface for key gen and encrypt/decrypt";
   let description = [{
-    Creates a UserInterface<word> from a context. The UserInterface handles
-    key generation, encryption, and decryption. Note: for test purposes only.
+    Creates a UserInterface<word> from an owning context (DPS). The result is the
+    owning user_interface; `$output` is the destination buffer hint (becomes a
+    `std::unique_ptr<UserInterface<word>>&` out-param at the boundary):
+    `ui_out = std::make_unique<UserInterface<word>>(ctx)`.
   }];
-  let arguments = (ins Cheddar_Context:$ctx);
-  let results = (outs Cheddar_UserInterface:$ui);
+  let arguments = (ins Cheddar_AnyOwningContextLike:$ctx,
+                       Cheddar_UserInterfaceLike:$output);
+  let results = (outs Cheddar_UserInterfaceResult:$result);
 }
 
-def Cheddar_GetEncoderOp : Cheddar_Op<"get_encoder"> {
+def Cheddar_CreateBootContextOp : Cheddar_DpsOp<"create_boot_context"> {
+  let summary = "Create a CHEDDAR bootstrapping context from parameters";
+  let description = [{
+    Creates a `BootContext<word>` from a Parameter object (DPS), for programs
+    that bootstrap. Bootstrapping is parameterized by the CoeffToSlot (CtS) and
+    SlotToCoeff (StC) level budgets -- a depth/rotation trade-off that mirrors
+    OpenFHE's `levelBudgetEncode`/`levelBudgetDecode` -- carried here as the
+    `numCtsLevels`/`numStcLevels` attributes. `$output` is the destination
+    buffer hint; after bufferization the result becomes a
+    `memref<!cheddar.boot_context>` re-typed to `std::shared_ptr<BootContext<word>>&`
+    at the emitc boundary:
+    `ctx_out = BootContext<word>::Create(params, BootParameter(params.max_level_, numCtsLevels, numStcLevels, logMessageRatio))`.
+
+    `logMessageRatio` ~ log2(q0 / scale): the headroom between the bottom modulus
+    and the message scale that CHEDDAR's EvalMod assumes. It governs bootstrap
+    precision -- too small and large messages hit the sine-approximation domain
+    edge, too large and the absolute noise floor (~ q0/scale) dominates small
+    messages. When omitted, the emitter falls back to CHEDDAR's default.
+  }];
+  let arguments = (ins
+    Cheddar_Parameter:$params,
+    Builtin_IntegerAttr:$numCtsLevels,
+    Builtin_IntegerAttr:$numStcLevels,
+    OptionalAttr<Builtin_IntegerAttr>:$logMessageRatio,
+    Cheddar_BootContextLike:$output
+  );
+  let results = (outs Cheddar_BootContextResult:$result);
+}
+
+def Cheddar_PrepareBootstrapOp : Cheddar_DpsOp<"prepare_bootstrap", [], "Ui"> {
+  let summary = "Run the one-time bootstrap precompute and rotation-key setup";
+  let description = [{
+    Performs the one-time bootstrapping preparation on a `!cheddar.boot_context`
+    and threads the resulting rotation keys into the UserInterface (DPS on
+    `$ui`). Emits the canonical CHEDDAR sequence:
+      ctx->PrepareEvalMod();
+      ctx->PrepareEvalSpecialFFT(numSlots);
+      EvkRequest req; ctx->AddRequiredRotations(req, numSlots);
+      ui->PrepareRotationKey(req);
+    `numSlots` is the number of slots the bootstrap refreshes (full-slot boot
+    uses the context's slot count). Must run after the boot context + user
+    interface are created and (for programs that also rotate outside boot) after
+    the program's own `prepare_rot_key`s, so all keys land in one EvkMap.
+  }];
+  let arguments = (ins
+    Cheddar_BootContextLike:$ctx,
+    Cheddar_UserInterfaceLike:$ui,
+    Builtin_IntegerAttr:$numSlots
+  );
+  let results = (outs Cheddar_UserInterfaceResult:$result);
+}
+
+def Cheddar_GetEncoderOp : Cheddar_Op<"get_encoder", [Pure]> {
   let summary = "Get the encoder from a CHEDDAR context";
   let description = [{
     Returns a reference to the context's encoder (context->encoder_).
   }];
-  let arguments = (ins Cheddar_Context:$ctx);
+  let arguments = (ins Cheddar_AnyContext:$ctx);
   let results = (outs Cheddar_Encoder:$encoder);
 }
 
-def Cheddar_GetEvkMapOp : Cheddar_Op<"get_evk_map"> {
+def Cheddar_GetEvkMapOp : Cheddar_Op<"get_evk_map", [Pure]> {
   let summary = "Get the evaluation key map from a UserInterface";
   let description = [{
     Returns the EvkMap from the UserInterface (ui.GetEvkMap()).
@@ -57,7 +202,7 @@ def Cheddar_GetEvkMapOp : Cheddar_Op<"get_evk_map"> {
   let results = (outs Cheddar_EvkMap:$evkMap);
 }
 
-def Cheddar_GetMultKeyOp : Cheddar_Op<"get_mult_key"> {
+def Cheddar_GetMultKeyOp : Cheddar_Op<"get_mult_key", [Pure]> {
   let summary = "Get the multiplication evaluation key";
   let description = [{
     Returns the multiplication key from the UserInterface
@@ -67,92 +212,136 @@ def Cheddar_GetMultKeyOp : Cheddar_Op<"get_mult_key"> {
   let results = (outs Cheddar_EvalKey:$key);
 }
 
-def Cheddar_PrepareRotKeyOp : Cheddar_Op<"prepare_rot_key"> {
+def Cheddar_PrepareRotKeyOp : Cheddar_DpsOp<"prepare_rot_key", [], "Ui"> {
   let summary = "Generate a rotation key for a given distance";
   let description = [{
-    Calls ui.PrepareRotationKey(distance, max_level) to generate a rotation key.
-    Must be called before using rotation with that distance.
-    The max_level parameter specifies the maximum ciphertext level at which
-    this rotation key will be used.
+    Calls `ui->PrepareRotationKey(distance, maxLevel)` to generate a rotation
+    key, mutating the UserInterface in place. DPS: `$ui` is the in-place
+    destination and the result is the updated UserInterface (threaded to the
+    next setup op / the configure return). Must be called before using rotation
+    with that distance; `maxLevel` is the maximum ciphertext level at which the
+    key will be used.
   }];
   let arguments = (ins
-    Cheddar_UserInterface:$ui,
+    Cheddar_UserInterfaceLike:$ui,
     Builtin_IntegerAttr:$distance,
     Builtin_IntegerAttr:$maxLevel
   );
-  let results = (outs);
+  let results = (outs Cheddar_UserInterfaceResult:$result);
+}
+
+def Cheddar_MakeParameterOp : Cheddar_Op<"make_parameter", [Pure]> {
+  let summary = "Construct a CHEDDAR Parameter from CKKS scheme parameters";
+  let description = [{
+    Builds a `cheddar::Parameter<word>` from the CKKS modulus chain. The main
+    primes are the CKKS `Q` limbs and the aux primes are the `P` limbs; the
+    canonical level config is one-main-prime-per-level (`{{1, 0}, {2, 0}, ...}`)
+    and the default encryption level is `#mainPrimes - 1`, both derived from
+    `mainPrimes` by the emitter. `logScale` is the log2 of the default CKKS
+    scale. This is the single setup op that produces the `!cheddar.parameter`
+    consumed by `cheddar.create_context`, so a generated `__configure` is
+    self-contained.
+
+    Bootstrapping programs override the defaults: `defaultEncryptionLevel`
+    pins the encryption level below the chain top (the boot-circuit primes sit
+    above it), and `denseHammingWeight`/`sparseHammingWeight` set the secret-key
+    hamming weights CHEDDAR's BootContext requires. Each is omitted (and the
+    emitter falls back to `#mainPrimes - 1` / not emitting a SetHammingWeight
+    call) for non-bootstrapping programs.
+  }];
+  let arguments = (ins
+    Builtin_IntegerAttr:$logN,
+    Builtin_IntegerAttr:$logScale,
+    DenseI64ArrayAttr:$mainPrimes,
+    DenseI64ArrayAttr:$auxPrimes,
+    OptionalAttr<Builtin_IntegerAttr>:$defaultEncryptionLevel,
+    OptionalAttr<Builtin_IntegerAttr>:$denseHammingWeight,
+    OptionalAttr<Builtin_IntegerAttr>:$sparseHammingWeight
+  );
+  let results = (outs Cheddar_Parameter:$params);
+  let assemblyFormat = "attr-dict `:` type($params)";
 }
 
 //===----------------------------------------------------------------------===//
 // Encode / Encrypt / Decrypt operations
 //===----------------------------------------------------------------------===//
 
-def Cheddar_EncodeOp : Cheddar_Op<"encode", [PlaintextEncodeOpInterface]> {
+def Cheddar_EncodeOp : Cheddar_DpsOp<"encode", [PlaintextEncodeOpInterface]> {
   let summary = "Encode a message vector into a CHEDDAR plaintext";
   let description = [{
     Calls encoder.Encode(pt, level, scale, message). The message is a vector
     of complex numbers (or reals). `scale` is the C++ `double` value used by
-    CHEDDAR's Encoder.
+    CHEDDAR's Encoder. `$output` is the destination plaintext.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
-    RankedTensorOf<[AnyFloat, AnyComplex]>:$message,
+    Cheddar_FloatLike:$message,
+    Cheddar_PtLike:$output,
     Builtin_IntegerAttr:$level,
     F64Attr:$scale
   );
-  let results = (outs Cheddar_Plaintext:$plaintext);
+  let results = (outs Cheddar_PtResult:$result);
 }
 
-def Cheddar_EncodeConstantOp : Cheddar_Op<"encode_constant"> {
+def Cheddar_EncodeConstantOp : Cheddar_DpsOp<"encode_constant"> {
   let summary = "Encode a scalar double into a CHEDDAR constant";
   let description = [{
     Calls encoder.EncodeConstant(constant, level, scale, number).
     The result is in RNS form for efficient ciphertext-scalar ops.
-    `scale` is the C++ `double` value used by CHEDDAR's Encoder.
+    `scale` is the C++ `double` value used by CHEDDAR's Encoder. `$output` is
+    the destination constant.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
     AnyFloat:$value,
+    Cheddar_ConstLike:$output,
     Builtin_IntegerAttr:$level,
     F64Attr:$scale
   );
-  let results = (outs Cheddar_Constant:$constant);
+  let results = (outs Cheddar_ConstResult:$result);
 }
 
-def Cheddar_DecodeOp : Cheddar_Op<"decode"> {
+def Cheddar_DecodeOp : Cheddar_DpsOp<"decode", [], "Value"> {
   let summary = "Decode a CHEDDAR plaintext back to a message vector";
   let description = [{
-    Calls encoder.Decode(message, pt). Returns a vector of complex numbers.
+    Calls encoder.Decode(message, pt). `value` is the destination buffer the
+    decoded message is written into (the DPS init); the DPS interface verifier
+    ties it 1:1 to the `decoded` result (same type).
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
-    Cheddar_Plaintext:$plaintext
+    Cheddar_PtLike:$plaintext,
+    Cheddar_FloatLike:$value
   );
-  let results = (outs RankedTensorOf<[AnyFloat, AnyComplex]>:$message);
+  let results = (outs Variadic<AnyRankedTensor>:$decoded);
 }
 
-def Cheddar_EncryptOp : Cheddar_Op<"encrypt"> {
+def Cheddar_EncryptOp : Cheddar_DpsOp<"encrypt"> {
   let summary = "Encrypt a plaintext into a ciphertext";
   let description = [{
-    Calls ui.Encrypt(ct, pt). Test-only operation.
+    Calls ui.Encrypt(ct, pt). Test-only operation. `$output` is the destination
+    ciphertext.
   }];
   let arguments = (ins
     Cheddar_UserInterface:$ui,
-    Cheddar_Plaintext:$plaintext
+    Cheddar_PtLike:$plaintext,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$ciphertext);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_DecryptOp : Cheddar_Op<"decrypt"> {
+def Cheddar_DecryptOp : Cheddar_DpsOp<"decrypt"> {
   let summary = "Decrypt a ciphertext into a plaintext";
   let description = [{
-    Calls ui.Decrypt(pt, ct). Test-only operation.
+    Calls ui.Decrypt(pt, ct). Test-only operation. `$output` is the destination
+    plaintext.
   }];
   let arguments = (ins
     Cheddar_UserInterface:$ui,
-    Cheddar_Ciphertext:$ciphertext
+    Cheddar_CtLike:$ciphertext,
+    Cheddar_PtLike:$output
   );
-  let results = (outs Cheddar_Plaintext:$plaintext);
+  let results = (outs Cheddar_PtResult:$result);
 }
 
 //===----------------------------------------------------------------------===//
@@ -160,13 +349,14 @@ def Cheddar_DecryptOp : Cheddar_Op<"decrypt"> {
 //===----------------------------------------------------------------------===//
 
 class Cheddar_BinaryCtCtOp<string mnemonic, list<Trait> traits = []>
-    : Cheddar_Op<mnemonic, traits> {
+    : Cheddar_DpsOp<mnemonic, traits> {
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$lhs,
-    Cheddar_Ciphertext:$rhs
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$lhs,
+    Cheddar_CtLike:$rhs,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
 def Cheddar_AddOp : Cheddar_BinaryCtCtOp<"add"> {
@@ -191,129 +381,139 @@ def Cheddar_MultOp : Cheddar_BinaryCtCtOp<"mult", [IncreasesMulDepthOpInterface]
   }];
 }
 
-def Cheddar_AddPlainOp : Cheddar_Op<"add_plain"> {
+def Cheddar_AddPlainOp : Cheddar_DpsOp<"add_plain"> {
   let summary = "Add a plaintext to a ciphertext";
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$ciphertext,
-    Cheddar_Plaintext:$plaintext
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$ciphertext,
+    Cheddar_PtLike:$plaintext,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_SubPlainOp : Cheddar_Op<"sub_plain"> {
+def Cheddar_SubPlainOp : Cheddar_DpsOp<"sub_plain"> {
   let summary = "Subtract a plaintext from a ciphertext";
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$ciphertext,
-    Cheddar_Plaintext:$plaintext
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$ciphertext,
+    Cheddar_PtLike:$plaintext,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_MultPlainOp : Cheddar_Op<"mult_plain"> {
+def Cheddar_MultPlainOp : Cheddar_DpsOp<"mult_plain"> {
   let summary = "Multiply a ciphertext by a plaintext (no rescale)";
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$ciphertext,
-    Cheddar_Plaintext:$plaintext
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$ciphertext,
+    Cheddar_PtLike:$plaintext,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_AddConstOp : Cheddar_Op<"add_const"> {
+def Cheddar_AddConstOp : Cheddar_DpsOp<"add_const"> {
   let summary = "Add a constant to a ciphertext";
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$ciphertext,
-    Cheddar_Constant:$constant
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$ciphertext,
+    Cheddar_ConstLike:$constant,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_MultConstOp : Cheddar_Op<"mult_const"> {
+def Cheddar_MultConstOp : Cheddar_DpsOp<"mult_const"> {
   let summary = "Multiply a ciphertext by a constant (no rescale)";
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$ciphertext,
-    Cheddar_Constant:$constant
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$ciphertext,
+    Cheddar_ConstLike:$constant,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_NegOp : Cheddar_Op<"neg"> {
+def Cheddar_NegOp : Cheddar_DpsOp<"neg"> {
   let summary = "Negate a ciphertext";
   let description = [{
     Calls context->Neg(res, a).
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_RescaleOp : Cheddar_Op<"rescale"> {
+def Cheddar_RescaleOp : Cheddar_DpsOp<"rescale"> {
   let summary = "Rescale a ciphertext (drop one level)";
   let description = [{
     Calls context->Rescale(res, a). Reduces the ciphertext level by 1.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_LevelDownOp : Cheddar_Op<"level_down"> {
+def Cheddar_LevelDownOp : Cheddar_DpsOp<"level_down"> {
   let summary = "Reduce ciphertext to a target level";
   let description = [{
     Calls context->LevelDown(res, a, target_level).
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$output,
     Builtin_IntegerAttr:$targetLevel
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
 //===----------------------------------------------------------------------===//
 // Key-switching operations
 //===----------------------------------------------------------------------===//
 
-def Cheddar_RelinearizeOp : Cheddar_Op<"relinearize"> {
+def Cheddar_RelinearizeOp : Cheddar_DpsOp<"relinearize"> {
   let summary = "Relinearize a ciphertext (without rescale)";
   let description = [{
     Calls context->Relinearize(res, a, mult_key).
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
-    Cheddar_EvalKey:$multKey
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_EvalKey:$multKey,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_RelinearizeRescaleOp : Cheddar_Op<"relinearize_rescale"> {
+def Cheddar_RelinearizeRescaleOp : Cheddar_DpsOp<"relinearize_rescale"> {
   let summary = "Fused relinearize + rescale";
   let description = [{
     Calls context->RelinearizeRescale(res, a, mult_key). Faster than
     separate Relinearize + Rescale.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
-    Cheddar_EvalKey:$multKey
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_EvalKey:$multKey,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
 //===----------------------------------------------------------------------===//
 // Compound (fused) operations -- high-performance GPU kernels
 //===----------------------------------------------------------------------===//
 
-def Cheddar_HMultOp : Cheddar_Op<"hmult", [IncreasesMulDepthOpInterface]> {
+def Cheddar_HMultOp : Cheddar_DpsOp<"hmult", [IncreasesMulDepthOpInterface]> {
   let summary = "Fused multiply + relinearize (+ optional rescale)";
   let description = [{
     Calls context->HMult(res, a, b, mult_key, rescale).
@@ -321,118 +521,133 @@ def Cheddar_HMultOp : Cheddar_Op<"hmult", [IncreasesMulDepthOpInterface]> {
     rescaling is included (default: true).
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$lhs,
-    Cheddar_Ciphertext:$rhs,
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$lhs,
+    Cheddar_CtLike:$rhs,
     Cheddar_EvalKey:$multKey,
+    Cheddar_CtLike:$output,
     DefaultValuedAttr<BoolAttr, "true">:$rescale
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_HRotOp : Cheddar_Op<"hrot", [
+def Cheddar_HRotOp : Cheddar_DpsOp<"hrot", [
   DeclareOpInterfaceMethods<RotationOpInterface>
 ]> {
   let summary = "Fused key-switch + rotation";
   let description = [{
     Calls context->HRot(res, a, rot_key, distance). The rotation key is looked
-    up from the enclosing function's UserInterface using `distance`.
+    up from the `$ui` UserInterface operand using `distance`.
     Single fused GPU kernel. Supports both static and dynamic distances.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
+    Cheddar_AnyContext:$ctx,
+    Cheddar_UserInterface:$ui,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$output,
     Optional<AnySignlessIntegerOrIndex>:$dynamic_distance,
     OptionalAttr<Builtin_IntegerAttr>:$static_distance
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
   let hasVerifier = 1;
 }
 
-def Cheddar_HRotAddOp : Cheddar_Op<"hrot_add", [
+def Cheddar_HRotAddOp : Cheddar_DpsOp<"hrot_add", [
   DeclareOpInterfaceMethods<RotationOpInterface>
 ]> {
   let summary = "Fused rotation + addition";
   let description = [{
     Computes res = rotate(a, distance) + b in a single fused GPU kernel.
     Calls context->HRotAdd(res, a, b, rot_key, distance). The rotation key
-    is looked up from the enclosing function's UserInterface using `distance`.
+    is looked up from the `$ui` UserInterface operand using `distance`.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
-    Cheddar_Ciphertext:$addend,
+    Cheddar_AnyContext:$ctx,
+    Cheddar_UserInterface:$ui,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$addend,
+    Cheddar_CtLike:$output,
     Builtin_IntegerAttr:$distance
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_HConjOp : Cheddar_Op<"hconj"> {
+def Cheddar_HConjOp : Cheddar_DpsOp<"hconj"> {
   let summary = "Fused key-switch + conjugation";
   let description = [{
     Calls context->HConj(res, a, conj_key). The conjugation key is looked
-    up from the enclosing function's UserInterface.
+    up from the `$ui` UserInterface operand.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input
+    Cheddar_AnyContext:$ctx,
+    Cheddar_UserInterface:$ui,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_HConjAddOp : Cheddar_Op<"hconj_add"> {
+def Cheddar_HConjAddOp : Cheddar_DpsOp<"hconj_add"> {
   let summary = "Fused conjugation + addition";
   let description = [{
     Computes res = conj(a) + b in a single fused GPU kernel.
     Calls context->HConjAdd(res, a, b, conj_key). The conjugation key is
-    looked up from the enclosing function's UserInterface.
+    looked up from the `$ui` UserInterface operand.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
-    Cheddar_Ciphertext:$addend
+    Cheddar_AnyContext:$ctx,
+    Cheddar_UserInterface:$ui,
+    Cheddar_CtLike:$input,
+    Cheddar_CtLike:$addend,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_MadUnsafeOp : Cheddar_Op<"mad_unsafe"> {
+def Cheddar_MadUnsafeOp : Cheddar_DpsOp<"mad_unsafe", [], "Accumulator"> {
   let summary = "Fused multiply-accumulate with constant (no rescale)";
   let description = [{
     Computes res += a * constant (in-place accumulation).
-    Calls context->MadUnsafe(res, a, constant).
+    Calls context->MadUnsafe(res, a, constant). The `$accumulator` operand is
+    the in-place destination (the DPS init); the result is tied to it.
 
     Note: this op would typically be called `mac`,
     the current name reflects the spelling in Cheddar
     (`MadUnsafe`).
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$accumulator,
-    Cheddar_Ciphertext:$input,
-    Cheddar_Constant:$constant
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$accumulator,
+    Cheddar_CtLike:$input,
+    Cheddar_ConstLike:$constant
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
 //===----------------------------------------------------------------------===//
 // Extension operations (bootstrapping, linear transforms, poly eval)
 //===----------------------------------------------------------------------===//
 
-def Cheddar_BootOp : Cheddar_Op<"boot", [ResetsMulDepthOpInterface]> {
+def Cheddar_BootOp : Cheddar_DpsOp<"boot", [ResetsMulDepthOpInterface]> {
   let summary = "Bootstrap a ciphertext";
   let description = [{
     Calls boot_ctx->Boot(res, input, evk_map).
     Refreshes the ciphertext noise budget.
+
+    Requires a `!cheddar.boot_context` (not a plain `!cheddar.context`): `Boot`
+    is a BootContext method, so this op statically guarantees the context it
+    runs on is a BootContext and the emitter needs no downcast.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
-    Cheddar_EvkMap:$evkMap
+    Cheddar_BootContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_EvkMap:$evkMap,
+    Cheddar_CtLike:$output
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_LinearTransformOp : Cheddar_Op<"linear_transform", [
+def Cheddar_LinearTransformOp : Cheddar_DpsOp<"linear_transform", [
   DeclareOpInterfaceMethods<RotationOpInterface>
 ]> {
   let summary = "Apply a linear transform on a ciphertext";
@@ -445,31 +660,39 @@ def Cheddar_LinearTransformOp : Cheddar_Op<"linear_transform", [
     The `level` attribute specifies the modulus level for the operation.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
     Cheddar_EvkMap:$evkMap,
-    2DTensorOf<[AnyFloat]>:$diagonals,
+    TensorOrMemRef<[AnyFloat]>:$diagonals,
+    Cheddar_CtLike:$output,
     DenseI32ArrayAttr:$diagonal_indices,
     Builtin_IntegerAttr:$level,
-    Builtin_IntegerAttr:$logBabyStepGiantStepRatio
+    Builtin_IntegerAttr:$bs,
+    Builtin_IntegerAttr:$gs
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
+  let hasVerifier = 1;
 }
 
-def Cheddar_EvalPolyOp : Cheddar_Op<"eval_poly"> {
+def Cheddar_EvalPolyOp : Cheddar_DpsOp<"eval_poly"> {
   let summary = "Evaluate a polynomial on a ciphertext";
   let description = [{
     Evaluates a polynomial (e.g., Chebyshev approximation) on an encrypted
     input using CHEDDAR's EvalPoly extension.
+    `level` is the level the input ciphertext enters at; `outputLevel` is the
+    level the result lands at after the polynomial's multiplicative depth.
   }];
   let arguments = (ins
-    Cheddar_Context:$ctx,
-    Cheddar_Ciphertext:$input,
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
     Cheddar_EvkMap:$evkMap,
-    ArrayAttr:$coefficients,
-    Builtin_IntegerAttr:$level
+    Cheddar_CtLike:$output,
+    F64ArrayAttr:$coefficients,
+    Builtin_IntegerAttr:$level,
+    Builtin_IntegerAttr:$outputLevel
   );
-  let results = (outs Cheddar_Ciphertext:$output);
+  let results = (outs Cheddar_CtResult:$result);
+  let hasVerifier = 1;
 }
 
 #endif  // LIB_DIALECT_CHEDDAR_IR_CHEDDAROPS_TD_

--- a/lib/Dialect/Cheddar/IR/CheddarTypes.td
+++ b/lib/Dialect/Cheddar/IR/CheddarTypes.td
@@ -4,13 +4,15 @@
 include "CheddarDialect.td"
 
 include "lib/Dialect/HEIRInterfaces.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpAsmInterface.td"
 
 // A base class for all types in this dialect
 class Cheddar_Type<string name, string typeMnemonic, list<Trait> traits = []>
-    : TypeDef<Cheddar_Dialect, name, traits # [OpAsmTypeInterface]> {
+    : TypeDef<Cheddar_Dialect, name,
+              traits # [OpAsmTypeInterface, MemRefElementTypeInterface]> {
   let mnemonic = typeMnemonic;
   let genMnemonicAlias = 1;
 
@@ -27,12 +29,27 @@ class Cheddar_Type<string name, string typeMnemonic, list<Trait> traits = []>
 
 def Cheddar_Context : Cheddar_Type<"Context", "context"> {
   let description = [{
-    This type represents a CHEDDAR Context (or BootContext), which is the
-    main server-side computation engine. Created via Context::Create(param)
-    or BootContext::Create(param, boot_param).
+    This type represents a CHEDDAR Context, the main server-side computation
+    engine. Created via Context::Create(param).
   }];
   let asmName = "ctx";
 }
+
+def Cheddar_BootContext : Cheddar_Type<"BootContext", "boot_context"> {
+  let description = [{
+    This type represents a CHEDDAR BootContext: a Context extended with
+    bootstrapping support, created via BootContext::Create(param, boot_param).
+    A BootContext is-a Context in CHEDDAR, so it is accepted anywhere a Context
+    is via the `Cheddar_AnyContext` constraint; only `cheddar.boot` requires it
+    specifically (so the emitter can call `BootContext::Boot` with no downcast).
+  }];
+  let asmName = "boot_ctx";
+}
+
+// Most server-side ops run on either a plain Context or a BootContext (the
+// latter derives from the former in CHEDDAR). `cheddar.boot` is the exception:
+// it requires a Cheddar_BootContext.
+def Cheddar_AnyContext : AnyTypeOf<[Cheddar_Context, Cheddar_BootContext]>;
 
 def Cheddar_Parameter : Cheddar_Type<"Parameter", "parameter"> {
   let description = [{

--- a/tests/Dialect/Cheddar/IR/roundtrip.mlir
+++ b/tests/Dialect/Cheddar/IR/roundtrip.mlir
@@ -1,21 +1,31 @@
 // RUN: heir-opt %s | FileCheck %s
 
-// Test that the cheddar dialect can be parsed and printed.
+// Test that the cheddar dialect can be parsed and printed. Payload-producing
+// ops are destination-passing: their payload operands are `tensor<!cheddar.X>`
+// and they take a trailing `$output` init operand tied to the result.
 
 // --- Setup operations ---
 
+// CHECK: @test_make_parameter
+func.func @test_make_parameter() -> !cheddar.parameter {
+  // CHECK: cheddar.make_parameter
+  // CHECK-SAME: logN = 14
+  %p = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2, 3>, auxPrimes = array<i64: 4, 5>} : !cheddar.parameter
+  return %p : !cheddar.parameter
+}
+
 // CHECK: @test_create_context
-func.func @test_create_context(%params: !cheddar.parameter) -> !cheddar.context {
+func.func @test_create_context(%params: !cheddar.parameter, %init: tensor<!cheddar.context>) -> tensor<!cheddar.context> {
   // CHECK: cheddar.create_context
-  %ctx = cheddar.create_context %params : (!cheddar.parameter) -> !cheddar.context
-  return %ctx : !cheddar.context
+  %ctx = cheddar.create_context %params, %init : (!cheddar.parameter, tensor<!cheddar.context>) -> tensor<!cheddar.context>
+  return %ctx : tensor<!cheddar.context>
 }
 
 // CHECK: @test_create_user_interface
-func.func @test_create_user_interface(%ctx: !cheddar.context) -> !cheddar.user_interface {
+func.func @test_create_user_interface(%ctx: tensor<!cheddar.context>, %init: tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface> {
   // CHECK: cheddar.create_user_interface
-  %ui = cheddar.create_user_interface %ctx : (!cheddar.context) -> !cheddar.user_interface
-  return %ui : !cheddar.user_interface
+  %ui = cheddar.create_user_interface %ctx, %init : (tensor<!cheddar.context>, tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %ui : tensor<!cheddar.user_interface>
 }
 
 // CHECK: @test_get_encoder
@@ -40,12 +50,12 @@ func.func @test_get_mult_key(%ui: !cheddar.user_interface) -> !cheddar.eval_key 
 }
 
 // CHECK: @test_prepare_rot_key
-func.func @test_prepare_rot_key(%ui: !cheddar.user_interface) {
+func.func @test_prepare_rot_key(%ui: tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface> {
   // CHECK: cheddar.prepare_rot_key
   // CHECK-SAME: distance = 3
   // CHECK-SAME: maxLevel = 10
-  cheddar.prepare_rot_key %ui {distance = 3 : i64, maxLevel = 10 : i64} : (!cheddar.user_interface) -> ()
-  return
+  %ui2 = cheddar.prepare_rot_key %ui {distance = 3 : i64, maxLevel = 10 : i64} : (tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %ui2 : tensor<!cheddar.user_interface>
 }
 
 // --- Encode / Encrypt / Decrypt ---
@@ -53,50 +63,55 @@ func.func @test_prepare_rot_key(%ui: !cheddar.user_interface) {
 // CHECK: @test_encode
 func.func @test_encode(
     %enc: !cheddar.encoder,
-    %msg: tensor<4xf64>) -> !cheddar.plaintext {
+    %msg: tensor<4xf64>,
+    %out: tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext> {
   // CHECK: cheddar.encode
   // CHECK-SAME: level = 5
   // CHECK-SAME: scale = 0x42C0000000000000
-  %pt = cheddar.encode %enc, %msg {level = 5 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, tensor<4xf64>) -> !cheddar.plaintext
-  return %pt : !cheddar.plaintext
+  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
+  return %pt : tensor<!cheddar.plaintext>
 }
 
 // CHECK: @test_encode_constant
 func.func @test_encode_constant(
     %enc: !cheddar.encoder,
-    %val: f64) -> !cheddar.constant {
+    %val: f64,
+    %out: tensor<!cheddar.constant>) -> tensor<!cheddar.constant> {
   // CHECK: cheddar.encode_constant
   // CHECK-SAME: level = 3
   // CHECK-SAME: scale = 0x42C0000000000000
-  %c = cheddar.encode_constant %enc, %val {level = 3 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, f64) -> !cheddar.constant
-  return %c : !cheddar.constant
+  %c = cheddar.encode_constant %enc, %val, %out {level = 3 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, f64, tensor<!cheddar.constant>) -> tensor<!cheddar.constant>
+  return %c : tensor<!cheddar.constant>
 }
 
 // CHECK: @test_decode
 func.func @test_decode(
     %enc: !cheddar.encoder,
-    %pt: !cheddar.plaintext) -> tensor<4xf64> {
+    %pt: tensor<!cheddar.plaintext>,
+    %dst: tensor<4xf64>) -> tensor<4xf64> {
   // CHECK: cheddar.decode
-  %msg = cheddar.decode %enc, %pt : (!cheddar.encoder, !cheddar.plaintext) -> tensor<4xf64>
+  %msg = cheddar.decode %enc, %pt, %dst : (!cheddar.encoder, tensor<!cheddar.plaintext>, tensor<4xf64>) -> tensor<4xf64>
   return %msg : tensor<4xf64>
 }
 
 // CHECK: @test_encrypt
 func.func @test_encrypt(
     %ui: !cheddar.user_interface,
-    %pt: !cheddar.plaintext) -> !cheddar.ciphertext {
+    %pt: tensor<!cheddar.plaintext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.encrypt
-  %ct = cheddar.encrypt %ui, %pt : (!cheddar.user_interface, !cheddar.plaintext) -> !cheddar.ciphertext
-  return %ct : !cheddar.ciphertext
+  %ct = cheddar.encrypt %ui, %pt, %out : (!cheddar.user_interface, tensor<!cheddar.plaintext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %ct : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_decrypt
 func.func @test_decrypt(
     %ui: !cheddar.user_interface,
-    %ct: !cheddar.ciphertext) -> !cheddar.plaintext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext> {
   // CHECK: cheddar.decrypt
-  %pt = cheddar.decrypt %ui, %ct : (!cheddar.user_interface, !cheddar.ciphertext) -> !cheddar.plaintext
-  return %pt : !cheddar.plaintext
+  %pt = cheddar.decrypt %ui, %ct, %out : (!cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
+  return %pt : tensor<!cheddar.plaintext>
 }
 
 // --- Binary ct-ct operations ---
@@ -104,31 +119,34 @@ func.func @test_decrypt(
 // CHECK: @test_add
 func.func @test_add(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.add
-  %result = cheddar.add %ctx, %ct0, %ct1 : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.add %ctx, %ct0, %ct1, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_sub
 func.func @test_sub(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.sub
-  %result = cheddar.sub %ctx, %ct0, %ct1 : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.sub %ctx, %ct0, %ct1, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_mult
 func.func @test_mult(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.mult
-  %result = cheddar.mult %ctx, %ct0, %ct1 : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.mult %ctx, %ct0, %ct1, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // --- Ct-pt / ct-const operations ---
@@ -136,51 +154,56 @@ func.func @test_mult(
 // CHECK: @test_add_plain
 func.func @test_add_plain(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %pt: !cheddar.plaintext) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %pt: tensor<!cheddar.plaintext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.add_plain
-  %result = cheddar.add_plain %ctx, %ct, %pt : (!cheddar.context, !cheddar.ciphertext, !cheddar.plaintext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.add_plain %ctx, %ct, %pt, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.plaintext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_sub_plain
 func.func @test_sub_plain(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %pt: !cheddar.plaintext) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %pt: tensor<!cheddar.plaintext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.sub_plain
-  %result = cheddar.sub_plain %ctx, %ct, %pt : (!cheddar.context, !cheddar.ciphertext, !cheddar.plaintext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.sub_plain %ctx, %ct, %pt, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.plaintext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_mult_plain
 func.func @test_mult_plain(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %pt: !cheddar.plaintext) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %pt: tensor<!cheddar.plaintext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.mult_plain
-  %result = cheddar.mult_plain %ctx, %ct, %pt : (!cheddar.context, !cheddar.ciphertext, !cheddar.plaintext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.mult_plain %ctx, %ct, %pt, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.plaintext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_add_const
 func.func @test_add_const(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %c: !cheddar.constant) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %c: tensor<!cheddar.constant>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.add_const
-  %result = cheddar.add_const %ctx, %ct, %c : (!cheddar.context, !cheddar.ciphertext, !cheddar.constant) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.add_const %ctx, %ct, %c, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.constant>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_mult_const
 func.func @test_mult_const(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %c: !cheddar.constant) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %c: tensor<!cheddar.constant>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.mult_const
-  %result = cheddar.mult_const %ctx, %ct, %c : (!cheddar.context, !cheddar.ciphertext, !cheddar.constant) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.mult_const %ctx, %ct, %c, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.constant>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // --- Unary operations ---
@@ -188,29 +211,32 @@ func.func @test_mult_const(
 // CHECK: @test_neg
 func.func @test_neg(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.neg
-  %result = cheddar.neg %ctx, %ct : (!cheddar.context, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.neg %ctx, %ct, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_rescale
 func.func @test_rescale(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.rescale
-  %result = cheddar.rescale %ctx, %ct : (!cheddar.context, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.rescale %ctx, %ct, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_level_down
 func.func @test_level_down(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.level_down
   // CHECK-SAME: targetLevel = 3
-  %result = cheddar.level_down %ctx, %ct {targetLevel = 3 : i64} : (!cheddar.context, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.level_down %ctx, %ct, %out {targetLevel = 3 : i64} : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // --- Key-switching operations ---
@@ -218,21 +244,23 @@ func.func @test_level_down(
 // CHECK: @test_relinearize
 func.func @test_relinearize(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %key: !cheddar.eval_key) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %key: !cheddar.eval_key,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.relinearize
-  %result = cheddar.relinearize %ctx, %ct, %key : (!cheddar.context, !cheddar.ciphertext, !cheddar.eval_key) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.relinearize %ctx, %ct, %key, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, !cheddar.eval_key, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_relinearize_rescale
 func.func @test_relinearize_rescale(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %key: !cheddar.eval_key) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %key: !cheddar.eval_key,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.relinearize_rescale
-  %result = cheddar.relinearize_rescale %ctx, %ct, %key : (!cheddar.context, !cheddar.ciphertext, !cheddar.eval_key) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.relinearize_rescale %ctx, %ct, %key, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, !cheddar.eval_key, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // --- Fused compound operations ---
@@ -240,120 +268,138 @@ func.func @test_relinearize_rescale(
 // CHECK: @test_hmult
 func.func @test_hmult(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext,
-    %key: !cheddar.eval_key) -> !cheddar.ciphertext {
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %key: !cheddar.eval_key,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hmult
-  %result = cheddar.hmult %ctx, %ct0, %ct1, %key {rescale = true} : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext, !cheddar.eval_key) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hmult %ctx, %ct0, %ct1, %key, %out {rescale = true} : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, !cheddar.eval_key, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_hmult_no_rescale
 func.func @test_hmult_no_rescale(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext,
-    %key: !cheddar.eval_key) -> !cheddar.ciphertext {
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %key: !cheddar.eval_key,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hmult
   // CHECK-SAME: rescale = false
-  %result = cheddar.hmult %ctx, %ct0, %ct1, %key {rescale = false} : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext, !cheddar.eval_key) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hmult %ctx, %ct0, %ct1, %key, %out {rescale = false} : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, !cheddar.eval_key, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_hrot_static
 func.func @test_hrot_static(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ui: !cheddar.user_interface,
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hrot
   // CHECK-SAME: static_distance = 5
-  %result = cheddar.hrot %ctx, %ct {static_distance = 5 : i64} : (!cheddar.context, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hrot %ctx, %ui, %ct, %out {static_distance = 5 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_hrot_dynamic
 func.func @test_hrot_dynamic(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %dist: index) -> !cheddar.ciphertext {
+    %ui: !cheddar.user_interface,
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>,
+    %dist: index) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hrot
-  %result = cheddar.hrot %ctx, %ct, %dist : (!cheddar.context, !cheddar.ciphertext, index) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hrot %ctx, %ui, %ct, %out, %dist : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, index) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_hrot_add
 func.func @test_hrot_add(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ui: !cheddar.user_interface,
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hrot_add
   // CHECK-SAME: distance = 3
-  %result = cheddar.hrot_add %ctx, %ct0, %ct1 {distance = 3 : i64} : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hrot_add %ctx, %ui, %ct0, %ct1, %out {distance = 3 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_hconj
 func.func @test_hconj(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ui: !cheddar.user_interface,
+    %ct: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hconj
-  %result = cheddar.hconj %ctx, %ct : (!cheddar.context, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hconj %ctx, %ui, %ct, %out : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_hconj_add
 func.func @test_hconj_add(
     %ctx: !cheddar.context,
-    %ct0: !cheddar.ciphertext,
-    %ct1: !cheddar.ciphertext) -> !cheddar.ciphertext {
+    %ui: !cheddar.user_interface,
+    %ct0: tensor<!cheddar.ciphertext>,
+    %ct1: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hconj_add
-  %result = cheddar.hconj_add %ctx, %ct0, %ct1 : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.hconj_add %ctx, %ui, %ct0, %ct1, %out : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_mad_unsafe
 func.func @test_mad_unsafe(
     %ctx: !cheddar.context,
-    %acc: !cheddar.ciphertext,
-    %ct: !cheddar.ciphertext,
-    %c: !cheddar.constant) -> !cheddar.ciphertext {
+    %acc: tensor<!cheddar.ciphertext>,
+    %ct: tensor<!cheddar.ciphertext>,
+    %c: tensor<!cheddar.constant>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.mad_unsafe
-  %result = cheddar.mad_unsafe %ctx, %acc, %ct, %c : (!cheddar.context, !cheddar.ciphertext, !cheddar.ciphertext, !cheddar.constant) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.mad_unsafe %ctx, %acc, %ct, %c : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.constant>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // --- Extension operations ---
 
 // CHECK: @test_boot
 func.func @test_boot(
-    %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %evk: !cheddar.evk_map) -> !cheddar.ciphertext {
+    %ctx: !cheddar.boot_context,
+    %ct: tensor<!cheddar.ciphertext>,
+    %evk: !cheddar.evk_map,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.boot
-  %result = cheddar.boot %ctx, %ct, %evk : (!cheddar.context, !cheddar.ciphertext, !cheddar.evk_map) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.boot %ctx, %ct, %evk, %out : (!cheddar.boot_context, tensor<!cheddar.ciphertext>, !cheddar.evk_map, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_linear_transform
 func.func @test_linear_transform(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
+    %ct: tensor<!cheddar.ciphertext>,
     %evk: !cheddar.evk_map,
-    %diags: tensor<2x4xf64>) -> !cheddar.ciphertext {
+    %diags: tensor<2x4xf64>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.linear_transform
+  // CHECK-SAME: bs = 2
   // CHECK-SAME: diagonal_indices = array<i32: 0, 1>
+  // CHECK-SAME: gs = 1
   // CHECK-SAME: level = 5
-  // CHECK-SAME: logBabyStepGiantStepRatio = 0
-  %result = cheddar.linear_transform %ctx, %ct, %evk, %diags {diagonal_indices = array<i32: 0, 1>, level = 5 : i64, logBabyStepGiantStepRatio = 0 : i64} : (!cheddar.context, !cheddar.ciphertext, !cheddar.evk_map, tensor<2x4xf64>) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  %result = cheddar.linear_transform %ctx, %ct, %evk, %diags, %out {diagonal_indices = array<i32: 0, 1>, level = 5 : i64, bs = 2 : i64, gs = 1 : i64} : (!cheddar.context, tensor<!cheddar.ciphertext>, !cheddar.evk_map, tensor<2x4xf64>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }
 
 // CHECK: @test_eval_poly
 func.func @test_eval_poly(
     %ctx: !cheddar.context,
-    %ct: !cheddar.ciphertext,
-    %evk: !cheddar.evk_map) -> !cheddar.ciphertext {
+    %ct: tensor<!cheddar.ciphertext>,
+    %evk: !cheddar.evk_map,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.eval_poly
   // CHECK-SAME: coefficients = [1.000000e+00, 2.000000e+00, 3.000000e+00]
-  %result = cheddar.eval_poly %ctx, %ct, %evk {coefficients = [1.0 : f64, 2.0 : f64, 3.0 : f64], level = 5 : i64} : (!cheddar.context, !cheddar.ciphertext, !cheddar.evk_map) -> !cheddar.ciphertext
-  return %result : !cheddar.ciphertext
+  // CHECK-SAME: level = 5
+  // CHECK-SAME: outputLevel = 4
+  %result = cheddar.eval_poly %ctx, %ct, %evk, %out {coefficients = [1.0 : f64, 2.0 : f64, 3.0 : f64], level = 5 : i64, outputLevel = 4 : i64} : (!cheddar.context, tensor<!cheddar.ciphertext>, !cheddar.evk_map, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
 }


### PR DESCRIPTION
This makes the cheddar dialect one-shot-bufferize compatible by making it Destination-Passing-Style, in preparation for a bufferize + emitC based emitter.

This PR also adds a few ops that were missing, especially around setup/parameter generation.

Since I still find DPS hard to get my head around, I left a lot of the verbose comments in, even if they're sometimes a bit LLM-y, just to make things a bit easier to follow along.