### PR TITLE
Fix IndexError in lit_to_bazel for files without run commands

### DIFF
--- a/scripts/lit_to_bazel_lib.py
+++ b/scripts/lit_to_bazel_lib.py
@@ -130,11 +130,11 @@ def get_command_without_bazel_prefix(lit_test_file) -> str:
   commands = convert_to_run_commands(run_lines)
   commands = [x for x in commands if "FileCheck" not in x]
   # remove consecutive and trailing pipes
-  if commands[-1] == PIPE:
+  if commands and commands[-1] == PIPE:
     commands.pop()
   deduped_commands = []
   for command in commands:
-    if command == PIPE and deduped_commands[-1] == PIPE:
+    if command == PIPE and deduped_commands and deduped_commands[-1] == PIPE:
       continue
     deduped_commands.append(command)
 

--- a/scripts/test_lit_to_bazel.py
+++ b/scripts/test_lit_to_bazel.py
@@ -8,6 +8,9 @@ patch = absltest.mock.patch
 PIPE = lit_to_bazel_lib.PIPE
 convert_to_run_commands = lit_to_bazel_lib.convert_to_run_commands
 normalize_lit_test_file_arg = lit_to_bazel_lib.normalize_lit_test_file_arg
+get_command_without_bazel_prefix = (
+    lit_to_bazel_lib.get_command_without_bazel_prefix
+)
 
 
 class LitToBazelTest(absltest.TestCase):
@@ -185,6 +188,35 @@ class LitToBazelTest(absltest.TestCase):
             ),
             "/workspace/tests/foo.mlir",
         )
+
+  def test_get_command_without_bazel_prefix_no_run_lines(self):
+    """A file with no RUN lines should yield an empty command, not crash."""
+    with absltest.mock.patch(
+        "builtins.open",
+        absltest.mock.mock_open(read_data="func.func @foo() -> i8\n"),
+    ):
+      self.assertEqual(get_command_without_bazel_prefix("fake.mlir"), "")
+
+  def test_get_command_without_bazel_prefix_only_filecheck(self):
+    """A file whose only RUN line is FileCheck should yield an empty command."""
+    with absltest.mock.patch(
+        "builtins.open",
+        absltest.mock.mock_open(read_data="// RUN: FileCheck %s\n"),
+    ):
+      self.assertEqual(get_command_without_bazel_prefix("fake.mlir"), "")
+
+  def test_get_command_without_bazel_prefix_filecheck_then_pipe(self):
+    """A FileCheck command followed by a pipe should not crash."""
+    with absltest.mock.patch(
+        "builtins.open",
+        absltest.mock.mock_open(
+            read_data="// RUN: FileCheck %s | heir-opt --canonicalize\n"
+        ),
+    ):
+      self.assertEqual(
+          get_command_without_bazel_prefix("fake.mlir"),
+          "| heir-opt --canonicalize",
+      )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`get_command_without_bazel_prefix` in `scripts/lit_to_bazel_lib.py` crashed with `IndexError: list index out of range` whenever the input file contained no `// RUN:` lines — or only `// RUN: FileCheck %s` lines — because it accessed `commands[-1]` (and later `deduped_commands[-1]`) on an empty list.

This is easy to trigger in practice: `lit_to_bazel` is a developer helper that is frequently pointed at plain `.mlir` input files (e.g. files under `tests/Examples/common/`) which are not lit tests and therefore have no `// RUN:` directives.

## Changes

- Guard the trailing-pipe removal with `if commands and commands[-1] == PIPE`.
- Guard the consecutive-pipe dedup with `if command == PIPE and deduped_commands and deduped_commands[-1] == PIPE`.
- Added unit tests for: a file with no RUN lines, a file whose only RUN line is FileCheck, and a FileCheck command followed by a pipe.

## Testing

- `python -m scripts.test_lit_to_bazel` — the 3 new tests pass. (Three pre-existing `normalize_lit_test_file_arg` tests fail only under Windows due to `os.path.join` path separators; they pass on Linux CI.)