### PR TITLE
fix: a series of small mgmt & lattigo bugs

### DIFF
--- a/lib/Analysis/OptimizeRelinearizationAnalysis/BUILD
+++ b/lib/Analysis/OptimizeRelinearizationAnalysis/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "@com_google_ortools//ortools/math_opt/solvers:gscip_solver",
         "@heir//lib/Analysis/DimensionAnalysis",
         "@heir//lib/Analysis/SecretnessAnalysis",
+        "@heir//lib/Dialect/Kernel/IR:Dialect",
         "@heir//lib/Dialect/Mgmt/IR:Dialect",
         "@heir//lib/Dialect/Secret/IR:Dialect",
         "@heir//lib/Dialect/TensorExt/IR:Dialect",

--- a/lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.cpp
+++ b/lib/Analysis/OptimizeRelinearizationAnalysis/OptimizeRelinearizationAnalysis.cpp
@@ -8,6 +8,7 @@
 
 #include "lib/Analysis/DimensionAnalysis/DimensionAnalysis.h"
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
+#include "lib/Dialect/Kernel/IR/KernelOps.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
 #include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
@@ -230,7 +231,12 @@ LogicalResult OptimizeRelinearizationAnalysis::solve() {
     }
 
     bool requireLinear = false;
-    if (isa<tensor_ext::RotateOp, secret::YieldOp, mgmt::ModReduceOp>(op)) {
+    // A linear transform is a bundle of rotations under Galois keys, and a
+    // Chebyshev evaluation multiplies its input, so like rotation both need a
+    // linear operand; without this the model may defer a relinearization past
+    // them and leave it applied to an already-linear result.
+    if (isa<tensor_ext::RotateOp, secret::YieldOp, mgmt::ModReduceOp,
+            kernel::LinearTransformOp, kernel::EvalChebyshevOp>(op)) {
       requireLinear = true;
     } else {
       SmallVector<OpOperand*, 4> secretOperands;

--- a/lib/Dialect/Kernel/IR/BUILD
+++ b/lib/Dialect/Kernel/IR/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect/LWE/IR:Dialect",
         "@heir//lib/Target/CompilationTarget",
+        "@heir//lib/Utils:MathUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:Support",

--- a/lib/Dialect/Kernel/IR/KernelOps.cpp
+++ b/lib/Dialect/Kernel/IR/KernelOps.cpp
@@ -11,6 +11,7 @@
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
 #include "lib/Target/CompilationTarget/CompilationTarget.h"
+#include "lib/Utils/MathUtils.h"
 #include "mlir/include/mlir/IR/BuiltinOps.h"  // from @llvm-project
 
 // IWYU pragma: begin_keep
@@ -117,7 +118,7 @@ int EvalChebyshevOp::getLevelsToDrop() {
   uint32_t degree = coefficients.size() - 1;
   switch (backend) {
     case BackendName::Lattigo:
-      baseDepth = std::bit_width(static_cast<uint64_t>(degree));
+      baseDepth = lattigoChebyshevDepth(degree);
       break;
     case BackendName::OpenFHE:
       if (degree == 0) {
@@ -187,10 +188,12 @@ LogicalResult LinearTransformOp::verify() {
       return emitOpError("input must be 1D or 2D ranked tensor");
     }
 
+    // The diagonals may be narrower than the ciphertext: the transform then
+    // acts on the leading slots and the backend's encoder zero-fills the rest.
     int64_t diagonalSlotSize = diagonalsType.getDimSize(1);
-    if (inputSize != diagonalSlotSize) {
+    if (inputSize < diagonalSlotSize) {
       return emitOpError("input slot size (")
-             << inputSize << ") must match diagonals slot size ("
+             << inputSize << ") is smaller than diagonals slot size ("
              << diagonalSlotSize << ")";
     }
   }

--- a/lib/Dialect/Lattigo/IR/BUILD
+++ b/lib/Dialect/Lattigo/IR/BUILD
@@ -90,6 +90,7 @@ cc_library(
         ":types_inc_gen",
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Utils",
+        "@heir//lib/Utils:MathUtils",
         "@heir//lib/Utils:RotationUtils",
         "@heir//lib/Utils/Tablegen:InPlaceOpInterface",
         "@llvm-project//mlir:IR",

--- a/lib/Dialect/Lattigo/IR/LattigoCKKSOps.td
+++ b/lib/Dialect/Lattigo/IR/LattigoCKKSOps.td
@@ -365,6 +365,10 @@ def Lattigo_CKKSLinearTransformOp : Lattigo_CKKSOp<"linear_transform", [
     This operation applies a linear transform on a CKKS ciphertext using
     the provided float diagonals.
 
+    The transform is built at the input ciphertext's own level, so evaluating
+    it technically consumes no level: the result comes back at the input's level
+    but with a multiplied scale (requiring a separate rescale afterwards).
+
     The linear transform is defined by a set of diagonals, where each diagonal
     represents a specific shift and scaling of the input ciphertext slots.
 
@@ -425,7 +429,10 @@ def Lattigo_CKKSNewPolynomialEvaluatorOp : Lattigo_CKKSOp<"new_polynomial_evalua
 }
 
 
-def Lattigo_CKKSChebyshevOp : Lattigo_CKKSOp<"chebyshev", [AllTypesMatch<["ciphertext", "output"]>]> {
+def Lattigo_CKKSChebyshevOp : Lattigo_CKKSOp<"chebyshev", [
+  AllTypesMatch<["ciphertext", "output"]>,
+  DeclareOpInterfaceMethods<ReducesLevelOpInterface, ["getLevelsToDrop", "getOperandsToReduce"]>
+]> {
   let summary = "Evaluate a chebyshev polynomial on a lattigo CKKS ciphertext";
   let description = [{
     This operation evaluates a chebyshev polynomial on a CKKS ciphertext using

--- a/lib/Dialect/Lattigo/IR/LattigoOps.cpp
+++ b/lib/Dialect/Lattigo/IR/LattigoOps.cpp
@@ -4,6 +4,7 @@
 
 #include "lib/Dialect/HEIRInterfaces.h"
 #include "lib/Dialect/Lattigo/IR/LattigoTypes.h"
+#include "lib/Utils/MathUtils.h"
 #include "lib/Utils/RotationUtils.h"
 #include "lib/Utils/Utils.h"
 #include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
@@ -75,6 +76,20 @@ int RLWEDropLevelOp::getLevelsToDrop() { return getLevelToDrop(); }
   return {&getOperation()->getOpOperand(1)};
 }
 
+int CKKSChebyshevOp::getLevelsToDrop() {
+  auto coefficients = getCoefficients().getValue();
+  if (coefficients.empty()) {
+    // The zero polynomial consumes no depth.
+    return 0;
+  }
+  return lattigoChebyshevDepth(coefficients.size() - 1);
+}
+
+::llvm::SmallVector<::mlir::OpOperand*> CKKSChebyshevOp::getOperandsToReduce(
+    const ::mlir::DataFlowSolver* solver) {
+  return {&getOperation()->getOpOperand(1)};
+}
+
 ::mlir::OpOperand& CKKSBootstrapOp::getOperandToReset() {
   return getOperation()->getOpOperand(1);
 }
@@ -131,7 +146,10 @@ CKKSRotateNewOp::getRotationIndices() {
 
 ::llvm::SmallVector<::mlir::OpFoldResult>
 CKKSLinearTransformOp::getRotationIndices() {
-  auto diagonalsType = cast<RankedTensorType>(getDiagonals().getType());
+  // The diagonals arrive as a tensor before bufferization and as a memref
+  // after it, and this accessor is reachable in both states.
+  //  Match on ShapedType so it does not assert on legal IR.
+  auto diagonalsType = cast<ShapedType>(getDiagonals().getType());
   int64_t slots = diagonalsType.getShape()[1];
   int64_t logBSGS = getLogBabyStepGiantStepRatio().getInt();
   auto rotations = lintransRotationIndices(

--- a/lib/Target/Lattigo/LattigoEmitter.cpp
+++ b/lib/Target/Lattigo/LattigoEmitter.cpp
@@ -2283,7 +2283,7 @@ LogicalResult LattigoEmitter::printOperation(CKKSBootstrapOp op) {
 
   std::string resultName = getName(op.getResult());
   emitAssignmentWithErr(resultName, getName(op.getEvaluator()) + ".Bootstrap(" +
-                                        getName(op.getInput()) + ")");
+                                        getName(op.getInput()) + ".CopyNew())");
   return success();
 }
 

--- a/lib/Target/Lattigo/TargetConfig.td
+++ b/lib/Target/Lattigo/TargetConfig.td
@@ -1,6 +1,9 @@
 include "lib/Target/CompilationTarget/HEIRTarget.td"
 
 def Lattigo : CompilationTarget<"lattigo"> {
-  let bootstrapLevelsConsumed = 16;
+  // Lattigo's bootstrapping circuit runs in its own part of the parameter set,
+  // whose ring carries extra primes, so a bootstrap returns the ciphertext at
+  // the top of the standard compute chain and consumes none of it.
+  let bootstrapLevelsConsumed = 0;
   let has_kernel_chebyshev = 1;
 }

--- a/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
@@ -143,6 +143,11 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
       return;
     }
 
+    // The data occupies minSlotCount slots regardless of how large the ring
+    // has to be, so the layouts' packing width is recorded before any bump
+    // below. Widening it would desync the packed layouts from the ciphertexts.
+    int64_t requestedSlotCount = minSlotCount;
+
     // for lattigo, defaults to extended encryption technique
     if (moduleIsLattigo(getOperation())) {
       encryptionTechniqueExtended = true;
@@ -170,7 +175,7 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
     auto* context = &getContext();
     OpBuilder builder(context);
     getOperation()->setAttr(kRequestedSlotCountAttrName,
-                            builder.getI64IntegerAttr(minSlotCount));
+                            builder.getI64IntegerAttr(requestedSlotCount));
     getOperation()->setAttr(
         kActualSlotCountAttrName,
         builder.getI64IntegerAttr(schemeParam.getRingDim() / 2));

--- a/lib/Transforms/SecretInsertMgmt/Pipeline.cpp
+++ b/lib/Transforms/SecretInsertMgmt/Pipeline.cpp
@@ -650,6 +650,13 @@ void insertBootstrapWaterLine(Operation* top, int bootstrapWaterline,
     if (isa<secret::SecretType>(value.getType())) {
       return;
     }
+    // Only a ciphertext can be bootstrapped. A plaintext has no level state
+    // for the analysis to track, which reads as "needs bootstrap", and
+    // refreshing it would leave a mgmt.bootstrap on a plaintext operand that
+    // no lowering can convert.
+    if (!isSecret(value, &solver)) {
+      return;
+    }
     if (auto* lattice = solver.lookupState<BootstrapWaterlineLattice>(value)) {
       if (lattice->getValue().getNeedsBootstrap()) {
         targets.push_back(value);

--- a/lib/Utils/MathUtils.h
+++ b/lib/Utils/MathUtils.h
@@ -1,6 +1,7 @@
 #ifndef LIB_UTILS_MATHUTILS_H_
 #define LIB_UTILS_MATHUTILS_H_
 
+#include <bit>
 #include <cstdint>
 #include <optional>
 
@@ -28,6 +29,12 @@ inline uint64_t nextPowerOfTwo(uint64_t v) {
 }
 
 inline bool isPowerOfTwo(int64_t n) { return (n > 0) && ((n & (n - 1)) == 0); }
+
+// Levels consumed by Lattigo's polynomial evaluator for a Chebyshev polynomial
+// of the given degree: one per level of the binary evaluation tree.
+inline int lattigoChebyshevDepth(uint32_t degree) {
+  return std::bit_width(static_cast<uint64_t>(degree));
+}
 
 // Convert an input APFloat to the given semantics
 APFloat convertFloatToSemantics(APFloat value,

--- a/lib/Utils/RotationUtils.h
+++ b/lib/Utils/RotationUtils.h
@@ -20,7 +20,7 @@ inline int64_t normalizeRotation(int64_t rot, int64_t slots) {
 /// Mirrors Lattigo's lintrans.FindBestBSGSRatio.
 inline int64_t findBestBSGSRatio(llvm::ArrayRef<int32_t> diags, int64_t slots,
                                  int64_t logMaxRatio) {
-  int64_t maxRatio = 1LL << logMaxRatio;
+  double maxRatio = static_cast<double>(1LL << logMaxRatio);
   for (int64_t n1 = 1; n1 < slots; n1 <<= 1) {
     llvm::DenseSet<int64_t> rotN1Set, rotN2Set;
     for (auto rot : diags) {
@@ -28,12 +28,12 @@ inline int64_t findBestBSGSRatio(llvm::ArrayRef<int32_t> diags, int64_t slots,
       rotN1Set.insert(normalizeRotation((r / n1) * n1, slots));
       rotN2Set.insert(r % n1);
     }
-    int64_t nbN1 = static_cast<int64_t>(rotN1Set.size()) - 1;
-    int64_t nbN2 = static_cast<int64_t>(rotN2Set.size()) - 1;
-    if (nbN1 > 0) {
-      if (nbN2 == maxRatio * nbN1) return n1;
-      if (nbN2 > maxRatio * nbN1) return n1 / 2;
-    }
+    double nbN1 = static_cast<double>(rotN1Set.size()) - 1;
+    double nbN2 = static_cast<double>(rotN2Set.size()) - 1;
+    // Float division without a nonzero guard, as Lattigo does it.
+    double ratio = nbN2 / nbN1;
+    if (ratio == maxRatio) return n1;
+    if (ratio > maxRatio) return n1 / 2;
   }
   return 1;
 }

--- a/tests/Dialect/Kernel/invalid.mlir
+++ b/tests/Dialect/Kernel/invalid.mlir
@@ -35,13 +35,13 @@ func.func @test_input_not_1d_or_2d(%arg0: tensor<1x2x3xf32>) -> tensor<1x2x3xf32
 
 // -----
 
-func.func @test_slot_size_mismatch(%arg0: tensor<4xf32>) -> tensor<4xf32> {
-  // expected-error@below {{input slot size (4) must match diagonals slot size (3)}}
+func.func @test_slot_size_mismatch(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+  // expected-error@below {{input slot size (2) is smaller than diagonals slot size (3)}}
   %0 = kernel.linear_transform %arg0 {
     diagonals = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf32>,
     diagonal_indices = array<i64: 0, 1>
-  } : tensor<4xf32> -> tensor<4xf32>
-  return %0 : tensor<4xf32>
+  } : tensor<2xf32> -> tensor<2xf32>
+  return %0 : tensor<2xf32>
 }
 
 // -----

--- a/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_chebyshev_levels.mlir
+++ b/tests/Dialect/Lattigo/Transforms/alloc_to_inplace_chebyshev_levels.mlir
@@ -1,0 +1,26 @@
+// RUN: heir-opt --lattigo-alloc-to-inplace %s | FileCheck %s
+
+// A chebyshev evaluation consumes bit_width(degree) levels, so its result sits
+// far below its operand. Reusing it as the storage for a higher-level op would
+// silently truncate that op's result to the chebyshev level, because lattigo
+// evaluates at min(operand, output) level.
+
+!ckks_evaluator = !lattigo.ckks.evaluator
+!params = !lattigo.ckks.parameter
+!poly_eval = !lattigo.ckks.polynomial_evaluator
+!pt = !lattigo.rlwe.plaintext
+!ct = !lattigo.rlwe.ciphertext
+
+// CHECK: func.func @chebyshev_consumes_levels
+func.func @chebyshev_consumes_levels(%params: !params, %evaluator: !ckks_evaluator, %ct: !ct, %pt: !pt) -> (!ct, !ct) {
+  %poly_eval = lattigo.ckks.new_polynomial_evaluator %params, %evaluator : (!params, !ckks_evaluator) -> !poly_eval
+  // A degree-15 polynomial drops 4 levels.
+  // CHECK: %[[CHEB:.*]] = lattigo.ckks.chebyshev
+  %cheb = lattigo.ckks.chebyshev %poly_eval, %ct {coefficients = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], targetScale = 1073741824} : (!poly_eval, !ct) -> !ct
+  // %cheb is dead after this point, but it is 4 levels below %ct, so the
+  // add on the untouched %ct must not be given %cheb as its output buffer.
+  // CHECK-NOT: lattigo.ckks.add %{{.*}}, %{{.*}}, %{{.*}}, %[[CHEB]]
+  // CHECK: lattigo.ckks.add_new %{{.*}}, %{{.*}}, %{{.*}} :
+  %high = lattigo.ckks.add_new %evaluator, %ct, %pt : (!ckks_evaluator, !ct, !pt) -> !ct
+  return %cheb, %high : !ct, !ct
+}

--- a/tests/Dialect/Mgmt/Transforms/bootstrap_config_recognized.mlir
+++ b/tests/Dialect/Mgmt/Transforms/bootstrap_config_recognized.mlir
@@ -18,6 +18,6 @@ module attributes {scheme.ckks} {
 // CHECK-OPENFHE: mgmt.bootstrap
 // CHECK-OPENFHE-SAME: {mgmt.mgmt = #mgmt.mgmt<level = 0>{{.*}}}
 
-// CHECK-LATTIGO: func.func @main(%arg0: !secret.secret<tensor<8xi8>> {mgmt.mgmt = #mgmt.mgmt<level = 16>})
+// CHECK-LATTIGO: func.func @main(%arg0: !secret.secret<tensor<8xi8>> {mgmt.mgmt = #mgmt.mgmt<level = 0>})
 // CHECK-LATTIGO: mgmt.bootstrap
 // CHECK-LATTIGO-SAME: {mgmt.mgmt = #mgmt.mgmt<level = 0>{{.*}}}

--- a/tests/Emitter/Lattigo/bootstrap.mlir
+++ b/tests/Emitter/Lattigo/bootstrap.mlir
@@ -2,7 +2,9 @@
 
 // CHECK: func Test_bootstrap(
 // CHECK-SAME: [[BOOT_EVAL:[^, ]+]] *bootstrapping.Evaluator, [[EVAL:[^, ]+]] *ckks.Evaluator, [[CT_IN:[^, ]+]] *rlwe.Ciphertext, [[CT_OTHER:[^, ]+]] *rlwe.Ciphertext
-// CHECK:   [[CT_OUT:[^, ]+]], err{{.*}} := [[BOOT_EVAL]].Bootstrap([[CT_IN]])
+// lattigo's Bootstrap mod-ups its argument in place, so the operand is
+// handed a copy to keep it usable afterwards.
+// CHECK:   [[CT_OUT:[^, ]+]], err{{.*}} := [[BOOT_EVAL]].Bootstrap([[CT_IN]].CopyNew())
 // CHECK:   if err{{.*}} != nil {
 // CHECK:     panic(err{{.*}})
 // CHECK:   }

--- a/tests/Examples/lattigo/ckks/relu_composite/BUILD
+++ b/tests/Examples/lattigo/ckks/relu_composite/BUILD
@@ -19,7 +19,7 @@ heir_lattigo_lib(
     go_library_name = "relucomposite",
     heir_opt_flags = [
         "--annotate-module=backend=lattigo scheme=ckks",
-        "--torch-linalg-to-ckks=min-slot-count=1024 use-composite-relu=true greedy-level-budget=14",
+        "--torch-linalg-to-ckks=min-slot-count=1024 use-composite-relu=true greedy-level-budget=30",
         "--scheme-to-lattigo",
     ],
     mlir_src = "@heir//tests/Examples/common:relu_composite.mlir",

--- a/tests/Transforms/secret_insert_mgmt/ckks/if.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/if.mlir
@@ -1,4 +1,8 @@
-// RUN: heir-opt "--secret-insert-mgmt-ckks=after-mul=true before-mul-include-first-mul=false bootstrap-waterline=10 level-budget=2 min-slot-count=1024" %s | FileCheck %s
+// RUN: heir-opt "--secret-insert-mgmt-ckks=after-mul=true before-mul-include-first-mul=false bootstrap-waterline=10 level-budget=18 min-slot-count=1024" %s | FileCheck %s
+
+// The level budget is stated in full: a lattigo bootstrap consumes none of the
+// compute chain, so the pass no longer adds its depth to the budget on the
+// test's behalf.
 
 // CHECK: func.func @matvec
 // CHECK-SAME: {mgmt.mgmt = #mgmt.mgmt<level = 1>}

--- a/tests/Transforms/secret_insert_mgmt/ckks/loop_invariant_hoist_reproducer.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/loop_invariant_hoist_reproducer.mlir
@@ -6,7 +6,11 @@
 
 #layout = #tensor_ext.layout<"{ [i0, i1] -> [ct, slot] : i0 = 0 and ct = 0 and (-i1 + slot) mod 16 = 0 and 0 <= i1 <= 12 and 0 <= slot <= 4095 }">
 #original_type = #tensor_ext.original_type<originalType = tensor<1x13xf32>, layout = #layout>
-module attributes {backend.lattigo, scheme.ckks} {
+// The level trajectory captured below was written assuming a bootstrap consumes 16 levels of the compute chain.
+// In fact, Lattigo's bootstrap levels separate from the compute chain, but that is incidental to this test
+// so we override the bootstrapLevelsConsumed backend config here to match the intended level trajectory.
+module attributes {backend.lattigo, scheme.ckks,
+                   backend.config_override = {bootstrapLevelsConsumed = 16 : i32}} {
   func.func private @_assign_layout_16889166383960922983() -> tensor<64x4096xf32> attributes {client.pack_func = {func_name = "tcresnet8small"}} {
     %cst = arith.constant dense_resource<__elided__> : tensor<48x48x6xf32>
     %c48_i32 = arith.constant 48 : i32


### PR DESCRIPTION
A series of small fixes, mostly around Lattigo and related mgmt/etc that seemed too small to warrant individual PRs (but I'm happy to split this up if needed)


Summaries/Explanations (🤖 generated, sorry) of the changes below: 

* **Mirror Lattigo's FindBestBSGSRatio exactly for sparse diagonal sets**

    findBestBSGSRatio guarded the ratio comparison with nbN1 > 0 and compared in
    integers. Lattigo divides in floating point without that guard, so a sparse
    diagonal set, where nbN1 reaches 0 with nbN2 > 0, must take the > maxRatio
    branch on the resulting +inf (and continue on a NaN 0/0). Guarding skips those
    iterations and can select a different baby-step size than the backend, which
    then generates rotation keys for the wrong Galois elements. Dense diagonal sets
    never reach nbN1 == 0, so this only shows up for sparse transforms such as an
    expanded convolution filter.

* **Record the packing width before the bootstrap bump**

    Lattigo bootstrapping needs LogN >= 14, and since the ring dimension follows
    from the slot count, the pass bumps minSlotCount to 8192 to get there. That
    bump is about the ring, but it was also written back as the requested slot
    count, which is what the layouts packed to and what plaintexts are encoded at.
    Widening it desyncs the packed layouts from the ciphertexts.

    Keep the pre-bump value for the requested-slot-count attribute.

* **Require a linear operand for the kernel ops when placing relinearization**

    A linear transform is a bundle of rotations under Galois keys, and a Chebyshev
    evaluation multiplies its input, so both need a linear ciphertext just as
    tensor_ext.rotate does. Without that constraint the model may defer a
    relinearization past them, leaving it applied to an already-linear result:
    lattigo then fails with "ctIn.Degree() should be 2 but is 1".

    This only becomes reachable once linear transforms survive to the backend.

* **Only bootstrap ciphertexts**

    The bootstrap target walk filtered values by secret type, which does not
    exclude a plaintext: a plaintext has no level for the analysis to track, that
    reads as "needs bootstrap", and the pass then put a mgmt.bootstrap on an
    mgmt.init. Nothing lowers that, and it surfaces far away as a ct-ct multiply
    against a plaintext operand ('ckks.mul' op operand #0 must be
    lwe-ciphertext-like).

    Ask the secretness analysis as well.

* **Charge lattigo's bootstrap no compute levels**

    Lattigo runs its bootstrapping circuit in its own parameter set, whose ring
    carries extra primes: bootstrapping.NewParametersFromLiteral takes the compute
    parameters as the *residual* ones. A bootstrap therefore returns the ciphertext
    at the top of the compute chain and consumes none of it. Probing the emitted Go
    for tcn confirms it: Bootstrap(in=41) returns out=26 with maxlevel=26.

    Charging 16 levels made every level after a bootstrap 16 too low, which both
    inflated the modulus chain and mis-scheduled the rescales that follow.

    The budget the pass works from is levelBudget + bootstrapLevelsConsumed, so
    a test that stated its budget net of the old 16-level charge now has to name
    the total it meant: if.mlir asks for 18 where it used to ask for 2.
    relu_composite now also inserts a real bootstrap, so its e2e test accepts
    the bootstrapping evaluator and covers the correspondingly slower path.
    loop_invariant_hoist_reproducer instead keeps the old charge as an explicit
    override: its module was captured off tcresnet8small under a 16-level
    charge, and reaching the loop with the levels exhausted is a precondition of
    the hoisting it asserts rather than a property of lattigo.

* **Bootstrap a copy so the operand survives**

    lattigo's Bootstrap mod-ups its argument into the bootstrapping ring in place
    and leaves it there, which a probe on the emitted Go shows plainly:

        boot BEFORE: ct4 lvl=1  log2scale=45
        boot AFTER : ct4 lvl=29 log2scale=52      <- argument clobbered
                     out ct92 lvl=14 log2scale=45 <- result is fine

    The op is a function of its operand, though, so the operand may still be live,
    and a composite ReLU makes that the common case: x * step(x) needs the
    un-bootstrapped x alongside the refreshed branch that produced step(x). On tcn,
    7 of 28 bootstrap operands are read again afterwards - already at the CKKS
    level, before any in-place assignment - so those reads take a ciphertext that
    is no longer in the compute ring. The values are wrong from there on, and the
    scale it leaves behind (2^52 against a base of 2^45) propagates until a later
    bootstrap fails lattigo's message-ratio check:

        panic: cannot BootstrapMany: initial Q/Scale = 7.999996
               < 0.5*Q[0]/MessageRatio = 256.000000

    Hand lattigo a copy. A ciphertext copy is negligible next to a bootstrap, so
    this is unconditional rather than guarded on the operand having later uses.

    This is the convention the dialect already uses for a value-semantics op whose
    lattigo call is in-place: rescale_new, drop_level_new and negate_new all copy
    the input and hand the copy to the in-place method. bootstrap was the one that
    passed its operand straight in. Keeping the op Pure is right - the copy is what
    makes it true - and it lets CSE deduplicate bootstraps of the same value, which
    is worth having for the most expensive op in the program.

    The op description still says it "applies bootstrapping in-place", which now
    describes the lattigo call rather than the op; worth a separate docs pass.

* **Model the level a lattigo chebyshev consumes**

    In the lattigo dialect every ciphertext has the same opaque type, so an
    analysis learns a value's level only from the interfaces an op declares.
    ckks.chebyshev declared none and was therefore modelled as consuming nothing,
    while it consumes one level per level of the binary evaluation tree. Nothing
    checks that belief, so the error is silent: alloc-to-inplace hands a
    chebyshev's exhausted buffer to a later op as its destination, the backend
    evaluates into it at min(operands, destination), and the quietly truncated
    result surfaces much later as "cannot Rescale: input Ciphertext level is too
    low". Declare ReducesLevelOpInterface, mirroring the depth
    kernel.eval_chebyshev already models.

    ckks.linear_transform deliberately does NOT declare it, and the op
    description now says why: the transform is built at the input ciphertext's
    own level, so evaluating it consumes no level, and the rescale the lowering
    emits straight afterwards is the single level the multiplication costs.
    Charging the transform as well double-counts, which drifts every value
    downstream of a transform one level too deep until the next bootstrap resets
    it, and makes the alloc-to-inplace level comparison unsound in a way the pass
    cannot see.

* **Do not assert in getRotationIndices on a bufferized diagonals operand**

    CKKSLinearTransformOp::getRotationIndices cast the diagonals operand to
    RankedTensorType. The operand is a tensor before bufferization and a memref
    after it, and the accessor is reachable in both states, so on an
    already-bufferized module the cast aborts:

        Casting.h:560: cast<To = mlir::RankedTensorType, From = mlir::ShapedType>:
        Assertion `isa<To>(Val)' failed

    The full pipeline runs configure-crypto-context before bufferization, so this
    does not fire during a normal compile. It fires when the analysis is run on a
    dumped module, which is how rotation-key collection gets debugged. Match on
    ShapedType, which is all the accessor needs.