### PR TITLE
Fix --//:enable_yosys=0

### DIFF
--- a/bazel/lit.bzl
+++ b/bazel/lit.bzl
@@ -5,7 +5,7 @@ load("@rules_python//python:py_test.bzl", "py_test")
 
 _DEFAULT_FILE_EXTS = ["mlir"]
 
-def lit_test(name = None, src = None, size = "small", tags = None, data = None):
+def lit_test(name = None, src = None, size = "small", tags = None, data = None, target_compatible_with = None):
     """Define a lit test.
 
     In its simplest form, a manually defined lit test would look like this:
@@ -33,6 +33,7 @@ def lit_test(name = None, src = None, size = "small", tags = None, data = None):
       size: the size of the test.
       tags: tags to pass to the target.
       data: the data to pass to the target.
+      target_compatible_with: constraints to pass to the target.
     """
     if not src:
         fail("src must be specified")
@@ -59,6 +60,7 @@ def lit_test(name = None, src = None, size = "small", tags = None, data = None):
         # needed for Python 3.11+, cf. https://github.com/llvm/llvm-project/pull/87022
         deps = [Label("@llvm-project//llvm:lit")],
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )
 
 def glob_lit_tests(
@@ -71,7 +73,9 @@ def glob_lit_tests(
         size_override = None,
         test_file_exts = None,
         default_tags = None,
-        tags_override = None):
+        tags_override = None,
+        target_compatible_with = None,
+        target_compatible_with_override = None):
     """Searches the caller's directory for files to run as lit tests.
 
     Args:
@@ -85,11 +89,15 @@ def glob_lit_tests(
         that should be defined as tests.
       default_tags: [str] tags to add to each test
       tags_override: tags to pass to each generated target.
+      target_compatible_with: constraints to pass to each generated target.
+      target_compatible_with_override: a dictionary giving per-source-file
+        constraints, overriding target_compatible_with.
     """
     exclude = exclude or []
     test_file_exts = test_file_exts or _DEFAULT_FILE_EXTS
     size_override = size_override or dict()
     tags_override = tags_override or dict()
+    target_compatible_with_override = target_compatible_with_override or dict()
     default_tags = default_tags or []
     tests = native.glob(["*." + ext for ext in test_file_exts], exclude = exclude, allow_empty = True)
 
@@ -99,4 +107,5 @@ def glob_lit_tests(
             size = size_override.get(curr_test, "small"),
             tags = default_tags + tags_override.get(curr_test, []),
             data = data,
+            target_compatible_with = target_compatible_with_override.get(curr_test, target_compatible_with),
         )

--- a/bazel/yosys.bzl
+++ b/bazel/yosys.bzl
@@ -1,0 +1,12 @@
+"""Helpers for targets that require Yosys support."""
+
+def requires_yosys():
+    """Marks a target incompatible unless built with --//:enable_yosys=1.
+
+    Incompatible targets are automatically skipped by wildcard patterns like
+    `bazel build //...`.
+    """
+    return select({
+        "@heir//:config_enable_yosys": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    })

--- a/lib/Pipelines/BooleanPipelineRegistration.cpp
+++ b/lib/Pipelines/BooleanPipelineRegistration.cpp
@@ -13,6 +13,7 @@
 #include "lib/Dialect/Secret/Conversions/SecretToCGGI/SecretToCGGI.h"
 #include "lib/Dialect/Secret/Transforms/AddDebugPort.h"
 #include "lib/Dialect/Secret/Transforms/DistributeGeneric.h"
+#include "lib/Pipelines/PipelineRegistration.h"
 #include "lib/Transforms/BooleanVectorizer/BooleanVectorizer.h"
 #include "lib/Transforms/FoldConstantTensors/FoldConstantTensors.h"
 #include "lib/Transforms/ForwardInsertToExtract/ForwardInsertToExtract.h"
@@ -22,6 +23,7 @@
 #include "lib/Transforms/MemrefToArith/MemrefToArith.h"
 #include "lib/Transforms/Secretize/Passes.h"
 #include "lib/Transforms/TensorLinalgToAffineLoops/TensorLinalgToAffineLoops.h"
+#include "lib/Transforms/UnusedMemRef/UnusedMemRef.h"
 #include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
 #include "mlir/include/mlir/Conversion/TensorToLinalg/TensorToLinalgPass.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/Affine/Transforms/Passes.h"  // from @llvm-project

--- a/tests/Emitter/verilog/BUILD
+++ b/tests/Emitter/verilog/BUILD
@@ -1,6 +1,7 @@
 # Tests depending on Yosys
 
 load("//bazel:lit.bzl", "glob_lit_tests")
