### PR TITLE
Record where a ciphertext argument starts on the modulus chain

### DIFF
--- a/lib/Analysis/LevelAnalysis/LevelAnalysis.h
+++ b/lib/Analysis/LevelAnalysis/LevelAnalysis.h
@@ -8,6 +8,7 @@
 
 #include "lib/Analysis/SecretnessAnalysis/SecretnessAnalysis.h"
 #include "lib/Dialect/Mgmt/IR/MgmtOps.h"
+#include "lib/Utils/AttributeUtils.h"
 #include "lib/Utils/Utils.h"
 #include "llvm/include/llvm/Support/Debug.h"        // from @llvm-project
 #include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
@@ -40,6 +41,11 @@
 // analysis, and mod_reduce/level_reduce causes levels do decrement.
 namespace mlir {
 namespace heir {
+/// Records how many levels a ciphertext function argument has already consumed
+/// on entry. Backend dialects give every ciphertext the same opaque type, so an
+/// analysis running after that lowering cannot recover the argument's level
+/// from the type and would otherwise assume the argument is fresh.
+constexpr StringRef kEntryLevelDepthAttrName = "lwe.entry_level_depth";
 
 constexpr int kDefaultLevelBudget = 40;
 
@@ -202,7 +208,24 @@ class LevelAnalysis
   friend class SecretnessAnalysisDependent<LevelAnalysis>;
 
   void setToEntryState(LevelLattice* lattice) override {
-    propagateIfChanged(lattice, lattice->join(LevelState(0)));
+    // A function argument is not necessarily fresh: a client may hand the
+    // entry point a ciphertext that has already consumed levels. Assuming
+    // depth 0 makes every value derived from such an argument look shallower
+    // than it is, which later reads as "this buffer still has levels left".
+    propagateIfChanged(
+        lattice,
+        lattice->join(LevelState(getEntryLevelDepth(lattice->getAnchor()))));
+  }
+
+  /// Levels already consumed by `value` on entry, from the attribute the
+  /// backend lowering leaves behind. Zero (fresh) when unannotated.
+  static int getEntryLevelDepth(Value value) {
+    auto attr = findAttributeAssociatedWith(value, kEntryLevelDepthAttrName);
+    if (failed(attr)) {
+      return 0;
+    }
+    auto intAttr = dyn_cast<IntegerAttr>(*attr);
+    return intAttr ? static_cast<int>(intAttr.getInt()) : 0;
   }
 
   LogicalResult visitOperation(Operation* op,

--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/BUILD
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/BUILD
@@ -14,6 +14,7 @@ cc_library(
     ],
     deps = [
         ":pass_inc_gen",
+        "@heir//lib/Analysis/LevelAnalysis",
         "@heir//lib/Dialect:ModuleAttributes",
         "@heir//lib/Dialect/BGV/IR:Dialect",
         "@heir//lib/Dialect/CKKS/IR:Dialect",

--- a/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
+++ b/lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.cpp
@@ -1,9 +1,12 @@
 #include "lib/Dialect/LWE/Conversions/LWEToLattigo/LWEToLattigo.h"
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 
+#include "lib/Analysis/LevelAnalysis/LevelAnalysis.h"
+#include "lib/Dialect/BGV/IR/BGVAttributes.h"
 #include "lib/Dialect/BGV/IR/BGVDialect.h"
 #include "lib/Dialect/BGV/IR/BGVOps.h"
 #include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
@@ -765,6 +768,24 @@ struct ConvertKernelEvalChebyshevOp
   }
 };
 
+// The top of the module's ciphertext modulus chain, i.e. the level a fresh
+// ciphertext sits at. Read from the scheme parameters rather than from any one
+// ciphertext type: an LWE type's own `elements` list can be a truncated view of
+// the chain (a fully consumed value shows up as `elements = <1 modulus>,
+// current = 0`), and measuring a level against a truncated list understates it.
+// Nullopt for a module without scheme parameters (hand-written test IR), where
+// the type's own list is the only chain length on offer.
+std::optional<int> getSchemeMaxLevel(Operation* moduleOp) {
+  Attribute schemeParam = getSchemeParamAttr(moduleOp);
+  if (auto ckksParam = dyn_cast<ckks::SchemeParamAttr>(schemeParam)) {
+    return static_cast<int>(ckksParam.getQ().size()) - 1;
+  }
+  if (auto bgvParam = dyn_cast<bgv::SchemeParamAttr>(schemeParam)) {
+    return static_cast<int>(bgvParam.getQ().size()) - 1;
+  }
+  return std::nullopt;
+}
+
 }  // namespace
 
 // BGV
@@ -903,6 +924,41 @@ struct LWEToLattigo : public impl::LWEToLattigoBase<LWEToLattigo> {
   void runOnOperation() override {
     // Save the dialect attributes of func::CallOp before conversion.
     saveFuncCallOpDialectAttrs();
+
+    // Every lattigo ciphertext has the same opaque type, so a ciphertext
+    // argument that does not start at the top of the modulus chain is
+    // indistinguishable from one that does afterwards. Record how far down the
+    // chain it starts while the LWE type still says so, so analyses running on
+    // the lowered IR do not assume every argument is at the top.
+    std::optional<int> schemeMaxLevel = getSchemeMaxLevel(getOperation());
+    getOperation()->walk([&](FunctionOpInterface funcOp) {
+      if (funcOp.getFunctionBody().empty()) {
+        return;
+      }
+      for (BlockArgument arg : funcOp.getArguments()) {
+        auto ctTy = dyn_cast<lwe::LWECiphertextType>(
+            getElementTypeOrSelf(arg.getType()));
+        if (!ctTy) {
+          continue;
+        }
+        auto chain = ctTy.getModulusChain();
+        if (!chain) {
+          continue;
+        }
+        // `current` indexes the module's Q chain, so the top of that chain --
+        // not the length of this type's own element list -- is what the level
+        // has to be measured against.
+        int maxLevel = schemeMaxLevel.value_or(
+            static_cast<int>(chain.getElements().size()) - 1);
+        int depth = maxLevel - chain.getCurrent();
+        if (depth <= 0) {
+          continue;
+        }
+        funcOp.setArgAttr(
+            arg.getArgNumber(), kEntryLevelDepthAttrName,
+            IntegerAttr::get(IntegerType::get(&getContext(), 64), depth));
+      }
+    });
 
     MLIRContext* context = &getContext();
     auto* module = getOperation();

--- a/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
+++ b/tests/Dialect/BGV/Conversions/bgv_to_lattigo/bgv_to_lattigo.mlir
@@ -32,7 +32,7 @@
 // CHECK: module
 module attributes {scheme.bgv} {
   // CHECK: @test_ops
-  // CHECK-SAME: ([[C:%.+]]: [[S:.*evaluator]], [[X:%.+]]: [[T:!lattigo.rlwe.ciphertext]], [[Y:%.+]]: [[T]], [[Z:%.+]]: [[P:!lattigo.rlwe.plaintext]])
+  // CHECK-SAME: ([[C:%.+]]: [[S:.*evaluator]], {{%.+}}: !lattigo.bgv.parameter, {{%.+}}: !lattigo.bgv.encoder, [[X:%.+]]: [[T:!lattigo.rlwe.ciphertext]]{{[^,]*}}, [[Y:%.+]]: [[T]]{{[^,]*}}, [[Z:%.+]]: [[P:!lattigo.rlwe.plaintext]])
   func.func @test_ops(%x : !ct, %y : !ct, %z : !pt) {
     // CHECK: %[[v1:.*]] = lattigo.bgv.add_new [[C]], %[[x:.*]], %[[y:.*]]: ([[S]], [[T]], [[T]]) -> [[T]]
     %add = bgv.add %x, %y  : (!ct, !ct) -> !ct

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/bootstrap.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/bootstrap.mlir
@@ -35,7 +35,10 @@
 // CHECK: func.func @bootstrap
 // CHECK-SAME: (%[[bEval:.*]]: ![[bEvalType]],
 // CHECK-SAME:  %[[eval:.*]]: ![[evalType]],
-// CHECK-SAME: , %[[ct:[a-z]+]]: ![[ctType]])
+// The bootstrap input sits at level 2 of the fourteen-modulus Q chain while its
+// own chain attribute lists only three of those moduli, so its depth has to be
+// measured against the scheme parameters.
+// CHECK-SAME: , %[[ct:[a-z]+]]: ![[ctType]] {lwe.entry_level_depth = 11 : i64})
 // CHECK: lattigo.ckks.bootstrap %[[bEval]], %[[ct]]
 
 module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 17, Q = [1106058412451299513, 1056763241666817029, 957769724367225479, 919081519653443687, 1030837924888066153, 1084354410096143723, 1135846243351935917, 1087115004561311021, 997960547764032911, 892538949448853293, 1002528331340998513, 1100798419621231379, 981696679688787961, 1061922508412786269], P = [1152921504606846976], logDefaultScale = 60>, scheme.ckks} {

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/entry_level_depth.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/entry_level_depth.mlir
@@ -1,0 +1,37 @@
+// RUN: heir-opt --lwe-to-lattigo %s | FileCheck %s
+
+// A lattigo ciphertext is opaque, so the level an argument starts at has to be
+// recorded here or it is lost. The level is measured against the module's Q
+// chain: an LWE type's own element list can be a truncated view of the chain,
+// and measuring against that understates the level.
+
+#inverse_canonical_encoding = #lwe.inverse_canonical_encoding<scaling_factor = 45>
+#key = #lwe.key<>
+#ring_f64_1_x1024 = #polynomial.ring<coefficientType = f64, polynomialModulus = <1 + x**1024>>
+
+!rns_L0 = !rns.rns<!mod_arith.int<36028797018652673 : i64>>
+!rns_L2 = !rns.rns<!mod_arith.int<36028797018652673 : i64>, !mod_arith.int<35184372121601 : i64>, !mod_arith.int<35184372744193 : i64>>
+#ring_rns_L0 = #polynomial.ring<coefficientType = !rns_L0, polynomialModulus = <1 + x**1024>>
+#ring_rns_L2 = #polynomial.ring<coefficientType = !rns_L2, polynomialModulus = <1 + x**1024>>
+#ciphertext_space_L0 = #lwe.ciphertext_space<ring = #ring_rns_L0, encryption_type = mix>
+#ciphertext_space_L2 = #lwe.ciphertext_space<ring = #ring_rns_L2, encryption_type = mix>
+
+// The fully consumed value carries only one chain element, so its own list puts
+// its "top" at level 0 and would report a depth of 0.
+#chain_truncated = #lwe.modulus_chain<elements = <36028797018652673 : i64>, current = 0>
+#chain_full = #lwe.modulus_chain<elements = <36028797018652673 : i64, 35184372121601 : i64, 35184372744193 : i64>, current = 2>
+
+!ct_L0 = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_f64_1_x1024, encoding = #inverse_canonical_encoding>, ciphertext_space = #ciphertext_space_L0, key = #key, modulus_chain = #chain_truncated>
+!ct_L2 = !lwe.lwe_ciphertext<plaintext_space = <ring = #ring_f64_1_x1024, encoding = #inverse_canonical_encoding>, ciphertext_space = #ciphertext_space_L2, key = #key, modulus_chain = #chain_full>
+
+// CHECK-DAG: ![[ctType:.*]] = !lattigo.rlwe.ciphertext
+
+module attributes {backend.lattigo, ckks.schemeParam = #ckks.scheme_param<logN = 10, Q = [36028797018652673, 35184372121601, 35184372744193], P = [1152921504606994433], logDefaultScale = 45>, scheme.ckks} {
+  // Q has three moduli, so the top of the chain is level 2: the argument at
+  // level 2 is unannotated and the one at level 0 records a depth of 2.
+  // CHECK: func.func @entry_levels
+  // CHECK-SAME: %{{[a-z_0-9]+}}: ![[ctType]], %{{[a-z_0-9]+}}: ![[ctType]] {lwe.entry_level_depth = 2 : i64})
+  func.func @entry_levels(%fresh: !ct_L2, %deep: !ct_L0) -> !ct_L2 {
+    return %fresh : !ct_L2
+  }
+}

--- a/tests/Dialect/LWE/Conversions/lwe_to_lattigo/eval_chebyshev.mlir
+++ b/tests/Dialect/LWE/Conversions/lwe_to_lattigo/eval_chebyshev.mlir
@@ -16,7 +16,7 @@
 // CHECK: ![[POLY_EVAL:.*]] = !lattigo.ckks.polynomial_evaluator
 
 module attributes {backend.lattigo, ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 35184372121601], P = [1152921504606994433], logDefaultScale = 45, encryptionTechnique = extended>, scheme.ckks} {
-  // CHECK: func.func @test_eval_chebyshev(%[[VAL_0:.*]]: ![[EVAL]], %[[VAL_1:.*]]: ![[PARAM]], %[[VAL_2:.*]]: ![[ENCODER]], %[[VAL_3:.*]]: ![[CT]]) -> ![[CT]]
+  // CHECK: func.func @test_eval_chebyshev(%[[VAL_0:.*]]: ![[EVAL]], %[[VAL_1:.*]]: ![[PARAM]], %[[VAL_2:.*]]: ![[ENCODER]], %[[VAL_3:.*]]: ![[CT]]{{.*}}) -> ![[CT]]
   // CHECK: %[[VAL_4:.*]] = lattigo.ckks.new_polynomial_evaluator %[[VAL_1]], %[[VAL_0]] : (![[PARAM]], ![[EVAL]]) -> ![[POLY_EVAL]]
   // CHECK: %[[VAL_5:.*]] = lattigo.ckks.chebyshev %[[VAL_4]], %[[VAL_3]] {coefficients = [1.000000e+00, 2.000000e+00], domain = array<f64: -1.000000e+00, 1.000000e+00>, targetScale = 35184372088832 : i64} : (![[POLY_EVAL]], ![[CT]]) -> ![[CT]]
   // CHECK: return %[[VAL_5]] : ![[CT]]


### PR DESCRIPTION
A ciphertext argument does not have to start at the top of the modulus chain. HEIR asks the client to encrypt at the level the computation actually begins at, which for a model whose first op is a linear transform can be well below the top. (e.g., `func.func @foo(%0: !lwe.lwe_ciphertext<..., modulus_chain = <elements = <11 moduli>, current = 2>>, ...)`

The lattigo lowering then gives every ciphertext the same opaque `!lattigo.rlwe.ciphertext`, and `LevelAnalysis::setToEntryState` joins every entry lattice to `LevelState(0)` (top of the chain).
As a result, the level analysis used by `--lattigo-alloc-to-inplace` is off, which causes incorrect (or, at least inefficient) buffer reuse.

This PR simply adds a `lwe.entry_level_depth` attribute to function arguments while still on the LWE types and uses that to determine the level at the `! lattigo.rlwe.ciphertext ` level.