### PR TITLE
preprocessing: make resource loading DPS

### DIFF
--- a/lib/Dialect/Preprocessing/IR/BUILD
+++ b/lib/Dialect/Preprocessing/IR/BUILD
@@ -24,6 +24,7 @@ cc_library(
         ":types_inc_gen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:BytecodeOpInterface",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:SideEffectInterfaces",
@@ -40,6 +41,7 @@ td_library(
     ],
     deps = [
         "@llvm-project//mlir:BuiltinDialectTdFiles",
+        "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",

--- a/lib/Dialect/Preprocessing/IR/PreprocessingOps.cpp
+++ b/lib/Dialect/Preprocessing/IR/PreprocessingOps.cpp
@@ -44,15 +44,27 @@ namespace preprocessing {
 }
 
 ::mlir::LogicalResult LoadResourceOp::verify() {
-  // The backends size their reads with ShapedType::getNumElements(), which
-  // asserts on a non-static shape, and the number of bytes to read from the
-  // file is not knowable without one.
-  auto shapedType = cast<ShapedType>(getResult().getType());
+  auto shapedType = cast<ShapedType>(getDestination().getType());
   if (!shapedType.hasStaticShape()) {
-    return emitOpError() << "result type " << shapedType
+    return emitOpError() << "destination type " << shapedType
                          << " must have a static shape";
   }
   return ::mlir::success();
+}
+
+Speculation::Speculatability LoadResourceOp::getSpeculatability() {
+  return isa<TensorType>(getDestination().getType())
+             ? Speculation::Speculatable
+             : Speculation::NotSpeculatable;
+}
+
+LoadResourceOp LoadResourceOp::getForDestination(Value value) {
+  for (Operation* user : value.getUsers()) {
+    auto loadResourceOp = dyn_cast<LoadResourceOp>(user);
+    if (loadResourceOp && loadResourceOp.getDestination() == value)
+      return loadResourceOp;
+  }
+  return {};
 }
 
 }  // namespace preprocessing

--- a/lib/Dialect/Preprocessing/IR/PreprocessingOps.h
+++ b/lib/Dialect/Preprocessing/IR/PreprocessingOps.h
@@ -14,6 +14,7 @@
 #include "mlir/include/mlir/IR/OpDefinition.h"       // from @llvm-project
 #include "mlir/include/mlir/IR/OpImplementation.h"   // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"          // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
 // IWYU pragma: end_keep

--- a/lib/Dialect/Preprocessing/IR/PreprocessingOps.td
+++ b/lib/Dialect/Preprocessing/IR/PreprocessingOps.td
@@ -6,6 +6,7 @@ include "PreprocessingTypes.td"
 
 include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -75,20 +76,53 @@ def Preprocessing_LoadOp : Preprocessing_Op<"load", [MemoryEffectsOpInterface]> 
 }
 
 