+load("//bazel:yosys.bzl", "requires_yosys")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
@@ -12,6 +13,7 @@ glob_lit_tests(
     ],
     default_tags = ["yosys"],
     driver = "@heir//tests:run_lit.sh",
+    target_compatible_with = requires_yosys(),
     test_file_exts = [
         "mlir",
         "v",

--- a/tests/Examples/jaxite/BUILD
+++ b/tests/Examples/jaxite/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@heir//tests/Examples/jaxite:test.bzl", "jaxite_end_to_end_test")
 load("@rules_python//python:py_library.bzl", "py_library")
 load("//bazel:lit.bzl", "glob_lit_tests")
+load("//bazel:yosys.bzl", "requires_yosys")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
@@ -13,6 +14,7 @@ glob_lit_tests(
     data = ["@heir//tests:test_utilities"],
     driver = "@heir//tests:run_lit.sh",
     exclude = ["fully_connected.jaxite.mlir"],
+    target_compatible_with = requires_yosys(),
     test_file_exts = ["mlir"],
 )
 
@@ -30,6 +32,7 @@ jaxite_end_to_end_test(
     ],
     mlir_src = "add_one_lut3.mlir",
     tags = ["yosys"],
+    target_compatible_with = requires_yosys(),
     test_src = "add_one_lut3_test.py",
     deps = [":test_utils"],
 )

--- a/tests/Examples/jaxite/test.bzl
+++ b/tests/Examples/jaxite/test.bzl
@@ -3,9 +3,9 @@
 load("@heir//tools:heir-jaxite.bzl", "fhe_jaxite_lib")
 load("@rules_python//python:py_test.bzl", "py_test")
 
-def jaxite_end_to_end_test(name, mlir_src, test_src, heir_opt_pass_flags = [], tags = [], deps = [], **kwargs):
+def jaxite_end_to_end_test(name, mlir_src, test_src, heir_opt_pass_flags = [], tags = [], deps = [], target_compatible_with = None, **kwargs):
     py_lib_target_name = "%s_py_lib" % name
-    fhe_jaxite_lib(name, mlir_src, py_lib_target_name = py_lib_target_name, tags = tags, deps = deps, heir_opt_pass_flags = heir_opt_pass_flags, **kwargs)
+    fhe_jaxite_lib(name, mlir_src, py_lib_target_name = py_lib_target_name, tags = tags, deps = deps, heir_opt_pass_flags = heir_opt_pass_flags, target_compatible_with = target_compatible_with, **kwargs)
     py_test(
         name = name,
         srcs = [test_src],
@@ -16,4 +16,5 @@ def jaxite_end_to_end_test(name, mlir_src, test_src, heir_opt_pass_flags = [], t
             "@abseil-py//absl/testing:absltest",
         ],
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )

--- a/tests/Examples/tfhe_rust/BUILD
+++ b/tests/Examples/tfhe_rust/BUILD
@@ -1,3 +1,4 @@
+load("@heir//bazel:yosys.bzl", "requires_yosys")
 load("@heir//tests/Examples/tfhe_rust:test.bzl", "tfhe_rs_end_to_end_test")
 load("@heir//tools:heir-tfhe-rs.bzl", "tfhe_rs_lib")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
@@ -63,6 +64,7 @@ tfhe_rs_end_to_end_test(
     tags = [
         "yosys",
     ],
+    target_compatible_with = requires_yosys(),
     test_src = "src/main_fully_connected.rs",
 )
 
@@ -81,6 +83,7 @@ tfhe_rs_end_to_end_test(
     tags = [
         "yosys",
     ],
+    target_compatible_with = requires_yosys(),
     test_src = "src/main_sbox.rs",
 )
 
@@ -99,6 +102,7 @@ tfhe_rs_end_to_end_test(
     tags = [
         "yosys",
     ],
+    target_compatible_with = requires_yosys(),
     test_src = "src/main_multi_output.rs",
 )
 

--- a/tests/Examples/tfhe_rust/test.bzl
+++ b/tests/Examples/tfhe_rust/test.bzl
@@ -3,7 +3,7 @@
 load("@heir//tools:heir-tfhe-rs.bzl", "tfhe_rs_lib")
 load("@rules_rust//rust:defs.bzl", "rust_test")
 
