### PR TITLE
Absorb ciphertext layout changes into plaintext matrix for convolutions

### DIFF
--- a/lib/Kernel/BUILD
+++ b/lib/Kernel/BUILD
@@ -142,6 +142,7 @@ cc_test(
         "@heir//lib/Utils/Layout:Convolution",
         "@heir//lib/Utils/Layout:ConvolutionTestUtil",
         "@heir//lib/Utils/Layout:Evaluate",
+        "@heir//lib/Utils/Layout:IslConversion",
         "@heir//lib/Utils/Layout:Utils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",

--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -17,6 +17,7 @@
 #include "lib/Utils/Layout/Convolution.h"
 #include "lib/Utils/Layout/ConvolutionTestUtil.h"
 #include "lib/Utils/Layout/Evaluate.h"
+#include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/Layout/Utils.h"
 #include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
@@ -848,6 +849,91 @@ TEST_P(KernelImplementationTest, TestConv1dCwFcwStride2) {
 
   // Result is 4 2x2 tensors with a row-major layout.
   EXPECT_EQ(actualUnpacked, expected);
+}
+
+// Absorbing the data packing into the filter's column space widens the diagonal
+// layout to the full ciphertext. The kernel folds its partial sums using its
+// own column count, so that count must be the width the layout was built with,
+// not the logical C*W of the expanded Toeplitz matrix.
+TEST(KernelImplementationTest, TestConv1dCwFcwAbsorbedPackingWidth) {
+  MLIRContext context;
+  RankedTensorType dataType =
+      RankedTensorType::get({1, 2, 6}, mlir::IndexType::get(&context));
+  RankedTensorType filterType =
+      RankedTensorType::get({2, 2, 3}, mlir::IndexType::get(&context));
+  RankedTensorType outputType =
+      RankedTensorType::get({1, 2, 4}, mlir::IndexType::get(&context));
+
+  int64_t numSlots = 32;
+  int64_t stride = 1;
+  bool interchangeRows = true;
+
+  tensor3d data = {{{0, 1, 2, 3, 4, 5}, {6, 7, 8, 9, 10, 11}}};
+  tensor3d filter = {{{3, 4, 1}, {1, 5, 2}}, {{1, 2, 3}, {2, 2, 2}}};
+
+  tensor3d expected = {{{0, 0, 0, 0}, {0, 0, 0, 0}}};
+  for (int f = 0; f < 2; ++f)
+    for (int w = 0; w < 4; ++w)
+      for (int c = 0; c < 2; ++c)
+        for (int k = 0; k < 3; ++k)
+          expected[0][f][w] += filter[f][c][k] * data[0][c][w + k];
+
+  std::function<int(const std::vector<int64_t>&)> getFilterValueFn =
+      [&](const std::vector<int64_t>& domainPoint) -> int {
+    return filter[domainPoint[0]][domainPoint[1]][domainPoint[2]];
+  };
+
+  auto runKernel = [&](const std::vector<std::vector<int>>& packedData,
+                       const presburger::IntegerRelation& filterLayout,
+                       ArrayRef<int64_t> matrixShape) {
+    LiteralValue matrixInput = evaluateLayout(filterLayout, getFilterValueFn);
+    LiteralValue vectorInput = packedData[0];
+    auto dag = implementHaleviShoup(vectorInput, matrixInput, matrixShape.vec(),
+                                    DagType::intTensor(32, {numSlots}),
+                                    /*zeroDiagonals=*/{}, /*unroll=*/true);
+    auto slots = std::get<std::vector<int>>(evalKernel(dag)[0].get());
+    auto resultLayout = get1dConvResultRelation(outputType, stride, 0, numSlots,
+                                                interchangeRows);
+    return unpackLayoutTo3DTensor<int>(resultLayout, {slots}, {1, 2, 4});
+  };
+
+  // Row-major data: the matrix columns are logical data indices, so the
+  // expanded Toeplitz width is the width the layout was built with.
+  auto rowMajorLayout = getRowMajorLayoutRelation(dataType, numSlots);
+  auto rowMajorFilter = get1dConvCwFcwFilterDiagonalizedRelation(
+      filterType, dataType, stride, 0, numSlots, interchangeRows);
+  ASSERT_TRUE(succeeded(rowMajorFilter));
+  auto expandedType =
+      get1dConvCwFcwFilterExpandedType(filterType, dataType, stride, 0);
+  EXPECT_EQ(runKernel(evaluateLayout(rowMajorLayout, getDataValueFn3D(data)),
+                      rowMajorFilter.value(), expandedType.getShape()),
+            expected);
+
+  // Gap-packed data: element j sits in slot 2j. Absorbing that packing makes
+  // the matrix columns ciphertext slots, so the matrix is numSlots wide.
+  auto gappedLayout =
+      getIntegerRelationFromIslStr(
+          "{ [n, c, w] -> [ct, slot] : n = 0 and ct = 0 and 0 <= c <= 1 and "
+          "0 <= w <= 5 and slot = 12c + 2w }")
+          .value();
+  auto columnPermutation =
+      get1dConvDataColumnPermutation(dataType, gappedLayout);
+  ASSERT_TRUE(succeeded(columnPermutation));
+  auto representative =
+      getDiagonalColumnRepresentative(columnPermutation.value(), numSlots);
+  ASSERT_TRUE(succeeded(representative));
+
+  auto absorbedFilter = get1dConvCwFcwFilterDiagonalizedRelation(
+      filterType, dataType, stride, 0, numSlots, interchangeRows,
+      &representative.value());
+  ASSERT_TRUE(succeeded(absorbedFilter));
+  SmallVector<int64_t> absorbedShape = {expandedType.getDimSize(0), numSlots};
+  // The gap packing leaves the top slots empty, so state the ciphertext shape
+  // rather than letting it come from the relation's tightest slot bound.
+  std::vector<std::vector<int>> gappedData = evaluateLayout<int>(
+      gappedLayout, getDataValueFn3D(data), SmallVector<int64_t>{1, numSlots});
+  EXPECT_EQ(runKernel(gappedData, absorbedFilter.value(), absorbedShape),
+            expected);
 }
 
 // End-to-end Halevi-Shoup matvec for a padded strided 1-D multichannel conv, in

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -1328,6 +1328,18 @@ struct ConvertLinalgConv1DNcwFcw
                                             stride, matrixOperand->padding);
   }
 
