### PR TITLE
tfhe-rust-hl: handle affine loop iter_args

### DIFF
--- a/lib/Target/TfheRustHL/TfheRustHLEmitter.cpp
+++ b/lib/Target/TfheRustHL/TfheRustHLEmitter.cpp
@@ -387,7 +387,13 @@ LogicalResult TfheRustHLEmitter::printOperation(affine::AffineForOp op) {
   if (!op.getInits().empty()) {
     suffix = " });\n";
 
-    emitAssignPrefix(op->getResult(0));
+    if (op.getNumResults() == 1) {
+      emitAssignPrefix(op.getResult(0));
+    } else {
+      os << "let (" << commaSeparatedValues(op.getResults(), [&](Value value) {
+        return variableNames->getNameForValue(value);
+      }) << ") = ";
+    }
 
     os << "(" << op.getConstantLowerBound() << ".."
        << op.getConstantUpperBound() << ")" << ".fold(";
@@ -402,10 +408,11 @@ LogicalResult TfheRustHLEmitter::printOperation(affine::AffineForOp op) {
                                  [&](Value value) {
                                    return variableNames->getNameForValue(value);
                                  })
-         << "), |mut ("
+         << "), |("
          << commaSeparatedValues(op.getRegionIterArgs(),
                                  [&](Value value) {
-                                   return variableNames->getNameForValue(value);
+                                   return "mut " +
+                                          variableNames->getNameForValue(value);
                                  })
          << "), ";
     }
@@ -432,11 +439,18 @@ LogicalResult TfheRustHLEmitter::printOperation(affine::AffineForOp op) {
 }
 
 LogicalResult TfheRustHLEmitter::printOperation(affine::AffineYieldOp op) {
-  if (op->getNumResults() != 0) {
-    return op.emitOpError() << "AffineYieldOp has non-zero number of results";
+  if (op.getNumOperands() == 0) {
+    return success();
   }
 
-  os << variableNames->getNameForValue(op->getOperand(0)) << "\n";
+  if (op.getNumOperands() == 1) {
+    os << variableNames->getNameForValue(op.getOperand(0)) << "\n";
+    return success();
+  }
+
+  os << "(" << commaSeparatedValues(op.getOperands(), [&](Value value) {
+    return variableNames->getNameForValue(value);
+  }) << ")\n";
 
   return success();
 }

--- a/tests/Regression/issue_3344.mlir
+++ b/tests/Regression/issue_3344.mlir
@@ -1,0 +1,10 @@
+// RUN: heir-translate --emit-tfhe-rust-hl %s | FileCheck %s
+
+// CHECK: pub fn f(
+// CHECK: for [[I:.*]] in 0..16 {
+// CHECK-NEXT: }
+func.func @f() {
+  affine.for %i = 0 to 16 {
+  }
+  return
+}

--- a/tests/Regression/issue_3344_multiple_iter_args.mlir
+++ b/tests/Regression/issue_3344_multiple_iter_args.mlir
@@ -1,0 +1,17 @@
+// RUN: heir-translate --emit-tfhe-rust-hl %s | FileCheck %s
+
+// CHECK: pub fn multiple_iter_args(
+// CHECK: let [[INIT0:.*]] = 0u32;
+// CHECK-NEXT: let [[INIT1:.*]] = 1u32;
+// CHECK-NEXT: let ([[RESULT0:.*]], [[RESULT1:.*]]) = (0..16).fold(([[INIT0]], [[INIT1]]), |(mut [[ITER0:.*]], mut [[ITER1:.*]]), [[I:.*]]| {
+// CHECK-NEXT: ([[ITER0]], [[ITER1]])
+// CHECK-NEXT: });
+// CHECK-NEXT: ([[RESULT0]], [[RESULT1]])
+func.func @multiple_iter_args() -> (i32, i32) {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %result0, %result1 = affine.for %i = 0 to 16 iter_args(%iter0 = %c0, %iter1 = %c1) -> (i32, i32) {
+    affine.yield %iter0, %iter1 : i32, i32
+  }
+  return %result0, %result1 : i32, i32
+}


### PR DESCRIPTION
Fixes #3344

New logic:
*  no operands / iter_args -> return success / do nothing
* 1 operand / iter_arg-> old behaviour
* multiple operands/ iter_args -> target the (fixed up  by 🤖 ) tuple emitter

note: the previous check for non-zero results was dead (`affine.yield` has zero results by definition/verifier) and got removed. 