-def tfhe_rs_end_to_end_test(name, mlir_src, test_src, heir_opt_flags = [], heir_translate_flags = [], data = [], tags = [], deps = [], size = "small", **kwargs):
+def tfhe_rs_end_to_end_test(name, mlir_src, test_src, heir_opt_flags = [], heir_translate_flags = [], data = [], tags = [], deps = [], size = "small", target_compatible_with = None, **kwargs):
     """A rule for running generating tfhe-rs and running a test on it.
 
     Args:
@@ -16,10 +16,11 @@ def tfhe_rs_end_to_end_test(name, mlir_src, test_src, heir_opt_flags = [], heir_
       tags: Tags to pass to rust_test
       deps: Deps to pass to rust_test and cc_library
       size: Size override to pass to rust_test
+      target_compatible_with: constraints to pass to all generated targets.
       **kwargs: Keyword arguments to pass to cc_library and rust_test.
     """
     rs_lib_target_name = "%s_rs_lib" % name
-    tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags, heir_translate_flags, data, tags, deps, **kwargs)
+    tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags, heir_translate_flags, data, tags, deps, target_compatible_with = target_compatible_with, **kwargs)
     rust_test(
         name = name,
         srcs = [test_src],
@@ -30,5 +31,6 @@ def tfhe_rs_end_to_end_test(name, mlir_src, test_src, heir_opt_flags = [], heir_
         tags = tags,
         data = data,
         size = size,
+        target_compatible_with = target_compatible_with,
         **kwargs
     )

--- a/tests/Examples/tfhe_rust_hl/cpu/BUILD
+++ b/tests/Examples/tfhe_rust_hl/cpu/BUILD
@@ -1,3 +1,4 @@
+load("@heir//bazel:yosys.bzl", "requires_yosys")
 load("@heir//tests/Examples/tfhe_rust:test.bzl", "tfhe_rs_end_to_end_test")
 
 package(default_applicable_licenses = ["@heir//:license"])
@@ -31,6 +32,10 @@ tfhe_rs_end_to_end_test(
     ],
     heir_translate_flags = ["--emit-tfhe-rust-hl"],
     mlir_src = "add_round_key.mlir",
+    # TODO: the no-yosys --mlir-to-cggi=data-type=Integer pipeline produces IR
+    # for this input that crashes --emit-tfhe-rust-hl (OpOperand index
+    # assertion); only built with yosys until that is fixed.
+    target_compatible_with = requires_yosys(),
     test_src = "src/main_add_round_key.rs",
 )
 
@@ -43,5 +48,9 @@ tfhe_rs_end_to_end_test(
     ],
     heir_translate_flags = ["--emit-tfhe-rust-hl"],
     mlir_src = "hello_world_clean_xsmall.mlir",
+    # TODO: the no-yosys --mlir-to-cggi=data-type=Integer pipeline produces IR
+    # for this input that crashes --emit-tfhe-rust-hl (OpOperand index
+    # assertion); only built with yosys until that is fixed.
+    target_compatible_with = requires_yosys(),
     test_src = "src/main_hello_world.rs",
 )

--- a/tests/Regression/BUILD
+++ b/tests/Regression/BUILD
@@ -1,4 +1,5 @@
 load("//bazel:lit.bzl", "glob_lit_tests")
+load("//bazel:yosys.bzl", "requires_yosys")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
@@ -11,6 +12,9 @@ glob_lit_tests(
     },
     tags_override = {
         "issue_2466.mlir": ["nofastbuild"],
+    },
+    target_compatible_with_override = {
+        "issue_1086.mlir": requires_yosys(),
     },
     test_file_exts = ["mlir"],
 )

--- a/tests/Transforms/mlir_to_tfhe_rs/BUILD
+++ b/tests/Transforms/mlir_to_tfhe_rs/BUILD
@@ -1,4 +1,5 @@
 load("//bazel:lit.bzl", "glob_lit_tests")
+load("//bazel:yosys.bzl", "requires_yosys")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
@@ -44,6 +45,7 @@ glob_lit_tests(
             "manual",
         ],
     },
+    target_compatible_with = requires_yosys(),
     test_file_exts = ["mlir"],
 )
 

--- a/tests/Transforms/yosys_optimizer/BUILD
+++ b/tests/Transforms/yosys_optimizer/BUILD
@@ -1,4 +1,5 @@
 load("//bazel:lit.bzl", "glob_lit_tests")
+load("//bazel:yosys.bzl", "requires_yosys")
 
 package(default_applicable_licenses = ["@heir//:license"])
 
@@ -32,5 +33,6 @@ glob_lit_tests(
             "manual",
         ],
     },
+    target_compatible_with = requires_yosys(),
     test_file_exts = ["mlir"],
 )

