### PR TITLE
lattigo: fix galois key generation for negative rotations

### DIFF
--- a/lib/Dialect/Lattigo/Transforms/BUILD
+++ b/lib/Dialect/Lattigo/Transforms/BUILD
@@ -51,6 +51,7 @@ cc_library(
         "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/Lattigo/IR:Dialect",
         "@heir//lib/Utils",
+        "@heir//lib/Utils:RotationUtils",
         "@heir//lib/Utils:TransformUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.cpp
@@ -13,6 +13,7 @@
 #include "lib/Dialect/Lattigo/IR/LattigoOps.h"
 #include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
 #include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Utils/RotationUtils.h"
 #include "lib/Utils/TransformUtils.h"
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"           // from @llvm-project
@@ -325,10 +326,12 @@ LogicalResult convertFuncForScheme(func::FuncOp op) {
 
   // Lattigo requires manually computing the galois element from the rotation
   // shift.
+  auto n = 1 << logN;
   for (auto rotIndex : rotIndices) {
     auto galoisElement = 1;
+    rotIndex = normalizeRotation(rotIndex, n / 2);
     while (rotIndex > 0) {
-      galoisElement = (galoisElement * 5) % (1 << (logN + 1));
+      galoisElement = (galoisElement * 5) % (2 * n);
       rotIndex--;
     }
     auto galoisElementAttr = IntegerAttr::get(

--- a/tests/Dialect/Lattigo/Transforms/configure_crypto_context_rotate_negative.mlir
+++ b/tests/Dialect/Lattigo/Transforms/configure_crypto_context_rotate_negative.mlir
@@ -1,0 +1,19 @@
+// RUN: heir-opt --lattigo-configure-crypto-context=entry-function=rotate_negative %s | FileCheck %s
+
+!evaluator = !lattigo.ckks.evaluator
+!ct = !lattigo.rlwe.ciphertext
+
+module attributes {scheme.ckks, ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 35184372121601], P = [1152921504606994433], logDefaultScale = 45>} {
+  func.func @rotate_negative(%evaluator : !evaluator, %ct : !ct) -> !ct {
+    %shift = arith.constant -512 : index
+    %res = lattigo.ckks.rotate_new %evaluator, %ct, %shift : (!evaluator, !ct, index) -> !ct
+    return %res : !ct
+  }
+}
+
+// A rotation by -512 with logN = 13 requires the galois element
+// 5^(-512 mod 2N) mod 2N = 5^15872 mod 16384 = 2049, not 1.
+// CHECK: @rotate_negative
+// CHECK: @rotate_negative__configure
+// CHECK: lattigo.rlwe.gen_galois_key
+// CHECK-SAME: galoisElement = 2049

--- a/tests/Regression/issue_3337.mlir
+++ b/tests/Regression/issue_3337.mlir
@@ -1,0 +1,44 @@
+// RUN: heir-opt --lattigo-configure-crypto-context %s | FileCheck %s
+
+// The galois key for the rotation by -512 must be generated for galois
+// element 5^(-512 mod 2N) mod 2N = 2049, not 1.
+// CHECK: lattigo.rlwe.gen_galois_key
+// CHECK-SAME: galoisElement = 2049
+
+!ct = !lattigo.rlwe.ciphertext
+!decryptor = !lattigo.rlwe.decryptor
+!encoder = !lattigo.ckks.encoder
+!encryptor_pk = !lattigo.rlwe.encryptor<publicKey = true>
+!evaluator = !lattigo.ckks.evaluator
+!param = !lattigo.ckks.parameter
+!pt = !lattigo.rlwe.plaintext
+module attributes {backend.lattigo, ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 35184372121601], P = [1152921504606994433], logDefaultScale = 45>, scheme.actual_slot_count = 4096 : i64, scheme.ckks, scheme.requested_slot_count = 1024 : i64} {
+  func.func @rotate512__preprocessed(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %arg0: tensor<1x!ct>) -> tensor<1x!ct> attributes {client.preprocessed_func = {func_name = "rotate512"}} {
+    %c0 = arith.constant 0 : index
+    %c-512 = arith.constant -512 : index
+    %extracted = tensor.extract %arg0[%c0] : tensor<1x!ct>
+    %ct = lattigo.ckks.rotate_new %evaluator, %extracted, %c-512 : (!evaluator, !ct, index) -> !ct
+    %0 = tensor.empty() : tensor<1x!ct>
+    %inserted = tensor.insert %ct into %0[%c0] : tensor<1x!ct>
+    return %inserted : tensor<1x!ct>
+  }
+  func.func @rotate512(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %arg0: tensor<1x!ct> {secret.secret}) -> (tensor<1x!ct> {secret.secret}) {
+    %0 = call @rotate512__preprocessed(%evaluator, %param, %encoder, %arg0) : (!evaluator, !param, !encoder, tensor<1x!ct>) -> tensor<1x!ct>
+    return %0 : tensor<1x!ct>
+  }
+  func.func @rotate512__encrypt__arg0(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %encryptor: !encryptor_pk, %arg0: tensor<1024xf32>) -> tensor<1x!ct> attributes {client.enc_func = {func_name = "rotate512", index = 0 : i64}} {
+    %pt = lattigo.ckks.new_plaintext %param : (!param) -> !pt
+    %pt_0 = lattigo.ckks.encode %encoder, %arg0, %pt {scale = 45 : i64} : (!encoder, tensor<1024xf32>, !pt) -> !pt
+    %ct = lattigo.rlwe.encrypt %encryptor, %pt_0 : (!encryptor_pk, !pt) -> !ct
+    %from_elements = tensor.from_elements %ct : tensor<1x!ct>
+    return %from_elements : tensor<1x!ct>
+  }
+  func.func @rotate512__decrypt__result0(%evaluator: !evaluator, %param: !param, %encoder: !encoder, %decryptor: !decryptor, %arg0: tensor<1x!ct>) -> tensor<1024xf32> attributes {client.dec_func = {func_name = "rotate512", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32>
+    %extracted = tensor.extract %arg0[%c0] : tensor<1x!ct>
+    %pt = lattigo.rlwe.decrypt %decryptor, %extracted : (!decryptor, !ct) -> !pt
+    %0 = lattigo.ckks.decode %encoder, %pt, %cst : (!encoder, !pt, tensor<1024xf32>) -> tensor<1024xf32>
+    return %0 : tensor<1024xf32>
+  }
+}


### PR DESCRIPTION
Lattigo's `ConfigureCryptoContext` should use `normalizeRotation` on the rotation index first, otherwise negative rotations simply get galois element "1" since the loop was never entered.

Fixes #3337 