-def Preprocessing_LoadResourceOp : Preprocessing_Op<"load_resource",
-    // Marked as Pure to allow CSE/LICM.
-    [Pure]> {
+def Preprocessing_LoadResourceOp : Preprocessing_Op<"load_resource", [
+    DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+    DestinationStyleOpInterface,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
   let summary = "Load a constant resource from an external binary file";
   let description = [{
-    Loads raw bytes from the file specified by `path` and interprets them
-    as a tensor or memref of the result type.
+    Loads raw bytes from the file specified by `path` into `destination`. With
+    a tensor destination, the op returns a tensor of the same type that is tied
+    to the destination. With a memref destination, the op has no results.
+
+    Tensor results are treated as read-only during bufferization. A later write
+    is placed in separate storage.
 
     This op is inserted by the `externalize-constants` pass.
   }];
-  let arguments = (ins StrAttr:$path);
-  let results = (outs AnyTypeOf<[AnyTensor, AnyMemRef]>:$result);
+  let arguments = (ins
+    StrAttr:$path,
+    AnyTypeOf<[AnyTensor, AnyMemRef]>:$destination
+  );
+  let results = (outs Variadic<AnyTensor>:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$path attr-dict `:` type($result)";
+  let extraClassDeclaration = [{
+    ::mlir::MutableOperandRange getDpsInitsMutable() {
+      return ::mlir::MutableOperandRange(
+          getOperation(), getDestinationMutable().getOperandNumber(), 1);
+    }
+
+    ::mlir::Value getLoadedResource() {
+      return getNumResults() == 1 ? getOperation()->getResult(0)
+                                  : getDestination();
+    }
+
+    static LoadResourceOp getForDestination(::mlir::Value value);
+  }];
+  let extraClassDefinition = [{
+    void $cppClass::getEffects(::llvm::SmallVectorImpl<
+        ::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>>
+            &effects) {
+      if (::llvm::isa<::mlir::MemRefType>(getDestination().getType()))
+        effects.emplace_back(::mlir::MemoryEffects::Write::get(),
+                             &getDestinationMutable(),
+                             ::mlir::SideEffects::DefaultResource::get());
+    }
+  }];
+  let assemblyFormat =
+      "$path `into` $destination attr-dict `:` functional-type(operands, results)";
 }
 
 #endif  // LIB_DIALECT_PREPROCESSING_IR_PREPROCESSINGOPS_TD_

--- a/lib/Dialect/Preprocessing/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Preprocessing/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -3,78 +3,57 @@
 #include "lib/Dialect/Preprocessing/IR/PreprocessingDialect.h"
 #include "lib/Dialect/Preprocessing/IR/PreprocessingOps.h"
 #include "mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/Bufferization/IR/BufferizationTypeInterfaces.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/Attributes.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributeInterfaces.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace preprocessing {
 
-// load_resource requires special bufferization because in the backend it
-// corresponds to populating static global data with bytes from a file, and
-// bufferizing this requires us to avoid inserting deallocations.
 struct LoadResourceOpInterface
-    : public ::mlir::bufferization::BufferizableOpInterface::ExternalModel<
+    : public bufferization::BufferizableOpInterface::ExternalModel<
           LoadResourceOpInterface, LoadResourceOp> {
-  LogicalResult bufferize(
-      Operation* op, RewriterBase& rewriter,
-      const ::mlir::bufferization::BufferizationOptions& options,
-      ::mlir::bufferization::BufferizationState& state) const {
-    auto loadResourceOp = cast<LoadResourceOp>(op);
-    auto tensorType = dyn_cast<RankedTensorType>(loadResourceOp.getType());
-
-    if (!tensorType) return success();
-
-    Attribute memorySpace;
-    if (auto memSpace = options.defaultMemorySpaceFn(
-            cast<::mlir::bufferization::TensorLikeType>(tensorType)))
-      memorySpace = *memSpace;
-    else
-      return op->emitError("could not infer memory space");
-
-    auto memrefType =
-        MemRefType::get(tensorType.getShape(), tensorType.getElementType(),
-                        MemRefLayoutAttrInterface(), memorySpace);
-
-    ::mlir::bufferization::replaceOpWithNewBufferizedOp<LoadResourceOp>(
-        rewriter, op, memrefType, loadResourceOp.getPathAttr());
-    return success();
-  }
-
-  // Everything else is boilerplate for this core step: telling MLIR it cannot
-  // write to this buffer.
-  bool isWritable(Operation* op, Value value,
-                  const ::mlir::bufferization::AnalysisState& state) const {
+  bool bufferizesToMemoryRead(Operation* op, OpOperand& opOperand,
+                              const bufferization::AnalysisState& state) const {
     return false;
   }
 
-  FailureOr<::mlir::bufferization::BufferLikeType> getBufferType(
-      Operation* op, Value value,
-      const ::mlir::bufferization::BufferizationOptions& options,
-      const ::mlir::bufferization::BufferizationState& state,
-      SmallVector<Value>& invocationStack) const {
+  bool bufferizesToMemoryWrite(
+      Operation* op, OpOperand& opOperand,
+      const bufferization::AnalysisState& state) const {
     auto loadResourceOp = cast<LoadResourceOp>(op);
-    auto tensorType = dyn_cast<RankedTensorType>(loadResourceOp.getType());
-    if (!tensorType) return failure();
+    return loadResourceOp.isDpsInit(&opOperand);
+  }
 
-    Attribute memorySpace;
-    if (auto memSpace = options.defaultMemorySpaceFn(
-            cast<::mlir::bufferization::TensorLikeType>(tensorType)))
-      memorySpace = *memSpace;
-    else
-      return op->emitError("could not infer memory space");
+  bufferization::AliasingValueList getAliasingValues(
+      Operation* op, OpOperand& opOperand,
+      const bufferization::AnalysisState& state) const {
+    auto loadResourceOp = cast<LoadResourceOp>(op);
+    if (loadResourceOp.isDpsInit(&opOperand)) {
+      return {{loadResourceOp.getTiedOpResult(&opOperand),
+               bufferization::BufferRelation::Equivalent}};
+    }
+    return {};
+  }
 
-    return cast<::mlir::bufferization::BufferLikeType>(
-        MemRefType::get(tensorType.getShape(), tensorType.getElementType(),
-                        MemRefLayoutAttrInterface(), memorySpace));
+  bool isWritable(Operation* op, Value value,
+                  const bufferization::AnalysisState& state) const {
+    return false;
+  }
+
+  LogicalResult bufferize(Operation* op, RewriterBase& rewriter,
+                          const bufferization::BufferizationOptions& options,
+                          bufferization::BufferizationState& state) const {
+    auto loadResourceOp = cast<LoadResourceOp>(op);
+    FailureOr<Value> destination = bufferization::getBuffer(
+        rewriter, loadResourceOp.getDestination(), options, state);
+    if (failed(destination)) return failure();
+
+    LoadResourceOp::create(rewriter, op->getLoc(), TypeRange{},
+                           loadResourceOp.getPathAttr(), *destination);
+    bufferization::replaceOpWithBufferizedValues(rewriter, op, *destination);
+    return success();
   }
 };
 

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -225,15 +225,15 @@ FailureOr<bool> LattigoEmitter::collectResourcesToLoad(ModuleOp moduleOp) {
   LogicalResult prepassResult = success();
   moduleOp.walk([&](preprocessing::LoadResourceOp op) {
     hasResources = true;
-    Value result = op.getResult();
+    Value resource = op.getLoadedResource();
     // These globals are emitted once at module scope, so they cannot be named
     // after the SSA value: SelectVariableNames restarts its numbering in each
     // function, and two functions would produce the same global. Index into
     // `resources` instead, which is module-wide.
     std::string globalName = "g_resource" + std::to_string(resources.size());
-    resourceGlobals[result] = globalName;
+    resourceGlobals[resource] = globalName;
 
-    auto type = result.getType();
+    auto type = resource.getType();
     auto typeString = convertType(type);
     if (failed(typeString)) {
       prepassResult = failure();
@@ -1285,6 +1285,8 @@ LogicalResult LattigoEmitter::printOperation(scf::YieldOp op) {
 }
 
 LogicalResult LattigoEmitter::printOperation(memref::AllocOp op) {
+  if (preprocessing::LoadResourceOp::getForDestination(op.getResult()))
+    return success();
   MemRefType type = op.getType();
   auto eltTypeStr = convertType(type.getElementType());
   if (failed(eltTypeStr)) return failure();

--- a/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
+++ b/lib/Target/OpenFhePke/OpenFhePkeEmitter.cpp
@@ -1381,6 +1381,9 @@ LogicalResult OpenFhePkeEmitter::printOperation(tensor::ConcatOp op) {
 }
 
 LogicalResult OpenFhePkeEmitter::printOperation(tensor::EmptyOp op) {
+  if (preprocessing::LoadResourceOp::getForDestination(op.getResult()))
+    return success();
+
   // std::vector<std::vector<CiphertextT>> result(size);
   RankedTensorType resultType = op.getResult().getType();
   if (failed(emitType(resultType, op->getLoc()))) {
@@ -1710,8 +1713,8 @@ LogicalResult OpenFhePkeEmitter::printOperation(tensor::FromElementsOp op) {
 
 LogicalResult OpenFhePkeEmitter::printOperation(
     ::mlir::heir::preprocessing::LoadResourceOp op) {
-  auto result = op.getResult();
-  auto type = result.getType();
+  Value resource = op.getLoadedResource();
+  Type type = resource.getType();
 
   Type eltType;
   if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
@@ -1732,7 +1735,7 @@ LogicalResult OpenFhePkeEmitter::printOperation(
     size = shapedType.getNumElements();
   }
 
-  std::string varName = variableNames->getNameForValue(result);
+  std::string varName = variableNames->getNameForValue(resource);
 
   os << "static const std::vector<" << cppEltType.value() << "> " << varName
      << " = load_resource<" << cppEltType.value() << ">(\"" << op.getPath()
@@ -1742,6 +1745,8 @@ LogicalResult OpenFhePkeEmitter::printOperation(
 }
 
 LogicalResult OpenFhePkeEmitter::printOperation(memref::AllocOp op) {
+  if (preprocessing::LoadResourceOp::getForDestination(op.getResult()))
+    return success();
   auto type = cast<MemRefType>(op.getType());
   if (!type.hasStaticShape()) {
     return emitError(op.getLoc(), "Only static shapes are supported");

--- a/lib/Target/TfheRust/TfheRustEmitter.cpp
+++ b/lib/Target/TfheRust/TfheRustEmitter.cpp
@@ -699,8 +699,8 @@ LogicalResult TfheRustEmitter::printOperation(tensor::FromElementsOp op) {
 
 LogicalResult TfheRustEmitter::printOperation(
     ::mlir::heir::preprocessing::LoadResourceOp op) {
-  auto result = op.getResult();
-  auto type = result.getType();
+  Value resource = op.getLoadedResource();
+  Type type = resource.getType();
 
   Type eltType;
   if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
@@ -721,7 +721,7 @@ LogicalResult TfheRustEmitter::printOperation(
     size = shapedType.getNumElements();
   }
 
-  std::string varName = variableNames->getNameForValue(result);
+  std::string varName = variableNames->getNameForValue(resource);
 
   os << "static DATA_" << varName << ": OnceLock<Vec<" << rustEltType.value()
      << ">> = OnceLock::new();\n";
@@ -733,6 +733,8 @@ LogicalResult TfheRustEmitter::printOperation(
 }
 
 LogicalResult TfheRustEmitter::printOperation(memref::AllocOp op) {
+  if (preprocessing::LoadResourceOp::getForDestination(op.getResult()))
+    return success();
   os << "let mut " << variableNames->getNameForValue(op.getMemref())
      << " : HashMap<";
   if (op.getType().getRank() > 1) os << "(";
@@ -823,8 +825,7 @@ LogicalResult TfheRustEmitter::printOperation(memref::StoreOp op) {
 void TfheRustEmitter::printLoadOp(memref::LoadOp op) {
   os << variableNames->getNameForValue(op.getMemref());
   if (dyn_cast_or_null<memref::GetGlobalOp>(op.getMemRef().getDefiningOp()) ||
-      dyn_cast_or_null<::mlir::heir::preprocessing::LoadResourceOp>(
-          op.getMemRef().getDefiningOp())) {
+      preprocessing::LoadResourceOp::getForDestination(op.getMemRef())) {
     // Global arrays are 1-dimensional, so flatten the index
 
     os << "["

--- a/lib/Transforms/ExternalizeConstants/BUILD
+++ b/lib/Transforms/ExternalizeConstants/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )
 

--- a/lib/Transforms/ExternalizeConstants/ExternalizeConstants.cpp
+++ b/lib/Transforms/ExternalizeConstants/ExternalizeConstants.cpp
@@ -5,16 +5,17 @@
 #include <vector>
 
 #include "lib/Dialect/Preprocessing/IR/PreprocessingOps.h"
-#include "llvm/include/llvm/Support/FileSystem.h"      // from @llvm-project
-#include "llvm/include/llvm/Support/MD5.h"             // from @llvm-project
-#include "llvm/include/llvm/Support/Path.h"            // from @llvm-project
-#include "llvm/include/llvm/Support/raw_ostream.h"     // from @llvm-project
-#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"    // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"         // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"         // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"            // from @llvm-project
-#include "mlir/include/mlir/Support/WalkResult.h"      // from @llvm-project
+#include "llvm/include/llvm/Support/FileSystem.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/MD5.h"               // from @llvm-project
+#include "llvm/include/llvm/Support/Path.h"              // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/WalkResult.h"        // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -128,11 +129,14 @@ struct ExternalizeConstants
       llvm::sys::path::append(runtimePath, fileName);
 
       rewriter.setInsertionPoint(constantOp);
+      Value destination = tensor::EmptyOp::create(rewriter, constantOp.getLoc(),
+                                                  tensorType.getShape(),
+                                                  tensorType.getElementType());
       auto loadOp = preprocessing::LoadResourceOp::create(
-          rewriter, constantOp.getLoc(), tensorType,
-          rewriter.getStringAttr(runtimePath.str()));
+          rewriter, constantOp.getLoc(), TypeRange{tensorType},
+          rewriter.getStringAttr(runtimePath.str()), destination);
 
-      rewriter.replaceOp(constantOp, loadOp.getResult());
+      rewriter.replaceOp(constantOp, loadOp->getResult(0));
       return WalkResult::advance();
     });
   }

--- a/lib/Transforms/ExternalizeConstants/ExternalizeConstants.td
+++ b/lib/Transforms/ExternalizeConstants/ExternalizeConstants.td
@@ -22,7 +22,8 @@ def ExternalizeConstants : Pass<"externalize-constants"> {
 
   let dependentDialects = [
     "mlir::arith::ArithDialect",
-    "mlir::heir::preprocessing::PreprocessingDialect"
+    "mlir::heir::preprocessing::PreprocessingDialect",
+    "mlir::tensor::TensorDialect"
   ];
 }
 

--- a/tests/Dialect/Preprocessing/IR/load_resource_verifier.mlir
+++ b/tests/Dialect/Preprocessing/IR/load_resource_verifier.mlir
@@ -1,20 +1,19 @@
 // RUN: heir-opt --verify-diagnostics --split-input-file %s
 
-// The emitters compute the resource size with ShapedType::getNumElements(),
-// which asserts unless the shape is static, so reject non-static shapes here
-// rather than crashing in the backend.
-
-func.func @dynamic_dim() -> memref<?xi32> {
+// Resource emitters use getNumElements(), which requires a static shape.
+func.func @dynamic_dim(%destination: memref<?xi32>) {
   // expected-error@+1 {{must have a static shape}}
-  %0 = preprocessing.load_resource "p/dyn.bin" : memref<?xi32>
-  return %0 : memref<?xi32>
+  preprocessing.load_resource "p/dyn.bin" into %destination
+      : (memref<?xi32>) -> ()
+  return
 }
 
 // -----
 
-func.func @unranked() -> tensor<*xi32> {
+func.func @unranked(%destination: tensor<*xi32>) -> tensor<*xi32> {
   // expected-error@+1 {{must have a static shape}}
-  %0 = preprocessing.load_resource "p/unranked.bin" : tensor<*xi32>
+  %0 = preprocessing.load_resource "p/unranked.bin" into %destination
+      : (tensor<*xi32>) -> tensor<*xi32>
   return %0 : tensor<*xi32>
 }
 
@@ -22,6 +21,8 @@ func.func @unranked() -> tensor<*xi32> {
 
 // A static shape is accepted.
 func.func @static_ok() -> tensor<4xi32> {
-  %0 = preprocessing.load_resource "p/static.bin" : tensor<4xi32>
+  %destination = tensor.empty() : tensor<4xi32>
+  %0 = preprocessing.load_resource "p/static.bin" into %destination
+      : (tensor<4xi32>) -> tensor<4xi32>
   return %0 : tensor<4xi32>
 }

--- a/tests/Dialect/Preprocessing/Transforms/load_resource_bufferize.mlir
+++ b/tests/Dialect/Preprocessing/Transforms/load_resource_bufferize.mlir
@@ -1,10 +1,28 @@
 // RUN: heir-opt --one-shot-bufferize="bufferize-function-boundaries" %s | FileCheck %s
 
 // CHECK: func.func @test_load_resource() -> memref<4xi32> {
-// CHECK: %[[RES:.*]] = preprocessing.load_resource "some/path.bin" : memref<4xi32>
-// CHECK-NOT: memref.dealloc
+// CHECK-NEXT: %[[RES:[^ ]+]] = memref.alloc() {alignment = 64 : i64} : memref<4xi32>
+// CHECK-NEXT: preprocessing.load_resource "some/path.bin" into %[[RES]] : (memref<4xi32>) -> ()
 // CHECK: return %[[RES]] : memref<4xi32>
 func.func @test_load_resource() -> tensor<4xi32> {
-  %0 = preprocessing.load_resource "some/path.bin" : tensor<4xi32>
+  %destination = tensor.empty() : tensor<4xi32>
+  %0 = preprocessing.load_resource "some/path.bin" into %destination
+      : (tensor<4xi32>) -> tensor<4xi32>
   return %0 : tensor<4xi32>
+}
+
+// CHECK: func.func @test_write_after_load
+// CHECK: %[[RESOURCE:[^ ]+]] = memref.alloc() {alignment = 64 : i64} : memref<4xi32>
+// CHECK-NEXT: preprocessing.load_resource "some/path.bin" into %[[RESOURCE]] : (memref<4xi32>) -> ()
+// CHECK: %[[COPY:[^ ]+]] = memref.alloc() {alignment = 64 : i64} : memref<4xi32>
+// CHECK: memref.copy %[[RESOURCE]], %[[COPY]] : memref<4xi32> to memref<4xi32>
+// CHECK: memref.store %arg0, %[[COPY]]
+// CHECK: return %[[COPY]] : memref<4xi32>
+func.func @test_write_after_load(%value: i32) -> tensor<4xi32> {
+  %destination = tensor.empty() : tensor<4xi32>
+  %loaded = preprocessing.load_resource "some/path.bin" into %destination
+      : (tensor<4xi32>) -> tensor<4xi32>
+  %index = arith.constant 0 : index
+  %updated = tensor.insert %value into %loaded[%index] : tensor<4xi32>
+  return %updated : tensor<4xi32>
 }

--- a/tests/Emitter/Lattigo/emit_lattigo_external_constants.mlir
+++ b/tests/Emitter/Lattigo/emit_lattigo_external_constants.mlir
@@ -84,7 +84,9 @@
 
 module attributes {scheme.bgv} {
   func.func @test_external_constant(%arg0: memref<4xi32>) -> memref<4xi32> {
-    %0 = preprocessing.load_resource "some/path/constant_1.bin" : memref<4xi32>
+    %0 = memref.alloc() : memref<4xi32>
+    preprocessing.load_resource "some/path/constant_1.bin" into %0
+        : (memref<4xi32>) -> ()
     %res = memref.alloc() : memref<4xi32>
     affine.for %i = 0 to 4 {
       %val0 = memref.load %arg0[%i] : memref<4xi32>
@@ -96,7 +98,9 @@ module attributes {scheme.bgv} {
   }
 
   func.func @test_external_constant_i1(%arg0: memref<4xi1>) -> memref<4xi1> {
-    %0 = preprocessing.load_resource "some/path/constant_i1.bin" : memref<4xi1>
+    %0 = memref.alloc() : memref<4xi1>
+    preprocessing.load_resource "some/path/constant_i1.bin" into %0
+        : (memref<4xi1>) -> ()
     %res = memref.alloc() : memref<4xi1>
     affine.for %i = 0 to 4 {
       %val0 = memref.load %arg0[%i] : memref<4xi1>

--- a/tests/Emitter/Lattigo/emit_lattigo_resource_width.mlir
+++ b/tests/Emitter/Lattigo/emit_lattigo_resource_width.mlir
@@ -7,7 +7,8 @@
 // CHECK: resource element type 'f16' is stored as 2 bytes per element, but the generated loader reads float32
 module attributes {scheme.bgv} {
   func.func @f16_resource() -> memref<4xf16> {
-    %0 = preprocessing.load_resource "p/f16.bin" : memref<4xf16>
+    %0 = memref.alloc() : memref<4xf16>
+    preprocessing.load_resource "p/f16.bin" into %0 : (memref<4xf16>) -> ()
     return %0 : memref<4xf16>
   }
 }

--- a/tests/Emitter/Openfhe/emit_openfhe_pke_external_constants.mlir
+++ b/tests/Emitter/Openfhe/emit_openfhe_pke_external_constants.mlir
@@ -56,9 +56,16 @@
 // CHECK:     [[v1]][[[i]]] = [[and]];
 // CHECK:   }
 
+// CHECK: std::vector<int32_t> test_tensor_external_constant()
+// CHECK-NOT: std::vector<int32_t> {{[^ ]*}}(4);
+// CHECK: static const std::vector<int32_t> [[resource:[^ ]*]] = load_resource<int32_t>("some/path/tensor_constant.bin", 4);
+// CHECK: return [[resource]];
+
 module attributes {scheme.bgv} {
   func.func @test_external_constant(%arg0: memref<4xi32>) -> memref<4xi32> {
-    %0 = preprocessing.load_resource "some/path/constant_1.bin" : memref<4xi32>
+    %0 = memref.alloc() : memref<4xi32>
+    preprocessing.load_resource "some/path/constant_1.bin" into %0
+        : (memref<4xi32>) -> ()
     %res = memref.alloc() : memref<4xi32>
     affine.for %i = 0 to 4 {
       %val0 = memref.load %arg0[%i] : memref<4xi32>
@@ -70,7 +77,9 @@ module attributes {scheme.bgv} {
   }
 
   func.func @test_external_constant_i1(%arg0: memref<4xi1>) -> memref<4xi1> {
-    %0 = preprocessing.load_resource "some/path/constant_i1.bin" : memref<4xi1>
+    %0 = memref.alloc() : memref<4xi1>
+    preprocessing.load_resource "some/path/constant_i1.bin" into %0
+        : (memref<4xi1>) -> ()
     %res = memref.alloc() : memref<4xi1>
     affine.for %i = 0 to 4 {
       %val0 = memref.load %arg0[%i] : memref<4xi1>
@@ -79,5 +88,13 @@ module attributes {scheme.bgv} {
       memref.store %and, %res[%i] : memref<4xi1>
     }
     return %res : memref<4xi1>
+  }
+
+  func.func @test_tensor_external_constant() -> tensor<4xi32> {
+    %destination = tensor.empty() : tensor<4xi32>
+    %resource = preprocessing.load_resource
+        "some/path/tensor_constant.bin" into %destination
+        : (tensor<4xi32>) -> tensor<4xi32>
+    return %resource : tensor<4xi32>
   }
 }

--- a/tests/Emitter/TfheRust/emit_tfhe_rust_external_constants.mlir
+++ b/tests/Emitter/TfheRust/emit_tfhe_rust_external_constants.mlir
@@ -47,7 +47,9 @@
 module {
   func.func @test_external_constant(%arg0: memref<4xi32>) -> memref<4xi32> {
     %c0 = arith.constant 0 : index
-    %0 = preprocessing.load_resource "some/path/constant_1.bin" : memref<4xi32>
+    %0 = memref.alloc() : memref<4xi32>
+    preprocessing.load_resource "some/path/constant_1.bin" into %0
+        : (memref<4xi32>) -> ()
     %res = memref.alloc() : memref<4xi32>
     %val0 = memref.load %arg0[%c0] : memref<4xi32>
     %val1 = memref.load %0[%c0] : memref<4xi32>
@@ -58,7 +60,9 @@ module {
 
   func.func @test_external_constant_i1(%arg0: memref<4xi1>) -> memref<4xi1> {
     %c0 = arith.constant 0 : index
-    %0 = preprocessing.load_resource "some/path/constant_i1.bin" : memref<4xi1>
+    %0 = memref.alloc() : memref<4xi1>
+    preprocessing.load_resource "some/path/constant_i1.bin" into %0
+        : (memref<4xi1>) -> ()
     %res = memref.alloc() : memref<4xi1>
     %val0 = memref.load %arg0[%c0] : memref<4xi1>
     %val1 = memref.load %0[%c0] : memref<4xi1>

--- a/tests/Transforms/externalize_constants.mlir
+++ b/tests/Transforms/externalize_constants.mlir
@@ -8,16 +8,20 @@ func.func @test_externalize() -> (tensor<2xi32>, tensor<4xi32>, tensor<4xi1>, te
   // CHECK-NEXT: %[[CST_SMALL:.*]] = arith.constant dense<[1, 2]> : tensor<2xi32>
   %cst_small = arith.constant dense<[1, 2]> : tensor<2xi32>
 
-  // CHECK-NEXT: %[[CST_LARGE:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" : tensor<4xi32>
+  // CHECK-NEXT: %[[CST_LARGE_DEST:.*]] = tensor.empty() : tensor<4xi32>
+  // CHECK-NEXT: %[[CST_LARGE:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" into %[[CST_LARGE_DEST]] : (tensor<4xi32>) -> tensor<4xi32>
   %cst_large = arith.constant dense<[3, 4, 5, 6]> : tensor<4xi32>
 
-  // CHECK-NEXT: %[[CST_I1:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" : tensor<4xi1>
+  // CHECK-NEXT: %[[CST_I1_DEST:.*]] = tensor.empty() : tensor<4xi1>
+  // CHECK-NEXT: %[[CST_I1:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" into %[[CST_I1_DEST]] : (tensor<4xi1>) -> tensor<4xi1>
   %cst_i1 = arith.constant dense<[true, false, true, false]> : tensor<4xi1>
 
-  // CHECK-NEXT: %[[CST_RES_I32:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" : tensor<4xi32>
+  // CHECK-NEXT: %[[CST_RES_I32_DEST:.*]] = tensor.empty() : tensor<4xi32>
+  // CHECK-NEXT: %[[CST_RES_I32:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" into %[[CST_RES_I32_DEST]] : (tensor<4xi32>) -> tensor<4xi32>
   %cst_res_i32 = arith.constant dense_resource<resource_i32> : tensor<4xi32>
 
-  // CHECK-NEXT: %[[CST_RES_I1:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" : tensor<4xi1>
+  // CHECK-NEXT: %[[CST_RES_I1_DEST:.*]] = tensor.empty() : tensor<4xi1>
+  // CHECK-NEXT: %[[CST_RES_I1:.*]] = preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" into %[[CST_RES_I1_DEST]] : (tensor<4xi1>) -> tensor<4xi1>
   %cst_res_i1 = arith.constant dense_resource<resource_i1> : tensor<4xi1>
 
   // CHECK-NEXT: return %[[CST_SMALL]], %[[CST_LARGE]], %[[CST_I1]], %[[CST_RES_I32]], %[[CST_RES_I1]]

--- a/tests/Transforms/externalize_constants_splat.mlir
+++ b/tests/Transforms/externalize_constants_splat.mlir
@@ -13,7 +13,7 @@ func.func @splat() -> (tensor<4xi32>, tensor<4xi1>, tensor<4xi32>) {
 
   // A non-splat of the same size is still externalized, so the skip above is
   // not disabling the pass wholesale.
-  // CHECK: preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" : tensor<4xi32>
+  // CHECK: preprocessing.load_resource "runtime_dir/constant_{{.*}}.bin" into {{.*}} : (tensor<4xi32>) -> tensor<4xi32>
   %dense_i32 = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
 
   return %splat_i32, %splat_i1, %dense_i32 : tensor<4xi32>, tensor<4xi1>, tensor<4xi32>


### PR DESCRIPTION
`preprocessing.load_resource` simply returned the file contents into a tensor SSA value, which would then bufferize into a kind-of "floating" memref without a real allocation backing it (the file was kind of acting as the conceptual "allocation" if I understand the previous bufferization interface implementation?). Eventually, EmitC (e.g., as in the Cheddar backend) would take this slightly-weird-bufferized state and somehow turn it into "auto x = loadResource(...)" or similar. This is fine for smaller resources, but for larger resources, the local variable's automatic stack-based storage would immediately cause stack overflows. 

This PR changes it so that `preprocessing.load_resource` becomes DPS and gets an explicit target allocation (`memref.alloc`, so on the heap) during bufferization. ~~For small resources, the old stack allocation behaviour can be  automatically recovered by `--promote-buffers-to-stack` during the bufferization pipeline.~~
EDIT: I removed this - we only externalise large things to begin with, so there's no point to do this, and it also removes the need to support `memref.alloca` in the emitters, and means this basically an NFC for the existing emitters, just making live easier for Cheddar (and other potential EmitC backends, I'd assume?)

~~Unfortunately, this does require making the existing emitters aware of this, so sorry for the noisy diff~~
  