--- a/tools/heir-jaxite.bzl
+++ b/tools/heir-jaxite.bzl
@@ -4,7 +4,7 @@ load("@heir//tools:heir-opt.bzl", "heir_opt")
 load("@heir//tools:heir-translate.bzl", "heir_translate")
 load("@rules_python//python:py_library.bzl", "py_library")
 
-def fhe_jaxite_lib(name, mlir_src, heir_opt_pass_flags = [], py_lib_target_name = "", tags = [], deps = [], **kwargs):
+def fhe_jaxite_lib(name, mlir_src, heir_opt_pass_flags = [], py_lib_target_name = "", tags = [], deps = [], target_compatible_with = None, **kwargs):
     """A rule for generating Jaxite code.
 
     Args:
@@ -14,6 +14,7 @@ def fhe_jaxite_lib(name, mlir_src, heir_opt_pass_flags = [], py_lib_target_name 
       py_lib_target_name: target_name for the py_library.
       tags: Tags to pass to py_test.
       deps: Deps to pass to py_test and py_library.
+      target_compatible_with: constraints to pass to all generated targets.
       **kwargs: Keyword arguments to pass to py_library and py_test.
     """
     heir_opt_name = name + ".heir_opt"
@@ -33,6 +34,7 @@ def fhe_jaxite_lib(name, mlir_src, heir_opt_pass_flags = [], py_lib_target_name 
             # HEIR jaxite only supports lut 3 operations
             data = ["@heir//lib/Transforms/YosysOptimizer/yosys:techmap_lut3.v"],
             tags = tags,
+            target_compatible_with = target_compatible_with,
         )
     else:
         generated_heir_opt_name = mlir_src
@@ -43,11 +45,13 @@ def fhe_jaxite_lib(name, mlir_src, heir_opt_pass_flags = [], py_lib_target_name 
         pass_flags = ["--emit-jaxite"],
         generated_filename = generated_py_filename,
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )
     py_library(
         name = py_lib_target_name,
         srcs = [":" + generated_py_filename],
         deps = deps + ["@heir_pip_deps//jaxite"],
         tags = tags,
+        target_compatible_with = target_compatible_with,
         **kwargs
     )

--- a/tools/heir-tfhe-rs.bzl
+++ b/tools/heir-tfhe-rs.bzl
@@ -4,7 +4,7 @@ load("@heir//tools:heir-opt.bzl", "heir_opt")
 load("@heir//tools:heir-translate.bzl", "heir_translate")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
-def tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags = [], heir_translate_flags = [], data = [], tags = [], deps = [], **kwargs):
+def tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags = [], heir_translate_flags = [], data = [], tags = [], deps = [], target_compatible_with = None, **kwargs):
     """A rule for running generating tfhe-rs and running a test on it.
 
     Args:
@@ -16,6 +16,7 @@ def tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags = [], heir_tr
       data: Data dependencies to be passed to heir_opt
       tags: Tags to pass to rust_library
       deps: Deps to pass to rust_library
+      target_compatible_with: constraints to pass to all generated targets.
       **kwargs: Keyword arguments to pass to rust_library.
     """
     rs_codegen_target = name + ".heir_translate_rs"
@@ -33,6 +34,7 @@ def tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags = [], heir_tr
             tags = tags,
             HEIR_YOSYS = True,
             data = ["@heir//lib/Transforms/YosysOptimizer/yosys:techmap_lut3.v", "@heir//lib/Transforms/YosysOptimizer/yosys:techmap_lut4.v"] + data,
+            target_compatible_with = target_compatible_with,
         )
     else:
         generated_heir_opt_name = mlir_src
@@ -43,6 +45,7 @@ def tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags = [], heir_tr
         pass_flags = heir_translate_flags,
         generated_filename = generated_rs_filename,
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )
     rust_library(
         name = rs_lib_target_name,
@@ -54,5 +57,6 @@ def tfhe_rs_lib(name, mlir_src, rs_lib_target_name, heir_opt_flags = [], heir_tr
         ],
         tags = tags,
         data = data,
+        target_compatible_with = target_compatible_with,
         **kwargs
     )


### PR DESCRIPTION
Trying to build without yosys failed because of missing includes (probably overly eagerly removed by some automated tool because they're only used in preprocessor-gated code?)

This has been around for a bit, and the weekly CI testing no-yosys has been failing because of it https://github.com/google/heir/actions/runs/31916922440/job/95090212968

EDIT: Did that CI ever pass? A bunch of tests do not seem to work for the non-yosys fallback branch, so I've tagged them as "requiring yosys" for now, but it looks like the non-yosys path is quite out of date?