+  // The shape the filter's diagonal layout was built against: the expanded
+  // Toeplitz shape, except that absorbing the data packing makes the columns
+  // ciphertext slots and widens the layout to the recorded ciphertext size.
+  std::vector<int64_t> layoutMatrixShape(
+      linalg::Conv1DNcwFcwOp op, RankedTensorType expandedMatrixType) const {
+    std::vector<int64_t> shape = expandedMatrixType.getShape().vec();
+    if (int64_t width = getAbsorbedMatrixWidth(op); width != 0) {
+      shape[1] = width;
+    }
+    return shape;
+  }
+
   LogicalResult haleviShoupKernel(
       linalg::Conv1DNcwFcwOp op, OpAdaptor adaptor,
       ContextAwareConversionPatternRewriter& rewriter) const {
@@ -1363,8 +1375,8 @@ struct ConvertLinalgConv1DNcwFcw
                                              data.getType().getShape().back());
     std::shared_ptr<ArithmeticDagNode<SSAValue>> implementedKernel =
         implementHaleviShoup(vectorLeaf, matrixLeaf,
-                             expandedMatrixType->getShape(), dagType,
-                             zeroDiagonals,
+                             layoutMatrixShape(op, expandedMatrixType.value()),
+                             dagType, zeroDiagonals,
                              /*unroll=*/unrollKernels);
 
     rewriter.setInsertionPointAfter(op);

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
@@ -143,41 +143,23 @@ std::pair<Value, LayoutAttr> convertToLayout(
 struct FoldedConvPadding {
   // What the Toeplitz matrix must be built against.
   ConvMatrixOperand matrixOperand;
-  // The layout the padded operand must already carry for the fold to be valid.
+  // The layout that holds only the unpadded data, at the positions the unpadded
+  // operand would occupy on its own.
   IntegerRelation targetRelation;
+  // Whether the padded operand already carries `targetRelation`.
+  bool layoutMatchesTarget = false;
 };
 
-// Try to fold a zero `tensor.pad` on the spatial dims of a conv's `data`
-// operand into the conv's own `padding` parameter.
+// The symmetric zero padding a `tensor.pad` puts on the last `numSpatialDims`
+// dims of `data`, as a conv's own `padding` parameter would express it.
 //
-// `matrixDataType` is the padded operand shape the Toeplitz matrix would
-// otherwise be built against: the op's data type for a 1-D conv, or the FHE
-// input shape recorded in the kernel info for a 2-D conv. It must be rank 3
-// (N, C, W) or rank 4 (N, C, H, W), both with N=1.
-//
-// Returns nullopt when the pattern does not apply, in which case the caller
-// keeps the unfolded path.
-std::optional<FoldedConvPadding> tryFoldPadIntoConvPadding(
-    Value data, RankedTensorType matrixDataType, LayoutAttr dataLayout,
-    int64_t ciphertextSize) {
-  int64_t rank = matrixDataType.getRank();
-  if ((rank != 3 && rank != 4) || matrixDataType.getDimSize(0) != 1) {
-    return std::nullopt;
-  }
-  // For a 2-D conv `matrixDataType` comes from the kernel info rather than from
-  // `data` itself, and the kernel info is copied verbatim across rank-changing
-  // ops, so its rank is not guaranteed to match the operand's layout. Comparing
-  // relations over different spaces is meaningless (and asserts), so bail out.
-  if (dataLayout.getIntegerRelation().getNumDomainVars() !=
-      static_cast<unsigned>(rank)) {
-    return std::nullopt;
-  }
-  // Dims 0 and 1 are (N, C); everything after them is spatial.
-  size_t numSpatialDims = rank - 2;
-
-  // DropUnitDims rewrites a rank-3 pad into
-  // collapse_shape -> tensor.pad (rank 2) -> expand_shape, so peel any
-  // reshape/cast chain to find the pad.
+// DropUnitDims rewrites a rank-3 pad into
+// collapse_shape -> tensor.pad (rank 2) -> expand_shape, so peel any
+// reshape/cast chain to find the pad. Returns nullopt unless the pad is by
+// zero, static, symmetric, equal across the spatial dims, and absent on the
+// leading dims, which is what a single `padding` parameter can express.
+std::optional<int64_t> getConvSpatialZeroPad(Value data,
+                                             size_t numSpatialDims) {
   Value cursor = data;
   tensor::PadOp padOp;
   while (Operation* def = cursor.getDefiningOp()) {
@@ -199,10 +181,6 @@ std::optional<FoldedConvPadding> tryFoldPadIntoConvPadding(
                               matchPattern(padValue, m_Zero()));
   if (!zeroPad) return std::nullopt;
 
-  // A conv's `padding` parameter is a single symmetric value shared by every
-  // spatial dim, so only a pad that is symmetric, equal across the spatial
-  // dims, and absent on the leading dims is expressible as one, and only when
-  // the bounds are static. The pad may have dropped leading unit dims.
   if (!padOp.getLow().empty() || !padOp.getHigh().empty()) return std::nullopt;
   ArrayRef<int64_t> low = padOp.getStaticLow();
   ArrayRef<int64_t> high = padOp.getStaticHigh();
@@ -215,6 +193,58 @@ std::optional<FoldedConvPadding> tryFoldPadIntoConvPadding(
     int64_t expectedPad = (low.size() - i <= numSpatialDims) ? p : 0;
     if (low[i] != expectedPad || high[i] != expectedPad) return std::nullopt;
   }
+  return p;
+}
+
+// Whether dropping the 1-D conv matrix columns that `columnPermutation` leaves
+// without a slot changes nothing, because each one multiplies a zero.
+//
+// Such a column is provably zero only inside the zero region of a `tensor.pad`
+// on `data`. Any other partial packing would lose live data.
+//
+// `operand.padding != 0` cannot reach here with a hole: that is the folded
+// path, where get1dConvDataColumnPermutation already rejected one.
+bool dropped1dConvColumnsAreZero(Value data, const ConvMatrixOperand& operand,
+                                 const IntegerRelation& columnPermutation) {
+  int64_t width = operand.dataType.getDimSize(2);
+  int64_t numColumns = operand.dataType.getDimSize(1) * width;
+  llvm::DenseSet<int64_t> mapped =
+      getMappedConvMatrixColumns(columnPermutation);
+  if (static_cast<int64_t>(mapped.size()) == numColumns) return true;
+
+  std::optional<int64_t> pad =
+      getConvSpatialZeroPad(data, /*numSpatialDims=*/1);
+  if (!pad) return false;
+  for (int64_t column = 0; column < numColumns; ++column) {
+    int64_t w = column % width;
+    if (!mapped.contains(column) && w >= *pad && w < width - *pad) return false;
+  }
+  return true;
+}
+
+// Try to fold a zero `tensor.pad` on the spatial dims of a conv's `data`
+// operand into the conv's own `padding` parameter.
+//
+// Returns nullopt when the pad pattern does not apply, in which case the caller
+// keeps the unfolded path.
+std::optional<FoldedConvPadding> tryFoldPadIntoConvPadding(
+    Value data, RankedTensorType matrixDataType, LayoutAttr dataLayout,
+    int64_t ciphertextSize) {
+  int64_t rank = matrixDataType.getRank();
+  if ((rank != 3 && rank != 4) || matrixDataType.getDimSize(0) != 1) {
+    return std::nullopt;
+  }
+  if (dataLayout.getIntegerRelation().getNumDomainVars() !=
+      static_cast<unsigned>(rank)) {
+    return std::nullopt;
+  }
+  // Dims 0 and 1 are (N, C); everything after them is spatial.
+  size_t numSpatialDims = rank - 2;
+
+  std::optional<int64_t> spatialPad =
+      getConvSpatialZeroPad(data, numSpatialDims);
+  if (!spatialPad) return std::nullopt;
+  int64_t p = *spatialPad;
 
   // The reshape chain above means the pad's spatial dims are not guaranteed to
   // be this conv operand's spatial dims, so validate before building a type
@@ -224,9 +254,7 @@ std::optional<FoldedConvPadding> tryFoldPadIntoConvPadding(
   if (!matrixOperand) return std::nullopt;
 
   // The layout we expect on the padded value: the unpadded row-major layout
-  // with each spatial index shifted by `p`. If the actual layout is anything
-  // else (a conversion intervened, a non-row-major producer, reshapes that did
-  // not cancel) do not fold.
+  // with each spatial index shifted by `p`.
   IntegerRelation expected =
       getRowMajorLayoutRelation(matrixOperand->dataType, ciphertextSize);
   unsigned domainOffset =
@@ -234,17 +262,100 @@ std::optional<FoldedConvPadding> tryFoldPadIntoConvPadding(
   for (int64_t dim = 2; dim < rank; ++dim) {
     expected = shiftVar(expected, domainOffset + dim, p);
   }
-  if (!isRelationEqual(dataLayout.getIntegerRelation(), expected)) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "conv found a pad of " << p
-               << " but the operand layout does not match the shifted "
-                  "unpadded row-major layout; not folding\n");
+  bool layoutMatchesTarget =
+      isRelationEqual(dataLayout.getIntegerRelation(), expected);
+
+  LLVM_DEBUG(
+      llvm::dbgs() << "conv can fold tensor.pad of " << p
+                   << " into the conv padding parameter; operand layout "
+                   << (layoutMatchesTarget ? "matches" : "does not match")
+                   << " the shifted unpadded row-major layout\n");
+  return FoldedConvPadding{*matrixOperand, expected, layoutMatchesTarget};
+}
+
+// How a 1-D conv will read its data operand.
+struct ConvDataPlan {
+  // What the Toeplitz matrix is built against.
+  ConvMatrixOperand matrixOperand;
+  // Set when the matrix absorbs the data's slot packing into its column space.
+  std::optional<IntegerRelation> columnPermutation;
+  // Set when the data must be converted to this relation first. Never set
+  // together with `columnPermutation`.
+  std::optional<IntegerRelation> conversionTarget;
+};
+
+// Encode the data's slot packing into the public diagonal filter packing, so
+// that a non-row-major single-ciphertext input needs no online conversion.
+// `operand` is what the matrix is built against, which fixes the column space
+// the permutation is indexed in.
+std::optional<IntegerRelation> tryAbsorbConv1dDataPacking(
+    Value data, Value filter, const ConvMatrixOperand& operand,
+    LayoutAttr dataLayout, int64_t minSlotCount, DataFlowSolver* solver) {
+  if (isSecret(filter, solver)) return std::nullopt;
+  Value logicalFilter = filter;
+  if (auto assignLayout =
+          logicalFilter.getDefiningOp<tensor_ext::AssignLayoutOp>()) {
+    logicalFilter = assignLayout.getValue();
+  }
+  auto filterConstantOp = logicalFilter.getDefiningOp<arith::ConstantOp>();
+  if (!filterConstantOp || !isa<ElementsAttr>(filterConstantOp.getValue())) {
     return std::nullopt;
   }
+  auto columnPermutation = get1dConvDataColumnPermutation(
+      operand.dataType, dataLayout.getIntegerRelation(), operand.padding);
+  if (failed(columnPermutation)) return std::nullopt;
+  // A replicated packing holds each element in several slots. Reduce it to one
+  // representative slot per element, so the column substitution is a function.
+  auto representative =
+      getDiagonalColumnRepresentative(columnPermutation.value(), minSlotCount);
+  if (failed(representative)) return std::nullopt;
+  if (!dropped1dConvColumnsAreZero(data, operand, representative.value())) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "conv_1d cannot absorb the data packing: it drops matrix "
+                  "columns that are not provably zero\n");
+    return std::nullopt;
+  }
+  return representative.value();
+}
 
-  LLVM_DEBUG(llvm::dbgs() << "conv folding tensor.pad of " << p
-                          << " into the conv padding parameter\n");
-  return FoldedConvPadding{*matrixOperand, expected};
+// Decide how a 1-D conv reads its data operand, taking the first of these that
+// holds. A folded operand comes first because it keeps the padding out of the
+// matrix columns, and reading the data where it already sits comes before
+// absorbing, because absorbing widens the matrix to the whole ciphertext.
+std::optional<ConvDataPlan> planFoldedConv1dDataAccess(
+    Value data, Value filter, RankedTensorType dataType, LayoutAttr dataLayout,
+    int64_t minSlotCount, DataFlowSolver* solver) {
+  std::optional<FoldedConvPadding> folded =
+      tryFoldPadIntoConvPadding(data, dataType, dataLayout, minSlotCount);
+  if (!folded) return std::nullopt;
+  if (folded->layoutMatchesTarget) return ConvDataPlan{folded->matrixOperand};
+  std::optional<IntegerRelation> absorbed = tryAbsorbConv1dDataPacking(
+      data, filter, folded->matrixOperand, dataLayout, minSlotCount, solver);
+  if (!absorbed) return std::nullopt;
+  return ConvDataPlan{folded->matrixOperand, std::move(absorbed)};
+}
+
+ConvDataPlan planConv1dDataAccess(Value data, Value filter,
+                                  RankedTensorType dataType,
+                                  LayoutAttr dataLayout, int64_t minSlotCount,
+                                  DataFlowSolver* solver) {
+  if (auto folded = planFoldedConv1dDataAccess(
+          data, filter, dataType, dataLayout, minSlotCount, solver)) {
+    return std::move(*folded);
+  }
+
+  // Unfolded: the matrix keeps a column per padded element, and the data must
+  // carry the plain row-major layout, either already or after absorption.
+  ConvMatrixOperand matrixOperand{dataType};
+  IntegerRelation rowMajor = getRowMajorLayoutRelation(dataType, minSlotCount);
+  if (isRelationEqual(dataLayout.getIntegerRelation(), rowMajor)) {
+    return ConvDataPlan{matrixOperand};
+  }
+  if (auto absorbed = tryAbsorbConv1dDataPacking(
+          data, filter, matrixOperand, dataLayout, minSlotCount, solver)) {
+    return ConvDataPlan{matrixOperand, std::move(absorbed)};
+  }
+  return ConvDataPlan{matrixOperand, std::nullopt, std::move(rowMajor)};
 }
 
 // Return a copy of the kernel info associated with the value and update the
@@ -1023,27 +1134,20 @@ LogicalResult LayoutPropagation::visitOperation(Conv1DNcwFcwOp op) {
 
   LayoutAttr dataLayout = getComposedLayoutAttr(data);
 
-  ConvMatrixOperand matrixOperand{dataType};
-  IntegerRelation targetDataRelation =
-      getRowMajorLayoutRelation(dataType, minSlotCount);
-  // A fold only succeeds once `data` is proven to already carry the target
-  // relation, so only the unfolded path can still need a conversion.
-  bool dataLayoutMatchesTarget = false;
-  if (auto folded =
-          tryFoldPadIntoConvPadding(data, dataType, dataLayout, minSlotCount)) {
-    matrixOperand = folded->matrixOperand;
-    targetDataRelation = folded->targetRelation;
-    dataLayoutMatchesTarget = true;
-  }
+  ConvDataPlan plan = planConv1dDataAccess(data, filter, dataType, dataLayout,
+                                           minSlotCount, solver);
+  const ConvMatrixOperand& matrixOperand = plan.matrixOperand;
 
-  if (!dataLayoutMatchesTarget &&
-      !isRelationEqual(dataLayout.getIntegerRelation(), targetDataRelation)) {
+  if (plan.conversionTarget) {
     LLVM_DEBUG(llvm::dbgs() << "conv_1d data input is not row major, "
                                "inserting layout conversion.\n");
-    auto [toReplace, newDataLayoutAttr] =
-        convertToLayout(ctx, builder, op, data, dataLayout, targetDataRelation);
+    auto [toReplace, newDataLayoutAttr] = convertToLayout(
+        ctx, builder, op, data, dataLayout, *plan.conversionTarget);
     debugAssignLayout(toReplace, newDataLayoutAttr);
     assignedLayouts.insert({toReplace, newDataLayoutAttr});
+  } else if (plan.columnPermutation) {
+    LLVM_DEBUG(llvm::dbgs() << "conv_1d absorbing data packing into the "
+                               "diagonal filter layout.\n");
   }
 
   // The kernel for this operation requires expanding the conv filter matrix
@@ -1051,7 +1155,8 @@ LogicalResult LayoutPropagation::visitOperation(Conv1DNcwFcwOp op) {
   LayoutAttr filterLayout = getComposedLayoutAttr(filter);
   auto convRelation = get1dConvCwFcwFilterDiagonalizedRelation(
       filterType, matrixOperand.dataType, stride, matrixOperand.padding,
-      minSlotCount, /*interchangeRows=*/interchangeRows);
+      minSlotCount, /*interchangeRows=*/interchangeRows,
+      plan.columnPermutation ? &*plan.columnPermutation : nullptr);
   if (failed(convRelation)) {
     return failure();
   }
@@ -1086,6 +1191,10 @@ LogicalResult LayoutPropagation::visitOperation(Conv1DNcwFcwOp op) {
   // Record what the filter was diagonalized against, so that
   // ConvertToCiphertextSemantics rebuilds the same expanded matrix shape.
   setConvFoldedPadding(op, matrixOperand.padding);
+  // Absorbing built the filter layout at full ciphertext width. The kernel
+  // folds its partial sums over the matrix width, so it must read the same
+  // number.
+  setAbsorbedMatrixWidth(op, plan.columnPermutation ? minSlotCount : 0);
 
   assignedLayouts.insert({result, resultLayoutAttr});
   setResultLayoutAttr(op, kernelInfoAttr);
@@ -1157,11 +1266,13 @@ LogicalResult LayoutPropagation::visitOperation(Conv2DNchwFchwOp op) {
   ConvMatrixOperand matrixOperand{fheInputType};
   IntegerRelation targetDataRelation =
       getRowMajorLayoutRelation(fheInputType, minSlotCount);
-  // A fold only succeeds once `data` is proven to already carry the target
-  // relation, so only the unfolded path can still need a conversion.
+  // This conv has no way to read the data anywhere but the target positions, so
+  // it only folds a pad that `data` already carries the target relation for.
+  // Only the unfolded path can then still need a conversion.
   bool dataLayoutMatchesTarget = false;
   if (auto folded = tryFoldPadIntoConvPadding(data, fheInputType, dataLayout,
-                                              minSlotCount)) {
+                                              minSlotCount);
+      folded && folded->layoutMatchesTarget) {
     matrixOperand = folded->matrixOperand;
     targetDataRelation = folded->targetRelation;
     dataLayoutMatchesTarget = true;

--- a/lib/Transforms/LayoutPropagation/Utils.cpp
+++ b/lib/Transforms/LayoutPropagation/Utils.cpp
@@ -74,23 +74,22 @@ std::optional<ConvMatrixOperand> foldConvSpatialPadding(
       RankedTensorType::get(shape, dataType.getElementType()), padding};
 }
 
-int64_t getConvFoldedPadding(Operation* op) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(kConvFoldedPaddingAttrName)) {
+int64_t getConvKernelParam(Operation* op, StringRef name) {
+  if (auto attr = op->getAttrOfType<IntegerAttr>(name)) {
     return attr.getInt();
   }
   return 0;
 }
 
-void setConvFoldedPadding(Operation* op, int64_t padding) {
-  if (padding == 0) {
+void setConvKernelParam(Operation* op, StringRef name, int64_t value) {
+  if (value == 0) {
     // Drop an attribute an earlier run or an op clone left behind: a conv that
-    // folded nothing must not be read as one that did.
-    op->removeAttr(kConvFoldedPaddingAttrName);
+    // folded or absorbed nothing must not be read as one that did.
+    op->removeAttr(name);
     return;
   }
-  op->setAttr(
-      kConvFoldedPaddingAttrName,
-      IntegerAttr::get(IntegerType::get(op->getContext(), 64), padding));
+  op->setAttr(name,
+              IntegerAttr::get(IntegerType::get(op->getContext(), 64), value));
 }
 
 int64_t maxOfMaxes(ArrayRef<int64_t> d1, ArrayRef<int64_t> d2) {

--- a/lib/Transforms/LayoutPropagation/Utils.h
+++ b/lib/Transforms/LayoutPropagation/Utils.h
@@ -24,6 +24,14 @@ constexpr StringLiteral kGapFactorKey = "gap_factor";
 // of a `tensor.pad` and into a conv's own `padding` parameter.
 constexpr StringLiteral kConvFoldedPaddingAttrName = "heir.conv_folded_padding";
 
+// The width of the matrix that a conv's diagonalized filter layout was built
+// against, when LayoutPropagation absorbed the data operand's slot packing into
+// the filter's column space. The columns are then ciphertext slots, so the
+// layout is built at the ciphertext size instead of the expanded Toeplitz
+// matrix's own C*W. Absent means the layout uses the Toeplitz width.
+constexpr StringLiteral kAbsorbedMatrixWidthAttrName =
+    "heir.absorbed_matrix_width";
+
 // A conv's data operand as its expanded Toeplitz matrix sees it, paired with
 // the conv `padding` parameter that goes with it.
 struct ConvMatrixOperand {
@@ -39,11 +47,30 @@ struct ConvMatrixOperand {
 std::optional<ConvMatrixOperand> foldConvSpatialPadding(
     RankedTensorType dataType, int64_t padding);
 
-// Reads back the padding folded into `op`'s own padding parameter; 0 if none.
-int64_t getConvFoldedPadding(Operation* op);
+// Reads back an integer conv kernel parameter LayoutPropagation recorded on
+// `op`; 0 when the attribute is absent.
+int64_t getConvKernelParam(Operation* op, StringRef name);
 
-// Records the padding folded into `op`'s own padding parameter.
-void setConvFoldedPadding(Operation* op, int64_t padding);
+// Records an integer conv kernel parameter on `op`. A value of 0 removes the
+// attribute instead of writing it, so an op clone cannot carry a stale one.
+void setConvKernelParam(Operation* op, StringRef name, int64_t value);
+
+// The padding folded into `op`'s own padding parameter; 0 if none.
+inline int64_t getConvFoldedPadding(Operation* op) {
+  return getConvKernelParam(op, kConvFoldedPaddingAttrName);
+}
+inline void setConvFoldedPadding(Operation* op, int64_t padding) {
+  setConvKernelParam(op, kConvFoldedPaddingAttrName, padding);
+}
+
+// The width `op`'s filter layout was diagonalized at; 0 when it absorbed
+// nothing and so uses the expanded Toeplitz width.
+inline int64_t getAbsorbedMatrixWidth(Operation* op) {
+  return getConvKernelParam(op, kAbsorbedMatrixWidthAttrName);
+}
+inline void setAbsorbedMatrixWidth(Operation* op, int64_t width) {
+  setConvKernelParam(op, kAbsorbedMatrixWidthAttrName, width);
+}
 
 struct KernelInfo {
   SmallVector<int64_t> inputShape;

--- a/lib/Utils/Layout/BUILD
+++ b/lib/Utils/Layout/BUILD
@@ -123,6 +123,7 @@ cc_test(
     name = "UtilsTest",
     srcs = ["UtilsTest.cpp"],
     deps = [
+        ":ConvolutionTestUtil",
         ":Evaluate",
         ":IslConversion",
         ":Utils",
@@ -144,6 +145,7 @@ cc_test(
         ":Convolution",
         ":ConvolutionTestUtil",
         ":Evaluate",
+        ":IslConversion",
         ":Utils",
         "@googletest//:gtest_main",
         "@heir//lib/Utils:MathUtils",

--- a/lib/Utils/Layout/Convolution.cpp
+++ b/lib/Utils/Layout/Convolution.cpp
@@ -4,12 +4,14 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/Layout/Utils.h"
 #include "lib/Utils/MathUtils.h"
+#include "llvm/include/llvm/ADT/DenseSet.h"            // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"           // from @llvm-project
 #include "llvm/include/llvm/Support/FormatVariadic.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
@@ -462,9 +464,74 @@ FailureOr<presburger::IntegerRelation> getConvFilterDiagonalizedRelation(
   return diagonalize2dMatrix(filterRelation, filterType, minSlotCount);
 }
 
+FailureOr<presburger::IntegerRelation> get1dConvDataColumnPermutation(
+    RankedTensorType matrixDataType,
+    const presburger::IntegerRelation& dataLayout, int64_t padding) {
+  assert(matrixDataType.getRank() == 3 && "expected 3-D data matrix");
+  assert(matrixDataType.getDimSize(0) == 1 && "expected N=1 batch size");
+  if (padding < 0) return failure();
+  int64_t channels = matrixDataType.getDimSize(1);
+  int64_t width = matrixDataType.getDimSize(2);
+
+  // Unflatten [j] -> [n, c, w] with j = c * W + w, matching the expanded
+  // matrix's column coordinate embedCol = c * totalColSize + singleCol. W is
+  // the matrix operand's width, so when a pad folded into the conv's own
+  // padding the column count excludes the padding. The layout still indexes the
+  // padded value, so offset the spatial index by `padding`: column j reads the
+  // slot of padded index (c, w + padding).
+  std::string unflattenStr = llvm::formatv(
+      "{{ [j] -> [n, c, w] : n = 0 and 0 <= c < {0} and {2} <= w < {1} + {2} "
+      "and j = c * {1} + w - {2} }",
+      channels, width, padding);
+  auto unflatten = getIntegerRelationFromIslStr(unflattenStr);
+  if (failed(unflatten)) return failure();
+
+  // [j] -> [n, c, w] -> [ct, slot]
+  presburger::IntegerRelation result(unflatten.value());
+  result.compose(dataLayout);
+
+  // Require a single ciphertext. The ct coordinate is kept so the result stays
+  // in the [j] -> [ct, slot] shape that isOneToOneSingleCiphertextPacking
+  // validates; the consumer drops it before composing.
+  unsigned ctPos = result.getVarKindOffset(presburger::VarKind::Range);
+  auto ctLb = result.getConstantBound64(presburger::BoundType::LB, ctPos);
+  auto ctUb = result.getConstantBound64(presburger::BoundType::UB, ctPos);
+  if (!ctLb.has_value() || !ctUb.has_value() || ctLb.value() != 0 ||
+      ctUb.value() != 0) {
+    return failure();
+  }
+
+  // With a fold every column is an unpadded element, so a missing one means
+  // `padding` does not line the window up with the layout's domain and
+  // composing would drop real data. Count the columns rather than compare their
+  // bounds, so a hole in the middle of the domain fails too. Without a fold the
+  // columns still cover the padded positions, whose zeros are dropped on
+  // purpose, so leave that case to the caller.
+  if (padding > 0 &&
+      static_cast<int64_t>(getMappedConvMatrixColumns(result).size()) !=
+          channels * width) {
+    return failure();
+  }
+  result.removeRedundantConstraints();
+  result.simplify();
+  return result;
+}
+
+llvm::DenseSet<int64_t> getMappedConvMatrixColumns(
+    const presburger::IntegerRelation& columnPermutation) {
+  PointPairCollector collector(/*domainDims=*/1, /*rangeDims=*/2);
+  enumeratePoints(columnPermutation, collector);
+  llvm::DenseSet<int64_t> columns;
+  for (const auto& [domain, range] : collector.points) {
+    columns.insert(domain[0]);
+  }
+  return columns;
+}
+
 FailureOr<presburger::IntegerRelation> get1dConvCwFcwFilterDiagonalizedRelation(
     RankedTensorType filterType, RankedTensorType dataType, int64_t stride,
-    int64_t padding, int64_t minSlotCount, bool interchangeRows) {
+    int64_t padding, int64_t minSlotCount, bool interchangeRows,
+    const presburger::IntegerRelation* dataSlotPermutation) {
   auto expandedFilterRelation =
       get1dConvCwFcwFilterRelation(filterType, dataType, stride, padding);
   // Permutate the rows of the matrix to minimize the number of non-zero
@@ -489,7 +556,26 @@ FailureOr<presburger::IntegerRelation> get1dConvCwFcwFilterDiagonalizedRelation(
         /*equality=*/true);
     expandedFilterRelation.compose(rowInterchangeRelation);
   }
-  return diagonalize2dMatrix(expandedFilterRelation, filterType, minSlotCount);
+
+  // Absorb the data's actual slot packing into the matrix's column space:
+  // lift [j] -> [slot] to [row, j] -> [row, slot] with a row passthrough, then
+  // compose so that logical column j lands where the diagonal kernel reads the
+  // slot the data element really occupies.
+  if (dataSlotPermutation) {
+    expandedFilterRelation.compose(
+        liftVectorPermutationToMatrixColumns(*dataSlotPermutation));
+    expandedFilterRelation.removeRedundantConstraints();
+    expandedFilterRelation.simplify();
+  }
+
+  // Absorbing re-indexes the columns by ciphertext slot, so the matrix spans
+  // the whole ciphertext and the diagonal layout wraps columns modulo the same
+  // size the kernel rotates modulo. Otherwise the Toeplitz width applies, which
+  // diagonalize2dMatrix reads off the relation's own column bound.
+  std::optional<int64_t> numColumns;
+  if (dataSlotPermutation) numColumns = minSlotCount;
+  return diagonalize2dMatrix(expandedFilterRelation, filterType, minSlotCount,
+                             numColumns);
 }
 
 FailureOr<std::vector<IntegerRelation>> get2dConvChwFchwFilterAsSequence(

--- a/lib/Utils/Layout/Convolution.h
+++ b/lib/Utils/Layout/Convolution.h
@@ -2,8 +2,10 @@
 #define LIB_UTILS_LAYOUT_CONVOLUTION_H_
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
+#include "llvm/include/llvm/ADT/DenseSet.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"     // from @llvm-project
@@ -84,9 +86,41 @@ RankedTensorType get2dConvChwFchwFilterExpandedType(
 // input vector. Each row corresponds to one filter multiplication. The filter
 // type is assumed to be 3-D with dimensions (f, c, w) and the data type is
 // assumed to be 3-D with dimensions (1, c, w).
+// `dataSlotPermutation`, when non-null, maps the flattened data index [j] to
+// the [ct, slot] the element actually occupies. It re-indexes the matrix's
+// column space by that packing, so the diagonal kernel reads the data where it
+// already sits instead of converting the ciphertext. It must give each column
+// at most one slot and no two columns the same slot; see
+// getDiagonalColumnRepresentative. A column with no slot is dropped, which is
+// correct exactly when that element is zero.
 FailureOr<presburger::IntegerRelation> get1dConvCwFcwFilterDiagonalizedRelation(
     RankedTensorType filterType, RankedTensorType dataType, int64_t stride,
-    int64_t padding, int64_t minSlotCount, bool interchangeRows = true);
+    int64_t padding, int64_t minSlotCount, bool interchangeRows = true,
+    const presburger::IntegerRelation* dataSlotPermutation = nullptr);
+
+// Flattens a 3-D (1, C, W) data layout `[n, c, w] -> [ct, slot]` into the
+// column-space permutation `[j] -> [ct, slot]` with j = c * W + w, as accepted
+// by `get1dConvCwFcwFilterDiagonalizedRelation`'s `dataSlotPermutation`.
+//
+// `matrixDataType` is the operand the Toeplitz matrix is built against, so it
+// fixes W and therefore the column space. `padding` is the padding the matrix
+// carries in its own `padding` parameter. It is nonzero when a `tensor.pad`
+// folded into the conv: the matrix is then built against the unpadded operand
+// while `dataLayout` still indexes the padded value, so column j must read the
+// slot of padded index (c, w + padding).
+//
+// Fails if the layout does not pack the data into ciphertext zero, and, when
+// `padding` is nonzero, if the shifted window leaves any column without a slot.
+// Every column is real data in that case, so dropping one would drop data.
+FailureOr<presburger::IntegerRelation> get1dConvDataColumnPermutation(
+    RankedTensorType matrixDataType,
+    const presburger::IntegerRelation& dataLayout, int64_t padding = 0);
+
+// The columns j = c * W + w that `columnPermutation` gives a slot to read. The
+// diagonal kernel drops any column outside this set from the plaintext matrix,
+// so a caller that absorbs a packing must check that those elements are zero.
+llvm::DenseSet<int64_t> getMappedConvMatrixColumns(
+    const presburger::IntegerRelation& columnPermutation);
 
 // Returns a sequence of IntegerRelations that represents the layout mapping as
 // a series of simple steps (Toeplitz expansion, row interchange, flattening,

--- a/lib/Utils/Layout/ConvolutionTest.cpp
+++ b/lib/Utils/Layout/ConvolutionTest.cpp
@@ -10,6 +10,7 @@
 #include "lib/Utils/Layout/Convolution.h"
 #include "lib/Utils/Layout/ConvolutionTestUtil.h"
 #include "lib/Utils/Layout/Evaluate.h"
+#include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/Layout/Utils.h"
 #include "lib/Utils/MathUtils.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"  // from @llvm-project
@@ -1139,6 +1140,160 @@ TEST(ConvolutionTest, TestConv2dChwFchwDiagonalizedInterchangedNonSquare) {
                                    padding, /*ciphertextSize=*/128,
                                    /*interchangeRows=*/true);
   }
+}
+
+// A gap-2 packing of a (1, 2, 4) operand: element (c, w) sits in slot
+// 2 * (4c + w). `low` shifts the layout's spatial domain, which is what
+// tensor.pad does to the layout of the value it pads.
+IntegerRelation gappedDataLayout(int64_t low) {
+  std::string lowStr = std::to_string(low);
+  return getIntegerRelationFromIslStr(
+             "{ [n, c, w] -> [ct, slot] : n = 0 and ct = 0 and 0 <= c <= 1 "
+             "and " +
+             lowStr + " <= w <= 3 + " + lowStr + " and slot = 2 * (4c + w - " +
+             lowStr + ") }")
+      .value();
+}
+
+TEST(ConvolutionTest, TestConv1dDataColumnPermutation) {
+  MLIRContext context;
+  RankedTensorType dataType =
+      RankedTensorType::get({1, 2, 4}, IndexType::get(&context));
+
+  auto permutation = get1dConvDataColumnPermutation(
+      dataType, gappedDataLayout(/*low=*/0), /*padding=*/0);
+  ASSERT_TRUE(succeeded(permutation));
+
+  // Column j reads slot 2j: the matrix consumes the gapped packing in place.
+  std::vector<std::pair<int64_t, int64_t>> expected;
+  for (int64_t j = 0; j < 8; ++j) expected.push_back({j, 2 * j});
+  EXPECT_EQ(collectSlots(permutation.value()), expected);
+}
+
+TEST(ConvolutionTest, TestConv1dDataColumnPermutationFoldedPadding) {
+  // A pad of 1 folded into the conv's own padding: the matrix is built against
+  // the unpadded (1, 2, 4) operand, while the layout indexes the padded
+  // (1, 2, 6) value. Column j must still read the slot holding unpadded
+  // element j, so the same gap-2 packing comes back as column j -> slot 2j.
+  MLIRContext context;
+  RankedTensorType matrixDataType =
+      RankedTensorType::get({1, 2, 4}, IndexType::get(&context));
+
+  auto permutation = get1dConvDataColumnPermutation(
+      matrixDataType, gappedDataLayout(/*low=*/1), /*padding=*/1);
+  ASSERT_TRUE(succeeded(permutation));
+
+  std::vector<std::pair<int64_t, int64_t>> expected;
+  for (int64_t j = 0; j < 8; ++j) expected.push_back({j, 2 * j});
+  EXPECT_EQ(collectSlots(permutation.value()), expected);
+}
+
+TEST(ConvolutionTest, TestConv1dDataColumnPermutationRejectsInteriorHole) {
+  // Same folded-pad shape as above, but the layout maps only every third
+  // spatial index, so columns 1, 2, 5 and 6 get no slot. The lowest and highest
+  // columns still have one, so the bounds run 0..7 exactly as in the healthy
+  // case, and a check that only compares them accepts this and silently drops
+  // four real elements from the plaintext matrix. With a fold every column is
+  // real data, so it must fail.
+  MLIRContext context;
+  RankedTensorType matrixDataType =
+      RankedTensorType::get({1, 2, 4}, IndexType::get(&context));
+
+  // Without a fold the columns still span the padded value, so a column with no
+  // slot may be a pad zero and the caller decides. This case shows the bounds
+  // cannot see the hole: columns 0 and 7 are both mapped, yet half are missing.
+  IntegerRelation unfoldedHole =
+      getIntegerRelationFromIslStr(
+          "{ [n, c, w] -> [ct, slot] : n = 0 and ct = 0 and 0 <= c <= 1 and "
+          "0 <= w <= 3 and w mod 3 = 0 and slot = 2 * (4c + w) }")
+          .value();
+  auto unchecked = get1dConvDataColumnPermutation(matrixDataType, unfoldedHole,
+                                                  /*padding=*/0);
+  ASSERT_TRUE(succeeded(unchecked));
+  auto mapped = getMappedConvMatrixColumns(unchecked.value());
+  EXPECT_EQ(mapped.size(), 4u);
+  EXPECT_TRUE(mapped.contains(0));
+  EXPECT_TRUE(mapped.contains(7));
+
+  // With a fold every column is real data, so the same shape of hole fails.
+  IntegerRelation foldedHole =
+      getIntegerRelationFromIslStr(
+          "{ [n, c, w] -> [ct, slot] : n = 0 and ct = 0 and 0 <= c <= 1 and "
+          "1 <= w <= 4 and (w - 1) mod 3 = 0 and slot = 2 * (4c + w - 1) }")
+          .value();
+  EXPECT_TRUE(failed(get1dConvDataColumnPermutation(matrixDataType, foldedHole,
+                                                    /*padding=*/1)));
+}
+
+TEST(ConvolutionTest, TestConv1dCwFcwDiagonalizedAbsorbsGappedPacking) {
+  // The end of the chain the two changes above serve: a folded pad and a gapped
+  // packing at once. The matrix is built against the unpadded (1, 2, 4) operand
+  // with the pad of 1 in its own `padding` parameter, and it absorbs the gap-2
+  // packing of the padded value. The result must be the reference Toeplitz
+  // matrix with column j moved to slot 2j, and zero everywhere else.
+  MLIRContext context;
+  const int64_t outputChannels = 2;
+  const int64_t inputChannels = 2;
+  const int64_t filterWidth = 3;
+  const int64_t dataWidth = 4;
+  const int64_t stride = 1;
+  const int64_t padding = 1;
+  const int64_t ciphertextSize = 16;
+
+  std::vector<std::vector<std::vector<int>>> filter(
+      outputChannels, std::vector<std::vector<int>>(
+                          inputChannels, std::vector<int>(filterWidth, 0)));
+  for (int64_t f = 0; f < outputChannels; ++f) {
+    for (int64_t c = 0; c < inputChannels; ++c) {
+      for (int64_t k = 0; k < filterWidth; ++k) {
+        filter[f][c][k] = (int)((f * 37 + c * 11 + k * 3) % 17) + 1;
+      }
+    }
+  }
+  std::function<int(const std::vector<int64_t>&)> getFilterValueFn =
+      [&](const std::vector<int64_t>& domainPoint) -> int {
+    return filter[domainPoint[0]][domainPoint[1]][domainPoint[2]];
+  };
+
+  RankedTensorType filterType = RankedTensorType::get(
+      {outputChannels, inputChannels, filterWidth}, IndexType::get(&context));
+  RankedTensorType matrixDataType = RankedTensorType::get(
+      {1, inputChannels, dataWidth}, IndexType::get(&context));
+
+  auto permutation = get1dConvDataColumnPermutation(
+      matrixDataType, gappedDataLayout(/*low=*/padding), padding);
+  ASSERT_TRUE(succeeded(permutation));
+
+  auto maybeRel = get1dConvCwFcwFilterDiagonalizedRelation(
+      filterType, matrixDataType, stride, padding, ciphertextSize,
+      /*interchangeRows=*/false, &permutation.value());
+  ASSERT_TRUE(succeeded(maybeRel));
+
+  auto expected =
+      reference1dConvCwFcwMatrix(filter, dataWidth, stride, padding);
+  int64_t rows = expected.size();
+  std::vector<std::vector<int>> expectedGapped(
+      rows, std::vector<int>(ciphertextSize, 0));
+  for (int64_t row = 0; row < rows; ++row) {
+    for (size_t col = 0; col < expected[row].size(); ++col) {
+      expectedGapped[row][2 * col] = expected[row][col];
+    }
+  }
+
+  auto packed = evaluateLayout(maybeRel.value(), getFilterValueFn);
+  EXPECT_EQ(undiagonalizeMatrix(packed, rows, ciphertextSize), expectedGapped);
+}
+
+TEST(ConvolutionTest, TestConv1dDataColumnPermutationRejectsWrongPadding) {
+  // The layout was shifted by 1, so reading it back with a padding of 2 moves
+  // the window past the end of its domain and leaves columns with no slot.
+  // Dropping those columns would drop real data, so this must fail instead.
+  MLIRContext context;
+  RankedTensorType matrixDataType =
+      RankedTensorType::get({1, 2, 4}, IndexType::get(&context));
+
+  EXPECT_TRUE(failed(get1dConvDataColumnPermutation(
+      matrixDataType, gappedDataLayout(/*low=*/1), /*padding=*/2)));
 }
 
 }  // namespace

--- a/lib/Utils/Layout/ConvolutionTestUtil.cpp
+++ b/lib/Utils/Layout/ConvolutionTestUtil.cpp
@@ -1,6 +1,7 @@
 #include "lib/Utils/Layout/ConvolutionTestUtil.h"
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "lib/Utils/Layout/Convolution.h"
@@ -16,6 +17,18 @@ namespace heir {
 int64_t convOutputExtent(int64_t dataExtent, int64_t filterExtent,
                          int64_t stride, int64_t padding) {
   return (dataExtent + 2 * padding - filterExtent) / stride + 1;
+}
+
+std::vector<std::pair<int64_t, int64_t>> collectSlots(
+    const presburger::IntegerRelation& relation) {
+  PointPairCollector collector(/*domainDims=*/1, /*rangeDims=*/2);
+  enumeratePoints(relation, collector);
+  std::vector<std::pair<int64_t, int64_t>> result;
+  for (const auto& [domain, range] : collector.points) {
+    result.push_back({domain[0], range[1]});
+  }
+  llvm::sort(result);
+  return result;
 }
 
 ConvTensor4D deterministicConvFilter(int64_t outputChannels,

--- a/lib/Utils/Layout/ConvolutionTestUtil.h
+++ b/lib/Utils/Layout/ConvolutionTestUtil.h
@@ -2,6 +2,7 @@
 #define LIB_UTILS_LAYOUT_CONVOLUTION_TEST_UTIL_H_
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
@@ -13,6 +14,12 @@ namespace heir {
 
 // A dense (N, C, H, W) integer tensor, as the conv test references use it.
 using ConvTensor4D = std::vector<std::vector<std::vector<std::vector<int>>>>;
+
+// Returns the [idx] -> slot pairs of a single-ciphertext packing or
+// column-space permutation, sorted, so that a test can compare a relation
+// against an expected packing directly.
+std::vector<std::pair<int64_t, int64_t>> collectSlots(
+    const presburger::IntegerRelation& relation);
 
 // Number of windows a filter of `filterExtent` takes across one spatial dim of
 // `dataExtent`, zero-padded by `padding` on both ends. Shared so that every

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -15,7 +15,10 @@
 
 #include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/MathUtils.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseSet.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"          // from @llvm-project
 #include "llvm/include/llvm/Support/ErrorHandling.h"  // from @llvm-project
 #include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
@@ -34,6 +37,8 @@
 #include "include/isl/space_type.h"  // from @isl
 #include "include/isl/val.h"         // from @isl
 #include "include/isl/val_type.h"    // from @isl
+
+#define DEBUG_TYPE "layout-utils"
 
 namespace mlir {
 namespace heir {
@@ -236,7 +241,7 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
 
 FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
     presburger::IntegerRelation relation, RankedTensorType originalType,
-    int64_t minSlotCount) {
+    int64_t minSlotCount, std::optional<int64_t> numColumns) {
   // Get size of the matrix.
   auto rowBound = relation.getConstantBound64(
       BoundType::UB, relation.getVarKindOffset(VarKind::Range));
@@ -245,9 +250,10 @@ FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
   if (!rowBound.has_value() || !colBound.has_value()) {
     return failure();
   }
-  RankedTensorType matrixType =
-      RankedTensorType::get({rowBound.value() + 1, colBound.value() + 1},
-                            originalType.getElementType());
+  int64_t columns = numColumns.value_or(colBound.value() + 1);
+  if (columns <= colBound.value()) return failure();
+  RankedTensorType matrixType = RankedTensorType::get(
+      {rowBound.value() + 1, columns}, originalType.getElementType());
   auto diagonalRelation = getDiagonalLayoutRelation(matrixType, minSlotCount);
 
   // Compose these relations.
@@ -604,19 +610,80 @@ void prependPassthroughDim(IntegerRelation& relation, std::optional<int64_t> lb,
   }
 }
 
-IntegerRelation foldVectorPermutationIntoMatrixLayout(
-    const IntegerRelation& vectorPermutation,
-    const IntegerRelation& matrixLayout) {
+FailureOr<IntegerRelation> getDiagonalColumnRepresentative(
+    const IntegerRelation& relation, int64_t numSlots) {
+  if (relation.getNumDomainVars() != 1 || relation.getNumRangeVars() != 2)
+    return failure();
+
+  PointPairCollector points(relation.getNumDomainVars(),
+                            relation.getNumRangeVars());
+  enumeratePoints(relation, points);
+  if (points.points.empty()) return failure();
+
+  // Collect the slots that hold each element.
+  llvm::DenseMap<int64_t, SmallVector<int64_t>> copiesOf;
+  for (const auto& [domain, range] : points.points) {
+    if (range[0] != 0) return failure();
+    copiesOf[domain[0]].push_back(range[1]);
+  }
+
+  // Every entry of copiesOf got at least one slot, so numCopies is positive.
+  int64_t numCopies = copiesOf.begin()->second.size();
+  if (numSlots % numCopies != 0) return failure();
+  int64_t period = numSlots / numCopies;
+  LLVM_DEBUG(llvm::dbgs() << "representative: points=" << points.points.size()
+                          << " elements=" << copiesOf.size()
+                          << " copies=" << numCopies << " period=" << period
+                          << " numSlots=" << numSlots << "\n");
+
+  int64_t maxRepresentative = 0;
+  llvm::DenseSet<int64_t> representatives;
+  for (auto& entry : copiesOf) {
+    SmallVector<int64_t>& slots = entry.second;
+    if (static_cast<int64_t>(slots.size()) != numCopies) return failure();
+    llvm::sort(slots);
+    // Every element must repeat on the same grid. If it does not, no single
+    // slot bound separates the representatives from the copies.
+    for (int64_t i = 1; i < numCopies; ++i) {
+      if (slots[i] - slots[i - 1] != period) return failure();
+    }
+    // Two elements must not share a representative slot.
+    if (!representatives.insert(slots[0]).second) return failure();
+    maxRepresentative = std::max(maxRepresentative, slots[0]);
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "representative: maxRep=" << maxRepresentative
+                          << " -> ACCEPT\n");
+
+  IntegerRelation result(relation);
+  if (numCopies > 1) {
+    result.addBound(BoundType::UB, result.getVarKindOffset(VarKind::Range) + 1,
+                    maxRepresentative);
+    result.removeRedundantConstraints();
+    result.simplify();
+  }
+  return result;
+}
+
+IntegerRelation liftVectorPermutationToMatrixColumns(
+    const IntegerRelation& vectorPermutation) {
   // vectorPermutation maps a vector index [col] -> [ct, slot] as a
   // single-ciphertext permutation (ct is fixed to zero). Drop the constant ct
   // output, leaving the pure index-to-slot permutation [col] -> [slot].
   IntegerRelation result(vectorPermutation);
   result.projectOut(result.getVarKindOffset(VarKind::Range), 1);
 
-  // Lift the permutation to a matrix domain by prepending a passthrough row
-  // dimension to both sides (row_in == row_out), giving
-  // [row, col] -> [row, slot].
+  // Prepend a passthrough row dimension to both sides (row_in == row_out),
+  // giving [row, col] -> [row, slot].
   prependPassthroughDim(result);
+  return result;
+}
+
+IntegerRelation foldVectorPermutationIntoMatrixLayout(
+    const IntegerRelation& vectorPermutation,
+    const IntegerRelation& matrixLayout) {
+  IntegerRelation result =
+      liftVectorPermutationToMatrixColumns(vectorPermutation);
 
   // Compose with the matrix layout (result;matrixLayout): the permutation's
   // [row, slot] output feeds the matrix layout's [row, col] input, so the

--- a/lib/Utils/Layout/Utils.h
+++ b/lib/Utils/Layout/Utils.h
@@ -66,9 +66,15 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
     RankedTensorType matrixType, int64_t minSlotCount);
 
 // Applies a diagonal layout onto a given 2-D matrix layout.
+//
+// By default the matrix width comes from the relation's own column bound.
+// `numColumns` overrides it, which matters when the columns are ciphertext
+// slots: the diagonal layout indexes columns modulo the width rounded up to a
+// power of two, while the transform that consumes it rotates modulo the
+// ciphertext size. Passing the ciphertext size keeps the two moduli equal.
 FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
     presburger::IntegerRelation relation, RankedTensorType originalType,
-    int64_t minSlotCount);
+    int64_t minSlotCount, std::optional<int64_t> numColumns = std::nullopt);
 
 // Returns an IntegerRelation that represents a bicyclic layout for a matrix.
 // See https://eprint.iacr.org/2024/1762 for details.
@@ -121,6 +127,27 @@ bool isRelationRowMajor(RankedTensorType vectorType, int64_t numSlots,
 // vector element occupying exactly one distinct slot.
 bool isOneToOneSingleCiphertextPacking(
     const presburger::IntegerRelation& relation);
+
+// Reduces a possibly replicated single-ciphertext packing [idx] -> [ct, slot]
+// to one representative slot per element, so that the packing can serve as the
+// column substitution of a Halevi-Shoup diagonal matvec.
+//
+// Fails if the packing spans more than one ciphertext, if the copies of an
+// element do not sit on a common grid, or if two elements share a
+// representative slot.
+//
+// Elements with no slot stay out of the result. The diagonal matvec then drops
+// their matrix columns, which is correct exactly when those elements are zero.
+FailureOr<presburger::IntegerRelation> getDiagonalColumnRepresentative(
+    const presburger::IntegerRelation& relation, int64_t numSlots);
+
+// Lifts a single-ciphertext vector permutation [col] -> [ct, slot] into the
+// column space of a matrix, giving [row, col] -> [row, slot]. It drops the
+// constant ct output and prepends a passthrough row dimension, so that
+// composing with it re-indexes a matrix's columns by the slot the element
+// really occupies, leaving the rows alone.
+presburger::IntegerRelation liftVectorPermutationToMatrixColumns(
+    const presburger::IntegerRelation& vectorPermutation);
 
 // Folds a single-ciphertext vector permutation (as accepted by
 // isOneToOneSingleCiphertextPacking) into a matrix layout, returning the matrix

--- a/lib/Utils/Layout/UtilsTest.cpp
+++ b/lib/Utils/Layout/UtilsTest.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"  // from @googletest
+#include "lib/Utils/Layout/ConvolutionTestUtil.h"
 #include "lib/Utils/Layout/Evaluate.h"
 #include "lib/Utils/Layout/IslConversion.h"
 #include "lib/Utils/Layout/Utils.h"
@@ -916,6 +917,78 @@ TEST(UtilsTest, TestIsOneToOneSingleCiphertextPacking) {
                                  "3 }")
                                  .value();
   EXPECT_FALSE(isOneToOneSingleCiphertextPacking(multipleCiphertexts));
+}
+
+TEST(UtilsTest, TestGetDiagonalColumnRepresentativeNotReplicated) {
+  // slot = 3i mod 8 fills all 8 slots, so the packing already reads one slot
+  // per element and passes through unchanged.
+  auto permutation = getIntegerRelationFromIslStr(
+                         "{ [i] -> [ct, slot] : ct = 0 and (slot - 3i) mod 8 "
+                         "= 0 and 0 <= i <= 7 and 0 <= slot <= 7 }")
+                         .value();
+  auto result = getDiagonalColumnRepresentative(permutation, /*numSlots=*/8);
+  ASSERT_TRUE(succeeded(result));
+  EXPECT_EQ(collectSlots(result.value()), collectSlots(permutation));
+}
+
+TEST(UtilsTest, TestGetDiagonalColumnRepresentativeReplicated) {
+  // Two copies of [0, 8) in 16 slots. The representative keeps the low copy.
+  auto replicated = getIntegerRelationFromIslStr(
+                        "{ [i] -> [ct, slot] : ct = 0 and (slot - i) mod 8 = "
+                        "0 and 0 <= i <= 7 and 0 <= slot <= 15 }")
+                        .value();
+  auto result = getDiagonalColumnRepresentative(replicated, /*numSlots=*/16);
+  ASSERT_TRUE(succeeded(result));
+  std::vector<std::pair<int64_t, int64_t>> expected;
+  for (int64_t i = 0; i < 8; ++i) expected.push_back({i, i});
+  EXPECT_EQ(collectSlots(result.value()), expected);
+}
+
+TEST(UtilsTest, TestGetDiagonalColumnRepresentativePartialDomain) {
+  // A zero-padding region gets no slot at all, so the packing is defined on
+  // part of the index space only. That is still absorbable.
+  auto partial = getIntegerRelationFromIslStr(
+                     "{ [i] -> [ct, slot] : ct = 0 and slot = i and 2 <= i <= "
+                     "9 }")
+                     .value();
+  auto result = getDiagonalColumnRepresentative(partial, /*numSlots=*/16);
+  ASSERT_TRUE(succeeded(result));
+  EXPECT_EQ(collectSlots(result.value()).size(), 8u);
+}
+
+TEST(UtilsTest, TestGetDiagonalColumnRepresentativeSparseReplicated) {
+  // Four elements replicated on a period-8 grid in 16 slots. The
+  // representatives span only a quarter of the ciphertext, which is fine as
+  // long as the caller builds the matrix at full ciphertext width.
+  auto sparse = getIntegerRelationFromIslStr(
+                    "{ [i] -> [ct, slot] : ct = 0 and (slot - i) mod 8 = 0 "
+                    "and 0 <= i <= 3 and 0 <= slot <= 15 }")
+                    .value();
+  auto result = getDiagonalColumnRepresentative(sparse, /*numSlots=*/16);
+  ASSERT_TRUE(succeeded(result));
+  std::vector<std::pair<int64_t, int64_t>> expected;
+  for (int64_t i = 0; i < 4; ++i) expected.push_back({i, i});
+  EXPECT_EQ(collectSlots(result.value()), expected);
+}
+
+TEST(UtilsTest, TestGetDiagonalColumnRepresentativeRejectsSharedSlot) {
+  // Elements 0 and 2 both land on slot 0, and 1 and 3 both on slot 1. The
+  // column substitution would be ambiguous, so the packing must be rejected.
+  auto shared = getIntegerRelationFromIslStr(
+                    "{ [i] -> [ct, slot] : ct = 0 and (slot - i) mod 2 = 0 "
+                    "and 0 <= i <= 3 and 0 <= slot <= 3 }")
+                    .value();
+  EXPECT_TRUE(failed(getDiagonalColumnRepresentative(shared, /*numSlots=*/4)));
+}
+
+TEST(UtilsTest, TestGetDiagonalColumnRepresentativeRejectsMultipleCiphertexts) {
+  auto multipleCiphertexts = getIntegerRelationFromIslStr(
+                                 "{ [i] -> [ct, slot] : i = 4ct + slot and 0 "
+                                 "<= i <= 7 and 0 <= ct <= 1 and 0 <= slot <= "
+                                 "3 }")
+                                 .value();
+  EXPECT_TRUE(failed(getDiagonalColumnRepresentative(multipleCiphertexts,
+                                                     /*numSlots=*/4)));
 }
 
 TEST(UtilsTest, TestFoldVectorPermutationIntoMatrixLayout) {

--- a/tests/Examples/common/conv1d_ncw_gapped_padded.mlir
+++ b/tests/Examples/common/conv1d_ncw_gapped_padded.mlir
@@ -1,0 +1,25 @@
+// A two-layer 1-D conv chain. The first conv has stride 2, so it leaves its
+// result in a gapped packing. The second conv pads that result, so its data
+// operand is both gapped and padded. LayoutPropagation must fold the pad into
+// the second conv's own padding parameter and absorb the gapped packing into
+// its plaintext diagonal filter, with no online layout conversion.
+module {
+  func.func @conv1d_ncw_gapped_padded(%arg0 : tensor<1x2x8xf32> {secret.secret}) -> tensor<1x2x4xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %out1 = arith.constant dense<0.000000e+00> : tensor<1x2x4xf32>
+    %out2 = arith.constant dense<0.000000e+00> : tensor<1x2x4xf32>
+    %filter1 = arith.constant dense<[[[-1.0, -0.5, 0.0], [0.5, 1.0, -1.0]], [[-0.5, 0.0, 0.5], [1.0, -1.0, -0.5]]]> : tensor<2x2x3xf32>
+    %filter2 = arith.constant dense<[[[0.5, -1.0, 0.25], [-0.25, 0.5, 1.0]], [[1.0, 0.25, -0.5], [0.0, -1.0, 0.5]]]> : tensor<2x2x3xf32>
+    %padded1 = tensor.pad %arg0 low[0, 0, 1] high[0, 0, 1] {
+    ^bb0(%a: index, %b: index, %c: index):
+      tensor.yield %cst : f32
+    } : tensor<1x2x8xf32> to tensor<1x2x10xf32>
+    %conv1 = linalg.conv_1d_ncw_fcw {dilations = dense<1> : vector<1xi64>, strides = dense<2> : vector<1xi64>} ins(%padded1, %filter1 : tensor<1x2x10xf32>, tensor<2x2x3xf32>) outs(%out1 : tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
+    %padded2 = tensor.pad %conv1 low[0, 0, 1] high[0, 0, 1] {
+    ^bb0(%a: index, %b: index, %c: index):
+      tensor.yield %cst : f32
+    } : tensor<1x2x4xf32> to tensor<1x2x6xf32>
+    %conv2 = linalg.conv_1d_ncw_fcw {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>} ins(%padded2, %filter2 : tensor<1x2x6xf32>, tensor<2x2x3xf32>) outs(%out2 : tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
+    return %conv2 : tensor<1x2x4xf32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/conv1d_ncw_gapped_padded/BUILD
+++ b/tests/Examples/lattigo/ckks/conv1d_ncw_gapped_padded/BUILD
@@ -1,0 +1,22 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv1d_ncw_gapped_padded",
+    go_library_name = "conv1dncwgappedpadded",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--mlir-to-ckks=min-slot-count=1024 greedy-modulus-switch-after-mul=true",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "@heir//tests/Examples/common:conv1d_ncw_gapped_padded.mlir",
+)
+
+go_test(
+    name = "conv1dncwgappedpadded_test",
+    size = "small",
+    srcs = ["conv1d_ncw_gapped_padded_test.go"],
+    embed = [":conv1dncwgappedpadded"],
+)

--- a/tests/Examples/lattigo/ckks/conv1d_ncw_gapped_padded/conv1d_ncw_gapped_padded_test.go
+++ b/tests/Examples/lattigo/ckks/conv1d_ncw_gapped_padded/conv1d_ncw_gapped_padded_test.go
@@ -1,0 +1,35 @@
+package conv1dncwgappedpadded
+
+import (
+	"math"
+	"testing"
+)
+
+// The second conv in this chain takes a data operand that is both gapped (the
+// first conv has stride 2) and padded. LayoutPropagation folds that pad into the
+// conv's own padding parameter and absorbs the gapped packing into the plaintext
+// diagonal filter, so this checks that the absorbed matrix computes the same
+// numbers a plain convolution does.
+func TestConv1DGappedPadded(t *testing.T) {
+	evaluator, params, ecd, enc, dec := Conv1d_ncw_gapped_padded__configure()
+
+	arg0 := make([]float32, 16)
+	for i := 0; i < 16; i++ {
+		arg0[i] = float32(i) * 0.1
+	}
+
+	expected := []float32{
+		-1.0125, -0.8375, -0.875, 0.0125,
+		0.825, 0.1875, 0.5375, 0.6375,
+	}
+
+	ct0 := Conv1d_ncw_gapped_padded__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	resultCt := Conv1d_ncw_gapped_padded(evaluator, params, ecd, ct0)
+	result := Conv1d_ncw_gapped_padded__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+	errorThreshold := float64(0.05)
+	for i := range expected {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: %.4f != %.4f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Transforms/layout_propagation/conv1d_ncw_fcw_folded_padding_gapped.mlir
+++ b/tests/Transforms/layout_propagation/conv1d_ncw_fcw_folded_padding_gapped.mlir
@@ -1,0 +1,43 @@
+// RUN: heir-opt --layout-propagation=min-slot-count=1024 %s | FileCheck %s
+
+// A stride-2 conv leaves its result in a gapped packing. The second conv pads
+// that result, so its data operand is neither row major nor unpadded. Both convs
+// must still fold their pad into their own `padding` parameter, and neither may
+// pay for an online layout conversion: the second conv reads the gapped packing
+// where it sits by absorbing it into its plaintext diagonal filter.
+
+// The second conv absorbs, so its filter layout is built at the ciphertext
+// width rather than at the Toeplitz C*W. It must record that width, because the
+// kernel folds its partial sums over it.
+
+// CHECK-NOT: tensor_ext.convert_layout
+// CHECK: linalg.conv_1d_ncw_fcw
+// CHECK-SAME: heir.conv_folded_padding = 1 : i64
+// CHECK-NOT: tensor_ext.convert_layout
+// CHECK: linalg.conv_1d_ncw_fcw
+// CHECK-SAME: heir.absorbed_matrix_width = 1024 : i64
+// CHECK-SAME: heir.conv_folded_padding = 1 : i64
+// CHECK-NOT: tensor_ext.convert_layout
+
+func.func @conv1d_gapped_folded_padding(
+    %arg0: !secret.secret<tensor<1x8x8xf32>>) -> !secret.secret<tensor<1x8x4xf32>> {
+  %out = arith.constant dense<0.000000e+00> : tensor<1x8x4xf32>
+  %filter1 = arith.constant dense<2.000000e+00> : tensor<8x8x3xf32>
+  %filter2 = arith.constant dense<3.000000e+00> : tensor<8x8x3xf32>
+  %0 = secret.generic(%arg0 : !secret.secret<tensor<1x8x8xf32>>) {
+  ^body(%input0: tensor<1x8x8xf32>):
+    %zero = arith.constant 0.000000e+00 : f32
+    %padded0 = tensor.pad %input0 low[0, 0, 1] high[0, 0, 1] {
+    ^bb0(%i: index, %j: index, %k: index):
+      tensor.yield %zero : f32
+    } : tensor<1x8x8xf32> to tensor<1x8x10xf32>
+    %1 = linalg.conv_1d_ncw_fcw {dilations = dense<1> : vector<1xi64>, strides = dense<2> : vector<1xi64>} ins(%padded0, %filter1 : tensor<1x8x10xf32>, tensor<8x8x3xf32>) outs(%out : tensor<1x8x4xf32>) -> tensor<1x8x4xf32>
+    %padded1 = tensor.pad %1 low[0, 0, 1] high[0, 0, 1] {
+    ^bb0(%i: index, %j: index, %k: index):
+      tensor.yield %zero : f32
+    } : tensor<1x8x4xf32> to tensor<1x8x6xf32>
+    %2 = linalg.conv_1d_ncw_fcw {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>} ins(%padded1, %filter2 : tensor<1x8x6xf32>, tensor<8x8x3xf32>) outs(%out : tensor<1x8x4xf32>) -> tensor<1x8x4xf32>
+    secret.yield %2 : tensor<1x8x4xf32>
+  } -> !secret.secret<tensor<1x8x4xf32>>
+  return %0 : !secret.secret<tensor<1x8x4xf32>>
+}


### PR DESCRIPTION
We should be able to avoid rotating the ciphertext after convolutions and push the permutation into the plaintext. For our convolutional networks, this is particularly beneficial because they often look like: 

Activation -> Convolution -> Activation' -> Convolution'->...

This feels a bit too complex, but I have not been able to pull it apart into simpler pieces.