### PR TITLE
[Transforms] Replace SymbolTable::getVisibilityAttrName with SymbolOpInterface::getDefaultVisibilityAttrName

### DIFF
--- a/lib/Transforms/InlineActivations/InlineActivations.cpp
+++ b/lib/Transforms/InlineActivations/InlineActivations.cpp
@@ -74,7 +74,8 @@ struct InlineActivations : impl::InlineActivationsBase<InlineActivations> {
       for (Operation& op : funcOp.getBody().getOps()) {
         for (auto& attr : caller->getAttrs()) {
           if (attr.getName() == SymbolTable::getSymbolAttrName() ||
-              attr.getName() == SymbolTable::getVisibilityAttrName() ||
+              attr.getName() ==
+                  SymbolOpInterface::getDefaultVisibilityAttrName() ||
               attr.getName() == "callee") {
             continue;
           }


### PR DESCRIPTION
Updates deprecated `SymbolTable::getVisibilityAttrName()` references to `SymbolOpInterface::getDefaultVisibilityAttrName()` following LLVM PR [#218910](https://github.com/llvm/llvm-project/pull/218910).