### PR TITLE
Pad channels for interchange rows for convolutions

### DIFF
--- a/lib/Kernel/KernelImplementationTest.cpp
+++ b/lib/Kernel/KernelImplementationTest.cpp
@@ -850,6 +850,113 @@ TEST_P(KernelImplementationTest, TestConv1dCwFcwStride2) {
   EXPECT_EQ(actualUnpacked, expected);
 }
 
+// Direct 1-D multichannel convolution, as an independent reference for the
+// packed kernel.
+tensor3d reference1dConv(const tensor3d& data, const tensor3d& filter,
+                         int64_t stride) {
+  int64_t outputChannels = filter.size();
+  int64_t inputChannels = filter[0].size();
+  int64_t filterWidth = filter[0][0].size();
+  int64_t dataWidth = data[0][0].size();
+  int64_t outputWidth = (dataWidth - filterWidth) / stride + 1;
+  tensor3d result(1, std::vector<std::vector<int>>(
+                         outputChannels, std::vector<int>(outputWidth, 0)));
+  for (int64_t f = 0; f < outputChannels; ++f) {
+    for (int64_t ow = 0; ow < outputWidth; ++ow) {
+      for (int64_t c = 0; c < inputChannels; ++c) {
+        for (int64_t k = 0; k < filterWidth; ++k) {
+          result[0][f][ow] += data[0][c][ow * stride + k] * filter[f][c][k];
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// End-to-end Halevi-Shoup matvec for a strided 1-D multichannel conv whose
+// output channel count is not a multiple of the gap. The shuffle folds `gap`
+// channels into each gap-sized stretch, so the layout reserves whole stretches:
+// the Toeplitz matrix gains zero rows for the channels that are not there.
+void checkGapPaddedConv1dCwFcw(int64_t outputChannels, int64_t inputChannels,
+                               int64_t dataWidth, int64_t filterWidth,
+                               int64_t stride, int numSlots, bool unroll) {
+  SCOPED_TRACE("outputChannels = " + std::to_string(outputChannels) +
+               " inputChannels = " + std::to_string(inputChannels) +
+               " dataWidth = " + std::to_string(dataWidth) +
+               " filterWidth = " + std::to_string(filterWidth) +
+               " stride = " + std::to_string(stride));
+  MLIRContext context;
+  tensor3d data(1, std::vector<std::vector<int>>(
+                       inputChannels, std::vector<int>(dataWidth, 0)));
+  for (int64_t c = 0; c < inputChannels; ++c) {
+    for (int64_t w = 0; w < dataWidth; ++w) {
+      data[0][c][w] = (int)((c * 23 + w * 7) % 13);
+    }
+  }
+  tensor3d filter(outputChannels,
+                  std::vector<std::vector<int>>(
+                      inputChannels, std::vector<int>(filterWidth, 0)));
+  for (int64_t f = 0; f < outputChannels; ++f) {
+    for (int64_t c = 0; c < inputChannels; ++c) {
+      for (int64_t k = 0; k < filterWidth; ++k) {
+        filter[f][c][k] = (int)((f * 37 + c * 11 + k * 3) % 17) + 1;
+      }
+    }
+  }
+
+  RankedTensorType dataType = RankedTensorType::get(
+      {1, inputChannels, dataWidth}, mlir::IndexType::get(&context));
+  RankedTensorType filterType =
+      RankedTensorType::get({outputChannels, inputChannels, filterWidth},
+                            mlir::IndexType::get(&context));
+
+  auto dataLayout = getRowMajorLayoutRelation(dataType, numSlots);
+  std::vector<std::vector<int>> packedData =
+      evaluateLayout(dataLayout, getDataValueFn3D(data));
+
+  auto filterLayout = get1dConvCwFcwFilterDiagonalizedRelation(
+      filterType, dataType, stride, /*padding=*/0, numSlots,
+      /*interchangeRows=*/true);
+  ASSERT_TRUE(succeeded(filterLayout));
+  std::function<int(const std::vector<int64_t>&)> getFilterValueFn =
+      [&](const std::vector<int64_t>& domainPoint) -> int {
+    return filter[domainPoint[0]][domainPoint[1]][domainPoint[2]];
+  };
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayout(filterLayout.value(), getFilterValueFn);
+  auto expandedFilterShape = get1dConvCwFcwFilterExpandedType(
+      filterType, dataType, stride, /*padding=*/0, /*interchangeRows=*/true);
+
+  auto dag = implementHaleviShoup(
+      LiteralValue(packedData[0]), LiteralValue(packedFilter),
+      expandedFilterShape.getShape(), DagType::intTensor(32, {numSlots}),
+      /*zeroDiagonals=*/{}, unroll);
+  auto actual = std::get<std::vector<int>>(evalKernel(dag)[0].get());
+
+  tensor3d expected = reference1dConv(data, filter, stride);
+  int64_t outputWidth = expected[0][0].size();
+  RankedTensorType outputType = RankedTensorType::get(
+      {1, outputChannels, outputWidth}, mlir::IndexType::get(&context));
+  auto resultLayout =
+      get1dConvResultRelation(outputType, stride, /*padding=*/0, numSlots,
+                              /*interchangeRows=*/true);
+
+  EXPECT_EQ(unpackLayoutTo3DTensor<int>(resultLayout, {actual},
+                                        {1, outputChannels, outputWidth}),
+            expected);
+}
+
+TEST_P(KernelImplementationTest, TestConv1dCwFcwGapPaddedChannels) {
+  bool unroll = std::get<0>(GetParam());
+  // gap = 2, so the shuffle needs the output channels in pairs. 2 and 4 are the
+  // controls that need no padding at all.
+  for (int64_t outputChannels : {1, 2, 3, 4}) {
+    checkGapPaddedConv1dCwFcw(outputChannels, /*inputChannels=*/2,
+                              /*dataWidth=*/8, /*filterWidth=*/2,
+                              /*stride=*/2, /*numSlots=*/32, unroll);
+  }
+}
+
 // End-to-end Halevi-Shoup matvec for a padded strided 1-D multichannel conv, in
 // the packing production uses when LayoutPropagation folds a zero tensor.pad on
 // the width dim into the conv's own `padding` parameter: the data ciphertext is
@@ -887,8 +994,8 @@ void checkPaddedConv1dCwFcw(int64_t padding, const tensor3d& expected,
   // The matrix shape must be derived the same way the filter was diagonalized,
   // i.e. against the unpadded data type with padding = p: implementHaleviShoup
   // sizes the squat-diagonal collapse from nextPowerOfTwo of these dims.
-  auto expandedFilterShape =
-      get1dConvCwFcwFilterExpandedType(filterType, dataType, stride, padding);
+  auto expandedFilterShape = get1dConvCwFcwFilterExpandedType(
+      filterType, dataType, stride, padding, interchangeRows);
 
   auto dag = implementHaleviShoup(
       LiteralValue(packedData[0]), LiteralValue(packedFilter),
@@ -1007,6 +1114,99 @@ TEST_P(KernelImplementationTest, TestConv2dNchwFchwWithPadding) {
   // 256), so a matrix built against the padded operand would be sized wrong.
   checkPaddedConv2dChwFchw(/*stride=*/2, /*filterSize=*/2, /*padding=*/1,
                            /*numSlots=*/64, unroll, std::get<1>(GetParam()));
+}
+
+// End-to-end Halevi-Shoup matvec for a strided 2-D multichannel conv whose
+// output channel count is not a multiple of gap^2. The pixel shuffle folds
+// gap^2 channels into each gap x gap spatial block, so the layout reserves
+// whole blocks: the Toeplitz matrix gains zero rows for the channels that are
+// not there, and the result layout maps nothing into their slots.
+void checkGapPaddedConv2dChwFchw(int64_t outputChannels, int64_t inputChannels,
+                                 int64_t dataSize, int64_t filterSize,
+                                 int64_t stride, int numSlots, bool unroll) {
+  SCOPED_TRACE("outputChannels = " + std::to_string(outputChannels) +
+               " inputChannels = " + std::to_string(inputChannels) +
+               " dataSize = " + std::to_string(dataSize) +
+               " filterSize = " + std::to_string(filterSize) +
+               " stride = " + std::to_string(stride));
+  MLIRContext context;
+  tensor4d data(
+      1, std::vector<std::vector<std::vector<int>>>(
+             inputChannels, std::vector<std::vector<int>>(
+                                dataSize, std::vector<int>(dataSize, 0))));
+  for (int64_t c = 0; c < inputChannels; ++c) {
+    for (int64_t h = 0; h < dataSize; ++h) {
+      for (int64_t w = 0; w < dataSize; ++w) {
+        data[0][c][h][w] = (int)((c * 23 + h * 7 + w * 3) % 13);
+      }
+    }
+  }
+  tensor4d filter = deterministicConvFilter(outputChannels, inputChannels,
+                                            filterSize, filterSize);
+
+  RankedTensorType dataType = RankedTensorType::get(
+      {1, inputChannels, dataSize, dataSize}, mlir::IndexType::get(&context));
+  RankedTensorType filterType = RankedTensorType::get(
+      {outputChannels, inputChannels, filterSize, filterSize},
+      mlir::IndexType::get(&context));
+  SmallVector<int64_t> strides = {stride, stride};
+
+  auto dataLayout = getRowMajorLayoutRelation(dataType, numSlots);
+  std::vector<std::vector<int>> packedData =
+      evaluateLayout(dataLayout, getDataValueFn4D(data));
+
+  auto filterLayout = get2dConvChwFchwFilterDiagonalizedRelation(
+      filterType, dataType, strides, /*padding=*/0, numSlots,
+      /*interchangeRows=*/true);
+  ASSERT_TRUE(succeeded(filterLayout));
+  std::function<int(const std::vector<int64_t>&)> getFilterValueFn =
+      [&](const std::vector<int64_t>& domainPoint) -> int {
+    return filter[domainPoint[0]][domainPoint[1]][domainPoint[2]]
+                 [domainPoint[3]];
+  };
+  std::vector<std::vector<int>> packedFilter =
+      evaluateLayout(filterLayout.value(), getFilterValueFn);
+  auto expandedFilterShape = get2dConvChwFchwFilterExpandedType(
+      filterType, dataType, /*padding=*/0, strides, /*interchangeRows=*/true);
+
+  auto dag = implementHaleviShoup(
+      LiteralValue(packedData[0]), LiteralValue(packedFilter),
+      expandedFilterShape.getShape(), DagType::intTensor(32, {numSlots}),
+      /*zeroDiagonals=*/{}, unroll);
+  auto actual = std::get<std::vector<int>>(evalKernel(dag)[0].get());
+
+  tensor4d expected = reference2dConv(data, filter, stride, /*padding=*/0);
+  int64_t outputH = expected[0][0].size();
+  int64_t outputW = expected[0][0][0].size();
+  RankedTensorType outputType = RankedTensorType::get(
+      {1, outputChannels, outputH, outputW}, mlir::IndexType::get(&context));
+  auto resultLayout =
+      get2dConvResultRelation(outputType, strides, /*padding=*/0, numSlots,
+                              /*interchangeRows=*/true);
+  resultLayout.compose(
+      get2dConvRowInterchangeLayoutRelation(outputType, strides, numSlots));
+
+  EXPECT_EQ(unpackLayoutTo4DTensor<int>(resultLayout, {actual},
+                                        {1, outputChannels, outputH, outputW}),
+            expected);
+}
+
+TEST_P(KernelImplementationTest, TestConv2dNchwFchwGapPaddedChannels) {
+  bool unroll = std::get<0>(GetParam());
+  // gap = 2, so the shuffle needs the output channels in blocks of 4. The
+  // matrix must stay no taller than it is wide, which caps the padded channel
+  // count at 4 for one input channel and 8 for two. 4 and 8 are the controls
+  // that need no padding at all.
+  for (int64_t outputChannels : {1, 2, 3, 4}) {
+    checkGapPaddedConv2dChwFchw(outputChannels, /*inputChannels=*/1,
+                                /*dataSize=*/4, /*filterSize=*/2,
+                                /*stride=*/2, /*numSlots=*/64, unroll);
+  }
+  for (int64_t outputChannels : {2, 3, 5, 6, 7, 8}) {
+    checkGapPaddedConv2dChwFchw(outputChannels, /*inputChannels=*/2,
+                                /*dataSize=*/4, /*filterSize=*/2,
+                                /*stride=*/2, /*numSlots=*/64, unroll);
+  }
 }
 
 TEST_P(KernelImplementationTest,

--- a/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
+++ b/lib/Transforms/ConvertToCiphertextSemantics/ConvertToCiphertextSemantics.cpp
@@ -1460,9 +1460,12 @@ struct ConvertLinalgConv2DNchwFchw
     FailureOr<ConvMatrixOperand> matrixOperand =
         foldedConvMatrixOperand(op, dataType);
     if (failed(matrixOperand)) return failure();
+    auto strides = llvm::to_vector(op.getStrides().getValues<int64_t>());
+    // Rows only interchange for a strided conv; keep this in step with
+    // LayoutPropagation, which sizes the filter layout the same way.
     return get2dConvChwFchwFilterExpandedType(
-        filterType, matrixOperand->dataType, matrixOperand->padding,
-        llvm::to_vector(op.getStrides().getValues<int64_t>()));
+        filterType, matrixOperand->dataType, matrixOperand->padding, strides,
+        /*interchangeRows=*/strides[0] > 1);
   }
 
   LogicalResult haleviShoupKernel(

--- a/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
+++ b/lib/Transforms/LayoutPropagation/LayoutPropagation.cpp
@@ -1013,14 +1013,6 @@ LogicalResult LayoutPropagation::visitOperation(Conv1DNcwFcwOp op) {
     return op->emitOpError() << "Expected 3-D data tensor (N=1, C, W)";
   }
 
-  // Since the stride will be used as the gap factor, the layout requires that
-  // the number of output channels is divisible by gap.
-  // TODO(#2883): handle padding the output channels to be divisible by gap.
-  if (outputType.getDimSize(1) % stride != 0) {
-    return op->emitOpError()
-           << "Expected number of output channels to be divisible by gap";
-  }
-
   LayoutAttr dataLayout = getComposedLayoutAttr(data);
 
   ConvMatrixOperand matrixOperand{dataType};
@@ -1080,8 +1072,19 @@ LogicalResult LayoutPropagation::visitOperation(Conv1DNcwFcwOp op) {
                               /*interchangeRows=*/interchangeRows);
   LayoutAttr resultLayoutAttr =
       LayoutAttr::getFromIntegerRelation(ctx, resultRelation);
-  Attribute kernelInfoAttr =
-      cloneKernelInfoWithResultShape(data, outputType.getShape());
+  // The stride doubles as the gap factor: the shuffled layout folds `stride`
+  // output channels into each gap, so the ciphertext holds whole channel blocks
+  // of `stride`. When the channel count is not a multiple of it, the layout
+  // reserves the next multiple and leaves the extra channels empty; see
+  // getPaddedConvChannels.
+  int64_t paddedChannels =
+      getPaddedConvChannels(outputType.getDimSize(1), stride);
+  KernelInfo kernelInfo = {
+      .inputShape = llvm::to_vector(dataType.getShape()),
+      .resultShape = {outputType.getDimSize(0), paddedChannels / stride,
+                      outputType.getDimSize(2) * stride},
+      .gapFactor = stride};
+  Attribute kernelInfoAttr = makeKernelInfoAttr(ctx, kernelInfo);
 
   // Record what the filter was diagonalized against, so that
   // ConvertToCiphertextSemantics rebuilds the same expanded matrix shape.
@@ -1133,12 +1136,13 @@ LogicalResult LayoutPropagation::visitOperation(Conv2DNchwFchwOp op) {
     return op->emitOpError() << "Failed to get kernel info for data input";
   }
   // The gap factor accumulates the producer's gap, so it can exceed the stride
-  // when this conv follows another strided one. The interchanged layout divides
-  // the output channels by gap^2, so guard against the gap actually used rather
-  // than against the stride alone.
+  // when this conv follows another strided one.
   auto gapFactor = strides[0] * dataKernelInfo->gapFactor;
-  // TODO(#2883): handle padding the output channels to be divisible by gap^2.
-  if (interchangeRows &&
+  // The layout relations shuffle by this conv's own stride, so that is the
+  // block size the channel padding below rounds up to. A conv whose gap exceeds
+  // its stride packs its result against gap^2 instead, and padding cannot
+  // reconcile the two, so keep rejecting those rather than mis-packing them.
+  if (interchangeRows && gapFactor != strides[0] &&
       outputType.getDimSize(1) % (gapFactor * gapFactor) != 0) {
     return op->emitOpError()
            << "Expected number of output channels (" << outputType.getDimSize(1)
@@ -1176,7 +1180,12 @@ LogicalResult LayoutPropagation::visitOperation(Conv2DNchwFchwOp op) {
                             outputType.getDimSize(2) * gapFactor);
     int64_t wFhe = std::max(matrixOperand.dataType.getDimSize(3),
                             outputType.getDimSize(3) * gapFactor);
-    int64_t cFhe = outputType.getDimSize(1) / (gapFactor * gapFactor);
+    // The interchanged layout groups the output channels into gap x gap blocks,
+    // so the ciphertext holds whole blocks. A channel count that is not a
+    // multiple of gap^2 rounds up, and the extra channels stay empty.
+    int64_t cFhe =
+        getPaddedConvChannels(outputType.getDimSize(1), gapFactor * gapFactor) /
+        (gapFactor * gapFactor);
     fheOutputType =
         RankedTensorType::get({outputType.getDimSize(0), cFhe, hFhe, wFhe},
                               outputType.getElementType());
@@ -1238,8 +1247,8 @@ LogicalResult LayoutPropagation::visitOperation(Conv2DNchwFchwOp op) {
   // pixel-shuffled gap. Future users may need to insert a layout conversion.
   auto result = op->getResult(0);
   Attribute resultLayoutAttr;
-  presburger::IntegerRelation rel1 =
-      get2dConvResultRelation(outputType, strides, /*padding=*/0, minSlotCount);
+  presburger::IntegerRelation rel1 = get2dConvResultRelation(
+      outputType, strides, /*padding=*/0, minSlotCount, interchangeRows);
 
   if (interchangeRows) {
     presburger::IntegerRelation rel2 = get2dConvRowInterchangeLayoutRelation(

--- a/lib/Utils/Layout/Convolution.cpp
+++ b/lib/Utils/Layout/Convolution.cpp
@@ -12,6 +12,7 @@
 #include "lib/Utils/MathUtils.h"
 #include "llvm/include/llvm/ADT/STLExtras.h"           // from @llvm-project
 #include "llvm/include/llvm/Support/FormatVariadic.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/MathExtras.h"      // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
 #include "mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
@@ -24,6 +25,11 @@ using presburger::BoundType;
 using presburger::IntegerRelation;
 using presburger::PresburgerSpace;
 using presburger::VarKind;
+
+int64_t getPaddedConvChannels(int64_t outputChannels,
+                              int64_t channelsPerBlock) {
+  return llvm::alignTo(outputChannels, channelsPerBlock);
+}
 
 presburger::IntegerRelation get2dConvFilterRelation(RankedTensorType filterType,
                                                     RankedTensorType dataType,
@@ -261,7 +267,8 @@ RankedTensorType get2dConvFilterExpandedType(RankedTensorType filterType,
 RankedTensorType get1dConvCwFcwFilterExpandedType(RankedTensorType filterType,
                                                   RankedTensorType dataType,
                                                   int64_t stride,
-                                                  int64_t padding) {
+                                                  int64_t padding,
+                                                  bool interchangeRows) {
   // Get the filter relation for a single input and output channel and multiply
   // the dimensions by the number of input and output channels for the row and
   // column dimensions respectively.
@@ -274,6 +281,11 @@ RankedTensorType get1dConvCwFcwFilterExpandedType(RankedTensorType filterType,
 
   int64_t inputChannels = dataType.getDimSize(1);
   int64_t outputChannels = filterType.getDimSize(0);
+  // An interchanged layout reserves whole channel blocks of `stride`, so the
+  // matrix also has rows for the padding channels. Those rows stay zero.
+  if (interchangeRows) {
+    outputChannels = getPaddedConvChannels(outputChannels, stride);
+  }
 
   int64_t rows = outputChannels * singleResultType.getDimSize(0);
   int64_t cols = inputChannels * singleResultType.getDimSize(1);
@@ -283,7 +295,8 @@ RankedTensorType get1dConvCwFcwFilterExpandedType(RankedTensorType filterType,
 RankedTensorType get2dConvChwFchwFilterExpandedType(RankedTensorType filterType,
                                                     RankedTensorType dataType,
                                                     int64_t padding,
-                                                    ArrayRef<int64_t> strides) {
+                                                    ArrayRef<int64_t> strides,
+                                                    bool interchangeRows) {
   // Get the filter relation for a single input and output channel and multiply
   // the dimensions by the number of input and output channels for the row and
   // column dimensions respectively.
@@ -298,6 +311,12 @@ RankedTensorType get2dConvChwFchwFilterExpandedType(RankedTensorType filterType,
 
   int64_t inputChannels = dataType.getDimSize(1);
   int64_t outputChannels = filterType.getDimSize(0);
+  // An interchanged layout reserves whole g x g channel blocks, so the matrix
+  // also has rows for the padding channels. Those rows stay zero.
+  if (interchangeRows) {
+    outputChannels =
+        getPaddedConvChannels(outputChannels, strides[0] * strides[0]);
+  }
 
   int64_t rows = outputChannels * singleResultType.getDimSize(0);
   int64_t cols = inputChannels * singleResultType.getDimSize(1);
@@ -489,7 +508,13 @@ FailureOr<presburger::IntegerRelation> get1dConvCwFcwFilterDiagonalizedRelation(
         /*equality=*/true);
     expandedFilterRelation.compose(rowInterchangeRelation);
   }
-  return diagonalize2dMatrix(expandedFilterRelation, filterType, minSlotCount);
+  // Diagonalize against the shape the Halevi-Shoup kernel is sized from. The
+  // relation's own bounds can be tighter: an interchanged layout reserves rows
+  // for padding channels that no filter entry reaches.
+  auto expandedType = get1dConvCwFcwFilterExpandedType(
+      filterType, dataType, stride, padding, interchangeRows);
+  return diagonalize2dMatrix(expandedFilterRelation, filterType, minSlotCount,
+                             expandedType.getShape());
 }
 
 FailureOr<std::vector<IntegerRelation>> get2dConvChwFchwFilterAsSequence(
@@ -519,14 +544,22 @@ FailureOr<std::vector<IntegerRelation>> get2dConvChwFchwFilterAsSequence(
   auto totalRowSize = singleResultType.getDimSize(0);
   auto totalColSize = singleResultType.getDimSize(1);
 
-  int64_t maxRow = outputChannels * totalRowSize;
+  // An interchanged layout reserves whole g x g channel blocks, so the matrix
+  // also has rows for the padding channels. Those rows carry no filter entry
+  // and stay zero.
+  int64_t paddedOutputChannels =
+      interchangeRows ? getPaddedConvChannels(outputChannels, g * g)
+                      : outputChannels;
+
+  int64_t maxRow = paddedOutputChannels * totalRowSize;
   int64_t maxCol = inputChannels * totalColSize;
 
   int64_t paddedRows = isPowerOfTwo(maxRow) ? maxRow : nextPowerOfTwo(maxRow);
   int64_t paddedCols = isPowerOfTwo(maxCol) ? maxCol : nextPowerOfTwo(maxCol);
   int64_t numDiagonals = std::min(paddedRows, paddedCols);
 
-  int64_t step3F = interchangeRows ? outputChannels / (g * g) : outputChannels;
+  int64_t step3F =
+      interchangeRows ? paddedOutputChannels / (g * g) : outputChannels;
   int64_t step3H = interchangeRows ? outputH * g : outputH;
   int64_t step3W = interchangeRows ? outputW * g : outputW;
 
@@ -621,10 +654,16 @@ presburger::IntegerRelation get2dConvRowInterchangeRelation(int64_t c,
   //    h' = hi * g + (ci % g**2) // g
   //    w' = wi * g + (ci % g)
   // 3. Flatten (gW, gH, C) into idx_out = (c * g * h) * w' + (c) * h' + c'
+  //
+  // The shuffle needs g^2 channels per g x g spatial block, so the output
+  // reserves `paddedC` channels. When C is not a multiple of g^2, the last
+  // block is partly empty and the map is injective but not surjective.
   int64_t hOut = h * g;
   int64_t wOut = w * g;
-  int64_t cOut = c / (g * g);
+  int64_t paddedC = getPaddedConvChannels(c, g * g);
+  int64_t cOut = paddedC / (g * g);
   int64_t numElements = c * h * w;
+  int64_t numPaddedElements = paddedC * h * w;
 
   // One to one mapping from idx_in to idx_out.
   std::string islStr = llvm::formatv(
@@ -636,8 +675,9 @@ presburger::IntegerRelation get2dConvRowInterchangeRelation(int64_t c,
       "ho = hi * {10} + (ci % {10}^2) // {10} and "
       "idx_in = wi + hi * {6} + ci * {7} and "
       "idx_out = wo + ho * {8} + co * {9} and 0 <= idx_in < {11} and 0 <= "
-      "idx_out < {11} }",
-      h, w, c, hOut, wOut, cOut, w, h * w, wOut, hOut * wOut, g, numElements);
+      "idx_out < {12} }",
+      h, w, c, hOut, wOut, cOut, w, h * w, wOut, hOut * wOut, g, numElements,
+      numPaddedElements);
 
   return getIntegerRelationFromIslStr(islStr).value();
 }
@@ -650,9 +690,15 @@ presburger::IntegerRelation get1dConvRowInterchangeRelation(int64_t c,
   //    w' = wi * g + (ci % g)
   //    c' = ci // g
   // 3. Flatten (gW, C) into idx_out = (c * g) * w' + c'
+  //
+  // The shuffle needs g channels per gap of g, so the output reserves
+  // `paddedC` channels. When C is not a multiple of g, the last block is
+  // partly empty and the map is injective but not surjective.
   int64_t wOut = w * g;
-  int64_t cOut = c / (g);
+  int64_t paddedC = getPaddedConvChannels(c, g);
+  int64_t cOut = paddedC / g;
   int64_t numElements = c * w;
+  int64_t numPaddedElements = paddedC * w;
 
   // One to one mapping from idx_in to idx_out.
   std::string islStr = llvm::formatv(
@@ -662,8 +708,8 @@ presburger::IntegerRelation get1dConvRowInterchangeRelation(int64_t c,
       "wo = wi * {4} + (ci % {4}) and "
       "idx_in = wi + ci * {0} and "
       "idx_out = wo + co * {2} and "
-      "0 <= idx_in < {5} and 0 <= idx_out < {5} }",
-      w, c, wOut, cOut, g, numElements);
+      "0 <= idx_in < {5} and 0 <= idx_out < {6} }",
+      w, c, wOut, cOut, g, numElements, numPaddedElements);
 
   return getIntegerRelationFromIslStr(islStr).value();
 }
@@ -679,11 +725,20 @@ presburger::IntegerRelation get1dConvResultRelation(RankedTensorType outputType,
   auto flattenedOutput =
       getRowMajorLayoutRelation(outputType, outputType.getNumElements());
 
-  int64_t numCiphertexts =
-      std::ceil((float)outputType.getNumElements() / minSlotCount);
-  int64_t paddedSize = isPowerOfTwo(outputType.getNumElements())
-                           ? outputType.getNumElements()
-                           : nextPowerOfTwo(outputType.getNumElements());
+  // A shuffled result reserves whole channel blocks of `stride`, so the
+  // ciphertext holds `ambientElements` values even though only
+  // outputType.getNumElements() of them are real. The replication period has to
+  // match that larger extent.
+  int64_t ambientElements = outputType.getNumElements();
+  if (interchangeRows) {
+    ambientElements = getPaddedConvChannels(outputType.getDimSize(1), stride) *
+                      outputType.getDimSize(2);
+  }
+
+  int64_t numCiphertexts = std::ceil((float)ambientElements / minSlotCount);
+  int64_t paddedSize = isPowerOfTwo(ambientElements)
+                           ? ambientElements
+                           : nextPowerOfTwo(ambientElements);
 
   // Create the interchange permutation [idx_in] -> [idx_out] and add a domain
   // var = 0 to align with the range of the flattenedOutput relation.
@@ -727,7 +782,8 @@ presburger::IntegerRelation get1dConvResultRelation(RankedTensorType outputType,
 presburger::IntegerRelation get2dConvResultRelation(RankedTensorType outputType,
                                                     ArrayRef<int64_t> strides,
                                                     int64_t padding,
-                                                    int64_t minSlotCount) {
+                                                    int64_t minSlotCount,
+                                                    bool interchangeRows) {
   assert(llvm::all_equal(strides) && "strides must be equal");
 
   // First flatten the output tensor into a 1-D tensor of (ct, slot) where ct =
@@ -736,11 +792,22 @@ presburger::IntegerRelation get2dConvResultRelation(RankedTensorType outputType,
   auto flattenedOutput =
       getRowMajorLayoutRelation(outputType, outputType.getNumElements());
 
-  int64_t numCiphertexts =
-      std::ceil((float)outputType.getNumElements() / minSlotCount);
-  int64_t paddedSize = isPowerOfTwo(outputType.getNumElements())
-                           ? outputType.getNumElements()
-                           : nextPowerOfTwo(outputType.getNumElements());
+  // A pixel-shuffled result reserves whole g x g channel blocks, so the
+  // ciphertext holds `ambientElements` values even though only
+  // outputType.getNumElements() of them are real. The replication period must
+  // match that larger extent, and so must the interchange relation this gets
+  // composed with.
+  int64_t ambientElements = outputType.getNumElements();
+  if (interchangeRows) {
+    ambientElements = getPaddedConvChannels(outputType.getDimSize(1),
+                                            strides[0] * strides[0]) *
+                      outputType.getDimSize(2) * outputType.getDimSize(3);
+  }
+
+  int64_t numCiphertexts = std::ceil((float)ambientElements / minSlotCount);
+  int64_t paddedSize = isPowerOfTwo(ambientElements)
+                           ? ambientElements
+                           : nextPowerOfTwo(ambientElements);
 
   std::string mapToCtSlot = llvm::formatv(
       "{{ [in_ct, idx_out] -> [ct, slot] : in_ct = 0 and "
@@ -764,14 +831,20 @@ presburger::IntegerRelation get2dConvRowInterchangeLayoutRelation(
 
   int64_t hOut = h * g;
   int64_t wOut = w * g;
-  int64_t cOut = c / (g * g);
+  // The shuffle needs g^2 channels per g x g spatial block, so the result
+  // reserves whole blocks. When c is not a multiple of g^2 the last block is
+  // partly empty: the map stays injective, and the empty sub-pixels hold the
+  // zeros the padding rows of the filter matrix produce.
+  int64_t paddedC = getPaddedConvChannels(c, g * g);
+  int64_t cOut = paddedC / (g * g);
   int64_t numElements = outputType.getNumElements();
+  int64_t ambientElements = paddedC * h * w;
 
-  int64_t numCiphertexts =
-      std::ceil((float)outputType.getNumElements() / minSlotCount);
+  int64_t numCiphertexts = std::ceil((float)ambientElements / minSlotCount);
 
-  int64_t paddedSize =
-      isPowerOfTwo(numElements) ? numElements : nextPowerOfTwo(numElements);
+  int64_t paddedSize = isPowerOfTwo(ambientElements)
+                           ? ambientElements
+                           : nextPowerOfTwo(ambientElements);
 
   // Construct a row interchange relation: [ct, slot] -> [ct', slot']
   //
@@ -804,7 +877,7 @@ presburger::IntegerRelation get2dConvRowInterchangeLayoutRelation(
       "  k >= 0 and "
       // Add bounds for (slot_in_mod, slot_out_mod)
       "  0 <= slot_in_mod < {0} and slot_in_mod < {2} and "
-      "  0 <= slot_out_mod < {0} and slot_out_mod < {2} and "
+      "  0 <= slot_out_mod < {0} and slot_out_mod < {14} and "
       // Bounds for input tensor (H x W x C)
       "  0 <= hi < {3} and 0 <= wi < {4} and 0 <= ci < {5} and "
       // Bounds for output tensor (H_out x W_out x C_out)
@@ -817,20 +890,21 @@ presburger::IntegerRelation get2dConvRowInterchangeLayoutRelation(
       "  slot_in_mod = wi + hi * {4} + ci * {10} and "
       "  slot_out_mod = wo + ho * {11} + co * {12}"
       "}",
-      paddedSize,     // 0
-      minSlotCount,   // 1
-      numElements,    // 2
-      h,              // 3
-      w,              // 4
-      c,              // 5
-      hOut,           // 6
-      wOut,           // 7
-      cOut,           // 8
-      g,              // 9
-      h * w,          // 10
-      wOut,           // 11
-      hOut * wOut,    // 12
-      numCiphertexts  // 13
+      paddedSize,      // 0
+      minSlotCount,    // 1
+      numElements,     // 2
+      h,               // 3
+      w,               // 4
+      c,               // 5
+      hOut,            // 6
+      wOut,            // 7
+      cOut,            // 8
+      g,               // 9
+      h * w,           // 10
+      wOut,            // 11
+      hOut * wOut,     // 12
+      numCiphertexts,  // 13
+      ambientElements  // 14
   );
 
   auto rel = getIntegerRelationFromIslStr(islStr).value();

--- a/lib/Utils/Layout/Convolution.h
+++ b/lib/Utils/Layout/Convolution.h
@@ -11,6 +11,14 @@
 namespace mlir {
 namespace heir {
 
+// A gapped (pixel-shuffled) convolution layout folds a block of output channels
+// into each spatial block: `gap * gap` channels for a 2-D conv, `gap` channels
+// for a 1-D conv. That shuffle is a bijection only when the channel count is a
+// multiple of the block, so a layout reserves the next multiple and leaves the
+// extra channels empty. The expanded filter matrix has zero rows for them, and
+// the result layout maps nothing into their slots.
+int64_t getPaddedConvChannels(int64_t outputChannels, int64_t channelsPerBlock);
+
 // Returns an IntegerRelation that expands a 2-D filter matrix used in a
 // convolution into a 2-D matrix such that the convolution is
 // equivalent a matrix product with the flattened input vector. Each row
@@ -69,14 +77,20 @@ presburger::IntegerRelation get1dConvCwFcwFilterRelation(
     RankedTensorType filterType, RankedTensorType dataType, int64_t stride,
     int64_t padding);
 
+// `interchangeRows` must match the flag the filter layout was built with: an
+// interchanged (pixel-shuffled) layout reserves whole channel blocks, so its
+// matrix has extra zero rows when the channel count is not a multiple of the
+// block. The Halevi-Shoup kernel is sized from this type, so it has to agree
+// with the layout relation.
 RankedTensorType get1dConvCwFcwFilterExpandedType(RankedTensorType filterType,
                                                   RankedTensorType dataType,
                                                   int64_t stride,
-                                                  int64_t padding);
+                                                  int64_t padding,
+                                                  bool interchangeRows = true);
 
 RankedTensorType get2dConvChwFchwFilterExpandedType(
     RankedTensorType filterType, RankedTensorType dataType, int64_t padding,
-    ArrayRef<int64_t> strides = {1, 1});
+    ArrayRef<int64_t> strides = {1, 1}, bool interchangeRows = true);
 
 // Returns an IntegerRelation that represents a diagonalized 2-D Toeplitz matrix
 // that is used to compute a 1-D multichannel convolution filter such that the
@@ -137,10 +151,14 @@ presburger::IntegerRelation get1dConvResultRelation(
 // Returns an IntegerRelation that corresponds to the output layout of a 2-D
 // multi-channel convolution. This includes the row interchange from pixel
 // shuffling. The result is a relation mapping to (ct, slot) of the output.
-presburger::IntegerRelation get2dConvResultRelation(RankedTensorType outputType,
-                                                    ArrayRef<int64_t> strides,
-                                                    int64_t padding,
-                                                    int64_t minSlotCount);
+//
+// Set `interchangeRows` when the caller composes this with
+// get2dConvRowInterchangeLayoutRelation: a shuffled result reserves whole
+// channel blocks, and both relations must use that same larger extent as the
+// replication period.
+presburger::IntegerRelation get2dConvResultRelation(
+    RankedTensorType outputType, ArrayRef<int64_t> strides, int64_t padding,
+    int64_t minSlotCount, bool interchangeRows = false);
 
 presburger::IntegerRelation get2dConvRowInterchangeLayoutRelation(
     RankedTensorType outputType, ArrayRef<int64_t> strides,

--- a/lib/Utils/Layout/ConvolutionTest.cpp
+++ b/lib/Utils/Layout/ConvolutionTest.cpp
@@ -1022,21 +1022,25 @@ void checkConv2dChwFchwDiagonalized(
       {1, inputChannels, dataH, dataW}, IndexType::get(&context));
   SmallVector<int64_t> strides = {stride, stride};
 
-  auto expandedType = get2dConvChwFchwFilterExpandedType(filterType, dataType,
-                                                         padding, strides);
+  auto expandedType = get2dConvChwFchwFilterExpandedType(
+      filterType, dataType, padding, strides, interchangeRows);
   auto expected =
       reference2dConvChwFchwMatrix(filter, dataH, dataW, stride, padding);
   int64_t rows = expandedType.getDimSize(0);
   int64_t cols = expandedType.getDimSize(1);
-  ASSERT_EQ(rows, (int64_t)expected.size());
+  // An interchanged layout reserves whole g x g channel blocks, so its matrix
+  // can hold more rows than the reference has: the extra rows belong to the
+  // padding channels and stay zero.
+  int64_t referenceRows = (int64_t)expected.size();
+  ASSERT_GE(rows, referenceRows);
   ASSERT_EQ(cols, (int64_t)expected[0].size());
 
   // The non-diagonalized relation must agree with the reference Toeplitz
-  // matrix.
+  // matrix. It is not interchanged, so it has no padding rows.
   auto expandedRelation =
       get2dConvChwFchwFilterRelation(filterType, dataType, strides, padding);
   EXPECT_EQ(evaluateLayout(expandedRelation, getFilterValueFn,
-                           SmallVector<int64_t>{rows, cols}),
+                           SmallVector<int64_t>{referenceRows, cols}),
             expected);
 
   // Row interchange permutes the matrix rows into the pixel-shuffled order the
@@ -1050,7 +1054,9 @@ void checkConv2dChwFchwDiagonalized(
     int64_t outputH = convOutputExtent(dataH, filterSize, stride, padding);
     int64_t outputW = convOutputExtent(dataW, filterSize, stride, padding);
     int64_t wOut = outputW * g;
-    ASSERT_EQ(outputChannels % (g * g), 0);
+    // Sized to the reserved blocks, so the rows of the padding channels are
+    // present and zero.
+    expectedRows.assign(rows, std::vector<int>(cols, 0));
     for (int64_t f = 0; f < outputChannels; ++f) {
       for (int64_t oh = 0; oh < outputH; ++oh) {
         for (int64_t ow = 0; ow < outputW; ++ow) {
@@ -1123,6 +1129,20 @@ TEST(ConvolutionTest, TestConv2dChwFchwDiagonalizedInterchangedPadded) {
                                    /*inputChannels=*/2, /*filterSize=*/3,
                                    /*dataH=*/6, /*dataW=*/6, /*stride=*/2,
                                    padding, /*ciphertextSize=*/128,
+                                   /*interchangeRows=*/true);
+  }
+}
+
+TEST(ConvolutionTest, TestConv2dChwFchwDiagonalizedInterchangedChannelPadding) {
+  // Output channel counts that are not a multiple of gap^2 = 4. The
+  // interchanged layout reserves a whole block, so the matrix gains zero rows
+  // for the channels that are not there.
+  MLIRContext context;
+  for (int64_t outputChannels : {1, 2, 3, 5, 6, 7}) {
+    checkConv2dChwFchwDiagonalized(context, outputChannels,
+                                   /*inputChannels=*/2, /*filterSize=*/3,
+                                   /*dataH=*/6, /*dataW=*/6, /*stride=*/2,
+                                   /*padding=*/0, /*ciphertextSize=*/128,
                                    /*interchangeRows=*/true);
   }
 }

--- a/lib/Utils/Layout/ConvolutionTestUtil.cpp
+++ b/lib/Utils/Layout/ConvolutionTestUtil.cpp
@@ -165,8 +165,14 @@ get2dConvChwFchwFilterDiagonalizedRelation(RankedTensorType filterType,
           1}},
         /*equality=*/true);
 
+    // Diagonalize against the shape the Halevi-Shoup kernel is sized from. The
+    // interchange relation's own bounds can be tighter: the layout reserves
+    // rows for padding channels that no filter entry reaches.
+    auto expandedType = get2dConvChwFchwFilterExpandedType(
+        filterType, dataType, padding, strides, /*interchangeRows=*/true);
     auto diagonalizedInterchange =
-        diagonalize2dMatrix(rowInterchangeRelation, filterType, minSlotCount);
+        diagonalize2dMatrix(rowInterchangeRelation, filterType, minSlotCount,
+                            expandedType.getShape());
     if (failed(diagonalizedInterchange)) return failure();
 
     expandedFilterRelation.compose(diagonalizedInterchange.value());

--- a/lib/Utils/Layout/EvaluateTest.cpp
+++ b/lib/Utils/Layout/EvaluateTest.cpp
@@ -621,15 +621,23 @@ TEST(EvaluateTest, Conv2dResultRelationTwoCiphertextsWithInterchange) {
   EXPECT_THAT(result, Eq(expected));
 }
 
-TEST(EvaluateTest, TallConvFilterDiagonalizedRelationsEquivalence) {
-  MLIRContext context;
-  RankedTensorType filterType =
-      RankedTensorType::get({8, 1, 2, 2}, IndexType::get(&context));
-  RankedTensorType dataType =
-      RankedTensorType::get({1, 1, 4, 4}, IndexType::get(&context));
-  SmallVector<int64_t> strides = {2, 2};
+// Checks that the staged filter layout the pass uses agrees with the
+// single-relation reference for a 2-D conv of the given shape.
+void checkConv2dFilterRelationsEquivalence(MLIRContext& context,
+                                           int64_t outputChannels,
+                                           int64_t inputChannels,
+                                           int64_t dataSize, int64_t stride,
+                                           int64_t minSlotCount) {
+  SCOPED_TRACE("outputChannels = " + std::to_string(outputChannels) +
+               " inputChannels = " + std::to_string(inputChannels) +
+               " dataSize = " + std::to_string(dataSize) +
+               " stride = " + std::to_string(stride));
+  RankedTensorType filterType = RankedTensorType::get(
+      {outputChannels, inputChannels, 2, 2}, IndexType::get(&context));
+  RankedTensorType dataType = RankedTensorType::get(
+      {1, inputChannels, dataSize, dataSize}, IndexType::get(&context));
+  SmallVector<int64_t> strides = {stride, stride};
   int64_t padding = 0;
-  int64_t minSlotCount = 32;
 
   auto singleRel = get2dConvChwFchwFilterDiagonalizedRelation(
       filterType, dataType, strides, padding, minSlotCount,
@@ -649,15 +657,17 @@ TEST(EvaluateTest, TallConvFilterDiagonalizedRelationsEquivalence) {
     composed.compose(rels[i]);
   }
 
-  // Filter is 8x1x2x2
   std::vector<std::vector<std::vector<std::vector<int>>>> filter(
-      8, std::vector<std::vector<std::vector<int>>>(
-             1, std::vector<std::vector<int>>(2, std::vector<int>(2, 0))));
+      outputChannels, std::vector<std::vector<std::vector<int>>>(
+                          inputChannels, std::vector<std::vector<int>>(
+                                             2, std::vector<int>(2))));
   int val = 1;
-  for (int f = 0; f < 8; ++f) {
-    for (int kh = 0; kh < 2; ++kh) {
-      for (int kw = 0; kw < 2; ++kw) {
-        filter[f][0][kh][kw] = val++;
+  for (int f = 0; f < outputChannels; ++f) {
+    for (int c = 0; c < inputChannels; ++c) {
+      for (int kh = 0; kh < 2; ++kh) {
+        for (int kw = 0; kw < 2; ++kw) {
+          filter[f][c][kh][kw] = val++;
+        }
       }
     }
   }
@@ -672,6 +682,30 @@ TEST(EvaluateTest, TallConvFilterDiagonalizedRelationsEquivalence) {
   auto resultComposed = evaluateLayout(composed, getValueFn);
 
   EXPECT_THAT(resultComposed, Eq(resultSingle));
+}
+
+TEST(EvaluateTest, TallConvFilterDiagonalizedRelationsEquivalence) {
+  MLIRContext context;
+  checkConv2dFilterRelationsEquivalence(context, /*outputChannels=*/8,
+                                        /*inputChannels=*/1, /*dataSize=*/4,
+                                        /*stride=*/2, /*minSlotCount=*/32);
+}
+
+TEST(EvaluateTest, GapPaddedConvFilterDiagonalizedRelationsEquivalence) {
+  // Channel counts that are not a multiple of gap^2 = 4, so the layout pads the
+  // channel dimension. The staged relations must reserve the same padding rows
+  // as the single-relation reference.
+  MLIRContext context;
+  for (int64_t outputChannels : {1, 2, 3}) {
+    checkConv2dFilterRelationsEquivalence(context, outputChannels,
+                                          /*inputChannels=*/1, /*dataSize=*/4,
+                                          /*stride=*/2, /*minSlotCount=*/32);
+  }
+  for (int64_t outputChannels : {5, 6, 7}) {
+    checkConv2dFilterRelationsEquivalence(context, outputChannels,
+                                          /*inputChannels=*/2, /*dataSize=*/4,
+                                          /*stride=*/2, /*minSlotCount=*/64);
+  }
 }
 
 }  // namespace

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -236,18 +236,21 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
 
 FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
     presburger::IntegerRelation relation, RankedTensorType originalType,
-    int64_t minSlotCount) {
-  // Get size of the matrix.
-  auto rowBound = relation.getConstantBound64(
-      BoundType::UB, relation.getVarKindOffset(VarKind::Range));
-  auto colBound = relation.getConstantBound64(
-      BoundType::UB, relation.getVarKindOffset(VarKind::Range) + 1);
-  if (!rowBound.has_value() || !colBound.has_value()) {
-    return failure();
+    int64_t minSlotCount, ArrayRef<int64_t> matrixShape) {
+  SmallVector<int64_t> shape(matrixShape);
+  if (shape.empty()) {
+    // Get size of the matrix.
+    auto rowBound = relation.getConstantBound64(
+        BoundType::UB, relation.getVarKindOffset(VarKind::Range));
+    auto colBound = relation.getConstantBound64(
+        BoundType::UB, relation.getVarKindOffset(VarKind::Range) + 1);
+    if (!rowBound.has_value() || !colBound.has_value()) {
+      return failure();
+    }
+    shape = {rowBound.value() + 1, colBound.value() + 1};
   }
   RankedTensorType matrixType =
-      RankedTensorType::get({rowBound.value() + 1, colBound.value() + 1},
-                            originalType.getElementType());
+      RankedTensorType::get(shape, originalType.getElementType());
   auto diagonalRelation = getDiagonalLayoutRelation(matrixType, minSlotCount);
 
   // Compose these relations.

--- a/lib/Utils/Layout/Utils.h
+++ b/lib/Utils/Layout/Utils.h
@@ -66,9 +66,15 @@ presburger::IntegerRelation getDiagonalLayoutRelation(
     RankedTensorType matrixType, int64_t minSlotCount);
 
 // Applies a diagonal layout onto a given 2-D matrix layout.
+//
+// The matrix shape is read off `relation`'s own range bounds, which can be
+// tighter than the matrix the kernel is sized from: a trailing row or column
+// that no entry ever reaches lowers the derived bound. Pass `matrixShape` to
+// diagonalize against an explicit {rows, cols} instead, so that the layout and
+// the kernel agree.
 FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
     presburger::IntegerRelation relation, RankedTensorType originalType,
-    int64_t minSlotCount);
+    int64_t minSlotCount, ArrayRef<int64_t> matrixShape = {});
 
 // Returns an IntegerRelation that represents a bicyclic layout for a matrix.
 // See https://eprint.iacr.org/2024/1762 for details.

--- a/tests/Examples/lattigo/ckks/conv1d_ncw_channel_padding/BUILD
+++ b/tests/Examples/lattigo/ckks/conv1d_ncw_channel_padding/BUILD
@@ -1,0 +1,22 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv1d_ncw_channel_padding",
+    go_library_name = "conv1dncwchannelpadding",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--mlir-to-ckks=min-slot-count=1024 experimental-disable-loop-unroll=true",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "conv1d_ncw_channel_padding.mlir",
+)
+
+go_test(
+    name = "conv1d_ncw_channel_padding_test",
+    size = "small",
+    srcs = ["conv1d_ncw_channel_padding_test.go"],
+    embed = [":conv1dncwchannelpadding"],
+)

--- a/tests/Examples/lattigo/ckks/conv1d_ncw_channel_padding/conv1d_ncw_channel_padding.mlir
+++ b/tests/Examples/lattigo/ckks/conv1d_ncw_channel_padding/conv1d_ncw_channel_padding.mlir
@@ -1,0 +1,11 @@
+// A stride-2 conv whose 3 output channels are not a multiple of the gap 2. The
+// shuffled layout reserves a whole pair of channels, so one channel stays empty
+// and the Toeplitz matrix gets zero rows for it.
+module {
+  func.func @conv1d_channel_pad(%arg0: tensor<1x2x8xf32> {secret.secret}) -> tensor<1x3x4xf32> {
+    %filter = arith.constant dense<[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]], [[9.0, 10.0], [11.0, 12.0]]]> : tensor<3x2x2xf32>
+    %out = arith.constant dense<0.0> : tensor<1x3x4xf32>
+    %0 = linalg.conv_1d_ncw_fcw {dilations = dense<1> : vector<1xi64>, strides = dense<2> : vector<1xi64>} ins(%arg0, %filter : tensor<1x2x8xf32>, tensor<3x2x2xf32>) outs(%out : tensor<1x3x4xf32>) -> tensor<1x3x4xf32>
+    return %0 : tensor<1x3x4xf32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/conv1d_ncw_channel_padding/conv1d_ncw_channel_padding_test.go
+++ b/tests/Examples/lattigo/ckks/conv1d_ncw_channel_padding/conv1d_ncw_channel_padding_test.go
@@ -1,0 +1,55 @@
+package conv1dncwchannelpadding
+
+import (
+	"math"
+	"testing"
+)
+
+// conv1dNcwFcw computes a 1D convolution over a row-major NCW input tensor with
+// an FCW filter tensor.
+func conv1dNcwFcw(input []float32, filter []float32, Cin, Win, Cout, Kw, stride int) []float32 {
+	Wout := (Win-Kw)/stride + 1
+	output := make([]float32, Cout*Wout)
+	for f := 0; f < Cout; f++ {
+		for wo := 0; wo < Wout; wo++ {
+			var sum float32
+			for c := 0; c < Cin; c++ {
+				for kw := 0; kw < Kw; kw++ {
+					sum += input[c*Win+wo*stride+kw] * filter[f*(Cin*Kw)+c*Kw+kw]
+				}
+			}
+			output[f*Wout+wo] = sum
+		}
+	}
+	return output
+}
+
+// The conv has 3 output channels at stride 2, so the shuffled layout reserves a
+// whole pair of channels. The empty one must not disturb the three real ones.
+func TestConv1dChannelPadding(t *testing.T) {
+	evaluator, params, ecd, enc, dec := Conv1d_channel_pad__configure()
+
+	// Input: 1x2x8 = 16 elements (values 1..16)
+	arg0 := make([]float32, 16)
+	for i := range arg0 {
+		arg0[i] = float32(i + 1)
+	}
+	filter := []float32{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+	}
+	expected := conv1dNcwFcw(arg0, filter, 2, 8, 3, 2, 2)
+
+	ct0 := Conv1d_channel_pad__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	ctZero := Conv1d_channel_pad__encrypt__zero__0(evaluator, params, ecd, enc)
+	resultCt := Conv1d_channel_pad(evaluator, params, ecd, ct0, ctZero)
+	result := Conv1d_channel_pad__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	errorThreshold := float64(0.01)
+	for i := range expected {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: got %.4f, expected %.4f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/BUILD
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/BUILD
@@ -1,0 +1,22 @@
+load("@heir//tests/Examples/lattigo:test.bzl", "heir_lattigo_lib")
+load("@rules_go//go:def.bzl", "go_test")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+heir_lattigo_lib(
+    name = "conv2d_nchw_channel_padding",
+    go_library_name = "conv2dnchwchannelpadding",
+    heir_opt_flags = [
+        "--annotate-module=backend=lattigo scheme=ckks",
+        "--torch-linalg-to-ckks=min-slot-count=4096 scaling-mod-bits=45 first-mod-bits=60",
+        "--scheme-to-lattigo",
+    ],
+    mlir_src = "conv2d_nchw_channel_padding.mlir",
+)
+
+go_test(
+    name = "conv2d_nchw_channel_padding_test",
+    srcs = ["conv2d_nchw_channel_padding_test.go"],
+    embed = [":conv2dnchwchannelpadding"],
+    deps = [":conv2dnchwchannelpadding_utils"],
+)

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/conv2d_nchw_channel_padding.mlir
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/conv2d_nchw_channel_padding.mlir
@@ -1,0 +1,13 @@
+// A stride-2 conv whose 3 output channels are not a multiple of gap^2 = 4. The
+// pixel-shuffled layout reserves a whole 2x2 channel block, so one channel of
+// the block stays empty and the Toeplitz matrix gets zero rows for it.
+module {
+  func.func @conv2d_channel_pad(%arg0: tensor<1x1x4x4xf32> {secret.secret}) -> tensor<1x3x2x2xf32> {
+    %filter = arith.constant dense<[[[[1.0, 2.0], [3.0, 4.0]]], [[[5.0, 6.0], [7.0, 8.0]]], [[[9.0, 10.0], [11.0, 12.0]]]]> : tensor<3x1x2x2xf32>
+    %init = tensor.empty() : tensor<1x3x2x2xf32>
+    %conv = linalg.conv_2d_nchw_fchw {strides = dense<2> : vector<2xi64>, dilations = dense<1> : vector<2xi64>}
+      ins(%arg0, %filter : tensor<1x1x4x4xf32>, tensor<3x1x2x2xf32>)
+      outs(%init : tensor<1x3x2x2xf32>) -> tensor<1x3x2x2xf32>
+    return %conv : tensor<1x3x2x2xf32>
+  }
+}

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/conv2d_nchw_channel_padding_test.go
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/conv2d_nchw_channel_padding_test.go
@@ -1,0 +1,82 @@
+package conv2dnchwchannelpadding
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"tests/Examples/lattigo/ckks/conv2d_nchw_channel_padding/conv2dnchwchannelpadding_utils"
+)
+
+// conv2dNchwFchw computes a 2D convolution over a row-major NCHW input tensor
+// with an FCHW filter tensor.
+func conv2dNchwFchw(
+	input []float32, filter []float32,
+	N, Cin, Hin, Win int,
+	Cout, Kh, Kw int,
+	strideH, strideW int,
+) []float32 {
+	Hout := (Hin-Kh)/strideH + 1
+	Wout := (Win-Kw)/strideW + 1
+
+	output := make([]float32, N*Cout*Hout*Wout)
+
+	for n := 0; n < N; n++ {
+		for f := 0; f < Cout; f++ {
+			for ho := 0; ho < Hout; ho++ {
+				for wo := 0; wo < Wout; wo++ {
+					var sum float32
+					for c := 0; c < Cin; c++ {
+						for kh := 0; kh < Kh; kh++ {
+							for kw := 0; kw < Kw; kw++ {
+								hi := ho*strideH + kh
+								wi := wo*strideW + kw
+								inIdx := n*(Cin*Hin*Win) + c*(Hin*Win) + hi*Win + wi
+								filterIdx := f*(Cin*Kh*Kw) + c*(Kh*Kw) + kh*Kw + kw
+								sum += input[inIdx] * filter[filterIdx]
+							}
+						}
+					}
+					outIdx := n*(Cout*Hout*Wout) + f*(Hout*Wout) + ho*Wout + wo
+					output[outIdx] = sum
+				}
+			}
+		}
+	}
+	return output
+}
+
+// The conv has 3 output channels at stride 2, so the pixel-shuffled layout has
+// to reserve a full block of gap^2 = 4 channels. The fourth channel is empty
+// and must not disturb the three real ones.
+func TestConv2dChannelPadding(t *testing.T) {
+	evaluator, params, ecd, enc, dec := Conv2d_channel_pad__configure()
+
+	// Input: 1x1x4x4 = 16 elements (values 1..16)
+	arg0 := make([]float32, 16)
+	for i := range arg0 {
+		arg0[i] = float32(i + 1)
+	}
+	filter := []float32{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+	}
+	expected := conv2dNchwFchw(arg0, filter, 1, 1, 4, 4, 3, 2, 2, 2, 2)
+
+	ct0 := Conv2d_channel_pad__encrypt__arg0(evaluator, params, ecd, enc, arg0)
+	startPre := time.Now()
+	filterPlains := conv2dnchwchannelpadding_utils.Conv2d_channel_pad__preprocessing(params, ecd)
+	t.Logf("Preprocessing took %s", time.Since(startPre))
+	start := time.Now()
+	resultCt := Conv2d_channel_pad__preprocessed(evaluator, params, ecd, ct0, filterPlains)
+	t.Logf("Conv2d (preprocessed) took %s", time.Since(start))
+	result := Conv2d_channel_pad__decrypt__result0(evaluator, params, ecd, dec, resultCt)
+
+	errorThreshold := float64(0.01)
+	for i := range expected {
+		if math.Abs(float64(result[i]-expected[i])) > errorThreshold {
+			t.Errorf("Decryption error at index %d: got %.4f, expected %.4f", i, result[i], expected[i])
+		}
+	}
+}

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_padded/BUILD
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_padded/BUILD
@@ -8,7 +8,7 @@ heir_lattigo_lib(
     go_library_name = "conv2dnchwpadded",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--mlir-to-ckks=min-slot-count=1024 greedy-modulus-switch-after-mul=true",
+        "--mlir-to-ckks=min-slot-count=1024 greedy-modulus-switch-after-mul=true experimental-disable-loop-unroll=true",
         "--scheme-to-lattigo",
     ],
     mlir_src = "@heir//tests/Examples/common:conv2d_nchw_padded.mlir",

--- a/tests/Examples/lattigo/ckks/conv2d_nchw_padded/conv2d_nchw_padded_test.go
+++ b/tests/Examples/lattigo/ckks/conv2d_nchw_padded/conv2d_nchw_padded_test.go
@@ -24,7 +24,8 @@ func TestConv2DPadded(t *testing.T) {
 	}
 
 	ct0 := Conv2d_nchw_padded__encrypt__arg0(evaluator, params, ecd, enc, arg0)
-	resultCt := Conv2d_nchw_padded(evaluator, params, ecd, ct0)
+	ctZero := Conv2d_nchw_padded__encrypt__zero__0(evaluator, params, ecd, enc)
+	resultCt := Conv2d_nchw_padded(evaluator, params, ecd, ct0, ctZero)
 	result := Conv2d_nchw_padded__decrypt__result0(evaluator, params, ecd, dec, resultCt)
 	errorThreshold := float64(0.05)
 	for i := range expected {

--- a/tests/Transforms/layout_propagation/conv2d_nchw_channel_padding.mlir
+++ b/tests/Transforms/layout_propagation/conv2d_nchw_channel_padding.mlir
@@ -1,0 +1,48 @@
+// RUN: heir-opt --layout-propagation %s | FileCheck %s
+
+// A strided conv whose output channel count is not a multiple of gap^2. The
+// pixel-shuffled layout folds gap^2 = 4 channels into each 2x2 spatial block,
+// so the layout reserves ceil(6 / 4) = 2 blocks and leaves 2 channels of the
+// last block empty.
+
+// CHECK: @conv2d_nchw_six_channels
+func.func @conv2d_nchw_six_channels(%arg0: !secret.secret<tensor<1x1x10x10xf32>>) -> !secret.secret<tensor<1x6x5x5xf32>> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x6x5x5xf32>
+  %filter = arith.constant dense<2.500000e-01> : tensor<6x1x2x2xf32>
+
+  %0 = secret.generic(%arg0 : !secret.secret<tensor<1x1x10x10xf32>>) {
+  ^body(%input0: tensor<1x1x10x10xf32>):
+    // CHECK: linalg.conv_2d_nchw_fchw
+    // The result reserves ceil(6 / 4) = 2 channel blocks of 10x10 sub-pixels.
+    // CHECK-SAME: heir.kernel_info = {gap_factor = 2 : i64, input_shape = array<i64: 1, 1, 10, 10>, result_shape = array<i64: 1, 2, 10, 10>}
+    %1 = linalg.conv_2d_nchw_fchw
+      { dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64> }
+      ins(%input0, %filter : tensor<1x1x10x10xf32>, tensor<6x1x2x2xf32>)
+      outs(%cst : tensor<1x6x5x5xf32>) -> tensor<1x6x5x5xf32>
+    secret.yield %1 : tensor<1x6x5x5xf32>
+  } -> !secret.secret<tensor<1x6x5x5xf32>>
+  return %0 : !secret.secret<tensor<1x6x5x5xf32>>
+}
+
+// -----
+
+// The 1-D analogue: the shuffle folds `stride` channels into each gap, so 3
+// output channels at stride 2 reserve 4.
+
+// CHECK: @conv1d_ncw_three_channels
+func.func @conv1d_ncw_three_channels(%arg0: !secret.secret<tensor<1x1x16xf32>>) -> !secret.secret<tensor<1x3x8xf32>> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x3x8xf32>
+  %filter = arith.constant dense<2.500000e-01> : tensor<3x1x2xf32>
+
+  %0 = secret.generic(%arg0 : !secret.secret<tensor<1x1x16xf32>>) {
+  ^body(%input0: tensor<1x1x16xf32>):
+    // CHECK: linalg.conv_1d_ncw_fcw
+    // CHECK-SAME: heir.kernel_info = {gap_factor = 2 : i64, input_shape = array<i64: 1, 1, 16>, result_shape = array<i64: 1, 2, 16>}
+    %1 = linalg.conv_1d_ncw_fcw
+      { dilations = dense<1> : tensor<1xi64>, strides = dense<2> : tensor<1xi64> }
+      ins(%input0, %filter : tensor<1x1x16xf32>, tensor<3x1x2xf32>)
+      outs(%cst : tensor<1x3x8xf32>) -> tensor<1x3x8xf32>
+    secret.yield %1 : tensor<1x3x8xf32>
+  } -> !secret.secret<tensor<1x3x8xf32>>
+  return %0 : !secret.secret<tensor<1x3x8xf32>>
+}


### PR DESCRIPTION
This closes #2883 

This is something that needs to be done to support more convolution networks (for example, the naive Lola network does not compile because it we don't pad to satisfy that gap^2 | nrows. The Lola MLIR we have in the test is a prepadded version). 