### PR TITLE
Encode plaintext at highest used level instead of max level

### DIFF
--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -541,9 +541,12 @@ struct ConvertRlweEncodeOp : public OpConversionPattern<EncodeOp> {
     Value params = result2.value();
 
     Value input = adaptor.getInput();
+    // A missing level attribute leaves the allocation at
+    // params.MaxLevel().
     auto alloc = AllocOp::create(
         rewriter, op.getLoc(),
-        this->typeConverter->convertType(op.getOutput().getType()), params);
+        this->typeConverter->convertType(op.getOutput().getType()), params,
+        op.getLevelAttr());
 
     auto encoding = op.getEncoding();
     int64_t scale = lwe::getScalingFactorFromEncodingAttr(encoding);

--- a/lib/Dialect/LWE/IR/LWEOps.td
+++ b/lib/Dialect/LWE/IR/LWEOps.td
@@ -201,6 +201,15 @@ def LWE_RLWEEncodeOp : LWE_Op<"rlwe_encode", [
     be floating points, and a scaling factor described by the encoding will be
     applied.
 
+    The optional `level` attribute records the level of the ciphertext this
+    plaintext will be combined with, i.e., the `current` index of that
+    ciphertext's modulus chain. It is
+    recorded on the op rather than in `!lwe.lwe_plaintext` because that type is
+    not RNS-aware (see #1643), and it must be attached where the plaintext is
+    created, since passes such as `--split-preprocessing` later sever the
+    def-use chain to the consuming ciphertext op. When absent, backends fall
+    back to the top level of the modulus chain.
+
     Examples:
 
     ```
@@ -212,7 +221,7 @@ def LWE_RLWEEncodeOp : LWE_Op<"rlwe_encode", [
     SignlessIntegerOrFloatLike:$input,
     AnyPlaintextEncodingAttr:$encoding,
     Polynomial_RingAttr:$ring,
-    OptionalAttr<I64Attr>:$level,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$level,
     OptionalAttr<I64Attr>:$scale
   );
 

--- a/lib/Dialect/LWE/IR/LWETypes.cpp
+++ b/lib/Dialect/LWE/IR/LWETypes.cpp
@@ -1,6 +1,7 @@
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 
 #include <cstdint>
+#include <optional>
 
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
 #include "lib/Dialect/Polynomial/IR/PolynomialAttributes.h"
@@ -109,6 +110,12 @@ LWECiphertextType cloneAtLevel(LWECiphertextType inputType, int64_t level) {
           ctx, newRing, inputType.getCiphertextSpace().getEncryptionType(),
           inputType.getCiphertextSpace().getSize()),
       lwe::KeyAttr::get(ctx, 0), newChain);
+}
+
+std::optional<int64_t> getLevel(LWECiphertextType ctType) {
+  auto modulusChain = ctType.getModulusChain();
+  if (!modulusChain) return std::nullopt;
+  return modulusChain.getCurrent();
 }
 
 }  // namespace lwe

--- a/lib/Dialect/LWE/IR/LWETypes.h
+++ b/lib/Dialect/LWE/IR/LWETypes.h
@@ -2,6 +2,7 @@
 #define LIB_DIALECT_LWE_IR_LWETYPES_H_
 
 #include <cstdint>
+#include <optional>
 
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
 #include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
@@ -43,6 +44,11 @@ FailureOr<LWECiphertextType> applyModReduce(LWECiphertextType inputType);
 // Return the LWECiphertextType resulting from setting the level to a specific
 // value.
 LWECiphertextType cloneAtLevel(LWECiphertextType inputType, int64_t level);
+
+// Return the level of a ciphertext type, i.e., the index of the top modulus of
+// its modulus chain. Returns nullopt for schemes that don't use a modulus
+// chain
+std::optional<int64_t> getLevel(LWECiphertextType ctType);
 
 }  // namespace lwe
 }  // namespace heir

--- a/lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.cpp
+++ b/lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.cpp
@@ -1,0 +1,154 @@
+#include "lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/LWE/IR/LWETraits.h"
+#include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Dialect/ModuleAttributes.h"
+#include "llvm/include/llvm/ADT/DenseSet.h"               // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"              // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/TypeUtilities.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                   // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"                // from @llvm-project
+#include "mlir/include/mlir/Interfaces/CallInterfaces.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"               // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+#define GEN_PASS_DEF_ANNOTATEPLAINTEXTLEVEL
+#include "lib/Dialect/LWE/Transforms/Passes.h.inc"
+
+namespace {
+
+// Return the highest level among an op's ciphertext operands and results, or
+// nullopt if it touches no ciphertext carrying a modulus chain.
+std::optional<int64_t> highestCiphertextLevel(Operation* op) {
+  std::optional<int64_t> result;
+  auto join = [&](Value value) {
+    auto ctType =
+        dyn_cast<LWECiphertextType>(getElementTypeOrSelf(value.getType()));
+    if (!ctType) return;
+    std::optional<int64_t> level = getLevel(ctType);
+    if (!level) return;
+    result = result ? std::max(*result, *level) : *level;
+  };
+  for (Value operand : op->getOperands()) join(operand);
+  for (Value opResult : op->getResults()) join(opResult);
+  return result;
+}
+
+// Return true if an op's results account for every place a value it consumes
+// can end up, so the walk can follow them. Ops with regions route operands into
+// block arguments (`scf.for`'s iter_args) and calls route them into a callee,
+// neither of which the walk models; a terminator has no results to follow.
+bool forwardsThroughResults(Operation* op) {
+  return op->getNumResults() > 0 && op->getNumRegions() == 0 &&
+         !isa<CallOpInterface>(op) &&
+         llvm::all_of(op->getResults(), [](Value result) {
+           return isa<LWEPlaintextType>(getElementTypeOrSelf(result.getType()));
+         });
+}
+
+// Return the level to encode the plaintext at, or nullopt to leave it at the
+// top of the modulus chain. Plaintexts are not always consumed directly: the
+// encode op may feed a `tensor.from_elements` or similar first, so keep walking
+// forward through the ops that forward it until one that consumes it is
+// reached.
+//
+// The two kinds of consumer constrain the level differently:
+//
+//   - A ct-pt op sets a *lower bound*. The backend combines at the lower of the
+//     two levels, so encoding above the ciphertext costs limbs but nothing
+//     else, while encoding below it silently truncates that ciphertext. The
+//     highest such use is therefore the smallest level that serves them all.
+//
+//   - An encryption sets an *exact* level. It has no ciphertext operand to be
+//     clamped against: the backend builds the ciphertext at the plaintext's own
+//     level. Both `lwe.rlwe_encrypt` and `lwe.trivial_encrypt` work
+//     this way.
+//
+// One encoding can serve both only when the encryption's level also covers
+// every ct-pt use. When it does not, or when two encryptions want different
+// levels, no annotation is correct and the fallback takes over.
+std::optional<int64_t> findUseLevel(RLWEEncodeOp encodeOp) {
+  std::optional<int64_t> combinedLevel;
+  std::optional<int64_t> encryptedLevel;
+  SmallVector<Value> worklist = {encodeOp.getOutput()};
+  DenseSet<Operation*> visited;
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    for (Operation* user : value.getUsers()) {
+      if (!visited.insert(user).second) continue;
+
+      if (isa<RLWEEncryptOp, TrivialEncryptOp>(user)) {
+        // A consumer whose ciphertexts carry no modulus chain constrains
+        // nothing, and leaves the plaintext to whatever its other uses need.
+        std::optional<int64_t> level = highestCiphertextLevel(user);
+        if (!level) continue;
+        if (encryptedLevel && *encryptedLevel != *level) return std::nullopt;
+        encryptedLevel = *level;
+        continue;
+      }
+      if (user->hasTrait<IsCiphertextPlaintextOp>()) {
+        // Likewise for a ct-pt op whose ciphertexts carry no modulus chain.
+        if (std::optional<int64_t> level = highestCiphertextLevel(user)) {
+          combinedLevel =
+              combinedLevel ? std::max(*combinedLevel, *level) : *level;
+        }
+        continue;
+      }
+      if (!forwardsThroughResults(user)) return std::nullopt;
+      for (Value userResult : user->getResults()) {
+        worklist.push_back(userResult);
+      }
+    }
+  }
+
+  if (!encryptedLevel) return combinedLevel;
+  if (combinedLevel && *combinedLevel > *encryptedLevel) return std::nullopt;
+  return encryptedLevel;
+}
+
+struct AnnotatePlaintextLevel
+    : impl::AnnotatePlaintextLevelBase<AnnotatePlaintextLevel> {
+  using AnnotatePlaintextLevelBase::AnnotatePlaintextLevelBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    // BFV does no level management: every ciphertext sits at the bottom of the
+    // modulus chain, while the backend's ciphertexts still span the whole chain
+    // (the extra modulus is an artifact of the encryption technique). So the
+    // chain's `current` is not an encoding level here, and there is nothing to
+    // save by lowering one.
+    if (moduleIsBFV(module)) {
+      module->walk([&](RLWEEncodeOp encodeOp) { encodeOp.removeLevelAttr(); });
+      return;
+    }
+
+    module->walk([&](RLWEEncodeOp encodeOp) {
+      std::optional<int64_t> level = findUseLevel(encodeOp);
+      // Drop a level that no longer has a use to justify it
+      if (!level) {
+        encodeOp.removeLevelAttr();
+        return;
+      }
+      encodeOp.setLevel(*level);
+    });
+  }
+};
+
+}  // namespace
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.h
+++ b/lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.h
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_LWE_TRANSFORMS_ANNOTATEPLAINTEXTLEVEL_H_
+#define LIB_DIALECT_LWE_TRANSFORMS_ANNOTATEPLAINTEXTLEVEL_H_
+
+// IWYU pragma: begin_keep
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+namespace lwe {
+
+#define GEN_PASS_DECL_ANNOTATEPLAINTEXTLEVEL
+#include "lib/Dialect/LWE/Transforms/Passes.h.inc"
+
+}  // namespace lwe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_LWE_TRANSFORMS_ANNOTATEPLAINTEXTLEVEL_H_

--- a/lib/Dialect/LWE/Transforms/BUILD
+++ b/lib/Dialect/LWE/Transforms/BUILD
@@ -13,10 +13,27 @@ cc_library(
     ],
     deps = [
         ":AddDebugPort",
+        ":AnnotatePlaintextLevel",
         ":DecomposeLWEOps",
         ":ImplementTrivialEncryptionAsAddition",
         ":pass_inc_gen",
         "@heir//lib/Dialect/LWE/IR:Dialect",
+    ],
+)
+
+cc_library(
+    name = "AnnotatePlaintextLevel",
+    srcs = ["AnnotatePlaintextLevel.cpp"],
+    hdrs = ["AnnotatePlaintextLevel.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:CallOpInterfaces",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
     ],
 )
 

--- a/lib/Dialect/LWE/Transforms/Passes.h
+++ b/lib/Dialect/LWE/Transforms/Passes.h
@@ -4,6 +4,7 @@
 // IWYU pragma: begin_keep
 #include "lib/Dialect/LWE/IR/LWEDialect.h"
 #include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
+#include "lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.h"
 #include "lib/Dialect/LWE/Transforms/DecomposeLWEOps.h"
 #include "lib/Dialect/LWE/Transforms/ImplementTrivialEncryptionAsAddition.h"
 // IWYU pragma: end_keep

--- a/lib/Dialect/LWE/Transforms/Passes.td
+++ b/lib/Dialect/LWE/Transforms/Passes.td
@@ -69,6 +69,42 @@ def ImplementTrivialEncryptionAsAddition : Pass<"implement-trivial-encryption-as
   let options = [];
 }
 
+def AnnotatePlaintextLevel : Pass<"lwe-annotate-plaintext-level", "mlir::ModuleOp"> {
+  let summary = "Annotate `lwe.rlwe_encode` ops with the level they are used at";
+  let description = [{
+    Sets the `level` attribute of each `lwe.rlwe_encode` op to the level its
+    plaintext is used at, found by walking forward from the encode op through
+    plaintext-typed values.
+
+    Backends allocate a plaintext at the top of the modulus chain unless told
+    otherwise, but encoding cost is dominated by per-RNS-limb work, so a
+    plaintext only ever combined with a level 3 ciphertext is cheaper to encode
+    with 4 limbs than with all of them. For a ct-pt op the result is unchanged
+    either way: combining a ciphertext and a plaintext yields the lower of the
+    two levels, so annotating with the *highest* level among such uses is the
+    smallest choice that serves them all.
+
+    `lwe.rlwe_encrypt` is not a ct-pt op and does not follow that rule. It has
+    no ciphertext operand to be clamped against, so the backend builds the
+    ciphertext at the plaintext's own level and the annotation is exact rather
+    than a lower bound. Annotating an encryption therefore changes what the
+    client emits, not just how many limbs it encodes: where the entry level sits
+    below the top of the chain, the ciphertext now enters at the level its type
+    declares instead of at `MaxLevel`. A plaintext that both feeds an encryption
+    and is combined with a higher-level ciphertext has no correct level, and is
+    left to the fallback.
+
+    Run this after CSE. Identical encode ops that CSE has merged are cheaper as
+    one plaintext at the highest level than as several at their own levels,
+    since each encode pays a fixed cost on top of the per-limb work.
+
+    (* example filepath=tests/Dialect/LWE/Transforms/annotate_plaintext_level.mlir *)
+  }];
+  let dependentDialects = [
+    "mlir::heir::lwe::LWEDialect",
+  ];
+}
+
 def DecomposeLWEOps : Pass<"lwe-decompose"> {
   let summary = "Decomposes complex LWE ops into primitive LWE ops";
   let description = [{

--- a/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoBGVOps.td
@@ -17,9 +17,14 @@ def Lattigo_BGVNewPlaintextOp : Lattigo_BGVOp<"new_plaintext"> {
   let summary = "Create a new plaintext in the Lattigo BGV dialect";
   let description = [{
     This operation creates a new plaintext value in the Lattigo BGV dialect.
+
+    The optional `level` attribute is the level to allocate the plaintext at.
+    When absent, the
+    plaintext is allocated at `params.MaxLevel()`.
   }];
   let arguments = (ins
-    Lattigo_BGVParameter:$params
+    Lattigo_BGVParameter:$params,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$level
   );
   let results = (outs Lattigo_RLWEPlaintext:$plaintext);
 }

--- a/lib/Dialect/Lattigo/IR/LattigoCKKSOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoCKKSOps.td
@@ -19,9 +19,14 @@ def Lattigo_CKKSNewPlaintextOp : Lattigo_CKKSOp<"new_plaintext"> {
   let summary = "Create a new plaintext in the Lattigo CKKS dialect";
   let description = [{
     This operation creates a new plaintext value in the Lattigo CKKS dialect.
+
+    The optional `level` attribute is the level to allocate the plaintext at.
+     When absent, the
+    plaintext is allocated at `params.MaxLevel()`.
   }];
   let arguments = (ins
-    Lattigo_CKKSParameter:$params
+    Lattigo_CKKSParameter:$params,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$level
   );
   let results = (outs Lattigo_RLWEPlaintext:$plaintext);
 }

--- a/lib/Dialect/Secret/Conversions/Patterns.cpp
+++ b/lib/Dialect/Secret/Conversions/Patterns.cpp
@@ -86,10 +86,8 @@ LogicalResult ConvertClientConceal::lowerToTrivialEncryption(
 
   // Intentionally use op.getCleartext() because we don't want to type-convert
   // the input to a ciphertext.
-  IntegerAttr levelAttr;
   IntegerAttr scaleAttr;
-  if (auto mc = ctTy.getModulusChain()) {
-    levelAttr = rewriter.getI64IntegerAttr(mc.getCurrent());
+  if (ctTy.getModulusChain()) {
     scaleAttr =
         rewriter.getI64IntegerAttr(lwe::getScalingFactorFromEncodingAttr(
             ctTy.getPlaintextSpace().getEncoding()));
@@ -97,7 +95,7 @@ LogicalResult ConvertClientConceal::lowerToTrivialEncryption(
   auto encoded = lwe::RLWEEncodeOp::create(
       rewriter, op.getLoc(), encodeOpResultTy, op.getCleartext(),
       ctTy.getPlaintextSpace().getEncoding(),
-      ctTy.getPlaintextSpace().getRing(), levelAttr, scaleAttr);
+      ctTy.getPlaintextSpace().getRing(), /*level=*/nullptr, scaleAttr);
   auto newOp =
       lwe::TrivialEncryptOp::create(rewriter, op.getLoc(), resultTy, encoded);
   newOp->setAttrs(op->getAttrs());
@@ -153,20 +151,20 @@ LogicalResult ConvertClientConceal::matchAndRewrite(
   auto plaintextTy = lwe::LWEPlaintextType::get(op.getContext(),
                                                 resultCtTy.getPlaintextSpace());
 
-  IntegerAttr encLevelAttr;
+  // As above, --lwe-annotate-plaintext-level owns the level.
   IntegerAttr encScaleAttr;
-  if (auto mc = resultCtTy.getModulusChain()) {
-    encLevelAttr = rewriter.getI64IntegerAttr(mc.getCurrent());
+  if (resultCtTy.getModulusChain()) {
     encScaleAttr =
         rewriter.getI64IntegerAttr(lwe::getScalingFactorFromEncodingAttr(
             resultCtTy.getPlaintextSpace().getEncoding()));
   }
 
   auto encryptFn = [&](Value cleartext) -> lwe::RLWEEncryptOp {
-    auto encoded = lwe::RLWEEncodeOp::create(
-        rewriter, op.getLoc(), plaintextTy, cleartext,
-        resultCtTy.getPlaintextSpace().getEncoding(),
-        resultCtTy.getPlaintextSpace().getRing(), encLevelAttr, encScaleAttr);
+    auto encoded =
+        lwe::RLWEEncodeOp::create(rewriter, op.getLoc(), plaintextTy, cleartext,
+                                  resultCtTy.getPlaintextSpace().getEncoding(),
+                                  resultCtTy.getPlaintextSpace().getRing(),
+                                  /*level=*/nullptr, encScaleAttr);
     auto encryptOp = lwe::RLWEEncryptOp::create(
         rewriter, op.getLoc(), resultCtTy, encoded.getResult(), keyBlockArg);
     // Copy attributes from the original op to preserve any mgmt attrs needed by

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -9,6 +9,7 @@
 #include "lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.h"
 #include "lib/Dialect/LWE/Conversions/LWEToOpenfhe/LWEToOpenfhe.h"
 #include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
+#include "lib/Dialect/LWE/Transforms/AnnotatePlaintextLevel.h"
 #include "lib/Dialect/LWE/Transforms/ImplementTrivialEncryptionAsAddition.h"
 #include "lib/Dialect/Lattigo/Transforms/AllocToInPlace.h"
 #include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
@@ -550,6 +551,12 @@ void mlirToRLWEPipeline(OpPassManager& pm,
 
   // TODO(#2554): skip this pass if the backend supports trivial encryption
   pm.addPass(lwe::createImplementTrivialEncryptionAsAddition());
+
+  // Record the level each plaintext is used at, so backends can encode only the
+  // limbs it needs. This must run after the CSE above, which merges identical
+  // encode ops, and before split-preprocessing, which severs the use chain
+  // from an encode op to the ciphertext op consuming it.
+  pm.addPass(lwe::createAnnotatePlaintextLevel());
 
   // Add a __preprocessed helper for offline pre-packing of plaintexts
   if (options.enableSplitPreprocessing) {

--- a/lib/Pipelines/BUILD
+++ b/lib/Pipelines/BUILD
@@ -108,6 +108,7 @@ cc_library(
         "@heir//lib/Dialect/LWE/Conversions/LWEToOpenfhe",
         "@heir//lib/Dialect/LWE/Conversions/LWEToPolynomial",
         "@heir//lib/Dialect/LWE/Transforms:AddDebugPort",
+        "@heir//lib/Dialect/LWE/Transforms:AnnotatePlaintextLevel",
         "@heir//lib/Dialect/LWE/Transforms:ImplementTrivialEncryptionAsAddition",
         "@heir//lib/Dialect/Lattigo/Transforms:AllocToInPlace",
         "@heir//lib/Dialect/Lattigo/Transforms:ConfigureCryptoContext",

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -1654,6 +1654,48 @@ const auto* negateTemplate = R"GO(
     {2}.GetRLWEParameters().RingQ().AtLevel({1}.LevelQ()).Neg({1}.Value[{0}], {1}.Value[{0}])
   }
 )GO";
+
+// Return the number of moduli in the Q chain the parameters declare, or nullopt
+// when the module holds no parameters literal
+template <typename ParamsLiteralAttr, typename NewParamsOp>
+std::optional<int64_t> getQChainLength(Operation* op) {
+  auto module = op->getParentOfType<ModuleOp>();
+  if (!module) return std::nullopt;
+
+  std::optional<int64_t> length;
+  module.walk([&](NewParamsOp paramsOp) {
+    ParamsLiteralAttr literal = paramsOp.getParamsLiteral();
+    if (auto q = literal.getQ()) {
+      length = q.size();
+    } else if (auto logQ = literal.getLogQ()) {
+      length = logQ.size();
+    }
+    // Several parameter sets in one module would each bound their own
+    // plaintexts, which this lookup cannot tell apart. Decline to guess.
+    return length ? WalkResult::interrupt() : WalkResult::advance();
+  });
+  return length;
+}
+
+// Render the level argument of a {bgv,ckks}.NewPlaintext call. Fails when the
+// requested level is past the top of the modulus chain:
+template <typename ParamsLiteralAttr, typename NewParamsOp,
+          typename NewPlaintextOp>
+FailureOr<std::string> getPlaintextLevel(NewPlaintextOp op,
+                                         StringRef paramsName) {
+  std::optional<int64_t> level = op.getLevel();
+  if (!level) return (paramsName + ".MaxLevel()").str();
+
+  std::optional<int64_t> qChainLength =
+      getQChainLength<ParamsLiteralAttr, NewParamsOp>(op);
+  if (qChainLength && *level >= *qChainLength) {
+    return op.emitOpError()
+           << "level " << *level << " is past the top of the modulus chain, "
+           << "which has " << *qChainLength << " moduli and so a maximum level "
+           << "of " << (*qChainLength - 1);
+  }
+  return std::to_string(*level);
+}
 }  // namespace
 
 LogicalResult LattigoEmitter::printOperation(RLWENegateNewOp op) {
@@ -1710,10 +1752,16 @@ LogicalResult LattigoEmitter::printOperation(BGVNewEvaluatorOp op) {
 }
 
 LogicalResult LattigoEmitter::printOperation(BGVNewPlaintextOp op) {
+  FailureOr<std::string> level =
+      getPlaintextLevel<BGVParametersLiteralAttr,
+                        BGVNewParametersFromLiteralOp>(op,
+                                                       getName(op.getParams()));
+  if (failed(level)) return failure();
+
   std::string resultName = getName(op.getResult());
   os << resultName << " := bgv.NewPlaintext(";
   os << getName(op.getParams()) << ", ";
-  os << getName(op.getParams()) << ".MaxLevel()";
+  os << *level;
   os << ")\n";
   if (resultName != "_") {
     declaredVars.insert(resultName);
@@ -2004,10 +2052,16 @@ LogicalResult LattigoEmitter::printOperation(
 }
 
 LogicalResult LattigoEmitter::printOperation(CKKSNewPlaintextOp op) {
+  FailureOr<std::string> level =
+      getPlaintextLevel<CKKSParametersLiteralAttr,
+                        CKKSNewParametersFromLiteralOp>(
+          op, getName(op.getParams()));
+  if (failed(level)) return failure();
+
   std::string resultName = getName(op.getResult());
   os << resultName << " := ckks.NewPlaintext(";
   os << getName(op.getParams()) << ", ";
-  os << getName(op.getParams()) << ".MaxLevel()";
+  os << *level;
   os << ")\n";
   if (resultName != "_") {
     declaredVars.insert(resultName);

--- a/lib/Utils/ContextAwareConversionUtils.cpp
+++ b/lib/Utils/ContextAwareConversionUtils.cpp
@@ -59,10 +59,13 @@ FailureOr<Value> encodeCleartextAsPlaintext(
       ctx, lwe::PlaintextSpaceAttr::get(ctx, plaintextSpace.getRing(),
                                         plaintextEncoding));
 
-  IntegerAttr levelAttr;
+  // The level is deliberately left unset here, for
+  // `--lwe-annotate-plaintext-level` to fill in. Reading it off this one
+  // ciphertext would record a level per *use*, which keeps CSE from merging the
+  // encodings of a constant that several levels share. One plaintext at the
+  // highest of those levels serves them all, and costs fewer limbs in total.
   IntegerAttr scaleAttr;
-  if (auto mc = ciphertextElementType.getModulusChain()) {
-    levelAttr = builder.getI64IntegerAttr(mc.getCurrent());
+  if (ciphertextElementType.getModulusChain()) {
     scaleAttr = builder.getI64IntegerAttr(
         lwe::getScalingFactorFromEncodingAttr(plaintextEncoding));
   }
@@ -76,7 +79,7 @@ FailureOr<Value> encodeCleartextAsPlaintext(
   if (cleartextTensorTy.getRank() == 1) {
     Value encodeOp = lwe::RLWEEncodeOp::create(
                          builder, plaintextTy, cleartext, plaintextEncoding,
-                         plaintextSpace.getRing(), levelAttr, scaleAttr)
+                         plaintextSpace.getRing(), /*level=*/nullptr, scaleAttr)
                          .getResult();
     return encodeOp;
   }
@@ -95,10 +98,11 @@ FailureOr<Value> encodeCleartextAsPlaintext(
     SmallVector<OpFoldResult> strides(2, builder.getIndexAttr(1));
     auto slice = tensor::ExtractSliceOp::create(builder, sliceTy, cleartext,
                                                 offsets, sizes, strides);
-    Value encodedSlice = lwe::RLWEEncodeOp::create(
-                             builder, plaintextTy, slice, plaintextEncoding,
-                             plaintextSpace.getRing(), levelAttr, scaleAttr)
-                             .getResult();
+    Value encodedSlice =
+        lwe::RLWEEncodeOp::create(builder, plaintextTy, slice,
+                                  plaintextEncoding, plaintextSpace.getRing(),
+                                  /*level=*/nullptr, scaleAttr)
+            .getResult();
     encodedSlices.push_back(encodedSlice);
   }
 

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/plaintext_level.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/plaintext_level.mlir
@@ -1,0 +1,41 @@
+// RUN: heir-opt %s --lwe-to-lattigo | FileCheck %s
+
+// The level on an lwe.rlwe_encode op is the level of the ciphertext its
+// plaintext is combined with, and carries over to the plaintext allocation so
+// the backend only encodes the RNS limbs that survive first use.
+
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z4295294977_i64_ = !mod_arith.int<4295294977 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+#ring_Z4295294977_i64_1_x1024_ = #polynomial.ring<coefficientType = !Z4295294977_i64_, polynomialModulus = <1 + x**1024>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z4295294977_i64_1_x1024_, encoding = #full_crt_packing_encoding>
+#ring_rns_L1_1_x1024_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**1024>>
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x1024_, encryption_type = lsb>
+!ct_L1_ = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+
+module attributes {scheme.bgv} {
+  // CHECK: func @with_level
+  func.func @with_level(%ct: !ct_L1_, %value: tensor<1024xi64>) -> !ct_L1_ {
+    // CHECK: lattigo.bgv.new_plaintext %{{.*}} {level = 1 : i64}
+    // CHECK-NEXT: lattigo.bgv.encode
+    %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z4295294977_i64_1_x1024_, level = 1 : i64} : tensor<1024xi64> -> !pt
+    %res = lwe.rmul_plain %ct, %pt : (!ct_L1_, !pt) -> !ct_L1_
+    return %res : !ct_L1_
+  }
+
+  // An encode op with no level falls back to the top of the modulus chain.
+  // CHECK: func @without_level
+  func.func @without_level(%ct: !ct_L1_, %value: tensor<1024xi64>) -> !ct_L1_ {
+    // CHECK: lattigo.bgv.new_plaintext
+    // CHECK-NOT: level
+    // CHECK-NEXT: lattigo.bgv.encode
+    %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z4295294977_i64_1_x1024_} : tensor<1024xi64> -> !pt
+    %res = lwe.rmul_plain %ct, %pt : (!ct_L1_, !pt) -> !ct_L1_
+    return %res : !ct_L1_
+  }
+}

--- a/tests/Dialect/LWE/Transforms/annotate_plaintext_level.mlir
+++ b/tests/Dialect/LWE/Transforms/annotate_plaintext_level.mlir
@@ -1,0 +1,274 @@
+// RUN: heir-opt --lwe-annotate-plaintext-level --split-input-file %s | FileCheck %s
+
+!Z1005037682689_i64_ = !mod_arith.int<1005037682689 : i64>
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z998595133441_i64_ = !mod_arith.int<998595133441 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+#modulus_chain_L5_C3_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 3>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+!rns_L3_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_, !Z1005037682689_i64_, !Z998595133441_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#ring_rns_L1_1_x32_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**32>>
+#ring_rns_L3_1_x32_ = #polynomial.ring<coefficientType = !rns_L3_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #full_crt_packing_encoding>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x32_, encryption_type = lsb>
+#ciphertext_space_L3_ = #lwe.ciphertext_space<ring = #ring_rns_L3_1_x32_, encryption_type = lsb>
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+!pkey_L1_ = !lwe.lwe_public_key<key = #key, ring = #ring_rns_L1_1_x32_>
+!pkey_L3_ = !lwe.lwe_public_key<key = #key, ring = #ring_rns_L3_1_x32_>
+!ct_L1_ = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!ct_L3_ = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L3_, key = #key, modulus_chain = #modulus_chain_L5_C3_>
+
+// CHECK: func @single_use
+func.func @single_use(%ct: !ct_L1_, %value: tensor<32xi64>) -> !ct_L1_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 1 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %res = lwe.rmul_plain %ct, %pt : (!ct_L1_, !pt) -> !ct_L1_
+  return %res : !ct_L1_
+}
+
+// A plaintext shared by uses at several levels takes the highest of them, since
+// combining it with the lower-level ciphertext drops to that ciphertext's level
+// anyway.
+// CHECK: func @multiple_uses
+func.func @multiple_uses(%ct1: !ct_L1_, %ct3: !ct_L3_, %value: tensor<32xi64>) -> (!ct_L1_, !ct_L3_) {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 3 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %res1 = lwe.rmul_plain %ct1, %pt : (!ct_L1_, !pt) -> !ct_L1_
+  %res3 = lwe.rmul_plain %ct3, %pt : (!ct_L3_, !pt) -> !ct_L3_
+  return %res1, %res3 : !ct_L1_, !ct_L3_
+}
+
+// The plaintext of an encryption is read off the resulting ciphertext. Unlike a
+// ct-pt use this level is exact, not a lower bound: `rlwe_encrypt` has no
+// ciphertext operand to be clamped against, so the ciphertext is built at
+// whatever level the plaintext carries.
+// CHECK: func @encrypt
+func.func @encrypt(%value: tensor<32xi64>, %pk: !pkey_L1_) -> !ct_L1_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 1 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct = lwe.rlwe_encrypt %pt, %pk : (!pt, !pkey_L1_) -> !ct_L1_
+  return %ct : !ct_L1_
+}
+
+// An encryption's exact level also serves a ct-pt use at or below it, which
+// only drops to the ciphertext's own level.
+// CHECK: func @encrypt_covers_combine
+func.func @encrypt_covers_combine(%ct1: !ct_L1_, %value: tensor<32xi64>, %pk: !pkey_L3_) -> (!ct_L3_, !ct_L1_) {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 3 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct = lwe.rlwe_encrypt %pt, %pk : (!pt, !pkey_L3_) -> !ct_L3_
+  %res = lwe.rmul_plain %ct1, %pt : (!ct_L1_, !pt) -> !ct_L1_
+  return %ct, %res : !ct_L3_, !ct_L1_
+}
+
+// When a ct-pt use needs a level above the encryption's, no single level is
+// correct: raising it to 3 would build the encrypted ciphertext one limb above
+// the level its type declares, which is what the scale bookkeeping downstream
+// is computed against. Leave it to the fallback.
+// CHECK: func @encrypt_conflicts_with_combine
+func.func @encrypt_conflicts_with_combine(%ct3: !ct_L3_, %value: tensor<32xi64>, %pk: !pkey_L1_) -> (!ct_L1_, !ct_L3_) {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct = lwe.rlwe_encrypt %pt, %pk : (!pt, !pkey_L1_) -> !ct_L1_
+  %res = lwe.rmul_plain %ct3, %pt : (!ct_L3_, !pt) -> !ct_L3_
+  return %ct, %res : !ct_L1_, !ct_L3_
+}
+
+// Two encryptions wanting different levels cannot both be served by one
+// encoding either.
+// CHECK: func @conflicting_encryptions
+func.func @conflicting_encryptions(%value: tensor<32xi64>, %pk1: !pkey_L1_, %pk3: !pkey_L3_) -> (!ct_L1_, !ct_L3_) {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct1 = lwe.rlwe_encrypt %pt, %pk1 : (!pt, !pkey_L1_) -> !ct_L1_
+  %ct3 = lwe.rlwe_encrypt %pt, %pk3 : (!pt, !pkey_L3_) -> !ct_L3_
+  return %ct1, %ct3 : !ct_L1_, !ct_L3_
+}
+
+// Plaintexts are not always consumed directly, so the walk continues through
+// intervening plaintext-typed values.
+// CHECK: func @through_tensor
+func.func @through_tensor(%ct: tensor<1x!ct_L1_>, %value: tensor<32xi64>) -> tensor<1x!ct_L1_> {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 1 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %pts = tensor.from_elements %pt : tensor<1x!pt>
+  %res = lwe.rmul_plain %ct, %pts : (tensor<1x!ct_L1_>, tensor<1x!pt>) -> tensor<1x!ct_L1_>
+  return %res : tensor<1x!ct_L1_>
+}
+
+// With no ciphertext to read a level from, the encode op is left alone and the
+// backend falls back to the top of the modulus chain.
+// CHECK: func @no_ciphertext_use
+func.func @no_ciphertext_use(%value: tensor<32xi64>) -> !pt {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  return %pt : !pt
+}
+
+// CHECK: func @stale_level
+func.func @stale_level(%value: tensor<32xi64>) -> !pt {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_, level = 3 : i64} : tensor<32xi64> -> !pt
+  return %pt : !pt
+}
+
+// A plaintext forwarded into a callee is left alone. The ciphertext the call
+// happens to carry is not necessarily the one the plaintext is combined with
+// inside the callee, and a level below a real use would silently truncate the
+// ciphertext it meets there; falling back to the top of the chain only costs
+// encoding work.
+// CHECK: func @forwarded_to_call
+func.func @forwarded_to_call(%ct: !ct_L1_, %value: tensor<32xi64>) -> !ct_L1_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %res = func.call @combine(%ct, %pt) : (!ct_L1_, !pt) -> !ct_L1_
+  return %res : !ct_L1_
+}
+func.func private @combine(!ct_L1_, !pt) -> !ct_L1_
+
+// Likewise for a plaintext carried through a region: the walk does not follow
+// values into block arguments, so the ciphertext the loop carries alongside it
+// says nothing about where the plaintext lands.
+// CHECK: func @loop_carried
+func.func @loop_carried(%ct: !ct_L1_, %value: tensor<32xi64>) -> !ct_L1_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %res:2 = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %ct, %p = %pt) -> (!ct_L1_, !pt) {
+    %mul = lwe.rmul_plain %acc, %p : (!ct_L1_, !pt) -> !ct_L1_
+    scf.yield %mul, %p : !ct_L1_, !pt
+  }
+  return %res#0 : !ct_L1_
+}
+
+// -----
+
+// BFV keeps every ciphertext at the bottom of the modulus chain while the
+// backend's ciphertexts span the whole chain, so `current` is not an encoding
+// level and the encode op is left alone.
+
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L1_C0_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 17179967489 : i64>, current = 0>
+!rns_L0_ = !rns.rns<!Z1095233372161_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#ring_rns_L0_1_x32_ = #polynomial.ring<coefficientType = !rns_L0_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #full_crt_packing_encoding>
+#ciphertext_space_L0_ = #lwe.ciphertext_space<ring = #ring_rns_L0_1_x32_, encryption_type = lsb>
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+!ct_L0_ = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L0_, key = #key, modulus_chain = #modulus_chain_L1_C0_>
+
+module attributes {scheme.bfv} {
+  // CHECK: func @bfv
+  func.func @bfv(%ct: !ct_L0_, %value: tensor<32xi64>) -> !ct_L0_ {
+    // CHECK: lwe.rlwe_encode
+    // CHECK-NOT: level
+    %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+    %res = lwe.rmul_plain %ct, %pt : (!ct_L0_, !pt) -> !ct_L0_
+    return %res : !ct_L0_
+  }
+}
+
+// -----
+
+// `lwe.trivial_encrypt` fixes the level exactly, the same way `lwe.rlwe_encrypt`
+// does: it has no ciphertext operand to be clamped against, so the backend
+// builds the ciphertext at the plaintext's own level. The walk must not follow
+// its ciphertext result either, or a lower-level ct-pt op downstream of that
+// ciphertext would pull the plaintext below the level it was encrypted at.
+
+!Z1005037682689_i64_ = !mod_arith.int<1005037682689 : i64>
+!Z1032955396097_i64_ = !mod_arith.int<1032955396097 : i64>
+!Z1095233372161_i64_ = !mod_arith.int<1095233372161 : i64>
+!Z998595133441_i64_ = !mod_arith.int<998595133441 : i64>
+!Z65537_i64_ = !mod_arith.int<65537 : i64>
+#full_crt_packing_encoding = #lwe.full_crt_packing_encoding<scaling_factor = 0>
+#key = #lwe.key<>
+#modulus_chain_L5_C1_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 1>
+#modulus_chain_L5_C3_ = #lwe.modulus_chain<elements = <1095233372161 : i64, 1032955396097 : i64, 1005037682689 : i64, 998595133441 : i64, 972824936449 : i64, 959939837953 : i64>, current = 3>
+!rns_L1_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_>
+!rns_L3_ = !rns.rns<!Z1095233372161_i64_, !Z1032955396097_i64_, !Z1005037682689_i64_, !Z998595133441_i64_>
+#ring_Z65537_i64_1_x32_ = #polynomial.ring<coefficientType = !Z65537_i64_, polynomialModulus = <1 + x**32>>
+#ring_rns_L1_1_x32_ = #polynomial.ring<coefficientType = !rns_L1_, polynomialModulus = <1 + x**32>>
+#ring_rns_L3_1_x32_ = #polynomial.ring<coefficientType = !rns_L3_, polynomialModulus = <1 + x**32>>
+#plaintext_space = #lwe.plaintext_space<ring = #ring_Z65537_i64_1_x32_, encoding = #full_crt_packing_encoding>
+#ciphertext_space_L1_ = #lwe.ciphertext_space<ring = #ring_rns_L1_1_x32_, encryption_type = lsb>
+#ciphertext_space_L3_ = #lwe.ciphertext_space<ring = #ring_rns_L3_1_x32_, encryption_type = lsb>
+!pt = !lwe.lwe_plaintext<plaintext_space = #plaintext_space>
+!ct_L1_ = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L1_, key = #key, modulus_chain = #modulus_chain_L5_C1_>
+!ct_L3_ = !lwe.lwe_ciphertext<plaintext_space = #plaintext_space, ciphertext_space = #ciphertext_space_L3_, key = #key, modulus_chain = #modulus_chain_L5_C3_>
+
+// CHECK: func @trivial_encrypt
+func.func @trivial_encrypt(%value: tensor<32xi64>) -> !ct_L3_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 3 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct = lwe.trivial_encrypt %pt : !pt -> !ct_L3_
+  return %ct : !ct_L3_
+}
+
+// A ct-pt use below the trivial encryption's level is covered by it, exactly as
+// for `lwe.rlwe_encrypt`.
+// CHECK: func @trivial_encrypt_covers_combine
+func.func @trivial_encrypt_covers_combine(%ct1: !ct_L1_, %value: tensor<32xi64>) -> (!ct_L3_, !ct_L1_) {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 3 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct3 = lwe.trivial_encrypt %pt : !pt -> !ct_L3_
+  %res = lwe.rmul_plain %ct1, %pt : (!ct_L1_, !pt) -> !ct_L1_
+  return %ct3, %res : !ct_L3_, !ct_L1_
+}
+
+// The walk must stop at the trivial encryption rather than continue over its
+// ciphertext result. Following it would reach the level-1 rmul_plain below and
+// annotate level 1, which is a two-limb plaintext trivially encrypted into a
+// four-limb ciphertext.
+// CHECK: func @no_walk_through_ciphertext
+func.func @no_walk_through_ciphertext(%value: tensor<32xi64>, %other: !pt) -> !ct_L1_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 3 : i64
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %ct3 = lwe.trivial_encrypt %pt : !pt -> !ct_L3_
+  %ct1 = bgv.modulus_switch %ct3 {to_ring = #ring_rns_L1_1_x32_} : !ct_L3_ -> !ct_L1_
+  %res = lwe.rmul_plain %ct1, %other : (!ct_L1_, !pt) -> !ct_L1_
+  return %res : !ct_L1_
+}
+
+// A user that turns the plaintext into something other than a plaintext is a
+// consumer the walk does not model, so the fallback takes over. Following such a
+// result would leave plaintext dataflow: here the walk would run decode ->
+// cleartext -> re-encode -> rmul_plain and charge the first plaintext with the
+// level of a ciphertext it never meets, even though its only use is the decode.
+// CHECK: func @walk_stays_in_plaintext
+func.func @walk_stays_in_plaintext(%ct1: !ct_L1_, %value: tensor<32xi64>) -> !ct_L1_ {
+  // CHECK: lwe.rlwe_encode
+  // CHECK-NOT: level
+  %pt = lwe.rlwe_encode %value {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %decoded = lwe.rlwe_decode %pt {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : !pt -> tensor<32xi64>
+  // The re-encoded plaintext does reach the ciphertext, so it keeps its level.
+  // CHECK: lwe.rlwe_encode
+  // CHECK-SAME: level = 1 : i64
+  %pt2 = lwe.rlwe_encode %decoded {encoding = #full_crt_packing_encoding, ring = #ring_Z65537_i64_1_x32_} : tensor<32xi64> -> !pt
+  %res = lwe.rmul_plain %ct1, %pt2 : (!ct_L1_, !pt) -> !ct_L1_
+  return %res : !ct_L1_
+}

--- a/tests/Emitter/Lattigo/new_plaintext_level.mlir
+++ b/tests/Emitter/Lattigo/new_plaintext_level.mlir
@@ -1,0 +1,48 @@
+// RUN: heir-translate %s --emit-lattigo --split-input-file | FileCheck %s
+
+!pt = !lattigo.rlwe.plaintext
+!encoder = !lattigo.ckks.encoder
+!params = !lattigo.ckks.parameter
+
+module attributes {scheme.ckks} {
+  // CHECK: func Encode
+  func.func @encode(%params: !params, %encoder: !encoder, %value: tensor<8xf32>) -> !pt {
+    // CHECK: [[pt:[^, ].*]] := ckks.NewPlaintext([[params:[^,]*]], 2)
+    %pt = lattigo.ckks.new_plaintext %params {level = 2 : i64} : (!params) -> !pt
+    // CHECK: [[encoder:.*]].Encode(
+    %res = lattigo.ckks.encode %encoder, %value, %pt {scale = 45} : (!encoder, tensor<8xf32>, !pt) -> !pt
+    return %res : !pt
+  }
+}
+
+// -----
+
+!pt = !lattigo.rlwe.plaintext
+!encoder = !lattigo.ckks.encoder
+!params = !lattigo.ckks.parameter
+
+module attributes {scheme.ckks} {
+  // CHECK: func Encode
+  func.func @encode(%params: !params, %encoder: !encoder, %value: tensor<8xf32>) -> !pt {
+    // CHECK: [[pt:[^, ].*]] := ckks.NewPlaintext([[params:[^,]*]], [[params]].MaxLevel())
+    %pt = lattigo.ckks.new_plaintext %params : (!params) -> !pt
+    %res = lattigo.ckks.encode %encoder, %value, %pt {scale = 45} : (!encoder, tensor<8xf32>, !pt) -> !pt
+    return %res : !pt
+  }
+}
+
+// -----
+
+!pt = !lattigo.rlwe.plaintext
+!encoder = !lattigo.bgv.encoder
+!params = !lattigo.bgv.parameter
+
+module attributes {scheme.bgv} {
+  // CHECK: func Encode
+  func.func @encode(%params: !params, %encoder: !encoder, %value: tensor<8xi32>) -> !pt {
+    // CHECK: [[pt:[^, ].*]] := bgv.NewPlaintext([[params:[^,]*]], 1)
+    %pt = lattigo.bgv.new_plaintext %params {level = 1 : i64} : (!params) -> !pt
+    %res = lattigo.bgv.encode %encoder, %value, %pt {scale = 0} : (!encoder, tensor<8xi32>, !pt) -> !pt
+    return %res : !pt
+  }
+}

--- a/tests/Emitter/Lattigo/new_plaintext_level_out_of_range.mlir
+++ b/tests/Emitter/Lattigo/new_plaintext_level_out_of_range.mlir
@@ -1,0 +1,33 @@
+// RUN: not heir-translate %s --emit-lattigo --split-input-file 2>&1 | FileCheck %s
+
+!pt = !lattigo.rlwe.plaintext
+!params = !lattigo.ckks.parameter
+#paramsLiteral = #lattigo.ckks.parameters_literal<logN = 14, logQ = [55, 45, 45], logP = [61], logDefaultScale = 45>
+
+module attributes {scheme.ckks} {
+  func.func @ckks_level_past_chain() {
+    %params = lattigo.ckks.new_parameters_from_literal {paramsLiteral = #paramsLiteral} : () -> !params
+    // CHECK: level 5 is past the top of the modulus chain
+    // CHECK-SAME: 3 moduli
+    // CHECK-SAME: maximum level of 2
+    %pt = lattigo.ckks.new_plaintext %params {level = 5 : i64} : (!params) -> !pt
+    return
+  }
+}
+
+// -----
+
+!pt = !lattigo.rlwe.plaintext
+!params = !lattigo.bgv.parameter
+#paramsLiteral = #lattigo.bgv.parameters_literal<logN = 14, Q = [36028797019389953, 35184372121601], P = [36028797019488257], plaintextModulus = 65537>
+
+module attributes {scheme.bgv} {
+  func.func @bgv_level_past_chain() {
+    %params = lattigo.bgv.new_parameters_from_literal {paramsLiteral = #paramsLiteral} : () -> !params
+    // CHECK: level 4 is past the top of the modulus chain
+    // CHECK-SAME: 2 moduli
+    // CHECK-SAME: maximum level of 1
+    %pt = lattigo.bgv.new_plaintext %params {level = 4 : i64} : (!params) -> !pt
+    return
+  }
+}


### PR DESCRIPTION
For the Lola test that uses Lattigo, the encode time goes from 357 ms to 288 ms, and the memory use goes from 125 MB to 84 MB.