### PR TITLE
Fixed missing operation name scf.if

### DIFF
--- a/docs/content/en/docs/Design/do_transformation.md
+++ b/docs/content/en/docs/Design/do_transformation.md
@@ -26,7 +26,7 @@ of this transformation.
 func.func @my_function(%input : i1 {secret.secret}) -> () {
   ...
   // Violation: %input is used as a condition causing a data-dependent branch
-  %result =`%input -> (i16) {
+  %result = scf.if %input -> (i16) {
         %a = arith.muli %b, %c : i16
         scf.yield %a : i16
       } else {


### PR DESCRIPTION
The example of the if-transformation had a typo in the mlir code.
this should fix it.