### PR TITLE
Rotom: layout assignment pass

### DIFF
--- a/lib/Dialect/Rotom/IR/BUILD
+++ b/lib/Dialect/Rotom/IR/BUILD
@@ -14,16 +14,21 @@ cc_library(
     srcs = [
         "RotomAttributes.cpp",
         "RotomDialect.cpp",
+        "RotomOps.cpp",
     ],
     hdrs = [
         "RotomAttributes.h",
         "RotomDialect.h",
+        "RotomOps.h",
     ],
     deps = [
         ":attributes_inc_gen",
         ":dialect_inc_gen",
+        ":ops_inc_gen",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:InferTypeOpInterface",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
     ],
 )
@@ -33,10 +38,12 @@ td_library(
     srcs = [
         "RotomAttributes.td",
         "RotomDialect.td",
+        "RotomOps.td",
     ],
     includes = ["../../../.."],
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SideEffectInterfacesTdFiles",
     ],
 )
 
@@ -57,6 +64,17 @@ add_heir_dialect_library(
     dialect_doc_name = "rotom",
     kind = "attribute",
     td_file = "RotomAttributes.td",
+    deps = [
+        ":td_files",
+    ],
+)
+
+add_heir_dialect_library(
+    name = "ops_inc_gen",
+    dialect = "Rotom",
+    dialect_doc_name = "rotom",
+    kind = "op",
+    td_file = "RotomOps.td",
     deps = [
         ":td_files",
     ],

--- a/lib/Dialect/Rotom/IR/RotomAttributes.cpp
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.cpp
@@ -348,7 +348,7 @@ static LogicalResult verifyLayoutRolls(
     // A roll may not shift an index by an argument on its own axis: an axis
     // FROM rewrites every piece of the axis, including the one the by
     // argument reads,
-    // and a piece FROM taking a by on the same axis is a self-shear no
+    // and a piece FROM taking a by on the same axis is a self-roll no
     // packing needs. Gap and replication by arguments name no axis, so they
     // never collide.
     if (fromAxis == byAxis) {

--- a/lib/Dialect/Rotom/IR/RotomAttributes.cpp
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.cpp
@@ -9,6 +9,7 @@
 #include "llvm/include/llvm/ADT/DenseMap.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/DenseSet.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/ADT/Sequence.h"           // from @llvm-project
 #include "llvm/include/llvm/ADT/SmallVector.h"        // from @llvm-project
 #include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
 #include "mlir/include/mlir/IR/Attributes.h"          // from @llvm-project
@@ -43,13 +44,9 @@ size_t inferCtPrefixLen(ArrayRef<DimAttr> dims, int64_t n) {
 
 // Preprocesses a layout (`dims`, slot count `n`) into the `LayoutData`
 // descriptor used to emit ciphertext addresses; also the validity check
-// behind `LayoutAttr::verify`.
-//
-// `pieces` describes the traversal dimensions, replication dimensions, and
-// gap dimensions. When lowering to ISL, a traversal piece maps to
-// `(i / divBy) mod modBy`, where i is the index of the piece's tensor axis;
-// replication and gap pieces map to their own ISL existential variables
-// instead.
+// behind `LayoutAttr::verify`. `pieces` holds the traversal, replication,
+// and gap dimensions in packing order; see `LayoutData` in the header for
+// exact field semantics.
 static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
                                                   MLIRContext* ctx) {
   LayoutData data;
@@ -70,6 +67,12 @@ static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
     }
     if (d.isReplicate()) {
       data.pieces.push_back({d, LayoutPieceKind::Replication});
+      continue;
+    }
+    // A contraction spans no axis of the laid-out value, so it measures like
+    // a gap; only the code reading a `compute` placement tells the two apart.
+    if (d.isContraction()) {
+      data.pieces.push_back({d, LayoutPieceKind::Gap});
       continue;
     }
     if (d.getDim() < 0) return failure();
@@ -108,14 +111,14 @@ static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
       piece.divBy = 1;
       piece.modBy = 0;
     } else {
-      // Split piece: digit = (i / stride) mod extent.
+      // Split piece: it reads (i / stride) mod extent of the axis index.
       const int64_t extent = piece.dim.getSize();
       const int64_t full = dimFullExtent[piece.dim.getDim()];
       piece.modBy = (piece.divBy * extent < full) ? extent : 0;
     }
   }
 
-  // Each multi-piece tensor dim must be a valid mixed-radix decomposition:
+  // Each multi-piece tensor dim must be a valid split:
   // sorted by stride, the divisors are the cumulative products of the lower
   // extents (1, e0, e0*e1, ...), and the extents multiply to the full extent.
   for (auto& [dim, count] : pieceCount) {
@@ -147,7 +150,7 @@ static FailureOr<LayoutData> preprocessLayoutData(ArrayAttr dims, int64_t n,
   return data;
 }
 
-// The dim position is spelled `R` for replication and `G` for gap (the
+// The dim position is written `R` for replication and `G` for gap (the
 // readable forms, also how the printer emits them); the numeric ids -1 and
 // -2 are still accepted.
 static ParseResult parseDimTripleAfterLSquare(AsmParser& parser, int64_t& dim,
@@ -156,6 +159,8 @@ static ParseResult parseDimTripleAfterLSquare(AsmParser& parser, int64_t& dim,
     dim = -1;
   } else if (succeeded(parser.parseOptionalKeyword("G"))) {
     dim = -2;
+  } else if (succeeded(parser.parseOptionalKeyword("K"))) {
+    dim = kDimContraction;
   } else if (parser.parseInteger(dim)) {
     return failure();
   }
@@ -177,6 +182,8 @@ static void printDimTriple(AsmPrinter& printer, DimAttr dim) {
   printer << "[";
   if (dim.isReplicate()) {
     printer << "R";
+  } else if (dim.isContraction()) {
+    printer << "K";
   } else if (dim.isGap()) {
     printer << "G";
   } else {
@@ -227,25 +234,40 @@ static ParseResult parseLayoutDims(AsmParser& parser,
   }
 }
 
+// One argument of a roll pair: a bare non-negative integer is a dims-list
+// position (one piece); `axis N` names the whole tensor axis N.
+static ParseResult parseRollArg(AsmParser& parser, int64_t& encoded) {
+  const bool isAxis = succeeded(parser.parseOptionalKeyword("axis"));
+  int64_t value;
+  if (parser.parseInteger(value)) return failure();
+  if (value < 0) {
+    return parser.emitError(parser.getNameLoc())
+           << (isAxis ? "an axis roll argument must name a non-negative "
+                        "tensor axis"
+                      : "a piece roll argument must be a non-negative dims "
+                        "position (write a whole-axis argument as `axis N`)");
+  }
+  encoded = encodeRollArg({isAxis, value});
+  return success();
+}
+
 static ParseResult parseLayoutRolls(AsmParser& parser,
                                     SmallVector<int64_t>& rolls) {
   if (parser.parseLSquare()) return failure();
   if (succeeded(parser.parseOptionalRSquare())) return success();
 
+  // Each entry is one `(from, by)` pair, parenthesized -- the form the
+  // printer emits, so written and round-tripped layouts read alike.
   while (true) {
-    if (succeeded(parser.parseOptionalLParen())) {
-      int64_t from;
-      int64_t to;
-      if (parser.parseInteger(from) || parser.parseComma() ||
-          parser.parseInteger(to) || parser.parseRParen())
-        return failure();
-      rolls.push_back(from);
-      rolls.push_back(to);
-    } else {
-      int64_t value;
-      if (parser.parseInteger(value)) return failure();
-      rolls.push_back(value);
+    int64_t from;
+    int64_t by;
+    if (parser.parseLParen() || failed(parseRollArg(parser, from)) ||
+        parser.parseComma() || failed(parseRollArg(parser, by)) ||
+        parser.parseRParen()) {
+      return failure();
     }
+    rolls.push_back(from);
+    rolls.push_back(by);
 
     if (succeeded(parser.parseOptionalComma())) continue;
     return parser.parseRSquare();
@@ -255,48 +277,94 @@ static ParseResult parseLayoutRolls(AsmParser& parser,
 static LogicalResult verifyLayoutRolls(
     ArrayAttr dims, DenseI64ArrayAttr rolls,
     function_ref<InFlightDiagnostic()> emitError) {
-  if (!rolls) return success();
+  const bool noRolls = !rolls || rolls.empty();
+  if (noRolls) return success();
   ArrayRef<int64_t> r = rolls.asArrayRef();
-  if (r.empty()) return success();
   if (r.size() % 2 != 0) {
-    return emitError() << "rolls must contain an even number of integers "
-                          "(pairs of dim indices)";
+    return emitError() << "rolls must contain an even number of arguments "
+                          "(pairs)";
   }
 
   for (size_t i = 0; i < r.size(); i += 2) {
-    const int64_t ti = r[i];
-    const int64_t tj = r[i + 1];
-    if (ti == tj) {
-      return emitError() << "each roll must use two distinct dim indices";
+    const RollArg from = decodeRollArg(r[i]);
+    const RollArg by = decodeRollArg(r[i + 1]);
+
+    // Resolve each argument: the piece it names (null for axis arguments)
+    // and the tensor axis it reads or rewrites (sentinel for gap/replication
+    // pieces).
+    DimAttr fromPiece;
+    DimAttr byPiece;
+    int64_t fromAxis = 0;
+    int64_t byAxis = 0;
+    auto checkArg = [&](const RollArg& e, DimAttr& piece,
+                        int64_t& axisId) -> LogicalResult {
+      if (e.isAxis) {
+        // The piece count decides how the axis may be named: an `axis`
+        // argument is legal only for a split axis.
+        const AxisPieces pieces = axisPieces(dims, e.index);
+        if (pieces.count == 0) {
+          return emitError() << "an axis roll argument must name a tensor "
+                                "axis present in dims";
+        }
+        if (!pieces.isSplit()) {
+          return emitError() << "an axis roll argument requires a split "
+                                "axis; write an unsplit axis's argument as "
+                                "its piece position";
+        }
+        axisId = e.index;
+        return success();
+      }
+      if (e.index >= static_cast<int64_t>(dims.size())) {
+        return emitError() << "roll piece argument out of bounds for dims "
+                              "list";
+      }
+      piece = dyn_cast<DimAttr>(dims[e.index]);
+      if (!piece) {
+        return emitError() << "roll arguments must refer to #rotom.dim "
+                              "entries";
+      }
+      axisId = piece.getDim();
+      return success();
+    };
+    if (failed(checkArg(from, fromPiece, fromAxis)) ||
+        failed(checkArg(by, byPiece, byAxis))) {
+      return failure();
     }
-    if (ti < 0 || tj < 0 || ti >= static_cast<int64_t>(dims.size()) ||
-        tj >= static_cast<int64_t>(dims.size())) {
-      return emitError() << "roll dim index out of bounds for dims list";
-    }
-    auto di = dyn_cast<DimAttr>(dims[ti]);
-    auto dj = dyn_cast<DimAttr>(dims[tj]);
-    if (!di || !dj) {
-      return emitError() << "roll indices must refer to #rotom.dim entries";
-    }
-    // The extents need not match: roll(i, j) rewrites dims[i]'s index to
-    // (i_i - i_j) mod size(dims[i]), well-defined for any partner extent (a
+
+    // The extents need not match: a roll rewrites the from index to
+    // (idx - shift) mod extent(from), well-defined for any partner extent (a
     // smaller partner covers a prefix of the rotations, a larger one wraps).
-    // The rolled (from) dim must be a traversal dim -- it is the index
-    // expression being rewritten. The roll-by (second) dim may be any kind:
-    // rolling by a replication or gap dim shifts by that dim's block index,
-    // so each block holds a distinct cyclic rotation of the rolled dim -- the
-    // layout materializes every rotation and alignment becomes block
-    // selection. (A rolled-by gap thus claims its blocks, unlike a plain gap.)
-    if (di.isGap() || di.isReplicate()) {
-      return emitError() << "the rolled dim must be a traversal dim (dim >= 0)";
+    // FROM is the index expression being rewritten, so it must be a
+    // traversal piece or a whole (traversal) axis. The by argument may be
+    // any kind: rolling by a replication or gap piece shifts by that piece's
+    // block index, so each block holds a distinct cyclic rotation of the
+    // rolled index -- the layout materializes every rotation and alignment
+    // becomes block selection. (A rolled-by gap thus claims its blocks,
+    // unlike a plain gap.)
+    if (!from.isAxis && (fromPiece.isGap() || fromPiece.isReplicate())) {
+      return emitError() << "the rolled dim must be a traversal dim (dim >= "
+                            "0)";
+    }
+    // A roll may not shift an index by an argument on its own axis: an axis
+    // FROM rewrites every piece of the axis, including the one the by
+    // argument reads,
+    // and a piece FROM taking a by on the same axis is a self-shear no
+    // packing needs. Gap and replication by arguments name no axis, so they
+    // never collide.
+    if (fromAxis == byAxis) {
+      return emitError()
+             << "a roll may not shift an index by an argument on the same "
+                "axis";
     }
     // A rolled-by GAP claims one ciphertext block per gap index, each holding
-    // a distinct rotation of the rolled dim. If the gap is larger than the
-    // rolled dim's extent the rotations repeat (period = the from extent),
-    // claiming blocks the conversion/kernel accounting was never audited for.
+    // a distinct rotation of the rolled index. If the gap is larger than the
+    // rolled extent the rotations repeat (period = the from extent), claiming
+    // blocks the conversion/kernel accounting was never audited for.
     // (Replication partners of larger extent are intended -- replicate-then-
     // roll -- so only gaps are bounded.)
-    if (dj.isGap() && dj.getSize() > di.getSize()) {
+    const int64_t fromExtent =
+        from.isAxis ? axisPieces(dims, fromAxis).extent : fromPiece.getSize();
+    if (byPiece && byPiece.isGap() && byPiece.getSize() > fromExtent) {
       return emitError() << "a rolled-by gap dim must not exceed the rolled "
                             "dim's extent";
     }
@@ -327,8 +395,8 @@ Attribute DimAttr::parse(AsmParser& parser, Type type) {
 
 LogicalResult DimAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                               int64_t dim, int64_t size, int64_t stride) {
-  if (dim < -2) {
-    return emitError() << "`dim` must be >= -2, got " << dim;
+  if (dim < kDimContraction) {
+    return emitError() << "`dim` must be >= -3, got " << dim;
   }
   if (size <= 0) {
     return emitError() << "`size` must be > 0, got " << size;
@@ -345,10 +413,19 @@ void LayoutAttr::print(AsmPrinter& printer) const {
   DenseI64ArrayAttr rolls = getRolls();
   if (rolls && !rolls.asArrayRef().empty()) {
     ArrayRef<int64_t> values = rolls.asArrayRef();
+    auto printArg = [&](int64_t encoded) {
+      const RollArg e = decodeRollArg(encoded);
+      if (e.isAxis) printer << "axis ";
+      printer << e.index;
+    };
     printer << ", rolls = [";
     for (size_t i = 0; i < values.size(); i += 2) {
       if (i != 0) printer << ", ";
-      printer << "(" << values[i] << ", " << values[i + 1] << ")";
+      printer << "(";
+      printArg(values[i]);
+      printer << ", ";
+      printArg(values[i + 1]);
+      printer << ")";
     }
     printer << "]";
   }
@@ -436,6 +513,39 @@ Attribute LayoutAttr::parse(AsmParser& parser, Type type) {
       ArrayAttr::get(context, dims), n, DenseI64ArrayAttr::get(context, rolls));
 }
 
+namespace {
+template <typename RangeT>
+AxisPieces accumulateAxisPieces(RangeT&& dims, int64_t axis) {
+  AxisPieces pieces;
+  for (DimAttr d : dims) {
+    if (d.isGap() || d.isReplicate() || d.getDim() != axis) continue;
+    ++pieces.count;
+    pieces.extent *= d.getSize();
+  }
+  return pieces;
+}
+}  // namespace
+
+AxisPieces axisPieces(ArrayRef<DimAttr> dims, int64_t axis) {
+  return accumulateAxisPieces(dims, axis);
+}
+
+AxisPieces axisPieces(ArrayAttr dims, int64_t axis) {
+  return accumulateAxisPieces(dims.getAsRange<DimAttr>(), axis);
+}
+
+SmallVector<RollSpec> getRollSpecs(LayoutAttr layout) {
+  SmallVector<RollSpec> specs;
+  DenseI64ArrayAttr rolls = layout.getRolls();
+  if (!rolls) return specs;
+  ArrayRef<int64_t> r = rolls.asArrayRef();
+
+  for (size_t i = 0; i + 1 < r.size(); i += 2) {
+    specs.push_back({decodeRollArg(r[i]), decodeRollArg(r[i + 1])});
+  }
+  return specs;
+}
+
 FailureOr<LayoutData> preprocessLayoutAttr(LayoutAttr layout) {
   return preprocessLayoutData(layout.getDims(), layout.getN(),
                               layout.getContext());
@@ -452,7 +562,9 @@ LogicalResult LayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     return emitError() << "`dims` must be an array of `#rotom.dim<...>`";
   }
 
-  if (failed(verifyLayoutRolls(dims, rolls, emitError))) return failure();
+  if (failed(verifyLayoutRolls(dims, rolls, emitError))) {
+    return failure();
+  }
 
   SmallVector<DimAttr> dimVec;
   dimVec.reserve(dims.size());
@@ -478,7 +590,7 @@ LogicalResult LayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     return emitError() << "slot dims must fill the ciphertext exactly (slot "
                           "extent "
                        << slotExtent << " vs n = " << n
-                       << "); spell unused capacity as an explicit gap piece";
+                       << "); state unused capacity as an explicit gap piece";
   }
 
   return success();
@@ -500,6 +612,83 @@ LogicalResult SeedAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 
 void canonicalizeLayoutDims(MLIRContext* ctx, SmallVector<DimAttr>& dims,
                             int64_t n, SmallVector<int64_t>& rolls) {
+  // A unit axis -- one whose whole extent is one -- places no data: its index
+  // has a single value, so it contributes nothing to any address, and a
+  // factor of one changes no other piece's offset. Its position was therefore
+  // free, which is what let one packing have several forms and made every
+  // consumer walk past unit pieces. Pin it to the tail in axis order, where
+  // addUnitAxisPieces already puts the pieces it creates and where
+  // inferCtPrefixLen's trailing trim already assumes they live. The piece
+  // stays: the relation the layout lowers to needs one domain variable per
+  // tensor axis. This rewrites the form, never the packing.
+  {
+    llvm::DenseMap<int64_t, int64_t> extentOfAxis;
+    for (DimAttr d : dims) {
+      if (d.isGap() || d.isReplicate()) continue;
+      auto it = extentOfAxis.find(d.getDim());
+      extentOfAxis[d.getDim()] =
+          it == extentOfAxis.end() ? d.getSize() : it->second * d.getSize();
+    }
+    auto isUnitAxisPiece = [&](DimAttr d) {
+      if (d.isGap() || d.isReplicate()) return false;
+      auto it = extentOfAxis.find(d.getDim());
+      return it != extentOfAxis.end() && it->second == 1;
+    };
+    // Extent-one replication and gaps are NOT dropped: alignment pairs two
+    // layouts by piece count (pieceMovements requires the counts to match),
+    // so a piece like [R:1:1] is a positional placeholder even though it
+    // places no data. Dropping it loses the matmul kernel entirely.
+    auto isInert = [](DimAttr d) {
+      (void)d;
+      return false;
+    };
+    SmallVector<DimAttr> rest, units;
+    SmallVector<int64_t> restOld, unitOld;
+    bool dropped = false;
+    for (auto [p, d] : llvm::enumerate(dims)) {
+      if (isInert(d)) {
+        dropped = true;
+      } else if (isUnitAxisPiece(d)) {
+        units.push_back(d);
+        unitOld.push_back(static_cast<int64_t>(p));
+      } else {
+        rest.push_back(d);
+        restOld.push_back(static_cast<int64_t>(p));
+      }
+    }
+    const bool moved =
+        !units.empty() && unitOld.front() != static_cast<int64_t>(rest.size());
+    if (dropped || moved) {
+      SmallVector<int64_t> order(unitOld.size());
+      for (size_t i = 0; i < order.size(); ++i) {
+        order[i] = static_cast<int64_t>(i);
+      }
+      llvm::stable_sort(order, [&](int64_t x, int64_t y) {
+        return units[x].getDim() < units[y].getDim();
+      });
+      SmallVector<int64_t> newPos(dims.size(), -1);
+      SmallVector<DimAttr> out;
+      for (auto [i, oldIdx] : llvm::enumerate(restOld)) {
+        newPos[oldIdx] = static_cast<int64_t>(out.size());
+        out.push_back(rest[i]);
+      }
+      for (int64_t i : order) {
+        newPos[unitOld[i]] = static_cast<int64_t>(out.size());
+        out.push_back(units[i]);
+      }
+      SmallVector<int64_t> keptRolls;
+      for (size_t i = 0; i + 1 < rolls.size(); i += 2) {
+        const int64_t from = rolls[i], by = rolls[i + 1];
+        const bool fromGone = from >= 0 && newPos[from] < 0;
+        const bool byGone = by >= 0 && newPos[by] < 0;
+        if (fromGone || byGone) continue;
+        keptRolls.push_back(from >= 0 ? newPos[from] : from);
+        keptRolls.push_back(by >= 0 ? newPos[by] : by);
+      }
+      dims = std::move(out);
+      rolls = std::move(keptRolls);
+    }
+  }
   const size_t ctLen = inferCtPrefixLen(dims, n);
   int64_t slotExtent = 1;
   for (size_t p = ctLen; p < dims.size(); ++p) slotExtent *= dims[p].getSize();
@@ -508,7 +697,7 @@ void canonicalizeLayoutDims(MLIRContext* ctx, SmallVector<DimAttr>& dims,
   if (fill <= 1) return;
   dims.insert(dims.begin() + ctLen,
               DimAttr::get(ctx, /*dim=*/-2, fill, /*stride=*/1));
-  // Roll endpoints at or past the insertion shift right.
+  // Piece arguments at or past the insertion shift right.
   for (int64_t& encoded : rolls) {
     if (encoded >= static_cast<int64_t>(ctLen)) ++encoded;
   }

--- a/lib/Dialect/Rotom/IR/RotomAttributes.h
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.h
@@ -15,6 +15,57 @@
 
 namespace mlir::heir::rotom {
 
+// The dim id of a `K` piece; see DimAttr::isContraction.
+inline constexpr int64_t kDimContraction = -3;
+
+// One argument of a roll: either one piece of the layout (a position in its
+// dims list) or a whole tensor axis (written `axis N`; legal only when the
+// axis is packed as more than one piece).
+struct RollArg {
+  bool isAxis;
+  int64_t index;  // Dims-list position, or the tensor axis id when isAxis.
+  bool operator==(const RollArg& other) const {
+    return isAxis == other.isAxis && index == other.index;
+  }
+};
+
+// Argument encoding in the flat rolls storage: a piece argument is its
+// non-negative dims-list position, an axis argument is -(axis + 1).
+inline int64_t encodeRollArg(RollArg e) {
+  return e.isAxis ? -(e.index + 1) : e.index;
+}
+inline RollArg decodeRollArg(int64_t encoded) {
+  return encoded < 0 ? RollArg{true, -encoded - 1} : RollArg{false, encoded};
+}
+
+// One roll of a layout: FROM's index is rewritten to
+// (idx_from - shift(by)) mod extent(from), where a piece FROM rewrites only
+// the part of the axis index that piece reads, and an axis FROM rewrites the
+// whole axis index.
+struct RollSpec {
+  RollArg from;
+  RollArg by;
+};
+
+// The layout's rolls with both arguments decoded.
+llvm::SmallVector<RollSpec> getRollSpecs(LayoutAttr layout);
+
+// The traversal pieces one tensor axis occupies in a dims list: how many
+// there are, and the product of their extents -- the axis's full logical
+// extent, since a split factors it across pieces. Gap and
+// replication pieces name no tensor axis and are skipped.
+struct AxisPieces {
+  int64_t count = 0;
+  int64_t extent = 1;
+  // Whether a roll must name this axis with an `axis` argument: with a single
+  // piece, rolling the axis and rolling that piece are the same rewrite, and
+  // the piece form is canonical.
+  bool isSplit() const { return count > 1; }
+};
+
+AxisPieces axisPieces(llvm::ArrayRef<DimAttr> dims, int64_t axis);
+AxisPieces axisPieces(ArrayAttr dims, int64_t axis);
+
 enum class LayoutPieceKind { Traversal, Replication, Gap };
 
 struct LayoutPiece {
@@ -23,15 +74,15 @@ struct LayoutPiece {
   // axisIndex, divBy, and modBy lower a traversal piece into its term of the
   // ISL relation. The emitter builds an address `[i0, i1, ...] -> [ct, slot]`
   // with one variable per axis (LayoutData::axes); each piece contributes a
-  // term reading one mixed-radix digit of its axis's variable.
+  // term reading one part of its axis's variable.
   //
   // axisIndex picks the variable: an index into LayoutData::axes, emitted as
   // `i{axisIndex}`.
   int64_t axisIndex = -1;
-  // divBy and modBy pick which digit of that variable the piece reads, as
-  // (i / divBy) mod modBy. divBy is the digit's place value: the piece's
-  // stride when the axis is split across pieces, else 1. modBy is the digit's
-  // extent or 0 to drop the modulus on the most-significant digit.
+  // divBy and modBy pick which part of that variable the piece reads, as
+  // (i / divBy) mod modBy. divBy is that part's offset: the piece's
+  // stride when the axis is split across pieces, else 1. modBy is the piece's
+  // extent, or 0 to drop the modulus on the highest part.
   int64_t divBy = 1;
   int64_t modBy = 0;
 };

--- a/lib/Dialect/Rotom/IR/RotomAttributes.td
+++ b/lib/Dialect/Rotom/IR/RotomAttributes.td
@@ -24,7 +24,7 @@ def Rotom_DimAttr : Rotom_Attr<"Dim", "dim"> {
     * `-2`: gap (padding / unused slots; constrained to zero in materialization)
 
     Non-negative `dim` values index into the logical tensor shape. In the
-    assembly form the sentinels are spelled `R` (replication) and `G` (gap),
+    assembly form the sentinels are written `R` (replication) and `G` (gap),
     e.g. `[R:4:1]`; the numeric ids are also accepted on input.
   }];
 
@@ -35,8 +35,14 @@ def Rotom_DimAttr : Rotom_Attr<"Dim", "dim"> {
   );
 
   let extraClassDeclaration = [{
+    // Written `G`: slots this layout does not use.
     bool isGap() const { return getDim() == -2; }
+    // Written `R`: the piece repeats the data instead of advancing through it.
     bool isReplicate() const { return getDim() == -1; }
+    // Written `K`: the axis a matmul sums over. Only a `compute` placement
+    // has one -- the result layout carries a plain gap in its place -- so
+    // code walking a value's layout never meets it.
+    bool isContraction() const { return getDim() == -3; }
   }];
 
   let genVerifyDecl = 1;
@@ -55,11 +61,57 @@ def Rotom_LayoutAttr : Rotom_Attr<"Layout", "layout"> {
     with an explicit gap piece (e.g. `[G:4:1]`).
     See [Section 4.2 of the Rotom paper](https://eprint.iacr.org/2025/1319.pdf).
 
-    Optional **rolls** encode a `roll(i,j)` metadata object: each pair `(i, j)`
-    indexes into the `dims` array (the flattened `ct_dims + slot_dims` list) and
-    rewrites `dims[i]`'s index to `(idx_i - idx_j) mod size(dims[i])`. The two
-    extents need not match: the shift reduces modulo the rolled dim's extent, so
-    a smaller partner covers a prefix of the rotations and a larger one wraps.
+    Optional **rolls** encode `roll(from, by)` metadata objects, applied left
+    to right. Each argument is either a *piece* -- a position in the `dims`
+    list, written as a bare integer -- or a whole tensor *axis*, written
+    `axis N` (legal only when axis `N` is packed as more than one piece; the
+    piece form is canonical for an unsplit axis, where the two coincide).
+
+    ```mlir
+    // Halevi-Shoup diagonal of a 4x4 matrix: slot j of ciphertext i holds
+    // A[i, (j + i) mod 4]. Argument 1 (the axis-1 piece) is rolled by
+    // argument 0 (the axis-0 piece).
+    #diag = #rotom.layout<n = 4, rolls = [(1, 0)], dims = [[0:4:1] | [1:4:1]]>
+
+    // Axis 1 is split across two pieces, so a whole-axis roll names its
+    // argument `axis 1` rather than a piece position.
+    #split = #rotom.layout<n = 16, rolls = [(axis 1, 2)],
+                           dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+    ```
+
+    When an axis is split, each piece reads one part of that axis's index:
+    the piece of stride `s` and extent `e` reads `(i / s) mod e`, the way one
+    digit of a number reads one part of its value. A piece FROM rewrites that
+    part in place, `part(from) <- (part(from) - shift(by)) mod extent(from)`,
+    leaving the axis's other pieces untouched. An `axis` FROM instead rewrites
+    the whole axis index modulo its full extent and redistributes it over the
+    pieces, so the subtraction can carry from one piece into the next.
+
+    For example, axis 0 of extent 4 split across two pieces of extent 2 and
+    replicated twice, so replica `d` supplies the shift `d`:
+
+    ```mlir
+    // `[0:2:2]` carries the high part of axis 0's index and `[0:2:1]` the low
+    // part, so a replica's four slots hold elements 0, 1, 2, 3 in order. The
+    // two layouts differ only in whether the roll names the axis or the piece
+    // holding the low part.
+    #by_axis = #rotom.layout<n = 8, rolls = [(axis 0, 0)],
+                             dims = [[R:2:1], [0:2:2], [0:2:1]]>
+    #by_piece = #rotom.layout<n = 8, rolls = [(2, 0)],
+                              dims = [[R:2:1], [0:2:2], [0:2:1]]>
+    ```
+
+    Replica 0 shifts by 0, so both layouts hold `0, 1, 2, 3`. Replica 1 shifts
+    by 1, and there they differ: `#by_axis` holds `1, 2, 3, 0`, the whole axis
+    rotated by one, while `#by_piece` holds `1, 0, 3, 2`, each pair of slots
+    rotated inside itself.
+
+    The shift is the by argument's index: a
+    traversal piece's part of its axis index (the whole index when the axis is
+    unsplit), a whole axis's index via `axis`, a replication piece's replica
+    index, or a gap piece's block index. The two extents need not match: the shift
+    reduces modulo the rolled extent, so a smaller partner covers a prefix of
+    the rotations and a larger one wraps.
   }];
 
   let parameters = (ins

--- a/lib/Dialect/Rotom/IR/RotomDialect.cpp
+++ b/lib/Dialect/Rotom/IR/RotomDialect.cpp
@@ -3,6 +3,7 @@
 // IYWU pragma: begin_keep
 #include "lib/Dialect/Rotom/IR/RotomAttributes.h"
 #include "lib/Dialect/Rotom/IR/RotomDialect.cpp.inc"
+#include "lib/Dialect/Rotom/IR/RotomOps.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
 // IYWU pragma: end_keep
 
@@ -17,6 +18,10 @@ void RotomDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "lib/Dialect/Rotom/IR/RotomAttributes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "lib/Dialect/Rotom/IR/RotomOps.cpp.inc"
       >();
 }
 

--- a/lib/Dialect/Rotom/IR/RotomDialect.h
+++ b/lib/Dialect/Rotom/IR/RotomDialect.h
@@ -1,12 +1,27 @@
 #ifndef LIB_DIALECT_ROTOM_IR_ROTOMDIALECT_H_
 #define LIB_DIALECT_ROTOM_IR_ROTOMDIALECT_H_
 
+#include <cstdint>
+
 // IWYU pragma: begin_keep
+#include "llvm/include/llvm/ADT/StringRef.h"             // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/Dialect.h"                // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 // IWYU pragma: end_keep
 
 #include "lib/Dialect/Rotom/IR/RotomDialect.h.inc"
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+// Marks an elementwise arith op in Rotom
+inline constexpr llvm::StringLiteral kRotomElementwiseAttrName =
+    "rotom.elementwise";
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir
 
 #endif  // LIB_DIALECT_ROTOM_IR_ROTOMDIALECT_H_

--- a/lib/Dialect/Rotom/IR/RotomOps.cpp
+++ b/lib/Dialect/Rotom/IR/RotomOps.cpp
@@ -1,0 +1,92 @@
+#include "lib/Dialect/Rotom/IR/RotomOps.h"
+
+#include <tuple>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"   // from @llvm-project
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/Rotom/IR/RotomOps.cpp.inc"
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+LogicalResult ConvertLayoutOp::verify() {
+  if (getFrom().getN() != getTo().getN()) {
+    return emitOpError() << "the from and to layouts must have the same "
+                            "ciphertext size n; got "
+                         << getFrom().getN() << " and " << getTo().getN();
+  }
+  return success();
+}
+
+LogicalResult ApplyRollOp::verify() {
+  LayoutAttr from = getFrom();
+  LayoutAttr to = getTo();
+  if (from.getN() != to.getN()) {
+    return emitOpError() << "the from and to layouts must have the same "
+                            "ciphertext size n";
+  }
+  // A roll may swap the rolled piece with its partner, so the two piece lists
+  // must be the same multiset.
+  auto sortedDims = [](LayoutAttr layout) {
+    SmallVector<DimAttr> dims;
+    for (Attribute attr : layout.getDims()) dims.push_back(cast<DimAttr>(attr));
+    llvm::sort(dims, [](DimAttr a, DimAttr b) {
+      return std::tuple(a.getDim(), a.getSize(), a.getStride()) <
+             std::tuple(b.getDim(), b.getSize(), b.getStride());
+    });
+    return dims;
+  };
+  if (sortedDims(from) != sortedDims(to)) {
+    return emitOpError() << "the from and to layouts must have the same "
+                            "pieces; an apply_roll adds one roll and may swap "
+                            "the rolled piece with its partner";
+  }
+  ArrayRef<int64_t> fromRolls =
+      from.getRolls() ? from.getRolls().asArrayRef() : ArrayRef<int64_t>();
+  ArrayRef<int64_t> toRolls =
+      to.getRolls() ? to.getRolls().asArrayRef() : ArrayRef<int64_t>();
+  if (toRolls.size() != fromRolls.size() + 2 ||
+      toRolls.take_front(fromRolls.size()) != fromRolls) {
+    return emitOpError() << "the to layout must carry the from layout's rolls "
+                            "plus exactly one more";
+  }
+  return success();
+}
+
+LogicalResult MatmulOp::verify() {
+  const int64_t n = getCompute().getN();
+  if (getLhsLayout().getN() != n || getRhsLayout().getN() != n ||
+      getTo().getN() != n) {
+    return emitOpError() << "all layouts must have the same ciphertext size n";
+  }
+  return success();
+}
+
+LogicalResult BsgsMatmulOp::verify() {
+  if (getRollOperand() != 0 && getRollOperand() != 1) {
+    return emitOpError() << "roll_operand must name lhs (0) or rhs (1)";
+  }
+  if (getBaby() <= 0 || getRollTargets() <= 0) {
+    return emitOpError() << "baby and roll_targets must be positive";
+  }
+  if (getBaby() > getRollTargets()) {
+    return emitOpError() << "baby extent exceeds the target count";
+  }
+  const int64_t n = getRolled().getN();
+  if (getRollStride() <= 0 || getRollStride() >= n) {
+    return emitOpError() << "roll_stride must be a rotation amount in [1, n)";
+  }
+  if (getLhsLayout().getN() != n || getRhsLayout().getN() != n ||
+      getCompute().getN() != n || getTo().getN() != n) {
+    return emitOpError() << "every layout must share the ciphertext size n";
+  }
+  return success();
+}
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/IR/RotomOps.h
+++ b/lib/Dialect/Rotom/IR/RotomOps.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_ROTOM_IR_ROTOMOPS_H_
+#define LIB_DIALECT_ROTOM_IR_ROTOMOPS_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "mlir/include/mlir/Bytecode/BytecodeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/OpDefinition.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+#define GET_OP_CLASSES
+#include "lib/Dialect/Rotom/IR/RotomOps.h.inc"
+
+#endif  // LIB_DIALECT_ROTOM_IR_ROTOMOPS_H_

--- a/lib/Dialect/Rotom/IR/RotomOps.td
+++ b/lib/Dialect/Rotom/IR/RotomOps.td
@@ -1,0 +1,122 @@
+#ifndef LIB_DIALECT_ROTOM_IR_ROTOMOPS_TD_
+#define LIB_DIALECT_ROTOM_IR_ROTOMOPS_TD_
+
+include "lib/Dialect/Rotom/IR/RotomAttributes.td"
+include "lib/Dialect/Rotom/IR/RotomDialect.td"
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class Rotom_Op<string mnemonic, list<Trait> traits = []>
+    : Op<Rotom_Dialect, mnemonic, traits>;
+
+def Rotom_ConvertLayoutOp : Rotom_Op<"convert_layout",
+    [Pure, AllTypesMatch<["input", "result"]>]> {
+  let summary = "Convert from one Rotom layout to another.";
+  let description = [{
+    The op records one layout conversion decision. The `from` and `to`
+    layouts pack the same tensor at the same ciphertext size `n`. The
+    ciphertext counts of the two layouts can differ: an expansion and a
+    compaction are both this op.
+
+    The op stores the decision, not the steps. The lowering derives the
+    rotate/mask/accumulate steps from the two layouts with
+    `planLayoutConversion`, so the priced route is the emitted route.
+  }];
+  let arguments = (ins AnyRankedTensor:$input,
+                       Rotom_LayoutAttr:$from,
+                       Rotom_LayoutAttr:$to);
+  let results = (outs AnyRankedTensor:$result);
+  let assemblyFormat = "$input `:` type($input) `from` qualified($from) `to` qualified($to) attr-dict";
+  let hasVerifier = 1;
+}
+
+
+def Rotom_ApplyRollOp : Rotom_Op<"apply_roll",
+    [Pure, AllTypesMatch<["input", "result"]>]> {
+  let summary = "Align a value by one roll of its layout.";
+  let description = [{
+    The op applies a roll transformation. The `to` layout is the `from`
+    layout with exactly one more roll: `n` and the piece multiset are equal.
+    The applied roll is the last roll of `to`. The rolled piece and its partner
+    may trade places.
+
+    A roll alignment is the cheap conversion of the Rotom paper (Section
+    6.1). The lowering derives the rotation steps from the two layouts, the
+    same way rotom.convert_layout does; the distinct op makes the alignment
+    mechanism visible and separately priceable.
+  }];
+  let arguments = (ins AnyRankedTensor:$input,
+                       Rotom_LayoutAttr:$from,
+                       Rotom_LayoutAttr:$to);
+  let results = (outs AnyRankedTensor:$result);
+  let assemblyFormat = "$input `:` type($input) `from` qualified($from) `to` qualified($to) attr-dict";
+  let hasVerifier = 1;
+}
+
+def Rotom_MatmulOp : Rotom_Op<"matmul", [Pure]> {
+  let summary = "Matrix multiply of two layout-aligned operands.";
+  let description = [{
+    The compute kernel of a Rotom matmul plan. The operands arrive already
+    aligned: `lhs_layout` and `rhs_layout` name their placements in the
+    shared iteration space, `compute` names the placement the elementwise
+    product computes at, and `to` names the result layout after the
+    contraction axis is summed out. The lowering multiplies once at the
+    compute placement and reduces the contraction axis from its position in
+    `compute`: ciphertext-region pieces sum by block adds, slot-region
+    pieces by a log-tree rotate-and-reduce.
+
+    A matmul whose operand would arrive rolled by its ciphertext piece is a
+    `rotom.bsgs_matmul` instead.
+  }];
+  let arguments = (ins AnyRankedTensor:$lhs,
+                       AnyRankedTensor:$rhs,
+                       Rotom_LayoutAttr:$lhs_layout,
+                       Rotom_LayoutAttr:$rhs_layout,
+                       Rotom_LayoutAttr:$compute,
+                       Rotom_LayoutAttr:$to);
+  let results = (outs AnyRankedTensor:$result);
+  let assemblyFormat = "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasVerifier = 1;
+}
+
+def Rotom_BsgsMatmulOp : Rotom_Op<"bsgs_matmul", [Pure]> {
+  let summary = "Matmul that folds an operand's roll into a BSGS schedule.";
+  let description = [{
+    A matmul whose contraction runs over a roll by the ciphertext piece, with
+    the rolled operand facing a public one. Rolling first would cost one
+    rotation per target ciphertext; folding the roll into the multiply costs
+    B - 1 baby rotations, shared across the giant groups, plus G - 1 giant
+    rotations (the reference's BSGS_ROT_ROLL + BSGS_MATMUL).
+
+    The operand named by `roll_operand` (0 = lhs, 1 = rhs) arrives *unrolled*,
+    at the layout its own `..._layout` attribute names; `rolled` is the layout
+    the roll would have produced. Target ciphertext c reads that operand
+    rotated by `roll_stride * c`, negated when `roll_negative`, for
+    `roll_targets` targets. `baby` is B; G is roll_targets ceil-divided by it.
+
+    ```mlir
+    %0 = rotom.bsgs_matmul %w, %x : (tensor<10x512xf32>, tensor<512x1xf32>)
+           -> tensor<10x1xf32>
+      { roll_operand = 1 : i64, roll_stride = 64 : i64,
+        roll_targets = 16 : i64, baby = 4 : i64, ... }
+    ```
+  }];
+  let arguments = (ins AnyRankedTensor:$lhs,
+                       AnyRankedTensor:$rhs,
+                       Rotom_LayoutAttr:$lhs_layout,
+                       Rotom_LayoutAttr:$rhs_layout,
+                       Rotom_LayoutAttr:$rolled,
+                       Rotom_LayoutAttr:$compute,
+                       Rotom_LayoutAttr:$to,
+                       I64Attr:$roll_operand,
+                       I64Attr:$roll_stride,
+                       I64Attr:$roll_targets,
+                       I64Attr:$baby,
+                       UnitAttr:$roll_negative);
+  let results = (outs AnyRankedTensor:$result);
+  let assemblyFormat = "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasVerifier = 1;
+}
+
+#endif  // LIB_DIALECT_ROTOM_IR_ROTOMOPS_TD_

--- a/lib/Dialect/Rotom/Transforms/BUILD
+++ b/lib/Dialect/Rotom/Transforms/BUILD
@@ -2,10 +2,81 @@
 
 load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
     default_applicable_licenses = ["@heir//:license"],
     default_visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "DimMapsTest",
+    srcs = ["LayoutAssignment/DimMapsTest.cpp"],
+    deps = [
+        ":LayoutAssignment",
+        "@googletest//:gtest_main",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "layout_assignment_pass_inc_gen",
+    header_filename = "LayoutAssignment/LayoutAssignment.h.inc",
+    pass_name = "LayoutAssignment",
+    registration_name = "RotomLayoutAssignment",
+    td_file = "LayoutAssignment/LayoutAssignment.td",
+)
+
+cc_library(
+    name = "LayoutAssignment",
+    srcs = [
+        "LayoutAssignment/Candidate.cpp",
+        "LayoutAssignment/CostModel.cpp",
+        "LayoutAssignment/DimMaps.cpp",
+        "LayoutAssignment/LayoutAssignment.cpp",
+        "LayoutAssignment/ValueUtils.cpp",
+        "LayoutAssignment/gen/Binop.cpp",
+        "LayoutAssignment/gen/ReduceTranspose.cpp",
+        "LayoutAssignment/gen/Reshape.cpp",
+        "LayoutAssignment/gen/Structural.cpp",
+    ],
+    hdrs = [
+        "LayoutAssignment/AssignmentContext.h",
+        "LayoutAssignment/Candidate.h",
+        "LayoutAssignment/CostModel.h",
+        "LayoutAssignment/DimMaps.h",
+        "LayoutAssignment/Generators.h",
+        "LayoutAssignment/LayoutAssignment.h",
+        "LayoutAssignment/ValueUtils.h",
+    ],
+    deps = [
+        ":layout_assignment_pass_inc_gen",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@heir//lib/Dialect/Rotom/Utils:LayoutAlignment",
+        "@heir//lib/Dialect/Rotom/Utils:LayoutConversion",
+        "@heir//lib/Dialect/Rotom/Utils:RotomLayout",
+        "@heir//lib/Dialect/Rotom/Utils:RotomTensorExtLayoutLowering",
+        "@heir//lib/Dialect/Secret/IR:SecretPatterns",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Kernel",
+        "@heir//lib/Utils:AttributeUtils",
+        "@heir//lib/Utils:MathUtils",
+        "@heir//lib/Utils/Layout:IslConversion",
+        "@heir//lib/Utils/Layout:Utils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
 )
 
 add_heir_transforms(
@@ -63,7 +134,6 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TensorDialect",
     ],
 )
 
@@ -71,8 +141,10 @@ cc_library(
     name = "Transforms",
     hdrs = ["Passes.h"],
     deps = [
+        ":LayoutAssignment",
         ":MaterializeTensorExtLayout",
         ":SeedLayout",
+        ":layout_assignment_pass_inc_gen",
         ":materialize_tensor_ext_layout_pass_inc_gen",
         ":seed_layout_pass_inc_gen",
         "@heir//lib/Dialect/Rotom/IR:Dialect",

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h
@@ -1,0 +1,54 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_ASSIGNMENTCONTEXT_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_ASSIGNMENTCONTEXT_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "mlir/include/mlir/IR/Operation.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"      // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+class AssignmentContext {
+ public:
+  virtual ~AssignmentContext() = default;
+
+  // Seed `value` from its rotom.seed attribute (no-op if already processed).
+  virtual void seedValue(Value value) = 0;
+
+  // The candidate layouts assigned to `value` (seeding it first if needed).
+  virtual SmallVector<Candidate> candidatesForValue(Value value) = 0;
+
+  // Record `newCandidates` as the candidates for `value`, after validating and
+  // folding each into its assignment.
+  virtual void setCandidates(Value value,
+                             ArrayRef<Candidate> newCandidates) = 0;
+
+  // Set the chosen candidate set on every tensor result of `op`.
+  virtual void assignResultsFromCandidates(Operation* op,
+                                           ArrayRef<Candidate> chosen) = 0;
+
+  // Bring all of `op`'s operands onto a common result layout (the generic
+  // N-operand combiner).
+  virtual SmallVector<Candidate> chooseCommonOperandCandidates(
+      Operation* op, KernelKind kind) = 0;
+
+  // The specialized binary convert-then-compute combiner (add/sub/mul).
+  virtual SmallVector<Candidate> chooseElementwiseKernels(
+      ArrayRef<Value> operands, KernelKind kind,
+      function_ref<int64_t(LayoutAttr)> computeCostFn,
+      bool hasRotomKernel = false) = 0;
+
+  // Estimated rotation cost of converting `from` onto `to`.
+  // The price of a conversion the plan cannot express. A caller that can
+  // reject the step should do so; the price keeps it last for one that cannot.
+  static constexpr int64_t kUnlowerableConversion = 1LL << 60;
+  virtual int64_t conversionCost(LayoutAttr from, LayoutAttr to) = 0;
+};
+
+}  // namespace mlir::heir::rotom
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_ASSIGNMENTCONTEXT_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.cpp
@@ -1,0 +1,156 @@
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h"
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"              // from @llvm-project
+#include "llvm/include/llvm/ADT/StringRef.h"              // from @llvm-project
+#include "llvm/include/llvm/Support/ErrorHandling.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"     // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/DebugStringHelper.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"               // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+int64_t accumulatedCostOf(const Assignment& assignment) {
+  int64_t total = 0;
+  for (const auto& entry : assignment) total += entry.second.second;
+  return total;
+}
+
+bool mergeAssignments(Assignment& into, const Assignment& from) {
+  for (const auto& entry : from) {
+    auto it = into.find(entry.first);
+    if (it == into.end()) {
+      into.insert(entry);
+    } else if (it->second.first != entry.second.first) {
+      return false;
+    }
+  }
+  return true;
+}
+
+llvm::StringLiteral kernelKindName(KernelKind kind) {
+  switch (kind) {
+    case KernelKind::Tensor:
+      return "tensor";
+    case KernelKind::BlockArgument:
+      return "block_arg";
+    case KernelKind::Yield:
+      return "yield";
+    case KernelKind::PassThrough:
+      return "pass_through";
+    case KernelKind::Elementwise:
+      return "elementwise";
+    case KernelKind::Generic:
+      return "generic";
+    case KernelKind::Transpose:
+      return "transpose";
+    case KernelKind::Reduce:
+      return "reduce";
+    case KernelKind::Matmul:
+      return "matmul";
+    case KernelKind::CollapseShape:
+      return "collapse_shape";
+    case KernelKind::ExpandShape:
+      return "expand_shape";
+    case KernelKind::ExtractSlice:
+      return "extract_slice";
+    case KernelKind::InsertSlice:
+      return "insert_slice";
+  }
+  llvm_unreachable("unknown kernel kind");
+}
+
+bool isAddLike(Operation* op) {
+  return isa<arith::AddFOp, arith::AddIOp, arith::SubFOp, arith::SubIOp>(op);
+}
+
+bool isAdd(Operation* op) { return isa<arith::AddFOp, arith::AddIOp>(op); }
+
+bool isMulLike(Operation* op) { return isa<arith::MulFOp, arith::MulIOp>(op); }
+
+// Cost of running `op` once its operands are aligned to `alignedLayout` (the
+// compute layout): one HE op per ciphertext, so weight x numCt(alignedLayout).
+int64_t operationCost(Operation* op, LayoutAttr alignedLayout) {
+  int64_t numCt = layoutNumCiphertexts(alignedLayout);
+  const RotomCostModel& model = getCostModel();
+  if (isAddLike(op)) return model.add * numCt;
+  if (isMulLike(op)) return model.ciphertextMultiply * numCt;
+  return 0;
+}
+
+// A linalg.generic's cost is its body's per-ciphertext op costs summed at the
+// aligned (compute) layout its inputs are converted to.
+int64_t genericOperationCost(linalg::GenericOp op, LayoutAttr alignedLayout) {
+  int64_t cost = 0;
+  for (Operation& innerOp : op.getBody()->getOperations()) {
+    if (isa<linalg::YieldOp, arith::ConstantOp>(innerOp)) continue;
+    cost += operationCost(&innerOp, alignedLayout);
+  }
+  return cost;
+}
+
+std::string candidateTieKey(const Candidate& candidate) {
+  std::string key = kernelKindName(candidate.kind).str();
+  key += ":";
+  key += debugString(candidate.layout);
+  key += ":kernel=";
+  key += candidate.hasRotomKernel ? "rotom" : "none";
+  for (LayoutAttr operandLayout : candidate.operandLayouts) {
+    key += ":";
+    key += debugString(operandLayout);
+  }
+  return key;
+}
+
+bool isBetterCandidate(const Candidate& lhs, const Candidate& rhs) {
+  if (lhs.accumulatedCost != rhs.accumulatedCost)
+    return lhs.accumulatedCost < rhs.accumulatedCost;
+  if (lhs.hasRotomKernel != rhs.hasRotomKernel) {
+    return lhs.hasRotomKernel;
+  }
+  return candidateTieKey(lhs) < candidateTieKey(rhs);
+}
+
+SmallVector<Candidate> uniqueCandidates(ArrayRef<Candidate> candidates) {
+  SmallVector<Candidate> result;
+  // Keyed on the dimension-merged canonical layout, so split forms of the
+  // same packing ([0:2:8][0:8:1] vs [0:16:1]) compete as one entry and only
+  // the best survives. The frontier itself is never truncated: every distinct
+  // packing keeps its cheapest candidate.
+  SmallVector<LayoutAttr> keys;
+  for (const Candidate& candidate : candidates) {
+    LayoutAttr key = mergeAdjacentLayoutDims(candidate.layout);
+    size_t found = result.size();
+    for (size_t i = 0; i < result.size(); ++i) {
+      if (keys[i] == key &&
+          result[i].hasRotomKernel == candidate.hasRotomKernel) {
+        found = i;
+        break;
+      }
+    }
+    if (found == result.size()) {
+      result.push_back(candidate);
+      keys.push_back(key);
+      continue;
+    }
+    if (isBetterCandidate(candidate, result[found])) {
+      result[found] = candidate;
+    }
+  }
+  llvm::sort(result, [](const Candidate& lhs, const Candidate& rhs) {
+    return isBetterCandidate(lhs, rhs);
+  });
+  return result;
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h
@@ -1,0 +1,91 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_CANDIDATE_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_CANDIDATE_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"              // from @llvm-project
+#include "llvm/include/llvm/ADT/StringRef.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+// The kind of HE kernel a candidate represents. Used only for debug labels and
+// as a tie-breaker between otherwise equal-cost candidates.
+enum class KernelKind {
+  Tensor,
+  BlockArgument,
+  Yield,
+  PassThrough,
+  Elementwise,
+  Generic,
+  Transpose,
+  Reduce,
+  Matmul,
+  CollapseShape,
+  ExpandShape,
+  ExtractSlice,
+  InsertSlice,
+};
+
+llvm::StringLiteral kernelKindName(KernelKind kind);
+
+// The layout assignment of every value feeding a candidate: each such value
+// mapped to (its chosen layout, that kernel's own local cost). A shared
+// subexpression appears once, so summing the local costs never double-counts on
+// a DAG. The assignment of the winning root candidate IS the output.
+using Assignment = llvm::DenseMap<Value, std::pair<LayoutAttr, int64_t>>;
+
+// A candidate layout for a single value: the value's layout, the dedup'd
+// `accumulatedCost` (the sum over `assignment`), and the assignment itself.
+// `localCost` is transient -- the value's own kernel cost, folded into
+// `assignment`/`accumulatedCost` once the result value is known (see
+// setCandidates). `localCost` and `assignment` are last so the positional
+// aggregate-inits of the earlier fields keep working.
+struct Candidate {
+  LayoutAttr layout;
+  int64_t accumulatedCost = 0;
+  KernelKind kind = KernelKind::PassThrough;
+  SmallVector<Value> operands;
+  SmallVector<LayoutAttr> operandLayouts;
+  // True when the op has a Rotom elementwise lowering that can align its
+  // operands via conversion (ranked like a named kernel).
+  bool hasRotomKernel = false;
+  int64_t localCost = 0;
+  Assignment assignment;
+};
+
+// Sum of every kernel's local cost in the assignment (each value counted once).
+int64_t accumulatedCostOf(const Assignment& assignment);
+// Merges `from` into `into`. Returns false if they disagree on any value's
+// layout (an inconsistent combination of sub-assignments on a DAG), leaving
+// `into` partially merged -- the caller discards it.
+bool mergeAssignments(Assignment& into, const Assignment& from);
+
+// arith op classification.
+bool isAddLike(Operation* op);
+bool isAdd(Operation* op);
+bool isMulLike(Operation* op);
+
+// Cost model (op weights live in CostModel.h / cost_model.json).
+// `operationCost`/`genericOperationCost` score the compute from the aligned
+// (compute) layout the operands are converted to -- one HE op per ciphertext.
+int64_t operationCost(Operation* op, LayoutAttr alignedLayout);
+int64_t genericOperationCost(linalg::GenericOp op, LayoutAttr alignedLayout);
+
+// Ranking and deduplication. A candidate is "better" when it is cheaper, then
+// when it carries a Rotom kernel, then by a deterministic structural tie key.
+std::string candidateTieKey(const Candidate& candidate);
+bool isBetterCandidate(const Candidate& lhs, const Candidate& rhs);
+SmallVector<Candidate> uniqueCandidates(ArrayRef<Candidate> candidates);
+
+}  // namespace mlir::heir::rotom
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_CANDIDATE_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.cpp
@@ -1,0 +1,10 @@
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h"
+
+namespace mlir::heir::rotom {
+
+const RotomCostModel& getCostModel() {
+  static const RotomCostModel model;
+  return model;
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h
@@ -1,0 +1,26 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_COSTMODEL_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_COSTMODEL_H_
+
+#include <cstdint>
+
+namespace mlir::heir::rotom {
+
+// TODO: Temporary placeholders pending measured values.
+struct RotomCostModel {
+  int64_t rotation = 100;            // one ciphertext rotation (key-switch)
+  int64_t ciphertextMultiply = 100;  // one ct x ct multiply (+ relinearization)
+  int64_t add = 1;                   // one add / negligible, breaks ties
+  // Carrying cost per ciphertext of a value's chosen layout: a proxy for the
+  // downstream price of a fat value (bootstrap placement wants compact
+  // candidates -- every extra ciphertext is an extra future bootstrap).
+  // Keeps the search from inflating ciphertext counts when an equally cheap
+  // compact placement plus a rotation-only expansion exists.
+  int64_t ciphertextCount = 100;
+};
+
+// The active cost model (currently always the defaults above).
+const RotomCostModel& getCostModel();
+
+}  // namespace mlir::heir::rotom
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_COSTMODEL_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.cpp
@@ -1,0 +1,322 @@
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h"
+
+#include <cassert>
+#include <cstdint>
+#include <numeric>
+#include <optional>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Attributes.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"          // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+static bool hasOnlyUnitStrides(ArrayRef<int64_t> strides) {
+  return llvm::all_of(strides, [](int64_t stride) { return stride == 1; });
+}
+
+LayoutAttr remapLayoutDims(LayoutAttr layout, ArrayRef<int64_t> oldToNewDim) {
+  SmallVector<Attribute> dims;
+  MLIRContext* ctx = layout.getContext();
+  ArrayAttr oldDims = layout.getDims();
+  // Track where each old piece position lands in the new dims list (-1 when
+  // the piece is dropped), so rolls -- which index into the piece list --
+  // can be remapped rather than silently discarded.
+  SmallVector<int64_t> oldPosToNewPos(oldDims.size(), -1);
+  for (auto [oldPos, attr] : llvm::enumerate(oldDims)) {
+    auto dim = cast<DimAttr>(attr);
+    if (dim.isGap() || dim.isReplicate()) {
+      oldPosToNewPos[oldPos] = static_cast<int64_t>(dims.size());
+      dims.push_back(dim);
+      continue;
+    }
+
+    // The layout is compatible with the op's input, so its traversal dims are
+    // in range and the dim map resolves each one to a result dim (or -1 to
+    // drop) -- never the unmapped sentinel.
+    int64_t oldDim = dim.getDim();
+    assert(oldDim >= 0 && oldDim < static_cast<int64_t>(oldToNewDim.size()) &&
+           "layout dim out of range for the op's input rank");
+    int64_t newDim = oldToNewDim[oldDim];
+    if (newDim == -1) continue;  // dim dropped by the op
+    oldPosToNewPos[oldPos] = static_cast<int64_t>(dims.size());
+    dims.push_back(DimAttr::get(ctx, newDim, dim.getSize(), dim.getStride()));
+  }
+
+  // Carry the rolls across the remap, keeping each step: a piece argument
+  // moves to its piece's new position, an axis argument to the axis's new
+  // id. A roll whose argument the op drops cannot be represented on the
+  // result; rather than
+  // emit a layout that claims a plain packing for a diagonal one, signal
+  // failure (the caller drops the candidate).
+  SmallVector<int64_t> newRolls;
+  for (const RollSpec& roll : getRollSpecs(layout)) {
+    auto remapRollArg = [&](const RollArg& e) -> std::optional<int64_t> {
+      if (e.isAxis) {
+        const int64_t newDim = oldToNewDim[e.index];
+        if (newDim < 0) return std::nullopt;
+        return encodeRollArg({/*isAxis=*/true, newDim});
+      }
+      const int64_t newPos = oldPosToNewPos[e.index];
+      if (newPos < 0) return std::nullopt;
+      return encodeRollArg({/*isAxis=*/false, newPos});
+    };
+    std::optional<int64_t> newFrom = remapRollArg(roll.from);
+    std::optional<int64_t> newBy = remapRollArg(roll.by);
+    if (!newFrom || !newBy) return {};
+    newRolls.push_back(*newFrom);
+    newRolls.push_back(*newBy);
+  }
+
+  // getCanonical re-derives the split and re-inserts the gap fill: a
+  // dropped dim can leave the slot side underfilled.
+  SmallVector<DimAttr> dimVec;
+  dimVec.reserve(dims.size());
+  for (Attribute attr : dims) dimVec.push_back(cast<DimAttr>(attr));
+  return LayoutAttr::getCanonical(ctx, dimVec, layout.getN(), newRolls);
+}
+
+SmallVector<Candidate> remapCandidates(Value operand,
+                                       ArrayRef<Candidate> candidates,
+                                       ArrayRef<int64_t> oldToNewDim,
+                                       KernelKind kind, int64_t extraCost) {
+  SmallVector<Candidate> remapped;
+  for (const Candidate& candidate : candidates) {
+    // The remap relabels dims of the operand's data (no rotation), so the
+    // result inherits the operand's assignment and the only new local cost is
+    // `extraCost`.
+    Candidate result;
+    result.layout = remapLayoutDims(candidate.layout, oldToNewDim);
+    // A rolled candidate whose rolled dim the op drops cannot be represented
+    // on the result; skip it rather than misdescribe the packing.
+    if (!result.layout) continue;
+    result.kind = kind;
+    result.operands = {operand};
+    result.operandLayouts = {candidate.layout};
+    result.localCost = extraCost;
+    result.assignment = candidate.assignment;
+    result.accumulatedCost =
+        accumulatedCostOf(result.assignment) + result.localCost;
+    remapped.push_back(std::move(result));
+  }
+  return uniqueCandidates(remapped);
+}
+
+SmallVector<Candidate> chooseCommonCandidates(
+    ArrayRef<Value> operands, ArrayRef<SmallVector<Candidate>> candidateSets,
+    KernelKind kind, function_ref<int64_t(LayoutAttr)> localCostFn,
+    function_ref<int64_t(LayoutAttr, LayoutAttr)> conversionCostFn) {
+  if (operands.size() != candidateSets.size()) return {};
+
+  SmallVector<Candidate> targets;
+  for (const SmallVector<Candidate>& candidates : candidateSets) {
+    for (const Candidate& candidate : candidates) {
+      Candidate target;
+      target.layout = candidate.layout;
+      target.kind = kind;
+      targets.push_back(std::move(target));
+    }
+  }
+  targets = uniqueCandidates(targets);
+  if (targets.empty()) return {};
+
+  SmallVector<Candidate> chosen;
+  for (const Candidate& target : targets) {
+    int64_t localCost = localCostFn(target.layout);
+    bool valid = true;
+    Assignment assignment;
+    SmallVector<LayoutAttr> operandLayouts;
+    for (const SmallVector<Candidate>& candidates : candidateSets) {
+      if (candidates.empty()) continue;
+      const Candidate* bestCandidate = nullptr;
+      std::optional<Candidate> bestScoredCandidate;
+      int64_t bestConversion = 0;
+      for (const Candidate& candidate : candidates) {
+        int64_t conversion = conversionCostFn(candidate.layout, target.layout);
+        Candidate scoredCandidate = candidate;
+        scoredCandidate.accumulatedCost =
+            candidate.accumulatedCost + conversion;
+        scoredCandidate.kind = kind;
+        if (!bestScoredCandidate ||
+            isBetterCandidate(scoredCandidate, *bestScoredCandidate)) {
+          bestScoredCandidate = scoredCandidate;
+          bestCandidate = &candidate;
+          bestConversion = conversion;
+        }
+      }
+      if (!bestCandidate) {
+        valid = false;
+        break;
+      }
+      // Merge the chosen operand's assignment; a disagreement on a shared value
+      // means this combination is inconsistent, so drop the target.
+      if (!mergeAssignments(assignment, bestCandidate->assignment)) {
+        valid = false;
+        break;
+      }
+      localCost += bestConversion;
+      operandLayouts.push_back(bestCandidate->layout);
+    }
+    if (!valid) continue;
+    Candidate candidate;
+    candidate.layout = target.layout;
+    candidate.kind = kind;
+    candidate.operands = SmallVector<Value>(operands);
+    candidate.operandLayouts = operandLayouts;
+    candidate.localCost = localCost;
+    candidate.assignment = std::move(assignment);
+    candidate.accumulatedCost =
+        accumulatedCostOf(candidate.assignment) + candidate.localCost;
+    chosen.push_back(std::move(candidate));
+  }
+  return uniqueCandidates(chosen);
+}
+
+std::optional<SmallVector<int64_t>> getReductionDimMap(
+    int64_t inputRank, ArrayRef<int64_t> reductionDims) {
+  SmallVector<bool> isReduced(inputRank, false);
+  for (int64_t dim : reductionDims) {
+    if (dim < 0 || dim >= inputRank) return std::nullopt;
+    isReduced[dim] = true;
+  }
+
+  SmallVector<int64_t> oldToNew(inputRank, -1);
+  int64_t newDim = 0;
+  for (int64_t dim = 0; dim < inputRank; ++dim) {
+    if (isReduced[dim]) continue;
+    oldToNew[dim] = newDim++;
+  }
+  return oldToNew;
+}
+
+std::optional<SmallVector<int64_t>> getCollapseShapeDimMap(
+    RankedTensorType sourceType,
+    ArrayRef<ReassociationIndices> reassociationIndices) {
+  SmallVector<int64_t> oldToNew(sourceType.getRank(), -2);
+
+  for (auto [resultDim, group] : llvm::enumerate(reassociationIndices)) {
+    int64_t mappedDim = -1;
+    for (int64_t sourceDim : group) {
+      if (sourceDim < 0 || sourceDim >= sourceType.getRank()) {
+        return std::nullopt;
+      }
+
+      int64_t dimSize = sourceType.getDimSize(sourceDim);
+      if (dimSize == 1) {
+        oldToNew[sourceDim] = -1;
+        if (mappedDim == -1) mappedDim = sourceDim;
+        continue;
+      }
+      if (mappedDim != -1 && sourceType.getDimSize(mappedDim) != 1) {
+        return std::nullopt;
+      }
+      mappedDim = sourceDim;
+    }
+
+    if (mappedDim == -1) return std::nullopt;
+    oldToNew[mappedDim] = static_cast<int64_t>(resultDim);
+  }
+
+  return oldToNew;
+}
+
+std::optional<SmallVector<int64_t>> getExpandShapeDimMap(
+    RankedTensorType resultType,
+    ArrayRef<ReassociationIndices> reassociationIndices) {
+  SmallVector<int64_t> oldToNew;
+  oldToNew.reserve(reassociationIndices.size());
+
+  for (ArrayRef<int64_t> group : reassociationIndices) {
+    int64_t mappedDim = -1;
+    for (int64_t resultDim : group) {
+      if (resultDim < 0 || resultDim >= resultType.getRank()) {
+        return std::nullopt;
+      }
+
+      int64_t dimSize = resultType.getDimSize(resultDim);
+      if (dimSize == 1) {
+        if (mappedDim == -1) mappedDim = resultDim;
+        continue;
+      }
+      if (mappedDim != -1 && resultType.getDimSize(mappedDim) != 1) {
+        return std::nullopt;
+      }
+      mappedDim = resultDim;
+    }
+    if (mappedDim == -1) return std::nullopt;
+    oldToNew.push_back(mappedDim);
+  }
+
+  return oldToNew;
+}
+
+std::optional<SmallVector<int64_t>> getExtractSliceDimMap(
+    RankedTensorType resultType, ArrayRef<int64_t> staticSizes,
+    ArrayRef<int64_t> staticStrides) {
+  if (!hasOnlyUnitStrides(staticStrides)) return std::nullopt;
+
+  int64_t sourceRank = static_cast<int64_t>(staticSizes.size());
+  int64_t resultRank = resultType.getRank();
+  if (sourceRank == resultRank) {
+    SmallVector<int64_t> identity(sourceRank);
+    std::iota(identity.begin(), identity.end(), 0);
+    return identity;
+  }
+
+  SmallVector<int64_t> oldToNew(sourceRank, -2);
+  int64_t resultDim = 0;
+  for (int64_t sourceDim = 0; sourceDim < sourceRank; ++sourceDim) {
+    int64_t size = staticSizes[sourceDim];
+    if (resultDim < resultRank && size == resultType.getDimSize(resultDim)) {
+      oldToNew[sourceDim] = resultDim++;
+      continue;
+    }
+    if (size == 1) {
+      oldToNew[sourceDim] = -1;
+      continue;
+    }
+    return std::nullopt;
+  }
+
+  if (resultDim != resultRank) return std::nullopt;
+  return oldToNew;
+}
+
+std::optional<SmallVector<int64_t>> getInsertSliceDimMap(
+    RankedTensorType sourceType, RankedTensorType resultType,
+    ArrayRef<int64_t> staticSizes, ArrayRef<int64_t> staticStrides) {
+  if (!hasOnlyUnitStrides(staticStrides)) return std::nullopt;
+
+  int64_t sourceRank = sourceType.getRank();
+  int64_t resultRank = resultType.getRank();
+  if (sourceRank == resultRank) {
+    SmallVector<int64_t> identity(sourceRank);
+    std::iota(identity.begin(), identity.end(), 0);
+    return identity;
+  }
+
+  SmallVector<int64_t> sourceToResult(sourceRank, -2);
+  int64_t sourceDim = 0;
+  for (int64_t resultDim = 0; resultDim < resultRank; ++resultDim) {
+    int64_t size = staticSizes[resultDim];
+    if (sourceDim < sourceRank && size == sourceType.getDimSize(sourceDim)) {
+      sourceToResult[sourceDim++] = resultDim;
+      continue;
+    }
+    if (size == 1) continue;
+    return std::nullopt;
+  }
+
+  if (sourceDim != sourceRank) return std::nullopt;
+  return sourceToResult;
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h
@@ -1,0 +1,70 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_DIMMAPS_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_DIMMAPS_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"     // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+// Rewrites a layout's traversal dims from the producer's index space into a
+// consumer's index space using `oldToNewDim` (old dim -> new dim, or -1 to drop
+// the dim). The dim map is total over the input's dims, so this never fails.
+LayoutAttr remapLayoutDims(LayoutAttr layout, ArrayRef<int64_t> oldToNewDim);
+
+// Per-op dim maps for shape-changing ops. Each returns `oldToNew`, mapping
+// every input dim to its result dim (or -1 to drop it), or nullopt when the op
+// isn't a pure dim relabel and so can't flow a layout through.
+
+// linalg.reduce: drop the reduced dims, renumber the survivors.
+std::optional<SmallVector<int64_t>> getReductionDimMap(
+    int64_t inputRank, ArrayRef<int64_t> reductionDims);
+
+// tensor.collapse_shape: each reassociation group keeps its one non-size-1 dim
+// and drops the size-1 dims; nullopt if a group merges two real dims.
+std::optional<SmallVector<int64_t>> getCollapseShapeDimMap(
+    RankedTensorType sourceType,
+    ArrayRef<ReassociationIndices> reassociationIndices);
+
+// tensor.expand_shape (collapse's inverse): map each source dim to the one
+// non-size-1 result dim of its reassociation group.
+std::optional<SmallVector<int64_t>> getExpandShapeDimMap(
+    RankedTensorType resultType,
+    ArrayRef<ReassociationIndices> reassociationIndices);
+
+// Rank-reducing tensor.extract_slice: full-extent source dims map to the
+// matching result dims, dropped unit dims to -1. Unit strides only.
+std::optional<SmallVector<int64_t>> getExtractSliceDimMap(
+    RankedTensorType resultType, ArrayRef<int64_t> staticSizes,
+    ArrayRef<int64_t> staticStrides);
+
+// tensor.insert_slice source (extract's inverse): map each source dim to its
+// matching result dim, skipping inserted unit dims. Unit strides only.
+std::optional<SmallVector<int64_t>> getInsertSliceDimMap(
+    RankedTensorType sourceType, RankedTensorType resultType,
+    ArrayRef<int64_t> staticSizes, ArrayRef<int64_t> staticStrides);
+
+// Maps an operand's candidate layouts through `oldToNewDim` to produce the
+// result's candidates (single-operand, shape-changing ops).
+SmallVector<Candidate> remapCandidates(Value operand,
+                                       ArrayRef<Candidate> candidates,
+                                       ArrayRef<int64_t> oldToNewDim,
+                                       KernelKind kind, int64_t extraCost = 0);
+
+// Picks a common result layout across multiple operands, charging each operand
+// `conversionCostFn(operandLayout, resultLayout)` to realign onto it plus
+// `localCostFn(layout)` for the compute.
+SmallVector<Candidate> chooseCommonCandidates(
+    ArrayRef<Value> operands, ArrayRef<SmallVector<Candidate>> candidateSets,
+    KernelKind kind, function_ref<int64_t(LayoutAttr)> localCostFn,
+    function_ref<int64_t(LayoutAttr, LayoutAttr)> conversionCostFn);
+
+}  // namespace mlir::heir::rotom
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_DIMMAPS_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMapsTest.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMapsTest.cpp
@@ -1,0 +1,100 @@
+#include <cstdint>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"        // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using rotom::DimAttr;
+using rotom::LayoutAttr;
+using rotom::RotomDialect;
+
+class DimMapsTest : public ::testing::Test {
+ protected:
+  DimMapsTest() { context.loadDialect<RotomDialect>(); }
+
+  DimAttr dim(int64_t dim, int64_t size, int64_t stride = 1) {
+    return DimAttr::get(&context, dim, size, stride);
+  }
+
+  LayoutAttr layout(ArrayRef<Attribute> dims, int64_t n) {
+    return LayoutAttr::getCanonical(&context, asDims(dims), n);
+  }
+
+  LayoutAttr rolled(ArrayRef<Attribute> dims, int64_t n,
+                    ArrayRef<int64_t> rolls) {
+    return LayoutAttr::getCanonical(&context, asDims(dims), n, rolls);
+  }
+
+  SmallVector<DimAttr> asDims(ArrayRef<Attribute> dims) {
+    SmallVector<DimAttr> vec;
+    for (Attribute attr : dims) vec.push_back(cast<DimAttr>(attr));
+    return vec;
+  }
+
+  MLIRContext context;
+};
+
+// A rolled candidate remapped through an identity dim map keeps its roll --
+// dropping it would misdescribe the diagonal packing as plain.
+TEST_F(DimMapsTest, RemapCarriesRolls) {
+  LayoutAttr in = rolled({dim(0, 4), dim(1, 4)}, 16, /*rolls=*/{1, 0});
+  LayoutAttr out = rotom::remapLayoutDims(in, /*oldToNewDim=*/{0, 1});
+  EXPECT_EQ(out, in);
+}
+
+// Relabeling dims (dim 0 -> 1, dim 1 -> 0, i.e. a transpose) remaps the roll's
+// piece positions consistently; the pieces keep their list order so the roll
+// positions are unchanged, but the dim ids swap.
+TEST_F(DimMapsTest, RemapRelabelsRolledDims) {
+  LayoutAttr in = rolled({dim(0, 4), dim(1, 4)}, 16, /*rolls=*/{1, 0});
+  LayoutAttr out = rotom::remapLayoutDims(in, /*oldToNewDim=*/{1, 0});
+  LayoutAttr expected = rolled({dim(1, 4), dim(0, 4)}, 16, /*rolls=*/{1, 0});
+  EXPECT_EQ(out, expected);
+}
+
+// A roll whose piece the op drops cannot be represented on the result, so the
+// remap fails (the caller then drops the candidate) rather than emitting a
+// plain layout that hides the diagonal.
+TEST_F(DimMapsTest, RemapFailsWhenRolledDimDropped) {
+  // roll (from=pos1=dim1, by=pos0=dim0); dropping dim 0 removes the by-piece.
+  LayoutAttr in = rolled({dim(0, 4), dim(1, 4)}, 16, /*rolls=*/{1, 0});
+  LayoutAttr out = rotom::remapLayoutDims(in, /*oldToNewDim=*/{-1, 0});
+  EXPECT_EQ(out, nullptr);
+}
+
+// An axis roll argument names a tensor axis, so a relabeling remaps it
+// through the dim map (piece arguments travel positionally).
+TEST_F(DimMapsTest, RemapRelabelsAxisRollArgs) {
+  const int64_t axis0 = rotom::encodeRollArg({/*isAxis=*/true, 0});
+  const int64_t axis1 = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  // dim 0 split into two pieces, rolled whole by the dim 1 piece.
+  LayoutAttr in = rolled({dim(0, 4, /*stride=*/4), dim(0, 4), dim(1, 16)}, 16,
+                         /*rolls=*/{axis0, 2});
+  LayoutAttr out = rotom::remapLayoutDims(in, /*oldToNewDim=*/{1, 0});
+  LayoutAttr expected =
+      rolled({dim(1, 4, /*stride=*/4), dim(1, 4), dim(0, 16)}, 16,
+             /*rolls=*/{axis1, 2});
+  EXPECT_EQ(out, expected);
+
+  // Dropping the rolled axis makes the roll unrepresentable: remap fails.
+  EXPECT_EQ(rotom::remapLayoutDims(in, /*oldToNewDim=*/{-1, 0}), nullptr);
+}
+
+// A roll-free candidate passes through the remap unchanged.
+TEST_F(DimMapsTest, RemapRollFreeUnchanged) {
+  LayoutAttr in = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr out = rotom::remapLayoutDims(in, /*oldToNewDim=*/{0, 1});
+  EXPECT_EQ(out, in);
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h
@@ -1,0 +1,73 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_GENERATORS_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_GENERATORS_H_
+
+#include <optional>
+
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+// One candidate-layout generator per tensor op the layout assignment supports.
+// Each reads/writes candidates and queries costs only through the
+// AssignmentContext, so it is independent of the pass that drives it.
+// LayoutAssignment::visitOperation dispatches to these by op type.
+
+// Structural (gen/Structural.cpp): values that carry layouts unchanged.
+LogicalResult generateFunc(AssignmentContext& ctx, func::FuncOp op);
+LogicalResult generateSecretGeneric(AssignmentContext& ctx,
+                                    secret::GenericOp op);
+LogicalResult generateYield(AssignmentContext& ctx, secret::YieldOp op);
+// Bring all operands to a common layout; the dispatch default and the fallback
+// the shape generators reach for when an op's dim map is unsupported.
+LogicalResult generatePassThrough(AssignmentContext& ctx, Operation* op);
+
+// Elementwise (gen/Binop.cpp): convert-then-compute binary ops.
+LogicalResult generateElementwise(AssignmentContext& ctx, Operation* op);
+LogicalResult generateLinalgGeneric(AssignmentContext& ctx,
+                                    linalg::GenericOp op);
+
+// Reduce / transpose (gen/ReduceTranspose.cpp): dim-permuting and dim-dropping.
+LogicalResult generateTranspose(AssignmentContext& ctx, linalg::TransposeOp op);
+LogicalResult generateReduction(AssignmentContext& ctx, linalg::ReduceOp op);
+
+// Matmul (gen/Binop.cpp): the reference's binop pipeline for
+// matmul -- replicate each operand to the aligned shape, apply the sum roll
+// on either side, align the pair (a conversion or a roll), derive the result.
+// Every step is priced by estimateConversionCost, which covers conversions
+// and rolls alike; the lowering replays the same steps as rotom.convert_layout
+// and rotom.apply_roll ops, so no kernel name is attached.
+LogicalResult generateMatmul(AssignmentContext& ctx, linalg::MatmulOp op);
+// The cheapest alignment generateMatmul priced for one (lhs, rhs, result)
+// layout combination, re-derived deterministically for the rewrite. Each
+// chain runs from the operand's assigned layout to its aligned placement,
+// one kernel per step (a conversion, or a roll when the step adds one).
+struct MatmulAlignment {
+  SmallVector<LayoutAttr> lhsChain;
+  SmallVector<LayoutAttr> rhsChain;
+  LayoutAttr compute;
+  LayoutAttr result;
+};
+std::optional<MatmulAlignment> selectMatmulAlignment(
+    AssignmentContext& ctx, LayoutAttr lhs, LayoutAttr rhs, LayoutAttr result,
+    ArrayRef<int64_t> lhsShape, ArrayRef<int64_t> rhsShape);
+
+// Reshape / slice (gen/Reshape.cpp): dim collapse/expand and slice
+// insert/extract.
+LogicalResult generateCollapseShape(AssignmentContext& ctx,
+                                    tensor::CollapseShapeOp op);
+LogicalResult generateExpandShape(AssignmentContext& ctx,
+                                  tensor::ExpandShapeOp op);
+LogicalResult generateExtractSlice(AssignmentContext& ctx,
+                                   tensor::ExtractSliceOp op);
+LogicalResult generateInsertSlice(AssignmentContext& ctx,
+                                  tensor::InsertSliceOp op);
+
+}  // namespace mlir::heir::rotom
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_GENERATORS_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.cpp
@@ -1,0 +1,806 @@
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/IR/RotomOps.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.h"
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+#include "lib/Dialect/Rotom/Utils/LayoutConversion.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.h"
+#include "lib/Dialect/Secret/IR/SecretAttributes.h"
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "lib/Utils/AttributeUtils.h"
+#include "lib/Utils/Layout/IslConversion.h"
+#include "lib/Utils/Layout/Utils.h"
+#include "lib/Utils/MathUtils.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"              // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"             // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
+#include "llvm/include/llvm/Support/MathExtras.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"       // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Attributes.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Block.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Matchers.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/IR/Visitors.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+#include "mlir/include/mlir/Support/WalkResult.h"        // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+constexpr llvm::StringLiteral kRotomSeedAttrName = "rotom.seed";
+constexpr llvm::StringLiteral kRotomLayoutAttrName = "rotom.layout";
+
+#define GEN_PASS_DEF_LAYOUTASSIGNMENT
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h.inc"
+
+namespace {
+// The legality gate for a two-operand kernel at `result`: every layout
+// lowerable, all at one ciphertext size.
+bool lowerableTriple(LayoutAttr lhs, LayoutAttr rhs, LayoutAttr result) {
+  return lhs && rhs && result && lhs.getN() == rhs.getN() &&
+         lhs.getN() == result.getN() && isLowerableRotomLayout(lhs) &&
+         isLowerableRotomLayout(rhs) && isLowerableRotomLayout(result);
+}
+struct LayoutAssignment : public impl::LayoutAssignmentBase<LayoutAssignment>,
+                          public AssignmentContext {
+  using LayoutAssignmentBase::LayoutAssignmentBase;
+
+  DenseMap<Value, SmallVector<Candidate>> candidates;
+  DenseMap<Value, LayoutAttr> selectedLayouts;
+
+  void getDependentDialects(DialectRegistry& registry) const override {
+    registry.insert<secret::SecretDialect>();
+    registry.insert<tensor_ext::TensorExtDialect>();
+  }
+
+  void runOnOperation() override;
+
+  // --- Candidate generation: a forward pass that fills `candidates` for every
+  // value. visitOperation dispatches to one free generate* function per tensor
+  // op (declared in Generators.h, grouped by op family under gen/); each takes
+  // only an AssignmentContext, so the per-op kernel space can grow file by
+  // file. The methods here implement that AssignmentContext -- the shared
+  // seed/candidate/cost API the generators call back into. ---
+  LogicalResult generateCandidates(ModuleOp module);
+  LogicalResult visitOperation(Operation* op);
+  void seedValue(Value value) override;
+  void setCandidates(Value value, ArrayRef<Candidate> newCandidates) override;
+  SmallVector<Candidate> candidatesForValue(Value value) override;
+  void assignResultsFromCandidates(Operation* op,
+                                   ArrayRef<Candidate> chosen) override;
+  SmallVector<Candidate> chooseCommonOperandCandidates(
+      Operation* op, KernelKind kind) override;
+  SmallVector<Candidate> chooseElementwiseKernels(
+      ArrayRef<Value> operands, KernelKind kind,
+      function_ref<int64_t(LayoutAttr)> computeCostFn,
+      bool hasRotomKernel) override;
+  int64_t conversionCost(LayoutAttr from, LayoutAttr to) override;
+  int64_t cacheConversionCost(LayoutAttr from, LayoutAttr to, int64_t cost);
+  llvm::DenseMap<std::pair<LayoutAttr, LayoutAttr>, int64_t>
+      conversionCostCache;
+
+  // --- Layout search: each value's candidates already carry the dedup'd
+  // accumulated cost and the full assignment of everything feeding it, so
+  // selection is just picking the cheapest consistent assignment at each
+  // function's returned values -- no backward propagation. ---
+  void selectLayouts(ModuleOp module);
+  LogicalResult visitReturn(func::ReturnOp op);
+  void applyKernels(ModuleOp module);
+  void writeSelectedLayouts();
+
+  // --- Kernel materialization: the selected matmul plans become IR. Each
+  // rewrite emits the operand alignment ops (rotom.convert_layout and
+  // rotom.apply_roll) and one rotom.matmul carrying every layout of the
+  // plan, then erases the linalg.matmul and its dead zero-init chain. ---
+  struct MatmulRewrite {
+    linalg::MatmulOp op;
+    MatmulAlignment alignment;
+  };
+  SmallVector<MatmulRewrite> matmulRewrites;
+  // Emits the chain as ops: a rotom.apply_roll for a step that adds one roll,
+  // a rotom.convert_layout otherwise.
+  Value alignOperand(OpBuilder& builder, Location loc, Value value,
+                     ArrayRef<LayoutAttr> chain);
+  void rewriteMatmul(const MatmulRewrite& rewrite);
+};
+}  // namespace
+
+// A public constant is data packed at encode time, so each use may pack it
+// at the layout its own consumer wants (the reference's one-term-per-literal
+// model). CSE merges equal literals into one op; split them back per use so
+// two consumers never fight over one layout.
+static void splitConstantsPerUse(Operation* root) {
+  SmallVector<arith::ConstantOp> shared;
+  root->walk([&](arith::ConstantOp op) {
+    if (!isa<RankedTensorType>(op.getType())) return;
+    if (!op->hasOneUse() && !op->use_empty()) shared.push_back(op);
+  });
+  for (arith::ConstantOp op : shared) {
+    SmallVector<OpOperand*> uses;
+    for (OpOperand& use : op->getUses()) uses.push_back(&use);
+    // The first use keeps the original; every other use gets its own copy,
+    // placed right after the original: same block, so the boundary
+    // materialization treats it exactly like the original, and it dominates
+    // every use the original did.
+    for (size_t i = 1; i < uses.size(); ++i) {
+      OpBuilder builder(op.getOperation());
+      builder.setInsertionPointAfter(op);
+      Operation* clone = builder.clone(*op.getOperation());
+      uses[i]->set(clone->getResult(0));
+    }
+  }
+}
+
+void LayoutAssignment::seedValue(Value value) {
+  if (candidates.contains(value)) return;
+
+  FailureOr<Attribute> seedAttr =
+      findAttributeAssociatedWith(value, kRotomSeedAttrName);
+  if (failed(seedAttr)) return;
+
+  auto seed = dyn_cast<SeedAttr>(*seedAttr);
+  if (!seed) return;
+
+  SmallVector<Candidate> seeded;
+  auto addSourceCandidate = [&](LayoutAttr layout) {
+    Candidate seed;
+    seed.layout = layout;
+    seed.kind = KernelKind::Tensor;
+    seeded.push_back(std::move(seed));
+  };
+  // Seeds are offered as-is: rolled placements are not blanket-seeded. A
+  // consumer that wants a diagonal packing of a source introduces it itself
+  // -- a matmul plan repacks the source at its expanded placement (see
+  // alignOptions), and anything else pays the priced conversion.
+  for (Attribute attr : seed.getLayouts()) {
+    auto layout = dyn_cast<LayoutAttr>(attr);
+    if (!layout) continue;
+    addSourceCandidate(layout);
+  }
+  if (!seeded.empty()) setCandidates(value, seeded);
+}
+
+void LayoutAssignment::setCandidates(Value value,
+                                     ArrayRef<Candidate> newCandidates) {
+  if (!isTensorLike(value) || newCandidates.empty()) return;
+  const RotomCostModel& costModel = getCostModel();
+  SmallVector<Candidate> compatibleCandidates;
+  for (const Candidate& candidate : newCandidates) {
+    if (!isLayoutCompatibleWithValue(candidate.layout, value)) continue;
+    // Fold this value's own kernel into its assignment, so the assignment is
+    // the complete assignment of the value and everything feeding it, and
+    // `cost` is the dedup'd sum over that assignment.
+    Candidate finalized = candidate;
+    // Charge the ciphertext-count carrying cost of holding this value at
+    // this layout (a compactness pressure; see RotomCostModel). Block
+    // arguments and yields alias a value already charged, so they are
+    // exempt.
+    int64_t carryingCost = 0;
+    if (finalized.kind != KernelKind::BlockArgument &&
+        finalized.kind != KernelKind::Yield) {
+      carryingCost =
+          costModel.ciphertextCount * layoutNumCiphertexts(finalized.layout);
+    }
+    finalized.assignment[value] = {finalized.layout,
+                                   finalized.localCost + carryingCost};
+    finalized.accumulatedCost = accumulatedCostOf(finalized.assignment);
+    compatibleCandidates.push_back(std::move(finalized));
+  }
+  if (compatibleCandidates.empty()) {
+    return;
+  }
+
+  candidates[value] = uniqueCandidates(compatibleCandidates);
+}
+
+SmallVector<Candidate> LayoutAssignment::candidatesForValue(Value value) {
+  seedValue(value);
+  auto it = candidates.find(value);
+  if (it == candidates.end()) return {};
+  return it->second;
+}
+
+SmallVector<Candidate> LayoutAssignment::chooseCommonOperandCandidates(
+    Operation* op, KernelKind kind) {
+  SmallVector<Value> operands;
+  SmallVector<SmallVector<Candidate>> candidateSets;
+  for (Value operand : op->getOperands()) {
+    if (!isTensorLike(operand)) continue;
+    SmallVector<Candidate> operandCandidates = candidatesForValue(operand);
+    if (operandCandidates.empty()) continue;
+    operands.push_back(operand);
+    candidateSets.push_back(operandCandidates);
+  }
+  return chooseCommonCandidates(
+      operands, candidateSets, kind,
+      [&](LayoutAttr layout) { return operationCost(op, layout); },
+      [this](LayoutAttr from, LayoutAttr to) {
+        return conversionCost(from, to);
+      });
+}
+
+int64_t LayoutAssignment::conversionCost(LayoutAttr from, LayoutAttr to) {
+  if (from == to) return 0;
+  // The estimate counts the step plan, so it is worth remembering: the search
+  // asks for the same pair many times.
+  auto cached = conversionCostCache.find({from, to});
+  if (cached != conversionCostCache.end()) return cached->second;
+
+  // Structure-level estimate, O(#pieces): the search prices conversions from
+  // the layouts' traversal-piece and roll structures (batched distinct-shift
+  // rotations, one multiplicative depth of masking) without materializing
+  // relations or points, so search time does not scale with tensor extents
+  // or ciphertext counts. The emission derives the exact step plan from the
+  // relations once per SELECTED conversion; the estimate matches its counts
+  // on the structured conversions the search
+  // favors (fills, diagonalizations, block moves).
+  const RotomCostModel& costModel = getCostModel();
+  ConversionEstimate estimate = estimateConversionCost(from, to);
+  if (!estimate.lowerable) {
+    return cacheConversionCost(from, to, kUnlowerableConversion);
+  }
+  return cacheConversionCost(
+      from, to,
+      estimate.rotations * costModel.rotation +
+          (estimate.masks + estimate.accumulates) * costModel.add);
+}
+
+int64_t LayoutAssignment::cacheConversionCost(LayoutAttr from, LayoutAttr to,
+                                              int64_t cost) {
+  conversionCostCache[{from, to}] = cost;
+  return cost;
+}
+
+// A value is public when nothing it derives from is secret. Its data is known
+// at encode time, so it can be packed at any layout the consumer wants (the
+// reference's `not layout.secret` test, which replaces the operand's kernel
+// with a TENSOR kernel).
+bool isPublicValue(Value value) {
+  llvm::DenseSet<Value> seen;
+  SmallVector<Value> worklist = {value};
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (!seen.insert(current).second) continue;
+    if (isa<secret::SecretType>(current.getType())) return false;
+    if (auto arg = dyn_cast<BlockArgument>(current)) {
+      // A secret.generic body argument carries the secret operand's data.
+      if (isa<secret::GenericOp>(arg.getOwner()->getParentOp())) return false;
+      continue;
+    }
+    Operation* def = current.getDefiningOp();
+    if (!def) return false;
+    worklist.append(def->operand_begin(), def->operand_end());
+  }
+  return true;
+}
+
+// The near-zero price of repacking a source at a demanded placement: enough
+// to lose ties against an operand that already sits at its seeded layout, far
+// below any ciphertext conversion. Mirrors gen/Binop.cpp's matmul path.
+constexpr int64_t kSourceRepackCost = 1;
+
+// `oldToNew` (total over the source's dims, -1 to drop) read backwards:
+// total over the result's dims, -1 for the axes the op created.
+static SmallVector<int64_t> invertDimMap(ArrayRef<int64_t> oldToNew,
+                                         int64_t newRank) {
+  SmallVector<int64_t> newToOld(newRank, -1);
+  for (auto [oldDim, newDim] : llvm::enumerate(oldToNew)) {
+    if (newDim < 0 || newDim >= newRank) continue;
+    // A collapse folds several source dims onto one result dim, so the map
+    // has no unambiguous inverse; the caller must not repack through it.
+    if (newToOld[newDim] >= 0) return {};
+    newToOld[newDim] = static_cast<int64_t>(oldDim);
+  }
+  return newToOld;
+}
+
+// Repacks `value` at `layout` by carrying the layout back to the value the
+// client interface actually packs. Every step between is a pure relabel, so
+// the layout is remapped through the step's dim map rather than converted.
+// Returns false when the chain cannot carry it -- a step this does not
+// model, or a value with another consumer whose layout would be clobbered --
+// and then the candidate must be dropped, leaving the priced conversion
+// variants to compete.
+static bool repackPublicChain(Value value, LayoutAttr layout,
+                              Assignment& assignment,
+                              const RotomCostModel& costModel) {
+  Value current = value;
+  LayoutAttr currentLayout = layout;
+  // A packing chain is a handful of reshapes; the bound just stops a cycle.
+  for (int step = 0; step < 8; ++step) {
+    if (!current.hasOneUse()) return false;
+    assignment[current] = {
+        currentLayout,
+        kSourceRepackCost +
+            costModel.ciphertextCount * layoutNumCiphertexts(currentLayout)};
+    Operation* def = current.getDefiningOp();
+    if (!def) return true;  // a block argument: what the client interface packs
+
+    SmallVector<int64_t> newToOld;
+    Value source;
+    if (auto expand = dyn_cast<tensor::ExpandShapeOp>(def)) {
+      std::optional<SmallVector<int64_t>> forward = getExpandShapeDimMap(
+          expand.getResultType(), expand.getReassociationIndices());
+      if (!forward) return false;
+      newToOld = invertDimMap(*forward, expand.getResultType().getRank());
+      source = expand.getSrc();
+    } else if (auto collapse = dyn_cast<tensor::CollapseShapeOp>(def)) {
+      std::optional<SmallVector<int64_t>> forward = getCollapseShapeDimMap(
+          collapse.getSrcType(), collapse.getReassociationIndices());
+      if (!forward) return false;
+      newToOld = invertDimMap(*forward, collapse.getResultType().getRank());
+      source = collapse.getSrc();
+    } else if (auto transpose = dyn_cast<linalg::TransposeOp>(def)) {
+      // Result dim i reads source dim permutation[i].
+      newToOld = SmallVector<int64_t>(transpose.getPermutation());
+      source = transpose.getInput();
+    } else if (def->hasTrait<OpTrait::ConstantLike>()) {
+      return true;  // a constant is packed where it stands
+    } else {
+      return false;
+    }
+    if (newToOld.empty()) return false;
+    LayoutAttr pre = remapLayoutDims(currentLayout, newToOld);
+    if (!pre) return false;
+    current = source;
+    currentLayout = pre;
+  }
+  return false;
+}
+
+SmallVector<Candidate> LayoutAssignment::chooseElementwiseKernels(
+    ArrayRef<Value> operands, KernelKind kind,
+    function_ref<int64_t(LayoutAttr)> computeCostFn, bool hasRotomKernel) {
+  if (operands.size() != 2) return {};
+
+  auto lhsType =
+      dyn_cast<RankedTensorType>(getPlainValueType(operands[0].getType()));
+  auto rhsType =
+      dyn_cast<RankedTensorType>(getPlainValueType(operands[1].getType()));
+  if (!lhsType || !rhsType || lhsType.getRank() != rhsType.getRank()) {
+    return {};
+  }
+
+  SmallVector<Candidate> lhsCandidates = candidatesForValue(operands[0]);
+  SmallVector<Candidate> rhsCandidates = candidatesForValue(operands[1]);
+  SmallVector<Value> operandValues(operands.begin(), operands.end());
+
+  // Each (lhs, rhs) candidate pairing is aligned by the shared engine under
+  // the identity map: an aligned pair stands, otherwise one side converts
+  // onto the other's structure. The kernel computes at the aligned layout;
+  // its local cost is the compute plus the estimated cost of bringing each
+  // operand there (one side is free). The operands' assignments are merged,
+  // so a pairing whose sub-assignments disagree on a shared value is dropped,
+  // and the merge never double-counts shared work.
+  const auto map = OperatorAlignmentMap::identity(lhsType.getRank());
+  SmallVector<Candidate> kernels;
+  for (const Candidate& lhs : lhsCandidates) {
+    for (const Candidate& rhs : rhsCandidates) {
+      Assignment merged;
+      if (!mergeAssignments(merged, lhs.assignment) ||
+          !mergeAssignments(merged, rhs.assignment)) {
+        continue;
+      }
+      for (const AlignedPair& aligned :
+           alignPair(map, lhs.layout, rhs.layout)) {
+        if (aligned.lhs != aligned.rhs) continue;  // elementwise: one layout
+        LayoutAttr computeLayout = aligned.lhs;
+        // A source is data packed at encode time, so it can be packed at the
+        // compute layout instead of converted to it (the reference's
+        // match_public_kernel, which every binop path calls). Without this
+        // choice a ciphertext is dragged to the constant's seeded layout,
+        // and the conversion costs far more than repacking the constant.
+        const bool lhsRepackable = isPublicValue(operands[0]) &&
+                                   lhs.layout != computeLayout &&
+                                   isLowerableRotomLayout(computeLayout);
+        const bool rhsRepackable = isPublicValue(operands[1]) &&
+                                   rhs.layout != computeLayout &&
+                                   isLowerableRotomLayout(computeLayout);
+        for (int variant = 0; variant < 4; ++variant) {
+          const bool repackLhs = (variant & 1) && lhsRepackable;
+          const bool repackRhs = (variant & 2) && rhsRepackable;
+          if (repackLhs != bool(variant & 1)) continue;
+          if (repackRhs != bool(variant & 2)) continue;
+          // One value, one layout: a self-op must agree with itself.
+          if (operands[0] == operands[1] && repackLhs != repackRhs) continue;
+          LayoutAttr lhsLayout = repackLhs ? computeLayout : lhs.layout;
+          LayoutAttr rhsLayout = repackRhs ? computeLayout : rhs.layout;
+          int64_t localCost =
+              computeCostFn(computeLayout) +
+              (repackLhs ? 0 : conversionCost(lhs.layout, computeLayout)) +
+              (repackRhs ? 0 : conversionCost(rhs.layout, computeLayout));
+          const bool kernel =
+              hasRotomKernel &&
+              lowerableTriple(lhsLayout, rhsLayout, computeLayout);
+          Candidate candidate;
+          candidate.layout = computeLayout;
+          candidate.kind = kind;
+          candidate.operands = operandValues;
+          candidate.operandLayouts = {lhsLayout, rhsLayout};
+          candidate.hasRotomKernel = kernel;
+          candidate.localCost = localCost;
+          candidate.assignment = merged;
+          // A repacked source's assignment entry replaces the seed's, so it
+          // re-charges the ciphertext-count carrying cost at the repacked
+          // placement: repacking a source fat is not free.
+          bool repacked = true;
+          if (repackLhs) {
+            repacked &= repackPublicChain(operands[0], computeLayout,
+                                          candidate.assignment, getCostModel());
+          }
+          if (repackRhs) {
+            repacked &= repackPublicChain(operands[1], computeLayout,
+                                          candidate.assignment, getCostModel());
+          }
+          if (!repacked) continue;
+          candidate.accumulatedCost =
+              accumulatedCostOf(candidate.assignment) + candidate.localCost;
+          kernels.push_back(std::move(candidate));
+        }
+      }
+      // Pack a public operand exactly like its partner (match_public_kernel
+      // under the identity map). Alignment cannot reach a layout with gaps,
+      // because a gap never matches a partner's traversal or replication
+      // piece, so without this the consumer of a matmul result must convert
+      // away from it.
+      for (int side = 0; side < 2; ++side) {
+        if (operands[0] == operands[1]) break;  // one value, one layout
+        const Candidate& pub = side == 0 ? lhs : rhs;
+        const Candidate& keep = side == 0 ? rhs : lhs;
+        LayoutAttr computeLayout = keep.layout;
+        if (pub.layout == computeLayout) continue;  // the aligned case above
+        if (!isPublicValue(operands[side])) continue;
+        if (!isLowerableRotomLayout(computeLayout)) continue;
+        Candidate candidate;
+        candidate.layout = computeLayout;
+        candidate.kind = kind;
+        candidate.operands = operandValues;
+        candidate.operandLayouts = {computeLayout, computeLayout};
+        candidate.hasRotomKernel =
+            hasRotomKernel &&
+            lowerableTriple(computeLayout, computeLayout, computeLayout);
+        candidate.localCost = computeCostFn(computeLayout);
+        candidate.assignment = merged;
+        if (!repackPublicChain(operands[side], computeLayout,
+                               candidate.assignment, getCostModel())) {
+          continue;
+        }
+        candidate.accumulatedCost =
+            accumulatedCostOf(candidate.assignment) + candidate.localCost;
+        kernels.push_back(std::move(candidate));
+      }
+    }
+  }
+  return uniqueCandidates(kernels);
+}
+
+void LayoutAssignment::assignResultsFromCandidates(Operation* op,
+                                                   ArrayRef<Candidate> chosen) {
+  if (chosen.empty()) return;
+  for (Value result : op->getResults()) {
+    if (!isTensorLike(result)) continue;
+    setCandidates(result, chosen);
+  }
+}
+
+LogicalResult LayoutAssignment::visitReturn(func::ReturnOp op) {
+  auto func = op->getParentOfType<func::FuncOp>();
+
+  // The returned values share one function-wide assignment. Fold each return
+  // operand's cheapest candidate whose assignment is consistent with the
+  // choices made so far into a single assignment; that assignment is the
+  // function's layout assignment.
+  Assignment assignment;
+  SmallVector<std::pair<unsigned, LayoutAttr>> resultLayouts;
+  for (OpOperand& operand : op->getOpOperands()) {
+    Value value = operand.get();
+    seedValue(value);
+    auto it = candidates.find(value);
+    if (it == candidates.end() || it->second.empty()) continue;
+    for (const Candidate& candidate : it->second) {  // cheapest first
+      Assignment trial = assignment;
+      if (mergeAssignments(trial, candidate.assignment)) {
+        assignment = std::move(trial);
+        resultLayouts.push_back({operand.getOperandNumber(), candidate.layout});
+        break;
+      }
+    }
+  }
+
+  for (const auto& entry : assignment) {
+    selectedLayouts[entry.first] = entry.second.first;
+  }
+  for (const auto& [index, layout] : resultLayouts) {
+    func.setResultAttr(index, kRotomLayoutAttrName, layout);
+  }
+  return success();
+}
+
+LogicalResult LayoutAssignment::visitOperation(Operation* op) {
+  AssignmentContext& ctx = *this;
+  return TypeSwitch<Operation*, LogicalResult>(op)
+      .Case<func::FuncOp>(
+          [&](auto typedOp) { return generateFunc(ctx, typedOp); })
+      .Case<secret::GenericOp>(
+          [&](auto typedOp) { return generateSecretGeneric(ctx, typedOp); })
+      .Case<secret::YieldOp>(
+          [&](auto typedOp) { return generateYield(ctx, typedOp); })
+      .Case<arith::AddFOp, arith::AddIOp, arith::SubFOp, arith::SubIOp,
+            arith::MulFOp, arith::MulIOp>(
+          [&](auto typedOp) { return generateElementwise(ctx, typedOp); })
+      .Case<linalg::GenericOp>(
+          [&](auto typedOp) { return generateLinalgGeneric(ctx, typedOp); })
+      .Case<linalg::MatmulOp>(
+          [&](auto typedOp) { return generateMatmul(ctx, typedOp); })
+      .Case<linalg::TransposeOp>(
+          [&](auto typedOp) { return generateTranspose(ctx, typedOp); })
+      .Case<linalg::ReduceOp>(
+          [&](auto typedOp) { return generateReduction(ctx, typedOp); })
+      .Case<tensor::CollapseShapeOp>(
+          [&](auto typedOp) { return generateCollapseShape(ctx, typedOp); })
+      .Case<tensor::ExpandShapeOp>(
+          [&](auto typedOp) { return generateExpandShape(ctx, typedOp); })
+      .Case<tensor::ExtractSliceOp>(
+          [&](auto typedOp) { return generateExtractSlice(ctx, typedOp); })
+      .Case<tensor::InsertSliceOp>(
+          [&](auto typedOp) { return generateInsertSlice(ctx, typedOp); })
+      .Default([&](Operation* genericOp) {
+        return generatePassThrough(ctx, genericOp);
+      });
+}
+
+void LayoutAssignment::writeSelectedLayouts() {
+  for (auto& [value, layout] : selectedLayouts) {
+    setAttributeAssociatedWith(value, kRotomLayoutAttrName, layout);
+  }
+}
+
+LogicalResult LayoutAssignment::generateCandidates(ModuleOp module) {
+  // Forward pre-order walk: every op contributes candidate layouts for its
+  // results. Returns are search roots, not generators, so they are skipped.
+  WalkResult result = module.walk<WalkOrder::PreOrder>([&](Operation* op) {
+    if (isa<func::ReturnOp>(op)) return WalkResult::advance();
+    if (failed(visitOperation(op))) return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  return failure(result.wasInterrupted());
+}
+
+void LayoutAssignment::selectLayouts(ModuleOp module) {
+  // Each function's returned values' candidates already carry the full cost and
+  // assignment of their inputs, so selection is just committing the cheapest
+  // consistent assignment per function.
+  module.walk([&](func::ReturnOp op) { (void)visitReturn(op); });
+}
+
+void LayoutAssignment::applyKernels(ModuleOp module) {
+  // The assignment carries layouts, not kernels. Re-derive each elementwise
+  // op's Rotom kernel attribute from the final operand/result layouts (the only
+  // ops that carry one); a forced kernel is left untouched.
+  module.walk([&](Operation* op) {
+    if (auto matmul = dyn_cast<linalg::MatmulOp>(op)) {
+      // A matmul becomes IR: explicit conversion and roll-alignment ops on
+      // each operand, then a rotom.matmul op that names every layout of the
+      // plan. The rewrite happens after the walk (it erases this op). Only a
+      // zero-filled init qualifies; any other matmul keeps its upstream
+      // lowering.
+      auto fill = matmul.getOutputs()[0].getDefiningOp<linalg::FillOp>();
+      if (!fill || !(matchPattern(fill.getInputs()[0], m_AnyZeroFloat()) ||
+                     matchPattern(fill.getInputs()[0], m_Zero()))) {
+        return;
+      }
+      LayoutAttr lhs = selectedLayouts.lookup(matmul.getInputs()[0]);
+      LayoutAttr rhs = selectedLayouts.lookup(matmul.getInputs()[1]);
+      LayoutAttr result = selectedLayouts.lookup(matmul->getResult(0));
+      if (!lhs || !rhs || !result) return;
+      auto shapeOf = [](Value v) {
+        auto t = dyn_cast<RankedTensorType>(getPlainValueType(v.getType()));
+        return t ? SmallVector<int64_t>(t.getShape().begin(),
+                                        t.getShape().end())
+                 : SmallVector<int64_t>();
+      };
+      if (std::optional<MatmulAlignment> alignment = selectMatmulAlignment(
+              *this, lhs, rhs, result, shapeOf(matmul.getInputs()[0]),
+              shapeOf(matmul.getInputs()[1]))) {
+        matmulRewrites.push_back({matmul, *alignment});
+      }
+      return;
+    }
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1) return;
+    if (!isAddLike(op) && !isMulLike(op)) return;
+    auto existing = op->getAttrOfType<secret::KernelAttr>(
+        secret::SecretDialect::kKernelAttrName);
+    if (existing && existing.getForce()) return;
+
+    LayoutAttr lhs = selectedLayouts.lookup(op->getOperand(0));
+    LayoutAttr rhs = selectedLayouts.lookup(op->getOperand(1));
+    LayoutAttr result = selectedLayouts.lookup(op->getResult(0));
+    if (lowerableTriple(lhs, rhs, result)) {
+      op->setAttr(kRotomElementwiseAttrName, UnitAttr::get(op->getContext()));
+      // The alignment decision becomes IR: an operand at a different layout
+      // is brought to the compute layout by an explicit rotom.convert_layout
+      // op. The elementwise op then computes at one shared layout, and each
+      // conversion lowers as its own kernel.
+      OpBuilder builder(op);
+      auto convertOperand = [&](unsigned index, LayoutAttr from) {
+        if (from == result) return;
+        auto convert = ConvertLayoutOp::create(
+            builder, op->getLoc(), op->getOperand(index).getType(),
+            op->getOperand(index), from, result);
+        setAttributeAssociatedWith(convert.getResult(), kRotomLayoutAttrName,
+                                   result);
+        op->setOperand(index, convert.getResult());
+      };
+      convertOperand(0, lhs);
+      convertOperand(1, rhs);
+    } else {
+      op->removeAttr(kRotomElementwiseAttrName);
+    }
+  });
+  for (const MatmulRewrite& rewrite : matmulRewrites) {
+    rewriteMatmul(rewrite);
+  }
+  matmulRewrites.clear();
+}
+
+// Emits the conversion ops that bring `value` from `from` to `to`, split so
+// the alignment mechanism is visible: a general rotom.convert_layout to the
+// unrolled placement, then one rotom.apply_roll per roll of `to`. A rolled
+// source falls back to one general conversion.
+Value LayoutAssignment::alignOperand(OpBuilder& builder, Location loc,
+                                     Value value, ArrayRef<LayoutAttr> chain) {
+  auto rollCount = [](LayoutAttr l) {
+    return l.getRolls() ? l.getRolls().size() : 0;
+  };
+  // An apply_roll keeps the piece multiset and adds one roll. A step that
+  // also moves pieces -- the sum roll splitting the summation piece, or a
+  // repack mirroring the partner's pieces -- is a conversion.
+  auto samePieces = [](LayoutAttr a, LayoutAttr b) {
+    SmallVector<DimAttr> x = layoutDims(a), y = layoutDims(b);
+    if (x.size() != y.size()) return false;
+    auto less = [](DimAttr p, DimAttr q) {
+      return std::tuple(p.getDim(), p.getSize(), p.getStride()) <
+             std::tuple(q.getDim(), q.getSize(), q.getStride());
+    };
+    llvm::sort(x, less);
+    llvm::sort(y, less);
+    return x == y;
+  };
+  Value current = value;
+  for (size_t i = 1; i < chain.size(); ++i) {
+    LayoutAttr from = chain[i - 1], to = chain[i];
+    // A step between two spellings of one packing moves nothing: record the
+    // layout and emit no op.
+    if (from == to ||
+        mergeAdjacentLayoutDims(from) == mergeAdjacentLayoutDims(to)) {
+      selectedLayouts[current] = to;
+      continue;
+    }
+    const bool roll =
+        rollCount(to) == rollCount(from) + 2 && samePieces(from, to);
+    Value out = roll ? ApplyRollOp::create(builder, loc, current.getType(),
+                                           current, from, to)
+                           .getResult()
+                     : ConvertLayoutOp::create(builder, loc, current.getType(),
+                                               current, from, to)
+                           .getResult();
+    selectedLayouts[out] = to;
+    current = out;
+  }
+  return current;
+}
+
+void LayoutAssignment::rewriteMatmul(const MatmulRewrite& rewrite) {
+  linalg::MatmulOp op = rewrite.op;
+  const MatmulAlignment& alignment = rewrite.alignment;
+  OpBuilder builder(op);
+  Location loc = op.getLoc();
+  // An operand whose chain ends in a roll by the ciphertext piece, facing a
+  // public operand, keeps its pre-roll placement: the matmul folds the roll
+  // into a baby-step/giant-step schedule (the reference's BSGS_ROT_ROLL +
+  // BSGS_MATMUL), B - 1 + G - 1 rotations for T = B * G targets instead of T.
+  auto foldableRoll = [&](ArrayRef<LayoutAttr> chain,
+                          Value other) -> std::optional<BsgsSchedule> {
+    if (chain.size() < 2 || !isPublicValue(other)) return std::nullopt;
+    return bsgsScheduleOpt(chain[chain.size() - 2], chain.back());
+  };
+  auto babyExtent = [](int64_t targets) {
+    int64_t b = 1;
+    while (b * b < targets) ++b;
+    return b;
+  };
+  SmallVector<LayoutAttr> lhsChain(alignment.lhsChain);
+  SmallVector<LayoutAttr> rhsChain(alignment.rhsChain);
+  std::optional<BsgsSchedule> fold;
+  int64_t rollOperand = 0;
+  if ((fold = foldableRoll(rhsChain, op.getInputs()[0]))) {
+    rollOperand = 1;
+    rhsChain.pop_back();
+  } else if ((fold = foldableRoll(lhsChain, op.getInputs()[1]))) {
+    rollOperand = 0;
+    lhsChain.pop_back();
+  }
+  Value lhs = alignOperand(builder, loc, op.getInputs()[0], lhsChain);
+  Value rhs = alignOperand(builder, loc, op.getInputs()[1], rhsChain);
+  Value result;
+  if (fold) {
+    // The folded operand stops one step short of its chain: the kernel reads
+    // it unrolled and rotates each target itself.
+    LayoutAttr rolled = rollOperand == 1 ? alignment.rhsChain.back()
+                                         : alignment.lhsChain.back();
+    result = BsgsMatmulOp::create(builder, loc, op.getResult(0).getType(), lhs,
+                                  rhs, lhsChain.back(), rhsChain.back(), rolled,
+                                  alignment.compute, alignment.result,
+                                  rollOperand, fold->stride, fold->targets,
+                                  babyExtent(fold->targets), fold->negative)
+                 .getResult();
+  } else {
+    result =
+        MatmulOp::create(builder, loc, op.getResult(0).getType(), lhs, rhs,
+                         alignment.lhsChain.back(), alignment.rhsChain.back(),
+                         alignment.compute, alignment.result)
+            .getResult();
+  }
+  selectedLayouts.erase(op->getResult(0));
+  selectedLayouts[result] = alignment.result;
+  op.getResult(0).replaceAllUsesWith(result);
+  Value init = op.getOutputs()[0];
+  op.erase();
+  // The zero-init chain fed only the erased matmul: erase what died with it
+  // (the fill, its zero constant, and its tensor.empty), and drop the dead
+  // values from the selection map.
+  SmallVector<Value> worklist = {init};
+  while (!worklist.empty()) {
+    Operation* def = worklist.pop_back_val().getDefiningOp();
+    if (!def || !def->use_empty()) continue;
+    worklist.append(def->operand_begin(), def->operand_end());
+    for (Value result : def->getResults()) selectedLayouts.erase(result);
+    def->erase();
+  }
+}
+
+void LayoutAssignment::runOnOperation() {
+  splitConstantsPerUse(getOperation());
+
+  ModuleOp module = getOperation();
+  if (failed(generateCandidates(module))) {
+    signalPassFailure();
+    return;
+  }
+  selectLayouts(module);
+  applyKernels(module);
+  writeSelectedLayouts();
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_LAYOUTASSIGNMENT_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_LAYOUTASSIGNMENT_H_
+
+// IWYU pragma: begin_keep
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+#define GEN_PASS_DECL_LAYOUTASSIGNMENT
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h.inc"
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_LAYOUTASSIGNMENT_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.td
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.td
@@ -1,0 +1,21 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_LAYOUTASSIGNMENT_TD_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_LAYOUTASSIGNMENT_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def LayoutAssignment
+    : Pass<"rotom-assign-layout", "ModuleOp"> {
+  let summary = "Assign concrete Rotom layouts from seeded candidate layouts";
+  let description = [{
+    Consumes `rotom.seed` candidate layout attributes and assigns one concrete
+    `rotom.layout` to each participating SSA value. The pass performs a
+    deterministic candidate propagation over the SSA graph and records selected
+    layouts using the same value-associated attribute convention consumed by
+    `rotom-materialize-tensor-ext-layout`.
+  }];
+  let dependentDialects = [
+    "mlir::heir::rotom::RotomDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_LAYOUTASSIGNMENT_TD_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.cpp
@@ -1,0 +1,50 @@
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.h"
+
+#include <cstdint>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Secret/IR/SecretTypes.h"
+#include "lib/Utils/MathUtils.h"
+#include "mlir/include/mlir/IR/Attributes.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Types.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"     // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+Type getPlainValueType(Type type) {
+  if (auto secretType = dyn_cast<secret::SecretType>(type)) {
+    return secretType.getValueType();
+  }
+  return type;
+}
+
+bool isCiphertext(Value value) {
+  return isa<secret::SecretType>(value.getType());
+}
+
+bool isTensorLike(Value value) {
+  return isa<RankedTensorType>(getPlainValueType(value.getType()));
+}
+
+bool isLayoutCompatibleWithValue(LayoutAttr layout, Value value) {
+  auto type = dyn_cast<RankedTensorType>(getPlainValueType(value.getType()));
+  if (!type) return false;
+
+  int64_t rank = type.getRank();
+  for (Attribute attr : layout.getDims()) {
+    auto dim = cast<DimAttr>(attr);
+    if (dim.isGap() || dim.isReplicate()) continue;
+    int64_t dimIndex = dim.getDim();
+    if (dimIndex >= rank) return false;
+    int64_t typeDimSize = type.getDimSize(dimIndex);
+    if (typeDimSize == ShapedType::kDynamic) continue;
+    if (typeDimSize <= 0) continue;
+    int64_t paddedDimSize = nextPowerOfTwo(typeDimSize);
+    if (dim.getSize() * dim.getStride() > paddedDimSize) return false;
+  }
+  return true;
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.h
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.h
@@ -1,0 +1,31 @@
+#ifndef LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_VALUEUTILS_H_
+#define LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_VALUEUTILS_H_
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "mlir/include/mlir/IR/Types.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"  // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+// Unwraps a secret.secret type to the value type it protects; returns `type`
+// unchanged for non-secret types.
+Type getPlainValueType(Type type);
+
+// Returns true if `value` is (a secret of) a ranked tensor -- the values the
+// layout assignment reasons about.
+bool isTensorLike(Value value);
+
+// Returns true if `value` carries ciphertext data (a secret type). Work on
+// a non-secret value is host-side plaintext preparation: real, but orders of
+// magnitude cheaper than the same op on a ciphertext, and often folded into
+// the encoded constants outright.
+bool isCiphertext(Value value);
+
+// Returns true if `layout` can describe `value`'s tensor type: every
+// non-gap/non-replicate dim indexes a real tensor dimension and its
+// size*stride footprint fits the padded extent of that dimension.
+bool isLayoutCompatibleWithValue(LayoutAttr layout, Value value);
+
+}  // namespace mlir::heir::rotom
+
+#endif  // LIB_DIALECT_ROTOM_TRANSFORMS_LAYOUTASSIGNMENT_VALUEUTILS_H_

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/Binop.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/Binop.cpp
@@ -1,0 +1,469 @@
+// The two-operand generators: elementwise (add/sub/mul and the elementwise
+// linalg.generic) and matmul. Both run on the shared alignment engine of
+// LayoutAlignment -- the reference's gen_binop -- and differ only in the
+// operator map (identity vs. matmul), in whether the sum roll is offered,
+// and in how the result layout is derived.
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/ValueUtils.h"
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+#include "lib/Dialect/Rotom/Utils/LayoutConversion.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "llvm/include/llvm/Support/Debug.h"             // from @llvm-project
+#include "llvm/include/llvm/Support/MathExtras.h"        // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"    // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Utils/StructuredOpsUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/AffineMap.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+// Defined by the layout assignment pass: a value whose data is known at
+// encode time, so a matmul may fold a partner's roll into a BSGS schedule.
+bool isPublicValue(Value value);
+
+// What the rewrite will really charge for a chain that ends in a roll by the
+// ciphertext piece facing a public operand: the fold replaces one rotation
+// per target with B - 1 baby and G - 1 giant rotations. Returns the signed
+// adjustment to the chain's price, or 0 when no fold applies.
+static int64_t bsgsAdjustment(AssignmentContext& ctx,
+                              ArrayRef<LayoutAttr> chain, Value other) {
+  if (chain.size() < 2 || !isPublicValue(other)) return 0;
+  LayoutAttr from = chain[chain.size() - 2], to = chain.back();
+  std::optional<BsgsSchedule> roll = bsgsScheduleOpt(from, to);
+  if (!roll) return 0;
+  int64_t baby = 1;
+  while (baby * baby < roll->targets) ++baby;
+  const int64_t giants = (roll->targets + baby - 1) / baby;
+  const RotomCostModel& costModel = getCostModel();
+  // The step as priced now, against what the fold emits.
+  const int64_t asPriced = ctx.conversionCost(from, to);
+  const int64_t folded = ((baby - 1) + (giants - 1)) * costModel.rotation;
+  return folded - asPriced;
+}
+
+// ---- elementwise ----------------------------------------------------------
+
+// A linalg.generic is elementwise when every operand is read with the identity
+// indexing map under purely parallel iteration -- no broadcast, reduction, or
+// permutation -- so a layout can pass through it unchanged.
+static bool isElementwiseGeneric(linalg::GenericOp op) {
+  for (AffineMap map : op.getIndexingMapsArray()) {
+    if (!map.isIdentity()) return false;
+  }
+  for (utils::IteratorType iteratorType : op.getIteratorTypesArray()) {
+    if (iteratorType != utils::IteratorType::parallel) return false;
+  }
+  return true;
+}
+
+// True when the body is a single add-like op (ignoring the yield and any
+// constants), i.e. the generic computes an elementwise addition.
+static bool hasAddLikeBody(linalg::GenericOp op) {
+  bool foundAddLikeOp = false;
+  for (Operation& innerOp : op.getBody()->getOperations()) {
+    if (isa<linalg::YieldOp, arith::ConstantOp>(innerOp)) continue;
+    if (!isAddLike(&innerOp)) return false;
+    foundAddLikeOp = true;
+  }
+  return foundAddLikeOp;
+}
+
+LogicalResult generateElementwise(AssignmentContext& ctx, Operation* op) {
+  if (op->getNumOperands() == 2) {
+    const bool hasRotomKernel = isAddLike(op) || isMulLike(op);
+    SmallVector<Value> operands = {op->getOperand(0), op->getOperand(1)};
+    SmallVector<Candidate> kernels = ctx.chooseElementwiseKernels(
+        operands, KernelKind::Elementwise,
+        [&](LayoutAttr layout) { return operationCost(op, layout); },
+        hasRotomKernel);
+    if (!kernels.empty()) {
+      ctx.assignResultsFromCandidates(op, kernels);
+      return success();
+    }
+  }
+
+  SmallVector<Candidate> chosen =
+      ctx.chooseCommonOperandCandidates(op, KernelKind::Elementwise);
+  ctx.assignResultsFromCandidates(op, chosen);
+  return success();
+}
+
+LogicalResult generateLinalgGeneric(AssignmentContext& ctx,
+                                    linalg::GenericOp op) {
+  if (!isElementwiseGeneric(op)) return generatePassThrough(ctx, op);
+  if (hasAddLikeBody(op) && op.getInputs().size() == 2) {
+    SmallVector<Value> operands = {op.getInputs()[0], op.getInputs()[1]};
+    SmallVector<Candidate> kernels = ctx.chooseElementwiseKernels(
+        operands, KernelKind::Generic,
+        [&](LayoutAttr layout) { return genericOperationCost(op, layout); });
+    if (!kernels.empty()) {
+      ctx.assignResultsFromCandidates(op, kernels);
+      return success();
+    }
+  }
+
+  SmallVector<Value> operands;
+  SmallVector<SmallVector<Candidate>> candidateSets;
+  for (Value operand : op->getOperands()) {
+    if (!isTensorLike(operand)) continue;
+    SmallVector<Candidate> operandCandidates = ctx.candidatesForValue(operand);
+    if (operandCandidates.empty()) continue;
+    operands.push_back(operand);
+    candidateSets.push_back(operandCandidates);
+  }
+  SmallVector<Candidate> chosen = chooseCommonCandidates(
+      operands, candidateSets, KernelKind::Generic,
+      [&](LayoutAttr layout) { return genericOperationCost(op, layout); },
+      [&ctx](LayoutAttr from, LayoutAttr to) {
+        return ctx.conversionCost(from, to);
+      });
+  ctx.assignResultsFromCandidates(op, chosen);
+  return success();
+}
+
+// ---- matmul ---------------------------------------------------------------
+
+// The operands' axes read as the matmul iteration space, for any ranks: the
+// lhs is [..batch, i, k] and the rhs is [..batch, k, j], with a rank-1 operand
+// standing for [k]. A non-contraction axis takes its id in the result
+// [..batch, i, j]; the contraction takes kDimContraction, since the result
+// sums it out and carries a gap there instead.
+struct MatmulAxes {
+  int64_t lhsRank = 2, rhsRank = 2;
+  int64_t lhsSumDim() const { return lhsRank - 1; }
+  int64_t rhsSumDim() const { return rhsRank == 1 ? 0 : rhsRank - 2; }
+  int64_t batch() const {
+    return std::max(std::max<int64_t>(lhsRank - 2, 0),
+                    std::max<int64_t>(rhsRank - 2, 0));
+  }
+  int64_t lhsIter(int64_t axis) const {
+    if (axis == lhsSumDim()) return kDimContraction;
+    if (axis == lhsRank - 2) return batch();
+    return batch() - (lhsRank - 2) + axis;
+  }
+  int64_t rhsIter(int64_t axis) const {
+    if (axis == rhsSumDim()) return kDimContraction;
+    if (axis == rhsRank - 1) return batch() + 1;
+    return batch() - (rhsRank - 2) + axis;
+  }
+};
+namespace {
+// One priced way to run the matmul: the per-operand chains from the
+// operand's layout to its aligned placement, the compute placement, and the
+// result layout.
+struct MatmulOption {
+  SmallVector<LayoutAttr> lhsChain;
+  SmallVector<LayoutAttr> rhsChain;
+  LayoutAttr compute;
+  LayoutAttr result;
+};
+}  // namespace
+
+// The placement the elementwise product computes at, over the (i, j, k)
+// iteration space: piece by piece from the aligned pair, a traversal piece
+// naming its iteration axis and two replications staying replication.
+static LayoutAttr computeLayoutOf(const MatmulAxes& axes, LayoutAttr lhs,
+                                  LayoutAttr rhs) {
+  MLIRContext* ctx = lhs.getContext();
+  SmallVector<DimAttr> a = layoutDims(lhs), b = layoutDims(rhs);
+  SmallVector<DimAttr> out;
+  auto trav = [](DimAttr d) { return !d.isGap() && !d.isReplicate(); };
+  // The pair arrives aligned, so the two piece lists already correspond one
+  // to one and the walk steps them together. Alignment restates both sides at
+  // one granularity, and canonicalization pins a unit piece to the tail of
+  // each list, so a unit piece faces its partner rather than a data piece.
+  size_t ia = 0, ib = 0;
+  while (ia < a.size() || ib < b.size()) {
+    if (ia >= a.size() || ib >= b.size()) return {};
+    DimAttr x = a[ia++], y = b[ib++];
+    if (trav(x)) {
+      out.push_back(DimAttr::get(ctx, axes.lhsIter(x.getDim()), x.getSize(),
+                                 x.getStride()));
+    } else if (trav(y)) {
+      out.push_back(DimAttr::get(ctx, axes.rhsIter(y.getDim()), y.getSize(),
+                                 y.getStride()));
+    } else {
+      out.push_back(x);  // both replication, or a shared gap
+    }
+  }
+  LayoutAttr compute = LayoutAttr::getCanonical(ctx, out, lhs.getN());
+  return compute ? mergeAdjacentLayoutDims(compute) : LayoutAttr();
+}
+
+// The compute-and-reduce price of one option, exclusive of alignment: one
+// multiply per compute ciphertext, then the k reduction -- a log tree of
+// rotate-and-add for each slot-region k piece, and block adds for the
+// ciphertext-region k pieces.
+static int64_t matmulKernelCost(LayoutAttr compute) {
+  const RotomCostModel& costModel = getCostModel();
+  SmallVector<DimAttr> dims = layoutDims(compute);
+  const size_t ctLen = inferCtPrefixLen(dims, compute.getN());
+  const int64_t numCtCompute = layoutNumCiphertexts(compute);
+  int64_t ctK = 1, reduceSteps = 0;
+  for (size_t p = 0; p < dims.size(); ++p) {
+    DimAttr d = dims[p];
+    if (!d.isContraction()) continue;
+    if (p < ctLen) {
+      ctK *= d.getSize();
+    } else {
+      reduceSteps += llvm::Log2_64_Ceil(d.getSize());
+    }
+  }
+  const int64_t numCtResult = numCtCompute / ctK;
+  const int64_t reduceRotations = numCtResult * reduceSteps;
+  const int64_t reduceAdds =
+      numCtResult * reduceSteps + (numCtCompute - numCtResult);
+  return numCtCompute * costModel.ciphertextMultiply +
+         reduceRotations * costModel.rotation + reduceAdds * costModel.add;
+}
+
+// Price of a chain: one estimate per step (conversions and rolls alike).
+// Nullopt when a step's target cannot be lowered.
+static std::optional<int64_t> chainCost(AssignmentContext& ctx,
+                                        ArrayRef<LayoutAttr> chain) {
+  int64_t cost = 0;
+  for (size_t i = 1; i < chain.size(); ++i) {
+    if (!isLowerableRotomLayout(chain[i])) return std::nullopt;
+    const int64_t step = ctx.conversionCost(chain[i - 1], chain[i]);
+    // A step the lowering cannot emit makes the whole chain unusable.
+    if (step >= AssignmentContext::kUnlowerableConversion) return std::nullopt;
+    cost += step;
+  }
+  return cost;
+}
+
+static void extend(SmallVector<LayoutAttr>& chain, LayoutAttr next) {
+  if (chain.empty() || chain.back() != next) chain.push_back(next);
+}
+
+// The reference's gen_binop for matmul: replicate, the sum-roll variants
+// (neither, either, both sides), align each pair, derive the result.
+static SmallVector<MatmulOption> enumerateMatmulOptions(
+    LayoutAttr lhs, LayoutAttr rhs, ArrayRef<int64_t> lhsShape,
+    ArrayRef<int64_t> rhsShape) {
+  SmallVector<MatmulOption> options;
+  const MatmulAxes axes{static_cast<int64_t>(lhsShape.size()),
+                        static_cast<int64_t>(rhsShape.size())};
+  auto map = OperatorAlignmentMap::matmul(axes.lhsRank, axes.rhsRank);
+  auto rep = replicateForAlignment(map, lhs, rhs, lhsShape, rhsShape);
+
+  if (failed(rep)) return options;
+
+  struct Pair {
+    SmallVector<LayoutAttr> lhsChain, rhsChain;
+  };
+  SmallVector<Pair> pairs;
+  Pair base;
+  extend(base.lhsChain, lhs);
+  extend(base.lhsChain, rep->lhs);
+  extend(base.rhsChain, rhs);
+  extend(base.rhsChain, rep->rhs);
+  pairs.push_back(base);
+  std::optional<LayoutAttr> rolledLhs =
+      applySumRoll(rep->lhs, axes.lhsSumDim());
+  std::optional<LayoutAttr> rolledRhs =
+      applySumRoll(rep->rhs, axes.rhsSumDim());
+  if (rolledLhs && rolledRhs) {
+    Pair p = base;
+    extend(p.lhsChain, *rolledLhs);
+    extend(p.rhsChain, *rolledRhs);
+    pairs.push_back(p);
+  }
+  if (rolledRhs) {
+    Pair p = base;
+    extend(p.rhsChain, *rolledRhs);
+    pairs.push_back(p);
+  }
+  if (rolledLhs) {
+    Pair p = base;
+    extend(p.lhsChain, *rolledLhs);
+    pairs.push_back(p);
+  }
+
+  for (const Pair& pair : pairs) {
+    auto dbgPairs = alignPair(map, pair.lhsChain.back(), pair.rhsChain.back());
+
+    for (const AlignedPair& aligned : dbgPairs) {
+      MatmulOption option;
+      option.lhsChain = pair.lhsChain;
+      option.rhsChain = pair.rhsChain;
+      extend(option.lhsChain, aligned.lhs);
+      extend(option.rhsChain, aligned.rhs);
+      option.compute = computeLayoutOf(axes, aligned.lhs, aligned.rhs);
+      std::optional<LayoutAttr> result =
+          outputLayout(map, /*isMatmul=*/true, aligned.lhs, aligned.rhs,
+                       axes.lhsSumDim(), axes.rhsSumDim());
+
+      if (!option.compute || !result) continue;
+      option.result = *result;
+      options.push_back(std::move(option));
+    }
+  }
+  return options;
+}
+
+// A source candidate is data packed at encode time rather than computed
+// homomorphically (the reference's TENSOR kernel, which match_public_kernel
+// packs to whatever the other side needs). Its aligned placement is
+// reachable for free by assigning it as the source's own layout.
+static bool isSourceCandidate(const Candidate& candidate) {
+  return candidate.kind == KernelKind::Tensor;
+}
+
+// The near-zero price of repacking a source at a demanded placement: enough
+// to lose ties against an option whose operand already sits at its seeded
+// layout, far below any ciphertext conversion.
+constexpr int64_t kSourceRepackCost = 1;
+
+namespace {
+struct AlignChoice {
+  LayoutAttr layout;  // the operand's assigned layout under this choice
+  SmallVector<LayoutAttr> chain;
+  int64_t alignCost;
+  bool repack;
+};
+}  // namespace
+
+static SmallVector<AlignChoice, 2> alignChoices(AssignmentContext& ctx,
+                                                const Candidate& operand,
+                                                ArrayRef<LayoutAttr> chain) {
+  SmallVector<AlignChoice, 2> choices;
+  if (std::optional<int64_t> cost = chainCost(ctx, chain)) {
+    choices.push_back({operand.layout, SmallVector<LayoutAttr>(chain), *cost,
+                       /*repack=*/false});
+  }
+  LayoutAttr aligned = chain.back();
+  if (isSourceCandidate(operand) && operand.layout != aligned &&
+      isLowerableRotomLayout(aligned)) {
+    choices.push_back({aligned, {aligned}, 0, /*repack=*/true});
+  }
+  return choices;
+}
+
+static SmallVector<int64_t> shapeOf(Value value) {
+  auto type = dyn_cast<RankedTensorType>(getPlainValueType(value.getType()));
+  if (!type) return {};
+  return SmallVector<int64_t>(type.getShape().begin(), type.getShape().end());
+}
+
+std::optional<MatmulAlignment> selectMatmulAlignment(
+    AssignmentContext& ctx, LayoutAttr lhs, LayoutAttr rhs, LayoutAttr result,
+    ArrayRef<int64_t> lhsShape, ArrayRef<int64_t> rhsShape) {
+  std::optional<MatmulAlignment> best;
+  std::optional<int64_t> bestCost;
+  for (const MatmulOption& option :
+       enumerateMatmulOptions(lhs, rhs, lhsShape, rhsShape)) {
+    if (option.result != result) continue;
+    std::optional<int64_t> lhsCost = chainCost(ctx, option.lhsChain);
+    std::optional<int64_t> rhsCost = chainCost(ctx, option.rhsChain);
+    if (!lhsCost || !rhsCost) continue;
+    const int64_t cost = *lhsCost + *rhsCost + matmulKernelCost(option.compute);
+    if (!bestCost || cost < *bestCost) {
+      best = MatmulAlignment{option.lhsChain, option.rhsChain, option.compute,
+                             option.result};
+      bestCost = cost;
+    }
+  }
+  return best;
+}
+
+LogicalResult generateMatmul(AssignmentContext& ctx, linalg::MatmulOp op) {
+  // Only the default (i,k) x (k,j) indexing; transposed/broadcast variants
+  // pass through until they get their own dim maps.
+  if (op.hasUserDefinedMaps()) return generatePassThrough(ctx, op);
+
+  Value lhs = op.getInputs()[0];
+  Value rhs = op.getInputs()[1];
+  SmallVector<int64_t> lhsShape = shapeOf(lhs), rhsShape = shapeOf(rhs);
+  SmallVector<Candidate> lhsCandidates = ctx.candidatesForValue(lhs);
+  SmallVector<Candidate> rhsCandidates = ctx.candidatesForValue(rhs);
+  const RotomCostModel& costModel = getCostModel();
+
+  SmallVector<Candidate> candidates;
+  for (const Candidate& lhsCandidate : lhsCandidates) {
+    for (const Candidate& rhsCandidate : rhsCandidates) {
+      Assignment merged;
+      if (!mergeAssignments(merged, lhsCandidate.assignment) ||
+          !mergeAssignments(merged, rhsCandidate.assignment)) {
+        continue;
+      }
+      SmallVector<MatmulOption> dbgOptions = enumerateMatmulOptions(
+          lhsCandidate.layout, rhsCandidate.layout, lhsShape, rhsShape);
+
+      for (const MatmulOption& option : dbgOptions) {
+        const int64_t kernelCost = matmulKernelCost(option.compute);
+
+        for (const AlignChoice& lhsChoice :
+             alignChoices(ctx, lhsCandidate, option.lhsChain)) {
+          for (const AlignChoice& rhsChoice :
+               alignChoices(ctx, rhsCandidate, option.rhsChain)) {
+            // A self-matmul shares one source: both sides must agree on its
+            // single assigned layout.
+            if (lhs == rhs && (lhsChoice.repack != rhsChoice.repack ||
+                               lhsChoice.layout != rhsChoice.layout)) {
+              continue;
+            }
+            Candidate candidate;
+            candidate.layout = option.result;
+            candidate.kind = KernelKind::Matmul;
+            candidate.operands = {lhs, rhs};
+            candidate.operandLayouts = {lhsChoice.layout, rhsChoice.layout};
+            candidate.localCost =
+                lhsChoice.alignCost + rhsChoice.alignCost + kernelCost;
+            // Only a chain the rewrite will actually keep can be folded: a
+            // repacked source arrives already placed, with no chain to fold.
+            if (!rhsChoice.repack) {
+              candidate.localCost += bsgsAdjustment(ctx, rhsChoice.chain, lhs);
+            }
+            if (!lhsChoice.repack) {
+              candidate.localCost += bsgsAdjustment(ctx, lhsChoice.chain, rhs);
+            }
+            candidate.assignment = merged;
+            // A repacked source's assignment entry replaces the seed's, so
+            // it re-charges the ciphertext-count carrying cost at the
+            // repacked placement: repacking a source fat is not free.
+            if (lhsChoice.repack) {
+              candidate.assignment[lhs] = {
+                  lhsChoice.layout,
+                  kSourceRepackCost +
+                      costModel.ciphertextCount *
+                          layoutNumCiphertexts(lhsChoice.layout)};
+            }
+            if (rhsChoice.repack) {
+              candidate.assignment[rhs] = {
+                  rhsChoice.layout,
+                  kSourceRepackCost +
+                      costModel.ciphertextCount *
+                          layoutNumCiphertexts(rhsChoice.layout)};
+            }
+            candidate.accumulatedCost =
+                accumulatedCostOf(candidate.assignment) + candidate.localCost;
+
+            candidates.push_back(std::move(candidate));
+          }
+        }
+      }
+    }
+  }
+  ctx.assignResultsFromCandidates(op, uniqueCandidates(candidates));
+  return success();
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/ReduceTranspose.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/ReduceTranspose.cpp
@@ -1,0 +1,69 @@
+#include <cstdint>
+#include <optional>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/CostModel.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h"
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"             // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+LogicalResult generateTranspose(AssignmentContext& ctx,
+                                linalg::TransposeOp op) {
+  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+  if (!inputType) return generatePassThrough(ctx, op);
+
+  SmallVector<int64_t> oldToNew(inputType.getRank(), -2);
+  for (auto [outputDim, inputDim] : llvm::enumerate(op.getPermutation())) {
+    if (inputDim < 0 || inputDim >= inputType.getRank()) {
+      return generatePassThrough(ctx, op);
+    }
+    oldToNew[inputDim] = static_cast<int64_t>(outputDim);
+  }
+
+  SmallVector<Candidate> inputCandidates =
+      ctx.candidatesForValue(op.getInput());
+  SmallVector<Candidate> transposed = remapCandidates(
+      op.getInput(), inputCandidates, oldToNew, KernelKind::Transpose);
+  ctx.assignResultsFromCandidates(op, transposed);
+  return success();
+}
+
+LogicalResult generateReduction(AssignmentContext& ctx, linalg::ReduceOp op) {
+  for (auto [input, result] : llvm::zip(op.getInputs(), op.getResults())) {
+    SmallVector<Candidate> inputCandidates = ctx.candidatesForValue(input);
+    if (inputCandidates.empty()) continue;
+
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType) continue;
+
+    std::optional<SmallVector<int64_t>> oldToNew =
+        getReductionDimMap(inputType.getRank(), op.getDimensions());
+    if (!oldToNew) continue;
+
+    SmallVector<Candidate> reduced =
+        remapCandidates(input, inputCandidates, *oldToNew, KernelKind::Reduce);
+    for (Candidate& candidate : reduced) {
+      // A reduction sums its input ciphertexts, so its local cost is set by the
+      // aligned INPUT layout (operandLayouts[0]) -- one add per input
+      // ciphertext -- not the smaller reduced output layout.
+      if (candidate.operandLayouts.empty()) continue;
+      int64_t inputNumCt = layoutNumCiphertexts(candidate.operandLayouts[0]);
+      candidate.localCost += inputNumCt * getCostModel().add;
+    }
+    ctx.setCandidates(result, reduced);
+  }
+  return success();
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/Reshape.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/Reshape.cpp
@@ -1,0 +1,99 @@
+#include <cstdint>
+#include <optional>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/DimMaps.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h"
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"     // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+LogicalResult generateCollapseShape(AssignmentContext& ctx,
+                                    tensor::CollapseShapeOp op) {
+  std::optional<SmallVector<int64_t>> oldToNew =
+      getCollapseShapeDimMap(op.getSrcType(), op.getReassociationIndices());
+  if (!oldToNew) return generatePassThrough(ctx, op);
+
+  SmallVector<Candidate> collapsed =
+      remapCandidates(op.getSrc(), ctx.candidatesForValue(op.getSrc()),
+                      *oldToNew, KernelKind::CollapseShape);
+  ctx.assignResultsFromCandidates(op, collapsed);
+  return success();
+}
+
+LogicalResult generateExpandShape(AssignmentContext& ctx,
+                                  tensor::ExpandShapeOp op) {
+  std::optional<SmallVector<int64_t>> oldToNew =
+      getExpandShapeDimMap(op.getResultType(), op.getReassociationIndices());
+  if (!oldToNew) return generatePassThrough(ctx, op);
+
+  SmallVector<Candidate> expanded =
+      remapCandidates(op.getSrc(), ctx.candidatesForValue(op.getSrc()),
+                      *oldToNew, KernelKind::ExpandShape);
+  ctx.assignResultsFromCandidates(op, expanded);
+  return success();
+}
+
+LogicalResult generateExtractSlice(AssignmentContext& ctx,
+                                   tensor::ExtractSliceOp op) {
+  std::optional<SmallVector<int64_t>> oldToNew = getExtractSliceDimMap(
+      op.getResultType(), op.getStaticSizes(), op.getStaticStrides());
+  if (!oldToNew) return generatePassThrough(ctx, op);
+
+  SmallVector<Candidate> sliced =
+      remapCandidates(op.getSource(), ctx.candidatesForValue(op.getSource()),
+                      *oldToNew, KernelKind::ExtractSlice);
+  ctx.assignResultsFromCandidates(op, sliced);
+  return success();
+}
+
+LogicalResult generateInsertSlice(AssignmentContext& ctx,
+                                  tensor::InsertSliceOp op) {
+  SmallVector<Candidate> destCandidates = ctx.candidatesForValue(op.getDest());
+  if (!destCandidates.empty()) {
+    SmallVector<Candidate> sourceCandidates =
+        ctx.candidatesForValue(op.getSource());
+    std::optional<SmallVector<int64_t>> sourceToDest =
+        getInsertSliceDimMap(op.getSourceType(), op.getResultType(),
+                             op.getStaticSizes(), op.getStaticStrides());
+    if (sourceToDest) {
+      SmallVector<Candidate> expandedSource =
+          remapCandidates(op.getSource(), sourceCandidates, *sourceToDest,
+                          KernelKind::InsertSlice);
+      if (!expandedSource.empty()) {
+        SmallVector<Value> operands = {op.getDest(), op.getSource()};
+        SmallVector<SmallVector<Candidate>> sets = {destCandidates,
+                                                    expandedSource};
+        ctx.assignResultsFromCandidates(
+            op, chooseCommonCandidates(
+                    operands, sets, KernelKind::InsertSlice,
+                    [](LayoutAttr) { return 0; },
+                    [&ctx](LayoutAttr from, LayoutAttr to) {
+                      return ctx.conversionCost(from, to);
+                    }));
+        return success();
+      }
+    }
+    ctx.assignResultsFromCandidates(op, destCandidates);
+    return success();
+  }
+
+  std::optional<SmallVector<int64_t>> sourceToDest =
+      getInsertSliceDimMap(op.getSourceType(), op.getResultType(),
+                           op.getStaticSizes(), op.getStaticStrides());
+  if (!sourceToDest) return generatePassThrough(ctx, op);
+
+  SmallVector<Candidate> expandedSource =
+      remapCandidates(op.getSource(), ctx.candidatesForValue(op.getSource()),
+                      *sourceToDest, KernelKind::InsertSlice, /*extraCost=*/1);
+  ctx.assignResultsFromCandidates(op, expandedSource);
+  return success();
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/Structural.cpp
+++ b/lib/Dialect/Rotom/Transforms/LayoutAssignment/gen/Structural.cpp
@@ -1,0 +1,80 @@
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/AssignmentContext.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Candidate.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/Generators.h"
+#include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                 // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"             // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"    // from @llvm-project
+
+namespace mlir::heir::rotom {
+
+LogicalResult generateFunc(AssignmentContext& ctx, func::FuncOp op) {
+  for (Value arg : op.getArguments()) ctx.seedValue(arg);
+  return success();
+}
+
+LogicalResult generateSecretGeneric(AssignmentContext& ctx,
+                                    secret::GenericOp op) {
+  for (OpOperand& operand : op->getOpOperands()) {
+    SmallVector<Candidate> operandCandidates =
+        ctx.candidatesForValue(operand.get());
+    if (operandCandidates.empty()) continue;
+    BlockArgument blockArg =
+        op.getRegion().getArgument(operand.getOperandNumber());
+    SmallVector<Candidate> blockArgCandidates;
+    for (const Candidate& candidate : operandCandidates) {
+      // The block argument is the operand routed into the region: same data,
+      // same assignment, no extra cost.
+      Candidate blockArgCandidate;
+      blockArgCandidate.layout = candidate.layout;
+      blockArgCandidate.kind = KernelKind::BlockArgument;
+      blockArgCandidate.operands = {operand.get()};
+      blockArgCandidate.operandLayouts = {candidate.layout};
+      blockArgCandidate.assignment = candidate.assignment;
+      blockArgCandidate.accumulatedCost =
+          accumulatedCostOf(blockArgCandidate.assignment);
+      blockArgCandidates.push_back(std::move(blockArgCandidate));
+    }
+    ctx.setCandidates(blockArg, blockArgCandidates);
+  }
+  return success();
+}
+
+LogicalResult generateYield(AssignmentContext& ctx, secret::YieldOp op) {
+  auto generic = op->getParentOfType<secret::GenericOp>();
+  for (OpOperand& operand : op->getOpOperands()) {
+    SmallVector<Candidate> yielded = ctx.candidatesForValue(operand.get());
+    if (yielded.empty()) continue;
+    SmallVector<Candidate> resultCandidates;
+    for (const Candidate& candidate : yielded) {
+      // The generic's result is the yielded value: same data, same assignment.
+      Candidate resultCandidate;
+      resultCandidate.layout = candidate.layout;
+      resultCandidate.kind = KernelKind::Yield;
+      resultCandidate.operands = {operand.get()};
+      resultCandidate.operandLayouts = {candidate.layout};
+      resultCandidate.assignment = candidate.assignment;
+      resultCandidate.accumulatedCost =
+          accumulatedCostOf(resultCandidate.assignment);
+      resultCandidates.push_back(std::move(resultCandidate));
+    }
+    ctx.setCandidates(generic.getResult(operand.getOperandNumber()),
+                      resultCandidates);
+  }
+  return success();
+}
+
+LogicalResult generatePassThrough(AssignmentContext& ctx, Operation* op) {
+  SmallVector<Candidate> chosen =
+      ctx.chooseCommonOperandCandidates(op, KernelKind::PassThrough);
+  if (chosen.empty()) {
+    for (Value result : op->getResults()) ctx.seedValue(result);
+    return success();
+  }
+  ctx.assignResultsFromCandidates(op, chosen);
+  return success();
+}
+
+}  // namespace mlir::heir::rotom

--- a/lib/Dialect/Rotom/Transforms/Passes.h
+++ b/lib/Dialect/Rotom/Transforms/Passes.h
@@ -3,6 +3,7 @@
 
 // IWYU pragma: begin_keep
 #include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h"
 #include "lib/Dialect/Rotom/Transforms/MaterializeTensorExtLayout/MaterializeTensorExtLayout.h"
 #include "lib/Dialect/Rotom/Transforms/SeedLayout/SeedLayout.h"
 #include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
@@ -11,6 +12,9 @@
 namespace mlir {
 namespace heir {
 namespace rotom {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Rotom/Transforms/LayoutAssignment/LayoutAssignment.h.inc"
 
 #define GEN_PASS_REGISTRATION
 #include "lib/Dialect/Rotom/Transforms/MaterializeTensorExtLayout/MaterializeTensorExtLayout.h.inc"

--- a/lib/Dialect/Rotom/Transforms/SeedLayout/SeedLayout.cpp
+++ b/lib/Dialect/Rotom/Transforms/SeedLayout/SeedLayout.cpp
@@ -175,6 +175,34 @@ struct SeedLayout : public impl::SeedLayoutBase<SeedLayout> {
         } while (std::next_permutation(perm.begin(), perm.end()));
       }
 
+      // If the padded tensor is smaller than the ciphertext, no tuple reaches
+      // product == n (findValidTuples found nothing): pack every dimension
+      // fully into slots and replicate the packed block to fill the remaining
+      // capacity. Without this a small operand -- e.g. a 512-length activation
+      // at ciphertext size 32768 -- gets no seed, so the layout search has no
+      // candidate for it.
+      if (layouts.empty()) {
+        int64_t fullProd = 1;
+        for (int64_t d : dims) fullProd *= d;
+        if (fullProd > 0 && fullProd < n && n % fullProd == 0) {
+          int64_t replicationFactor = n / fullProd;
+          SmallVector<int64_t> perm(rank);
+          std::iota(perm.begin(), perm.end(), 0);
+          do {
+            // The replication dim is outermost (block replication): the packed
+            // block occupies slots [0, fullProd) and repeats every fullProd.
+            SmallVector<Attribute> allDims;
+            allDims.push_back(
+                DimAttr::get(ctx, /*dim=*/-1, replicationFactor, fullProd));
+            for (int64_t d : perm) {
+              allDims.push_back(DimAttr::get(ctx, d, dims[d], 1));
+            }
+            layouts.push_back(
+                LayoutAttr::get(ctx, ArrayAttr::get(ctx, allDims), n));
+          } while (std::next_permutation(perm.begin(), perm.end()));
+        }
+      }
+
       LLVM_DEBUG(llvm::dbgs()
                  << "\t- Found " << layouts.size() << " layouts for value\n");
 

--- a/lib/Dialect/Rotom/Utils/BUILD
+++ b/lib/Dialect/Rotom/Utils/BUILD
@@ -9,6 +9,86 @@ package(
 )
 
 cc_library(
+    name = "RotomLayout",
+    srcs = ["RotomLayout.cpp"],
+    hdrs = ["RotomLayout.h"],
+    deps = [
+        ":RotomTensorExtLayoutLowering",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "RotomLayoutTest",
+    srcs = ["RotomLayoutTest.cpp"],
+    deps = [
+        ":RotomLayout",
+        "@googletest//:gtest_main",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "LayoutConversion",
+    srcs = ["LayoutConversion.cpp"],
+    hdrs = ["LayoutConversion.h"],
+    deps = [
+        ":RotomLayout",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "LayoutConversionTest",
+    srcs = ["LayoutConversionTest.cpp"],
+    deps = [
+        ":LayoutConversion",
+        ":RotomLayout",
+        "@googletest//:gtest_main",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "LayoutAlignment",
+    srcs = ["LayoutAlignment.cpp"],
+    hdrs = ["LayoutAlignment.h"],
+    deps = [
+        ":RotomLayout",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_test(
+    name = "LayoutAlignmentTest",
+    srcs = ["LayoutAlignmentTest.cpp"],
+    deps = [
+        ":LayoutAlignment",
+        ":LayoutConversion",
+        ":RotomLayout",
+        "@googletest//:gtest_main",
+        "@heir//lib/Dialect/Rotom/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
     name = "RotomTensorExtLayoutLowering",
     srcs = ["RotomTensorExtLayoutLowering.cpp"],
     hdrs = ["RotomTensorExtLayoutLowering.h"],

--- a/lib/Dialect/Rotom/Utils/LayoutAlignment.cpp
+++ b/lib/Dialect/Rotom/Utils/LayoutAlignment.cpp
@@ -1,0 +1,958 @@
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseSet.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/OperationSupport.h"    // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+OperatorAlignmentMap OperatorAlignmentMap::identity(int64_t rank) {
+  OperatorAlignmentMap map;
+  for (int64_t d = 0; d < rank; ++d) {
+    map.lhsToRhs.push_back(d);
+    map.rhsToLhs.push_back(d);
+  }
+  return map;
+}
+
+OperatorAlignmentMap OperatorAlignmentMap::matmul(int64_t lhsRank,
+                                                  int64_t rhsRank) {
+  assert(lhsRank >= 1 && rhsRank >= 1 && "matmul operands need rank >= 1");
+  // A rank-1 operand is [k]. Otherwise the lhs is [..batch, m, k] and the
+  // rhs is [..batch, k, n].
+  const int64_t lhsBatch = std::max<int64_t>(lhsRank - 2, 0);
+  const int64_t rhsBatch = std::max<int64_t>(rhsRank - 2, 0);
+  const int64_t lhsK = lhsRank - 1;
+  const int64_t rhsK = rhsRank == 1 ? 0 : rhsRank - 2;
+
+  OperatorAlignmentMap map;
+  map.lhsToRhs.assign(lhsRank, kRepeatedDim);
+  map.rhsToLhs.assign(rhsRank, kRepeatedDim);
+  // Batch dims pair from the right.
+  const int64_t shared = std::min(lhsBatch, rhsBatch);
+  for (int64_t b = 0; b < shared; ++b) {
+    const int64_t l = lhsBatch - 1 - b;
+    const int64_t r = rhsBatch - 1 - b;
+    map.lhsToRhs[l] = r;
+    map.rhsToLhs[r] = l;
+  }
+  // The aligned dims pair with each other.
+  map.lhsToRhs[lhsK] = rhsK;
+  map.rhsToLhs[rhsK] = lhsK;
+  return map;
+}
+
+namespace {
+
+// Helper function to check traversal dimension alignment. For each dimension,
+// check if the size, stride, and type (gap or replicate) match according
+// to the operator alignment map.
+SmallVector<DimAttr> piecesOf(ArrayAttr dims,
+                              SmallVector<int64_t>* posMap = nullptr) {
+  SmallVector<DimAttr> out;
+  if (posMap) posMap->clear();
+  for (Attribute attr : dims) {
+    auto d = cast<DimAttr>(attr);
+    if (posMap) posMap->push_back(out.size());
+    out.push_back(d);
+  }
+  return out;
+}
+
+bool checkDimAlignment(const OperatorAlignmentMap& map,
+                       ArrayRef<DimAttr> lhsDims, ArrayRef<DimAttr> rhsDims) {
+  // Check if the dimensions are aligned.
+  // The reference uses two pointers to traverse the layout dimensions.
+  // The side whose run is smaller advances until the two runs hold the
+  // same extent, so one piece may face several on the other side: e.g.,
+  // [R:64] against [R:4][i:16].
+  auto runExtent = [](ArrayRef<DimAttr> dims, size_t from, size_t to) {
+    int64_t e = 1;
+    for (size_t i = from; i <= to; ++i) e *= dims[i].getSize();
+    return e;
+  };
+  auto isFill = [](DimAttr d) { return !d.isGap(); };
+  size_t aStart = 0, bStart = 0, aNext = 0, bNext = 0;
+  while (aNext < lhsDims.size() && bNext < rhsDims.size()) {
+    DimAttr a = lhsDims[aNext];
+    DimAttr b = rhsDims[bNext];
+    // Two gaps of one extent match outright.
+    if (a.isGap() && b.isGap() && a.getSize() == b.getSize()) {
+      ++aNext;
+      ++bNext;
+      aStart = aNext;
+      bStart = bNext;
+      continue;
+    }
+    // A gap never faces data.
+    if (isFill(a) != isFill(b)) return false;
+    // Two pieces that both name no axis (replication, or gaps of different
+    // extents) only need their runs to agree.
+    const bool aNamesAxis = isFill(a) && !a.isReplicate();
+    const bool bNamesAxis = isFill(b) && !b.isReplicate();
+    if (aNamesAxis || bNamesAxis) {
+      // The pair must be aligned by the operator map.
+      bool aligned;
+      if (aNamesAxis && bNamesAxis) {
+        aligned = map.lhsToRhs[a.getDim()] == b.getDim();
+      } else if (aNamesAxis) {
+        aligned =
+            map.lhsToRhs[a.getDim()] == OperatorAlignmentMap::kRepeatedDim;
+      } else {
+        aligned =
+            map.rhsToLhs[b.getDim()] == OperatorAlignmentMap::kRepeatedDim;
+      }
+      if (!aligned) return false;
+      // A piece facing exactly one piece keeps the stride rule.
+      if (aNamesAxis && bNamesAxis && aStart == aNext && bStart == bNext &&
+          a.getSize() == b.getSize() && a.getStride() != b.getStride()) {
+        return false;
+      }
+    }
+    const int64_t aExtent = runExtent(lhsDims, aStart, aNext);
+    const int64_t bExtent = runExtent(rhsDims, bStart, bNext);
+    if (aExtent == bExtent) {
+      ++aNext;
+      ++bNext;
+      aStart = aNext;
+      bStart = bNext;
+    } else if (aExtent > bExtent) {
+      ++bNext;
+    } else {
+      ++aNext;
+    }
+  }
+  return aNext == lhsDims.size() && bNext == rhsDims.size();
+}
+
+// Determines if a roll is exempt from alignment. A roll is exempt when the
+// other side has replication aligned to the roll's FROM piece.
+bool rollExempt(const OperatorAlignmentMap& map, const RollArg& from,
+                bool fromLhs, ArrayAttr lhsDims, ArrayAttr rhsDims) {
+  if (from.isAxis) {
+    const SmallVector<int64_t>& forward = fromLhs ? map.lhsToRhs : map.rhsToLhs;
+    return forward[from.index] == OperatorAlignmentMap::kRepeatedDim;
+  }
+  ArrayAttr other = fromLhs ? rhsDims : lhsDims;
+  return cast<DimAttr>(other[from.index]).isReplicate();
+}
+
+// Determines the rolls that are required for alignment.
+SmallVector<RollSpec> requiredRolls(const OperatorAlignmentMap& map,
+                                    LayoutAttr merged, bool isLhs,
+                                    ArrayAttr lhsDims, ArrayAttr rhsDims) {
+  SmallVector<RollSpec> out;
+  for (const RollSpec& roll : getRollSpecs(merged)) {
+    ArrayAttr own = isLhs ? lhsDims : rhsDims;
+    if (!rollExempt(map, roll.from, isLhs, lhsDims, rhsDims))
+      out.push_back(roll);
+  }
+  return out;
+}
+
+// Helper function to check if two roll arguments are the same.
+bool sameRollArg(const RollArg& a, const RollArg& b) {
+  return a.isAxis == b.isAxis && a.index == b.index;
+}
+
+// Helper function to check if the required rolls on one side have the same
+// roll on the other side.
+bool checkRollAlignment(const OperatorAlignmentMap& map, LayoutAttr lhsMerged,
+                        LayoutAttr rhsMerged, ArrayAttr lhsDims,
+                        ArrayAttr rhsDims) {
+  SmallVector<RollSpec> lhsRolls =
+      requiredRolls(map, lhsMerged, /*isLhs=*/true, lhsDims, rhsDims);
+  SmallVector<RollSpec> rhsRolls =
+      requiredRolls(map, rhsMerged, /*isLhs=*/false, lhsDims, rhsDims);
+  if (lhsRolls.size() != rhsRolls.size()) return false;
+  SmallVector<int64_t> lhsPos, rhsPos;
+  piecesOf(lhsDims, &lhsPos);
+  piecesOf(rhsDims, &rhsPos);
+  auto argsCorrespond = [&](const RollArg& a, const RollArg& b) {
+    if (a.isAxis != b.isAxis) return false;
+    if (a.isAxis) return map.lhsToRhs[a.index] == b.index;
+    return lhsPos[a.index] == rhsPos[b.index];
+  };
+  for (size_t i = 0; i < lhsRolls.size(); ++i) {
+    if (!argsCorrespond(lhsRolls[i].from, rhsRolls[i].from) ||
+        !argsCorrespond(lhsRolls[i].by, rhsRolls[i].by)) {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
+
+// Helper function to check if two layouts are aligned.
+bool isOperatorAligned(const OperatorAlignmentMap& map, LayoutAttr lhs,
+                       LayoutAttr rhs) {
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return false;
+  LayoutAttr lhsMerged = mergeAdjacentLayoutDims(lhs);
+  LayoutAttr rhsMerged = mergeAdjacentLayoutDims(rhs);
+  ArrayAttr lhsDims = lhsMerged.getDims();
+  ArrayAttr rhsDims = rhsMerged.getDims();
+  SmallVector<DimAttr> lhsNU = piecesOf(lhsDims);
+  SmallVector<DimAttr> rhsNU = piecesOf(rhsDims);
+  if (!checkDimAlignment(map, lhsNU, rhsNU)) return false;
+
+  return checkRollAlignment(map, lhsMerged, rhsMerged, lhsDims, rhsDims);
+}
+
+// Helper function to align the rolls of two layouts.
+FailureOr<RollAlignment> alignRolls(const OperatorAlignmentMap& map,
+                                    LayoutAttr lhs, LayoutAttr rhs) {
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return failure();
+  LayoutAttr lhsMerged = mergeAdjacentLayoutDims(lhs);
+  LayoutAttr rhsMerged = mergeAdjacentLayoutDims(rhs);
+  ArrayAttr lhsDims = lhsMerged.getDims();
+  ArrayAttr rhsDims = rhsMerged.getDims();
+  SmallVector<DimAttr> lhsNU = piecesOf(lhsDims);
+  SmallVector<DimAttr> rhsNU = piecesOf(rhsDims);
+  if (lhsNU.size() != rhsNU.size()) return failure();
+  if (!checkDimAlignment(map, lhsNU, rhsNU)) return failure();
+
+  SmallVector<RollSpec> lhsRolls =
+      requiredRolls(map, lhsMerged, /*isLhs=*/true, lhsDims, rhsDims);
+  SmallVector<RollSpec> rhsRolls =
+      requiredRolls(map, rhsMerged, /*isLhs=*/false, lhsDims, rhsDims);
+
+  // Translate a roll from one layout to the other.
+  auto translate = [&](const RollArg& arg,
+                       bool fromLhs) -> std::optional<RollArg> {
+    if (!arg.isAxis) return arg;
+    const SmallVector<int64_t>& forward = fromLhs ? map.lhsToRhs : map.rhsToLhs;
+    if (arg.index < 0 || arg.index >= static_cast<int64_t>(forward.size())) {
+      return std::nullopt;
+    }
+    const int64_t mapped = forward[arg.index];
+    if (mapped == OperatorAlignmentMap::kRepeatedDim) return std::nullopt;
+    return RollArg{/*isAxis=*/true, mapped};
+  };
+  auto contains = [](ArrayRef<RollSpec> rolls, const RollSpec& want) {
+    for (const RollSpec& have : rolls) {
+      if (sameRollArg(have.from, want.from) && sameRollArg(have.by, want.by)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  RollAlignment out;
+  for (const RollSpec& roll : lhsRolls) {
+    std::optional<RollArg> from = translate(roll.from, /*fromLhs=*/true);
+    std::optional<RollArg> by = translate(roll.by, /*fromLhs=*/true);
+    if (!from || !by) return failure();
+    RollSpec translated{*from, *by};
+    if (!contains(rhsRolls, translated)) out.addToRhs.push_back(translated);
+  }
+  for (const RollSpec& roll : rhsRolls) {
+    std::optional<RollArg> from = translate(roll.from, /*fromLhs=*/false);
+    std::optional<RollArg> by = translate(roll.by, /*fromLhs=*/false);
+    if (!from || !by) return failure();
+    RollSpec translated{*from, *by};
+    if (!contains(lhsRolls, translated)) out.addToLhs.push_back(translated);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Alignment steps
+// ---------------------------------------------------------------------------
+
+namespace {
+DimAttr mk(MLIRContext* ctx, int64_t dim, int64_t size, int64_t stride) {
+  return DimAttr::get(ctx, dim, size, stride);
+}
+bool isRepl(DimAttr d) { return d.isReplicate(); }
+bool isTraversal(DimAttr d) { return !d.isGap() && !d.isReplicate(); }
+
+// Computes the product of every non-gap extent (the reference's FILL
+// length).
+int64_t fillLen(ArrayRef<DimAttr> dims) {
+  int64_t out = 1;
+  for (DimAttr d : dims) {
+    if (!d.isGap()) out *= d.getSize();
+  }
+  return out;
+}
+int64_t capacity(ArrayRef<DimAttr> dims) {
+  int64_t out = 1;
+  for (DimAttr d : dims) out *= d.getSize();
+  return out;
+}
+
+// Determines the dims of one side that the map aligns with replication on
+// the other side, in ascending order.
+SmallVector<int64_t> broadcastDims(const SmallVector<int64_t>& otherToSide) {
+  SmallVector<int64_t> out;
+  for (int64_t d = 0; d < static_cast<int64_t>(otherToSide.size()); ++d) {
+    if (otherToSide[d] == OperatorAlignmentMap::kRepeatedDim) out.push_back(d);
+  }
+  return out;
+}
+
+// Helper function for alignedDims:
+// - builds a piece list for `dst`'s tensor in `src`'s piece order.
+std::optional<SmallVector<DimAttr>> mirrorDims(
+    ArrayRef<DimAttr> src, ArrayRef<DimAttr> dst,
+    const SmallVector<int64_t>& srcToDst, const SmallVector<int64_t>& dstToSrc,
+    MLIRContext* ctx) {
+  // Remaining extent and running stride of each dst tensor dim.
+  llvm::DenseMap<int64_t, int64_t> remaining, stride;
+  for (DimAttr d : dst) {
+    if (!isTraversal(d)) continue;
+    remaining[d.getDim()] *= 1;  // touch
+    remaining[d.getDim()] = remaining[d.getDim()] == 0
+                                ? d.getSize()
+                                : remaining[d.getDim()] * d.getSize();
+    stride[d.getDim()] = remaining[d.getDim()];
+  }
+  // The dst dims that a src replication piece may become, used in order.
+  SmallVector<int64_t> replTargets = broadcastDims(dstToSrc);
+
+  SmallVector<DimAttr> out;
+  for (DimAttr piece : src) {
+    if (piece.isGap()) {
+      out.push_back(piece);
+      continue;
+    }
+    int64_t target;
+    if (isRepl(piece)) {
+      // Take the first broadcast target with extent left; if none, the
+      // replication stays replication (the other side is replicated too).
+      target = -1;
+      for (int64_t d : replTargets) {
+        // A unit dim can absorb no copies: mirroring onto it would leave the
+        // whole replication over as replication anyway, so skip it and keep
+        // the piece as it is.
+        if (remaining.count(d) && remaining[d] > 1) {
+          target = d;
+          break;
+        }
+      }
+      if (target < 0) {
+        out.push_back(piece);
+        continue;
+      }
+    } else {
+      if (piece.getDim() >= static_cast<int64_t>(srcToDst.size())) {
+        return std::nullopt;
+      }
+      target = srcToDst[piece.getDim()];
+      if (target == OperatorAlignmentMap::kRepeatedDim) {
+        // The map broadcasts this src dim over the dst side: dst holds it as
+        // replication of the same extent.
+        out.push_back(mk(ctx, -1, piece.getSize(), piece.getStride()));
+        continue;
+      }
+      if (!remaining.count(target) || remaining[target] <= 0) {
+        return std::nullopt;
+      }
+    }
+    const int64_t extent = piece.getSize();
+    int64_t size, pieceStride;
+    if (remaining[target] <= extent) {
+      size = remaining[target];
+      pieceStride = stride[target] / size;
+      remaining[target] = 0;
+      stride[target] /= size;
+    } else {
+      size = extent;
+      pieceStride = stride[target] / size;
+      remaining[target] /= size;
+      stride[target] /= size;
+    }
+    // Add a replication piece for the leftover extent (extent / size).
+    if (isRepl(piece) && extent > size) {
+      out.push_back(mk(ctx, -1, extent / size, piece.getStride() * size));
+    }
+    // A paired traversal piece takes the mirrored side's stride.
+    out.push_back(mk(ctx, target, size,
+                     isTraversal(piece) ? piece.getStride() : pieceStride));
+  }
+  return out;
+}
+}  // namespace
+
+std::optional<AlignedDims> alignedDims(const OperatorAlignmentMap& map,
+                                       ArrayRef<DimAttr> lhsDims,
+                                       ArrayRef<DimAttr> rhsDims,
+                                       MLIRContext* ctx) {
+  auto forRhs = mirrorDims(lhsDims, rhsDims, map.lhsToRhs, map.rhsToLhs, ctx);
+  auto forLhs = mirrorDims(rhsDims, lhsDims, map.rhsToLhs, map.lhsToRhs, ctx);
+  if (!forRhs || !forLhs) return std::nullopt;
+  return AlignedDims{std::move(*forRhs), std::move(*forLhs)};
+}
+
+namespace {
+// Helper function to grow one side to `shapeLen` data elements (the
+// reference's replicate_dimensions inner loop). Gaps become replication right
+// to left; any missing factor is added as a new outermost replication piece.
+SmallVector<DimAttr> fillToShape(ArrayRef<DimAttr> dims, int64_t shapeLen,
+                                 MLIRContext* ctx) {
+  shapeLen /= fillLen(dims);
+  if (shapeLen <= 1) return SmallVector<DimAttr>(dims.begin(), dims.end());
+  SmallVector<DimAttr> out;
+  int64_t replicated = 1;
+  for (size_t p = dims.size(); p-- > 0;) {
+    DimAttr d = dims[p];
+    if (shapeLen > 1 && d.isGap()) {
+      if (d.getSize() <= shapeLen) {
+        shapeLen /= d.getSize();
+        out.insert(out.begin(), mk(ctx, -1, d.getSize(), replicated));
+        replicated *= d.getSize();
+      } else {
+        // Split the gap: the inner part becomes replication, the outer part
+        // stays gap.
+        const int64_t inner = shapeLen;
+        const int64_t outer = d.getSize() / shapeLen;
+        shapeLen = 1;
+        out.insert(out.begin(), mk(ctx, -1, inner, replicated));
+        out.insert(out.begin(), mk(ctx, -2, outer, 1));
+        replicated *= inner;
+      }
+    } else {
+      out.insert(out.begin(), d);
+    }
+  }
+  if (shapeLen > 1) out.insert(out.begin(), mk(ctx, -1, shapeLen, replicated));
+  return out;
+}
+}  // namespace
+
+FailureOr<ReplicatedPair> replicateForAlignment(const OperatorAlignmentMap& map,
+                                                LayoutAttr lhs, LayoutAttr rhs,
+                                                ArrayRef<int64_t> lhsShape,
+                                                ArrayRef<int64_t> rhsShape) {
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return failure();
+  MLIRContext* ctx = lhs.getContext();
+  SmallVector<DimAttr> a = layoutDims(lhs);
+  SmallVector<DimAttr> b = layoutDims(rhs);
+
+  // Pad the smaller side with gap ciphertexts so both cover the same
+  // capacity (the reference's match_kernel_dims).
+  const int64_t capA = capacity(a), capB = capacity(b);
+  if (capA < capB) a.insert(a.begin(), mk(ctx, -2, capB / capA, 1));
+  if (capB < capA) b.insert(b.begin(), mk(ctx, -2, capA / capB, 1));
+
+  // The aligned shape: one extent per aligned dim pair.
+  int64_t alignedLen = 1;
+  for (int64_t d = 0; d < static_cast<int64_t>(map.lhsToRhs.size()); ++d) {
+    if (d < static_cast<int64_t>(lhsShape.size())) alignedLen *= lhsShape[d];
+  }
+  for (int64_t d = 0; d < static_cast<int64_t>(map.rhsToLhs.size()); ++d) {
+    if (map.rhsToLhs[d] == OperatorAlignmentMap::kRepeatedDim &&
+        d < static_cast<int64_t>(rhsShape.size())) {
+      alignedLen *= rhsShape[d];
+    }
+  }
+  const int64_t shapeLen = std::max({fillLen(a), fillLen(b), alignedLen});
+
+  SmallVector<DimAttr> fa = fillToShape(a, shapeLen, ctx);
+  SmallVector<DimAttr> fb = fillToShape(b, shapeLen, ctx);
+  if (fillLen(fa) != fillLen(fb)) return failure();
+
+  SmallVector<int64_t> lhsRolls, rhsRolls;
+  if (auto r = lhs.getRolls())
+    lhsRolls.assign(r.asArrayRef().begin(), r.asArrayRef().end());
+  if (auto r = rhs.getRolls())
+    rhsRolls.assign(r.asArrayRef().begin(), r.asArrayRef().end());
+  // Prepended pieces shift piece arguments right.
+  auto shiftRolls = [](SmallVector<int64_t>& rolls, int64_t by) {
+    for (int64_t& e : rolls) {
+      RollArg arg = decodeRollArg(e);
+      if (!arg.isAxis) e = encodeRollArg({false, arg.index + by});
+    }
+  };
+  shiftRolls(lhsRolls,
+             static_cast<int64_t>(fa.size()) - layoutDims(lhs).size());
+  shiftRolls(rhsRolls,
+             static_cast<int64_t>(fb.size()) - layoutDims(rhs).size());
+
+  LayoutAttr outA = mergeAdjacentLayoutDims(
+      LayoutAttr::getCanonical(ctx, fa, lhs.getN(), lhsRolls));
+  LayoutAttr outB = mergeAdjacentLayoutDims(
+      LayoutAttr::getCanonical(ctx, fb, rhs.getN(), rhsRolls));
+  if (!outA || !outB) return failure();
+  return ReplicatedPair{outA, outB};
+}
+
+std::optional<LayoutAttr> applySumRoll(LayoutAttr layout, int64_t sumDim) {
+  if (!layout) return std::nullopt;
+  MLIRContext* ctx = layout.getContext();
+  SmallVector<DimAttr> dims = layoutDims(layout);
+  const size_t ctLen = inferCtPrefixLen(dims, layout.getN());
+
+  // Preconditions: a replication piece on the ciphertext side, a slot piece
+  // of sumDim, and no roll already touching sumDim.
+  int64_t ctRepl = -1;
+  for (size_t p = 0; p < ctLen; ++p) {
+    if (isRepl(dims[p])) {
+      if (ctRepl >= 0) return std::nullopt;  // the reference asserts one
+      ctRepl = p;
+    }
+  }
+  if (ctRepl < 0) return std::nullopt;
+  int64_t slotSum = -1;
+  for (size_t p = ctLen; p < dims.size(); ++p) {
+    if (dims[p].getDim() == sumDim &&
+        (slotSum < 0 || dims[p].getSize() > dims[slotSum].getSize())) {
+      slotSum = p;
+    }
+  }
+  if (slotSum < 0) return std::nullopt;
+  for (const RollSpec& roll : getRollSpecs(layout)) {
+    for (const RollArg& arg : {roll.from, roll.by}) {
+      if (arg.isAxis ? arg.index == sumDim
+                     : dims[arg.index].getDim() == sumDim) {
+        return std::nullopt;
+      }
+    }
+  }
+
+  // Match extents by splitting the larger side; the matched halves swap.
+  DimAttr ctPiece = dims[ctRepl];
+  DimAttr sumPiece = dims[slotSum];
+  SmallVector<DimAttr> out;
+  int64_t fromPos, byPos;
+  if (sumPiece.getSize() == ctPiece.getSize()) {
+    out = dims;
+    out[ctRepl] = sumPiece;
+    out[slotSum] = ctPiece;
+    fromPos = ctRepl;
+    byPos = slotSum;
+  } else if (sumPiece.getSize() < ctPiece.getSize()) {
+    // Split the ct replication: [matched][rest].
+    const int64_t e1 = sumPiece.getSize();
+    const int64_t e2 = ctPiece.getSize() / e1;
+    DimAttr matched = mk(ctx, -1, e1, ctPiece.getStride());
+    DimAttr rest = mk(ctx, -1, e2, e1 * ctPiece.getStride());
+    out.assign(dims.begin(), dims.begin() + ctRepl);
+    out.push_back(sumPiece);  // sum piece takes the matched slot
+    out.push_back(rest);
+    out.append(dims.begin() + ctRepl + 1, dims.end());
+    fromPos = ctRepl;
+    byPos = slotSum + 1;  // one piece was inserted before it
+    out[byPos] = matched;
+  } else {
+    // Split the slot sum piece: [hi (matched)][lo].
+    const int64_t e1 = ctPiece.getSize();
+    const int64_t e2 = sumPiece.getSize() / e1;
+    DimAttr hi = mk(ctx, sumDim, e1, e2 * sumPiece.getStride());
+    DimAttr lo = mk(ctx, sumDim, e2, sumPiece.getStride());
+    out = dims;
+    out[ctRepl] = hi;
+    out.erase(out.begin() + slotSum);
+    out.insert(out.begin() + slotSum, ctPiece);
+    out.insert(out.begin() + slotSum + 1, lo);
+    fromPos = ctRepl;
+    byPos = slotSum;
+  }
+
+  SmallVector<int64_t> rolls;
+  if (auto r = layout.getRolls())
+    rolls.assign(r.asArrayRef().begin(), r.asArrayRef().end());
+  // Existing piece arguments at or past an insertion shift right.
+  for (int64_t& e : rolls) {
+    RollArg arg = decodeRollArg(e);
+    if (arg.isAxis) continue;
+    int64_t idx = arg.index;
+    if (sumPiece.getSize() < ctPiece.getSize() && idx > ctRepl) ++idx;
+    if (sumPiece.getSize() > ctPiece.getSize() && idx > slotSum) ++idx;
+    e = encodeRollArg({false, idx});
+  }
+  rolls.push_back(encodeRollArg({false, fromPos}));
+  rolls.push_back(encodeRollArg({false, byPos}));
+  LayoutAttr rolled = LayoutAttr::getCanonical(ctx, out, layout.getN(), rolls);
+  if (!rolled) return std::nullopt;
+  return rolled;
+}
+
+namespace {
+SmallVector<int64_t> rollVec(LayoutAttr layout) {
+  SmallVector<int64_t> out;
+  if (auto r = layout.getRolls()) {
+    out.assign(r.asArrayRef().begin(), r.asArrayRef().end());
+  }
+  return out;
+}
+bool hasRolls(LayoutAttr layout) {
+  return layout.getRolls() && !layout.getRolls().empty();
+}
+
+// Applies rolls to `layout` so its pieces reach `target`'s order, which is a
+// reorder of the same pieces. Each out-of-place traversal piece is rolled by
+// the piece at its target position. Existing rolls are updated as in the
+// reference's roll_update. Nullopt when the pieces differ or an out-of-place
+// piece meets a partner with a different extent.
+std::optional<LayoutAttr> applyRoll(LayoutAttr layout,
+                                    ArrayRef<DimAttr> target) {
+  MLIRContext* ctx = layout.getContext();
+  SmallVector<DimAttr> dims = layoutDims(layout);
+  // Match on the pieces and swap by their full-list positions.
+  SmallVector<size_t> fullPos;  // filtered index -> full index
+  SmallVector<DimAttr> pieces, targetPieces;
+  for (size_t p = 0; p < dims.size(); ++p) {
+    fullPos.push_back(p);
+    pieces.push_back(dims[p]);
+  }
+  for (DimAttr d : target) {
+    if (d.getSize() != 1) targetPieces.push_back(d);
+  }
+  if (pieces.size() != targetPieces.size()) return std::nullopt;
+  for (DimAttr d : pieces) {
+    if (!llvm::is_contained(targetPieces, d)) return std::nullopt;
+  }
+  for (DimAttr d : targetPieces) {
+    if (!llvm::is_contained(pieces, d)) return std::nullopt;
+  }
+  SmallVector<int64_t> rolls = rollVec(layout);
+
+  for (size_t ti = 0; ti < targetPieces.size(); ++ti) {
+    DimAttr piece = targetPieces[ti];
+    if (!isTraversal(piece)) continue;
+    auto it = llvm::find(pieces, piece);
+    const size_t curIdx = it - pieces.begin();
+    if (curIdx == ti) continue;
+    const size_t cur = fullPos[curIdx];
+    const size_t i = fullPos[ti];
+    DimAttr partner = dims[i];
+    if (partner.getSize() != piece.getSize()) return std::nullopt;
+
+    // Rebase existing rolls across the swap of positions cur <-> i.
+    SmallVector<int64_t> rebased;
+    for (size_t r = 0; r + 1 < rolls.size(); r += 2) {
+      RollArg from = decodeRollArg(rolls[r]);
+      RollArg by = decodeRollArg(rolls[r + 1]);
+      RollArg newFrom = from;
+      if (!from.isAxis) {  // follows its piece
+        if (from.index == static_cast<int64_t>(cur))
+          newFrom.index = i;
+        else if (from.index == static_cast<int64_t>(i))
+          newFrom.index = cur;
+      }
+      RollArg newBy = by;  // positional
+      if (!newFrom.isAxis && !newBy.isAxis && newFrom.index == newBy.index) {
+        if (by.index == static_cast<int64_t>(cur))
+          newBy.index = i;
+        else if (by.index == static_cast<int64_t>(i))
+          newBy.index = cur;
+      }
+      rebased.push_back(encodeRollArg(newFrom));
+      rebased.push_back(encodeRollArg(newBy));
+    }
+    rolls = std::move(rebased);
+    std::swap(dims[cur], dims[i]);
+    std::swap(pieces[curIdx], pieces[ti]);
+    // Swapping the roll: the piece (now at i) by the partner (now at cur).
+    const int64_t newFrom = encodeRollArg({false, static_cast<int64_t>(i)});
+    const int64_t newBy = encodeRollArg({false, static_cast<int64_t>(cur)});
+    bool present = false;
+    for (size_t r = 0; r + 1 < rolls.size(); r += 2) {
+      if (rolls[r] == newFrom && rolls[r + 1] == newBy) present = true;
+    }
+    if (!present) {
+      rolls.push_back(newFrom);
+      rolls.push_back(newBy);
+    }
+  }
+  LayoutAttr out = LayoutAttr::getCanonical(ctx, dims, layout.getN(), rolls);
+  if (!out) return std::nullopt;
+  return out;
+}
+}  // namespace
+
+SmallVector<AlignedPair, 2> rollToAlign(const OperatorAlignmentMap& map,
+                                        LayoutAttr lhs, LayoutAttr rhs) {
+  SmallVector<AlignedPair, 2> out;
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return out;
+  // Early exit if a swap roll cannot fix differing rolls or differing strides.
+  LayoutAttr lhsMerged = mergeAdjacentLayoutDims(lhs);
+  LayoutAttr rhsMerged = mergeAdjacentLayoutDims(rhs);
+  ArrayAttr lhsMergedDims = lhsMerged.getDims();
+  ArrayAttr rhsMergedDims = rhsMerged.getDims();
+  if (lhsMergedDims.size() == rhsMergedDims.size() &&
+      !checkRollAlignment(map, lhsMerged, rhsMerged, lhsMergedDims,
+                          rhsMergedDims)) {
+    return out;
+  }
+  auto aligned =
+      alignedDims(map, layoutDims(lhs), layoutDims(rhs), lhs.getContext());
+  if (!aligned) return out;
+  {
+    SmallVector<DimAttr> a = layoutDims(lhs);
+    for (size_t p = 0; p < a.size() && p < aligned->forLhs.size(); ++p) {
+      DimAttr x = a[p], y = aligned->forLhs[p];
+      if (isTraversal(x) && isTraversal(y) && x.getStride() != y.getStride()) {
+        return out;
+      }
+    }
+  }
+  if (auto rolledRhs = applyRoll(rhs, aligned->forRhs)) {
+    if (isOperatorAligned(map, lhs, *rolledRhs))
+      out.push_back({lhs, *rolledRhs});
+  }
+  if (auto rolledLhs = applyRoll(lhs, aligned->forLhs)) {
+    if (isOperatorAligned(map, *rolledLhs, rhs))
+      out.push_back({*rolledLhs, rhs});
+  }
+  return out;
+}
+
+// Restates `dims` so its pieces correspond one to one with `reference`
+// Unit pieces on either side are carried through. Returns nullopt when the
+// lists cannot be made to correspond, or when `dims` carries rolls.
+static std::optional<SmallVector<DimAttr>> restateToMatch(
+    ArrayRef<DimAttr> reference, LayoutAttr layout, MLIRContext* ctx) {
+  if (layout.getRolls() && !layout.getRolls().empty()) return std::nullopt;
+  SmallVector<DimAttr> dims = layoutDims(layout);
+  size_t i = 0, j = 0;
+  while (i < reference.size() && j < dims.size()) {
+    const int64_t want = reference[i].getSize(), have = dims[j].getSize();
+    if (want == have) {
+      ++i;
+      ++j;
+      continue;
+    }
+    if (have < want || have % want != 0) return std::nullopt;
+    DimAttr piece = dims[j];
+    if (!piece.isReplicate() && !piece.isGap()) return std::nullopt;
+    // The piece facing the reference comes first, with the remainder inside
+    // it: [R:64:1] facing [R:4:16] becomes [R:4:16],[R:16:1], the outer
+    // part's stride being the inner part's extent, as the mirror writes it.
+    const int64_t rest = have / want;
+    DimAttr outer =
+        DimAttr::get(ctx, piece.getDim(), want, piece.getStride() * rest);
+    DimAttr inner = DimAttr::get(ctx, piece.getDim(), rest, piece.getStride());
+    dims[j] = outer;
+    dims.insert(dims.begin() + j + 1, inner);
+    ++i;
+    ++j;
+  }
+  return dims;
+}
+
+std::optional<LayoutAttr> matchPublicLayout(const OperatorAlignmentMap& map,
+                                            LayoutAttr lhs, LayoutAttr rhs,
+                                            bool matchLhs) {
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return std::nullopt;
+  MLIRContext* ctx = lhs.getContext();
+  std::optional<AlignedDims> aligned =
+      alignedDims(map, layoutDims(lhs), layoutDims(rhs), ctx);
+  if (!aligned) return std::nullopt;
+  ArrayRef<DimAttr> dims = matchLhs ? aligned->forLhs : aligned->forRhs;
+  LayoutAttr other = matchLhs ? rhs : lhs;
+  SmallVector<int64_t> rolls;
+  if (auto r = other.getRolls()) {
+    for (int64_t encoded : r.asArrayRef()) {
+      RollArg arg = decodeRollArg(encoded);
+      if (arg.isAxis) return std::nullopt;
+      if (arg.index < 0 || arg.index >= static_cast<int64_t>(dims.size())) {
+        return std::nullopt;
+      }
+      rolls.push_back(encoded);
+    }
+  }
+  LayoutAttr out = LayoutAttr::getCanonical(ctx, dims, lhs.getN(), rolls);
+  if (!out) return std::nullopt;
+  return out;
+}
+
+SmallVector<AlignedPair> alignPair(const OperatorAlignmentMap& map,
+                                   LayoutAttr lhs, LayoutAttr rhs) {
+  SmallVector<AlignedPair> out;
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return out;
+  if (isOperatorAligned(map, lhs, rhs)) {
+    MLIRContext* ctx = lhs.getContext();
+    if (layoutDims(lhs).size() != layoutDims(rhs).size()) {
+      if (auto r = restateToMatch(layoutDims(lhs), rhs, ctx)) {
+        SmallVector<Attribute> attrs(r->begin(), r->end());
+        if (LayoutAttr rr = LayoutAttr::get(ctx, ArrayAttr::get(ctx, attrs),
+                                            rhs.getN(), rhs.getRolls())) {
+          out.push_back({lhs, rr});
+          return out;
+        }
+      }
+      if (auto l = restateToMatch(layoutDims(rhs), lhs, ctx)) {
+        SmallVector<Attribute> attrs(l->begin(), l->end());
+        if (LayoutAttr ll = LayoutAttr::get(ctx, ArrayAttr::get(ctx, attrs),
+                                            lhs.getN(), lhs.getRolls())) {
+          out.push_back({ll, rhs});
+          return out;
+        }
+      }
+    }
+    out.push_back({lhs, rhs});
+    return out;
+  }
+  MLIRContext* ctx = lhs.getContext();
+  // Conversion candidates are conversions by only moving pieces.
+  if (!hasRolls(lhs) && !hasRolls(rhs)) {
+    if (auto aligned =
+            alignedDims(map, layoutDims(lhs), layoutDims(rhs), ctx)) {
+      LayoutAttr convRhs = mergeAdjacentLayoutDims(
+          LayoutAttr::getCanonical(ctx, aligned->forRhs, rhs.getN()));
+      LayoutAttr convLhs = mergeAdjacentLayoutDims(
+          LayoutAttr::getCanonical(ctx, aligned->forLhs, lhs.getN()));
+      if (convRhs && isOperatorAligned(map, lhs, convRhs)) {
+        out.push_back({lhs, convRhs});
+      }
+      if (convLhs && isOperatorAligned(map, convLhs, rhs)) {
+        out.push_back({convLhs, rhs});
+      }
+    }
+  }
+  // Repack candidates are conversions that are moved to public inputs.
+  auto withPartner = [&](LayoutAttr repacked, LayoutAttr partner,
+                         bool repackedIsLhs) {
+    std::optional<SmallVector<DimAttr>> restated =
+        restateToMatch(layoutDims(repacked), partner, ctx);
+    LayoutAttr partnerOut = partner;
+    if (restated) {
+      SmallVector<Attribute> attrs(restated->begin(), restated->end());
+      partnerOut = LayoutAttr::get(ctx, ArrayAttr::get(ctx, attrs),
+                                   partner.getN(), partner.getRolls());
+      if (!partnerOut) partnerOut = partner;
+    }
+    LayoutAttr l = repackedIsLhs ? repacked : partnerOut;
+    LayoutAttr r = repackedIsLhs ? partnerOut : repacked;
+    if (isOperatorAligned(map, l, r)) out.push_back({l, r});
+  };
+  if (std::optional<LayoutAttr> matched =
+          matchPublicLayout(map, lhs, rhs, /*matchLhs=*/true)) {
+    withPartner(*matched, rhs, /*repackedIsLhs=*/true);
+  }
+  if (std::optional<LayoutAttr> matched =
+          matchPublicLayout(map, lhs, rhs, /*matchLhs=*/false)) {
+    withPartner(*matched, lhs, /*repackedIsLhs=*/false);
+  }
+  // Roll candidates are conversions that require rolls.
+  for (const AlignedPair& p : rollToAlign(map, lhs, rhs)) out.push_back(p);
+  SmallVector<AlignedPair> unique;
+  for (const AlignedPair& p : out) {
+    bool seen = false;
+    for (const AlignedPair& q : unique) {
+      seen |= q.lhs == p.lhs && q.rhs == p.rhs;
+    }
+    if (!seen) unique.push_back(p);
+  }
+  return unique;
+}
+
+std::optional<LayoutAttr> outputLayout(const OperatorAlignmentMap& map,
+                                       bool isMatmul, LayoutAttr lhs,
+                                       LayoutAttr rhs, int64_t lhsSumDim,
+                                       int64_t rhsSumDim) {
+  if (!lhs || !rhs || lhs.getN() != rhs.getN()) return std::nullopt;
+  MLIRContext* ctx = lhs.getContext();
+  SmallVector<DimAttr> a = layoutDims(lhs);
+  SmallVector<DimAttr> b = layoutDims(rhs);
+
+  // A summation in the ciphertext dimensions removes the piece.
+  // A summation in the slot dimensions results in a gap piece.
+  const size_t ctLen = inferCtPrefixLen(a, lhs.getN());
+
+  SmallVector<DimAttr> outDims;
+  SmallVector<int64_t> posMap(a.size(), -1), posMapB(b.size(), -1);
+  // The pair arrives aligned, so the two lists correspond one to one and the
+  // walk steps them together.
+  size_t ia = 0, ib = 0;
+  while (ia < a.size() || ib < b.size()) {
+    if (ia >= a.size() || ib >= b.size()) return std::nullopt;
+    const size_t i = ia, j = ib;
+    DimAttr x = a[ia++];
+    DimAttr y = b[ib++];
+    if (isMatmul && i < ctLen &&
+        ((isTraversal(x) && x.getDim() == lhsSumDim) ||
+         (isTraversal(y) && y.getDim() == rhsSumDim))) {
+      continue;
+    }
+    posMap[i] = static_cast<int64_t>(outDims.size());
+    posMapB[j] = static_cast<int64_t>(outDims.size());
+    if (isMatmul) {
+      if (isTraversal(x) && x.getDim() == lhsSumDim) {
+        outDims.push_back(mk(ctx, -2, x.getSize(), x.getStride()));
+      } else if (isTraversal(y) && y.getDim() == rhsSumDim) {
+        outDims.push_back(mk(ctx, -2, y.getSize(), y.getStride()));
+      } else if (isTraversal(x) && !isTraversal(y)) {
+        outDims.push_back(x);
+      } else if (!isTraversal(x) && isTraversal(y)) {
+        outDims.push_back(y);
+      } else if (x.isGap() || y.isGap()) {
+        outDims.push_back(mk(ctx, -2, x.getSize(), x.getStride()));
+      } else {
+        // Both replication: the output holds neither dim here.
+        outDims.push_back(mk(ctx, -2, x.getSize(), x.getStride()));
+      }
+    } else {
+      if (isTraversal(x) || (!isTraversal(y))) {
+        outDims.push_back(x);
+      } else {
+        outDims.push_back(y);  // lhs replication over an rhs traversal dim
+      }
+    }
+  }
+
+  // Rolls along the summation dimension are dropped.
+  SmallVector<int64_t> rolls;
+  auto fromIsSum = [&](ArrayRef<DimAttr> dims, const RollArg& from,
+                       int64_t sumDim) {
+    return from.isAxis ? from.index == sumDim
+                       : dims[from.index].getDim() == sumDim;
+  };
+  auto remap = [&](RollArg arg, ArrayRef<int64_t> map, bool& ok) {
+    if (arg.isAxis) return arg;
+    if (arg.index < 0 || arg.index >= static_cast<int64_t>(map.size()) ||
+        map[arg.index] < 0) {
+      ok = false;
+      return arg;
+    }
+    arg.index = map[arg.index];
+    return arg;
+  };
+  auto append = [&](LayoutAttr layout, ArrayRef<DimAttr> dims, int64_t sumDim,
+                    ArrayRef<int64_t> map) {
+    for (const RollSpec& r : getRollSpecs(layout)) {
+      if (isMatmul && fromIsSum(dims, r.from, sumDim)) continue;
+      bool ok = true;
+      const RollArg fromArg = remap(r.from, map, ok);
+      const RollArg byArg = remap(r.by, map, ok);
+      if (!ok) continue;
+      const int64_t f = encodeRollArg(fromArg), by = encodeRollArg(byArg);
+      bool dup = false;
+      for (size_t k = 0; k + 1 < rolls.size(); k += 2) {
+        if (rolls[k] == f && rolls[k + 1] == by) dup = true;
+      }
+      if (!dup) {
+        rolls.push_back(f);
+        rolls.push_back(by);
+      }
+    }
+  };
+  append(lhs, a, lhsSumDim, posMap);
+  if (isMatmul) append(rhs, b, rhsSumDim, posMapB);
+
+  LayoutAttr out = LayoutAttr::getCanonical(ctx, outDims, lhs.getN(), rolls);
+  if (!out) return std::nullopt;
+  return mergeAdjacentLayoutDims(out);
+}
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/LayoutAlignment.h
+++ b/lib/Dialect/Rotom/Utils/LayoutAlignment.h
@@ -1,0 +1,99 @@
+#ifndef LIB_DIALECT_ROTOM_UTILS_LAYOUTALIGNMENT_H_
+#define LIB_DIALECT_ROTOM_UTILS_LAYOUTALIGNMENT_H_
+
+#include <cstdint>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+// The alignment map of an operator.
+// lhsToRhs[d] is the rhs dim that lhs dim d aligns with, or kRepeatedDim when
+// the rhs holds replication there. rhsToLhs is the reverse.
+struct OperatorAlignmentMap {
+  static constexpr int64_t kRepeatedDim = -1;
+  SmallVector<int64_t> lhsToRhs;
+  SmallVector<int64_t> rhsToLhs;
+
+  static OperatorAlignmentMap identity(int64_t rank);
+  // The matmul alignment map for the given operand ranks. The last lhs dim
+  // and the second-to-last rhs dim (dim 0 for a vector) are the contraction dim
+  // and align with each other; the free dims align with replication; leading
+  // batch dims align from the right, and a batch dim with no partner aligns
+  // with replication.
+  static OperatorAlignmentMap matmul(int64_t lhsRank = 2, int64_t rhsRank = 2);
+};
+
+// Determines if two layouts are aligned for the operator.
+bool isOperatorAligned(const OperatorAlignmentMap& map, LayoutAttr lhs,
+                       LayoutAttr rhs);
+
+// Determines the rolls each side must add to become aligned. Each added roll is
+// a ROLL kernel. Fails when the dims are not aligned.
+struct RollAlignment {
+  llvm::SmallVector<RollSpec> addToLhs;
+  llvm::SmallVector<RollSpec> addToRhs;
+  bool empty() const { return addToLhs.empty() && addToRhs.empty(); }
+};
+FailureOr<RollAlignment> alignRolls(const OperatorAlignmentMap& map,
+                                    LayoutAttr lhs, LayoutAttr rhs);
+
+// Determines the piece list each side needs to match the other side's piece
+// order: `forRhs` is a piece list for the rhs tensor in the lhs's order, and
+// `forLhs` the reverse.
+struct AlignedDims {
+  llvm::SmallVector<DimAttr> forRhs;
+  llvm::SmallVector<DimAttr> forLhs;
+};
+std::optional<AlignedDims> alignedDims(const OperatorAlignmentMap& map,
+                                       ArrayRef<DimAttr> lhsDims,
+                                       ArrayRef<DimAttr> rhsDims,
+                                       MLIRContext* ctx);
+
+// Grows each side to the operator's aligned shape by padding the smaller side
+// with gap ciphertexts, turns gaps into replication right to left, and adds
+// any missing factor as a new outermost replication piece. Fails when the two
+// sides cannot both reach the shape.
+struct ReplicatedPair {
+  LayoutAttr lhs;
+  LayoutAttr rhs;
+};
+FailureOr<ReplicatedPair> replicateForAlignment(const OperatorAlignmentMap& map,
+                                                LayoutAttr lhs, LayoutAttr rhs,
+                                                ArrayRef<int64_t> lhsShape,
+                                                ArrayRef<int64_t> rhsShape);
+
+struct AlignedPair {
+  LayoutAttr lhs;
+  LayoutAttr rhs;
+};
+
+// Applies the roll for swapping the summation dim to the ciphertext dims.
+std::optional<LayoutAttr> applySumRoll(LayoutAttr layout, int64_t sumDim);
+
+// Aligns with a roll.
+llvm::SmallVector<AlignedPair, 2> rollToAlign(const OperatorAlignmentMap& map,
+                                              LayoutAttr lhs, LayoutAttr rhs);
+
+// Repacks one side into the layout the other side needs, rolls included.
+std::optional<LayoutAttr> matchPublicLayout(const OperatorAlignmentMap& map,
+                                            LayoutAttr lhs, LayoutAttr rhs,
+                                            bool matchLhs);
+
+llvm::SmallVector<AlignedPair> alignPair(const OperatorAlignmentMap& map,
+                                         LayoutAttr lhs, LayoutAttr rhs);
+
+// Computes the result layout of an aligned pair.
+std::optional<LayoutAttr> outputLayout(const OperatorAlignmentMap& map,
+                                       bool isMatmul, LayoutAttr lhs,
+                                       LayoutAttr rhs, int64_t lhsSumDim,
+                                       int64_t rhsSumDim);
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ROTOM_UTILS_LAYOUTALIGNMENT_H_

--- a/lib/Dialect/Rotom/Utils/LayoutAlignmentTest.cpp
+++ b/lib/Dialect/Rotom/Utils/LayoutAlignmentTest.cpp
@@ -498,6 +498,19 @@ TEST_F(LayoutAlignmentTest, AlignedDimsKeepsReplicationBeyondUnitDim) {
   EXPECT_FALSE(rotom::alignPair(map, lhsLayout, rhsLayout).empty());
 }
 
+// Batch dims pair from the right at any rank, so a [b0, b1, i, k] lhs and a
+// [b1, k, j] rhs agree on b1 and leave b0 facing replication.
+TEST_F(LayoutAlignmentTest, MatmulMapPairsBatchDimsFromTheRight) {
+  auto map = rotom::OperatorAlignmentMap::matmul(/*lhsRank=*/4, /*rhsRank=*/3);
+  EXPECT_EQ(map.lhsToRhs[3], 1);  // k pairs with k
+  EXPECT_EQ(map.rhsToLhs[1], 3);
+  EXPECT_EQ(map.lhsToRhs[1], 0);  // innermost batch dims pair
+  EXPECT_EQ(map.rhsToLhs[0], 1);
+  EXPECT_EQ(map.lhsToRhs[0], rotom::OperatorAlignmentMap::kRepeatedDim);
+  EXPECT_EQ(map.lhsToRhs[2], rotom::OperatorAlignmentMap::kRepeatedDim);
+  EXPECT_EQ(map.rhsToLhs[2], rotom::OperatorAlignmentMap::kRepeatedDim);
+}
+
 }  // namespace
 }  // namespace heir
 }  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/LayoutAlignmentTest.cpp
+++ b/lib/Dialect/Rotom/Utils/LayoutAlignmentTest.cpp
@@ -1,0 +1,503 @@
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/Utils/LayoutAlignment.h"
+#include "lib/Dialect/Rotom/Utils/LayoutConversion.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Location.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using rotom::DimAttr;
+using rotom::LayoutAttr;
+using rotom::RotomDialect;
+
+class LayoutAlignmentTest : public ::testing::Test {
+ protected:
+  LayoutAlignmentTest() {
+    context.loadDialect<RotomDialect>();
+    context.loadDialect<tensor_ext::TensorExtDialect>();
+  }
+
+  DimAttr dim(int64_t dim, int64_t size, int64_t stride = 1) {
+    return DimAttr::get(&context, dim, size, stride);
+  }
+
+  LayoutAttr layout(ArrayRef<Attribute> dims, int64_t n) {
+    return LayoutAttr::get(&context, ArrayAttr::get(&context, dims), n);
+  }
+
+  MLIRContext context;
+};
+
+// Operator alignment, matmul map: lhs is A(i, k) with i innermost, rhs is
+// B(k, j) traversing k in lockstep and replicating where lhs traverses i.
+TEST_F(LayoutAlignmentTest, OperatorAlignedMatmulOperands) {
+  rotom::OperatorAlignmentMap map = rotom::OperatorAlignmentMap::matmul();
+  // lhs dims: i = 0, k = 1. rhs dims: k = 0, j = 1.
+  LayoutAttr lhsPacked = layout({dim(1, 4), dim(0, 4)}, 16);
+  LayoutAttr rhsPacked = layout({dim(0, 4), dim(/*dim=*/-1, 4)}, 16);
+  EXPECT_TRUE(rotom::isOperatorAligned(map, lhsPacked, rhsPacked));
+  // Swapping rhs's pieces breaks the positional correspondence.
+  LayoutAttr rhsSwapped = layout({dim(/*dim=*/-1, 4), dim(0, 4)}, 16);
+  EXPECT_FALSE(rotom::isOperatorAligned(map, lhsPacked, rhsSwapped));
+}
+
+// The matmul map by rank reproduces the reference's per-shape alignment
+// table: the 2-D default is {0:R, 1:0, R:1}; mat-vec and vec-mat drop the
+// missing free dim; block matmul locksteps the shared batch dim; a batched
+// lhs against a 2-D rhs pairs its batch dim with replication.
+TEST_F(LayoutAlignmentTest, MatmulMapGeneralizesOverOperandRanks) {
+  using Map = rotom::OperatorAlignmentMap;
+  const int64_t R = Map::kRepeatedDim;
+  auto check = [](const Map& map, ArrayRef<int64_t> lhsToRhs,
+                  ArrayRef<int64_t> rhsToLhs) {
+    EXPECT_EQ(SmallVector<int64_t>(map.lhsToRhs),
+              SmallVector<int64_t>(lhsToRhs));
+    EXPECT_EQ(SmallVector<int64_t>(map.rhsToLhs),
+              SmallVector<int64_t>(rhsToLhs));
+  };
+  check(Map::matmul(), {R, 0}, {1, R});
+  check(Map::matmul(2, 2), {R, 0}, {1, R});
+  check(Map::matmul(2, 1), {R, 0}, {1});
+  check(Map::matmul(1, 2), {0}, {0, R});
+  check(Map::matmul(1, 1), {0}, {0});
+  check(Map::matmul(3, 3), {0, R, 1}, {0, 2, R});
+  check(Map::matmul(3, 2), {R, R, 0}, {2, R});
+  check(Map::matmul(2, 3), {R, 1}, {R, 1, R});
+  check(Map::matmul(4, 3), {R, 0, R, 1}, {1, 3, R});
+}
+
+// Mat-vec with the map for ranks (2, 1): A(i, k) traverses k where x(k)
+// traverses k and replicates where A traverses i.
+TEST_F(LayoutAlignmentTest, OperatorAlignedMatVecOperands) {
+  auto map = rotom::OperatorAlignmentMap::matmul(2, 1);
+  LayoutAttr lhs = layout({dim(1, 4), dim(0, 4)}, 16);
+  LayoutAttr rhs = layout({dim(0, 4), dim(/*dim=*/-1, 4)}, 16);
+  EXPECT_TRUE(rotom::isOperatorAligned(map, lhs, rhs));
+  LayoutAttr rhsSwapped = layout({dim(/*dim=*/-1, 4), dim(0, 4)}, 16);
+  EXPECT_FALSE(rotom::isOperatorAligned(map, lhs, rhsSwapped));
+}
+
+// Block matmul with the map for ranks (3, 3): the batch dim locksteps on
+// both sides, then the 2-D pattern applies to the inner dims.
+TEST_F(LayoutAlignmentTest, OperatorAlignedBlockMatmulOperands) {
+  auto map = rotom::OperatorAlignmentMap::matmul(3, 3);
+  // lhs dims: b = 0, i = 1, k = 2. rhs dims: b = 0, k = 1, j = 2.
+  LayoutAttr lhs = layout({dim(0, 2), dim(2, 4), dim(1, 4)}, 32);
+  LayoutAttr rhs = layout({dim(0, 2), dim(1, 4), dim(/*dim=*/-1, 4)}, 32);
+  EXPECT_TRUE(rotom::isOperatorAligned(map, lhs, rhs));
+  // A batch dim paired with the wrong dim is misaligned.
+  LayoutAttr rhsBad = layout({dim(/*dim=*/-1, 2), dim(1, 4), dim(0, 4)}, 32);
+  EXPECT_FALSE(rotom::isOperatorAligned(map, lhs, rhsBad));
+}
+
+// A k-diagonal needs the matching roll on BOTH operands: the rolled dim (k)
+// pairs with a traversal dim on the other side.
+TEST_F(LayoutAlignmentTest, OperatorAlignmentRequiresMatchingContractionRoll) {
+  rotom::OperatorAlignmentMap map = rotom::OperatorAlignmentMap::matmul();
+  LayoutAttr lhsDiag = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(1, 4), dim(0, 4)}), /*n=*/16,
+      DenseI64ArrayAttr::get(&context, {0, 1}));
+  LayoutAttr rhsDiag = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 4), dim(/*dim=*/-1, 4)}),
+      /*n=*/16, DenseI64ArrayAttr::get(&context, {0, 1}));
+  LayoutAttr rhsPlain = layout({dim(0, 4), dim(/*dim=*/-1, 4)}, 16);
+  EXPECT_TRUE(rotom::isOperatorAligned(map, lhsDiag, rhsDiag));
+  EXPECT_FALSE(rotom::isOperatorAligned(map, lhsDiag, rhsPlain));
+}
+
+// A roll whose FROM piece pairs with replication on the other side is exempt:
+// every index of the replicated side reads the same value, so rolling the
+// traversal side cannot misalign the pairing.
+TEST_F(LayoutAlignmentTest, OperatorAlignmentExemptsRollOntoReplication) {
+  rotom::OperatorAlignmentMap map = rotom::OperatorAlignmentMap::matmul();
+  // FROM = the i piece (position 1), BY = the k piece (position 0).
+  LayoutAttr lhsRolled = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(1, 4), dim(0, 4)}), /*n=*/16,
+      DenseI64ArrayAttr::get(&context, {1, 0}));
+  LayoutAttr rhsPlain = layout({dim(0, 4), dim(/*dim=*/-1, 4)}, 16);
+  EXPECT_TRUE(rotom::isOperatorAligned(map, lhsRolled, rhsPlain));
+}
+
+// alignRolls is the constructive form of isOperatorAligned: where the checker
+// says "not aligned", this says which rolls each side must add.
+TEST_F(LayoutAlignmentTest, AlignRollsReportsNothingWhenAlreadyAligned) {
+  LayoutAttr a = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 4), dim(1, 4)}), 16,
+      DenseI64ArrayAttr::get(&context, {1, 0}));
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  ASSERT_TRUE(rotom::isOperatorAligned(map, a, a));
+  auto alignment = rotom::alignRolls(map, a, a);
+  ASSERT_TRUE(succeeded(alignment));
+  EXPECT_TRUE(alignment->empty());
+}
+
+TEST_F(LayoutAlignmentTest, AlignRollsAddsTheMissingRollToTheUnrolledSide) {
+  LayoutAttr rolled = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 4), dim(1, 4)}), 16,
+      DenseI64ArrayAttr::get(&context, {1, 0}));
+  LayoutAttr plain = layout({dim(0, 4), dim(1, 4)}, 16);
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  EXPECT_FALSE(rotom::isOperatorAligned(map, rolled, plain));
+
+  auto alignment = rotom::alignRolls(map, rolled, plain);
+  ASSERT_TRUE(succeeded(alignment));
+  // The rolled side needs nothing; the plain side must take the roll.
+  EXPECT_TRUE(alignment->addToLhs.empty());
+  ASSERT_EQ(alignment->addToRhs.size(), 1u);
+  EXPECT_FALSE(alignment->addToRhs[0].from.isAxis);
+  EXPECT_EQ(alignment->addToRhs[0].from.index, 1);
+  EXPECT_FALSE(alignment->addToRhs[0].by.isAxis);
+  EXPECT_EQ(alignment->addToRhs[0].by.index, 0);
+
+  // The report is symmetric under swapping the operands.
+  auto swapped = rotom::alignRolls(map, plain, rolled);
+  ASSERT_TRUE(succeeded(swapped));
+  EXPECT_TRUE(swapped->addToRhs.empty());
+  ASSERT_EQ(swapped->addToLhs.size(), 1u);
+}
+
+TEST_F(LayoutAlignmentTest, AlignRollsFailsWhenPieceStructuresDisagree) {
+  // No roll change repairs a placement disagreement.
+  LayoutAttr rowMajor = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr colMajor = layout({dim(1, 4), dim(0, 4)}, 16);
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  EXPECT_TRUE(failed(rotom::alignRolls(map, rowMajor, colMajor)));
+}
+
+// ---- alignment engine -----------------------------------------------------
+
+// Piece list as text, for readable failures: [d:size:stride] with R and G.
+static std::string fmtDims(ArrayRef<rotom::DimAttr> dims) {
+  std::string out;
+  for (rotom::DimAttr d : dims) {
+    out += "[";
+    out += d.isReplicate() ? "R" : d.isGap() ? "G" : std::to_string(d.getDim());
+    out += ":" + std::to_string(d.getSize()) + ":" +
+           std::to_string(d.getStride()) + "]";
+  }
+  return out;
+}
+static std::string fmtRolls(LayoutAttr layout) {
+  std::string out;
+  for (const rotom::RollSpec& r : rotom::getRollSpecs(layout)) {
+    auto arg = [](const rotom::RollArg& a) {
+      return (a.isAxis ? "axis " : "") + std::to_string(a.index);
+    };
+    out += "(" + arg(r.from) + "," + arg(r.by) + ")";
+  }
+  return out;
+}
+
+// The paper's A[i,k] x B[k,j] at 4x4, n = 16: A column-major and B row-major,
+// one ciphertext each. The aligned shape is i*k*j = 64, so each side gains a
+// factor of 4 as a new outermost (ciphertext) replication.
+TEST_F(LayoutAlignmentTest, ReplicateForAlignmentAddsOuterReplication) {
+  LayoutAttr a = layout({dim(1, 4), dim(0, 4)}, 16);  // A: slot = 4k + i
+  LayoutAttr b = layout({dim(0, 4), dim(1, 4)}, 16);  // B: slot = 4k + j
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  auto pair = rotom::replicateForAlignment(map, a, b, {4, 4}, {4, 4});
+  ASSERT_TRUE(succeeded(pair));
+  EXPECT_EQ(fmtDims(rotom::layoutDims(pair->lhs)), "[R:4:1][1:4:1][0:4:1]");
+  EXPECT_EQ(fmtDims(rotom::layoutDims(pair->rhs)), "[R:4:1][0:4:1][1:4:1]");
+  EXPECT_EQ(rotom::layoutNumCiphertexts(pair->lhs), 4);
+  EXPECT_EQ(rotom::layoutNumCiphertexts(pair->rhs), 4);
+}
+
+// apply_sum_roll: the replicated lhs has replication on the ciphertext side
+// and k in the slots; the two swap and k (now a ciphertext piece) rolls by
+// the replication (now a slot piece).
+TEST_F(LayoutAlignmentTest, ApplySumRollSwapsAndRollsTheSummationDim) {
+  LayoutAttr replicated =
+      layout({dim(/*dim=*/-1, 4), dim(1, 4), dim(0, 4)}, 16);
+  std::optional<LayoutAttr> rolled =
+      rotom::applySumRoll(replicated, /*sumDim=*/1);
+  ASSERT_TRUE(rolled.has_value());
+  EXPECT_EQ(fmtDims(rotom::layoutDims(*rolled)), "[1:4:1][R:4:1][0:4:1]");
+  EXPECT_EQ(fmtRolls(*rolled), "(0,1)");
+  EXPECT_EQ(rotom::layoutNumCiphertexts(*rolled), 4);
+
+  // The symmetric rhs: k is dim 0 there.
+  LayoutAttr rhs = layout({dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)}, 16);
+  std::optional<LayoutAttr> rolledRhs = rotom::applySumRoll(rhs, /*sumDim=*/0);
+  ASSERT_TRUE(rolledRhs.has_value());
+  EXPECT_EQ(fmtDims(rotom::layoutDims(*rolledRhs)), "[0:4:1][R:4:1][1:4:1]");
+  EXPECT_EQ(fmtRolls(*rolledRhs), "(0,1)");
+}
+
+TEST_F(LayoutAlignmentTest, ApplySumRollRefusesWithoutCiphertextReplication) {
+  // No replication on the ciphertext side: nothing to roll by.
+  LayoutAttr a = layout({dim(1, 4), dim(0, 4)}, 16);
+  EXPECT_FALSE(rotom::applySumRoll(a, /*sumDim=*/1).has_value());
+  // sumDim not in the slots.
+  LayoutAttr b = layout({dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)}, 16);
+  EXPECT_FALSE(rotom::applySumRoll(b, /*sumDim=*/5).has_value());
+}
+
+// The whole reference pipeline for one operand: replicate, then the sum roll.
+TEST_F(LayoutAlignmentTest, SumRollFromReplicatedSourceIsPureRotations) {
+  LayoutAttr replicated =
+      layout({dim(/*dim=*/-1, 4), dim(1, 4), dim(0, 4)}, 16);
+  std::optional<LayoutAttr> rolled =
+      rotom::applySumRoll(replicated, /*sumDim=*/1);
+  ASSERT_TRUE(rolled.has_value());
+  auto plan = rotom::planLayoutConversion(replicated, *rolled);
+  ASSERT_TRUE(succeeded(plan));
+  ASSERT_EQ(plan->steps.size(), 4u);
+  EXPECT_TRUE(plan->fills.empty());
+  for (const rotom::LayoutConversionStep& step : plan->steps) {
+    EXPECT_EQ(step.shift, 4 * step.targetCt);
+    EXPECT_EQ(step.targetSlots.size(), 16u);
+  }
+}
+
+// alignedDims mirrors each side's structure onto the other's tensor. For the
+// replicated matmul pair, lhs [R][k][i] seen from rhs becomes [j][k][R]: the
+// lhs replication broadcasts over j, k pairs with k, and i is replication on
+// the rhs side. Symmetrically rhs [R][k][j] seen from lhs is [i][k][R].
+TEST_F(LayoutAlignmentTest, AlignedDimsMirrorsStructureThroughTheMap) {
+  SmallVector<rotom::DimAttr> lhs = {dim(/*dim=*/-1, 4), dim(1, 4), dim(0, 4)};
+  SmallVector<rotom::DimAttr> rhs = {dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)};
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  auto aligned = rotom::alignedDims(map, lhs, rhs, &context);
+  ASSERT_TRUE(aligned.has_value());
+  EXPECT_EQ(fmtDims(aligned->forRhs), "[1:4:1][0:4:1][R:4:1]");
+  EXPECT_EQ(fmtDims(aligned->forLhs), "[0:4:1][1:4:1][R:4:1]");
+}
+
+// For an identity map the mirror is the relabeled copy, so a pair that is
+// already aligned mirrors to itself.
+TEST_F(LayoutAlignmentTest, AlignedDimsIsIdentityForAlignedElementwise) {
+  SmallVector<rotom::DimAttr> a = {dim(0, 4), dim(1, 4)};
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  auto aligned = rotom::alignedDims(map, a, a, &context);
+  ASSERT_TRUE(aligned.has_value());
+  EXPECT_EQ(fmtDims(aligned->forRhs), fmtDims(a));
+  EXPECT_EQ(fmtDims(aligned->forLhs), fmtDims(a));
+}
+
+// rollToAlign: the replicated matmul pair is not aligned (i sits where the
+// rhs has j). Rolling the rhs toward its mirror [j][k][R] moves j to the
+// ciphertext side by rolling it by the replication that was there.
+TEST_F(LayoutAlignmentTest, RollToAlignRollsTheOutOfPlacePieceBySwap) {
+  LayoutAttr lhs = layout({dim(/*dim=*/-1, 4), dim(1, 4), dim(0, 4)}, 16);
+  LayoutAttr rhs = layout({dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)}, 16);
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  ASSERT_FALSE(rotom::isOperatorAligned(map, lhs, rhs));
+
+  auto cands = rotom::rollToAlign(map, lhs, rhs);
+  ASSERT_EQ(cands.size(), 2u);
+  // Rhs rolled toward the lhs.
+  EXPECT_EQ(cands[0].lhs, lhs);
+  EXPECT_EQ(fmtDims(rotom::layoutDims(cands[0].rhs)), "[1:4:1][0:4:1][R:4:1]");
+  EXPECT_EQ(fmtRolls(cands[0].rhs), "(0,2)");
+  EXPECT_TRUE(rotom::isOperatorAligned(map, cands[0].lhs, cands[0].rhs));
+  // Lhs rolled toward the rhs.
+  EXPECT_EQ(cands[1].rhs, rhs);
+  EXPECT_EQ(fmtDims(rotom::layoutDims(cands[1].lhs)), "[0:4:1][1:4:1][R:4:1]");
+  EXPECT_EQ(fmtRolls(cands[1].lhs), "(0,2)");
+  EXPECT_TRUE(rotom::isOperatorAligned(map, cands[1].lhs, cands[1].rhs));
+}
+
+// alignPair on an unrolled pair offers both conversions and both rolls.
+TEST_F(LayoutAlignmentTest, AlignPairOffersConversionsAndRolls) {
+  LayoutAttr lhs = layout({dim(/*dim=*/-1, 4), dim(1, 4), dim(0, 4)}, 16);
+  LayoutAttr rhs = layout({dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)}, 16);
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  auto cands = rotom::alignPair(map, lhs, rhs);
+  ASSERT_EQ(cands.size(), 4u);
+  for (const rotom::AlignedPair& c : cands) {
+    EXPECT_TRUE(rotom::isOperatorAligned(map, c.lhs, c.rhs));
+  }
+  // Conversions first: the converted side has no rolls.
+  EXPECT_EQ(fmtDims(rotom::layoutDims(cands[0].rhs)), "[1:4:1][0:4:1][R:4:1]");
+  EXPECT_EQ(fmtRolls(cands[0].rhs), "");
+  EXPECT_EQ(fmtDims(rotom::layoutDims(cands[1].lhs)), "[0:4:1][1:4:1][R:4:1]");
+  EXPECT_EQ(fmtRolls(cands[1].lhs), "");
+  // Then the rolls.
+  EXPECT_EQ(fmtRolls(cands[2].rhs), "(0,2)");
+  EXPECT_EQ(fmtRolls(cands[3].lhs), "(0,2)");
+}
+
+TEST_F(LayoutAlignmentTest, AlignPairReturnsAlignedPairUnchanged) {
+  LayoutAttr a = layout({dim(0, 4), dim(1, 4)}, 16);
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  auto cands = rotom::alignPair(map, a, a);
+  ASSERT_EQ(cands.size(), 1u);
+  EXPECT_EQ(cands[0].lhs, a);
+  EXPECT_EQ(cands[0].rhs, a);
+}
+
+// Elementwise row-major vs column-major: two conversions. The roll
+// candidates are filtered out -- for an identity map a roll on one side
+// pairs with a traversal dim on the other, so it is required and unmatched.
+TEST_F(LayoutAlignmentTest, AlignPairElementwiseOffersOnlyConversions) {
+  LayoutAttr rowMajor = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr colMajor = layout({dim(1, 4), dim(0, 4)}, 16);
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  auto cands = rotom::alignPair(map, rowMajor, colMajor);
+  ASSERT_EQ(cands.size(), 2u);
+  EXPECT_EQ(cands[0].lhs, rowMajor);
+  EXPECT_EQ(cands[0].rhs, rowMajor);
+  EXPECT_EQ(cands[1].lhs, colMajor);
+  EXPECT_EQ(cands[1].rhs, colMajor);
+}
+
+// outputLayout, matmul: the summation piece becomes a gap, a replication
+// paired with a traversal dim becomes that dim, and a surviving roll carries
+// over at its position.
+TEST_F(LayoutAlignmentTest, OutputLayoutMatmulConsumesTheSummationDim) {
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  LayoutAttr lhs = layout({dim(/*dim=*/-1, 4), dim(1, 4), dim(0, 4)}, 16);
+  LayoutAttr convRhs = layout({dim(1, 4), dim(0, 4), dim(/*dim=*/-1, 4)}, 16);
+  auto out = rotom::outputLayout(map, /*isMatmul=*/true, lhs, convRhs,
+                                 /*lhsSumDim=*/1, /*rhsSumDim=*/0);
+  ASSERT_TRUE(out.has_value());
+  EXPECT_EQ(fmtDims(rotom::layoutDims(*out)), "[1:4:1][G:4:1][0:4:1]");
+  EXPECT_EQ(fmtRolls(*out), "");
+
+  // The rolled rhs candidate: its roll's FROM is j, not k, so it survives
+  // positionally -- j (ciphertext) rolled by the piece now at position 2, i.
+  LayoutAttr rolledRhs = LayoutAttr::get(
+      &context,
+      ArrayAttr::get(&context, {dim(1, 4), dim(0, 4), dim(/*dim=*/-1, 4)}), 16,
+      DenseI64ArrayAttr::get(&context, {0, 2}));
+  auto outRolled = rotom::outputLayout(map, true, lhs, rolledRhs, 1, 0);
+  ASSERT_TRUE(outRolled.has_value());
+  EXPECT_EQ(fmtDims(rotom::layoutDims(*outRolled)), "[1:4:1][G:4:1][0:4:1]");
+  EXPECT_EQ(fmtRolls(*outRolled), "(0,2)");
+}
+
+TEST_F(LayoutAlignmentTest, OutputLayoutElementwiseIsTheLhs) {
+  auto map = rotom::OperatorAlignmentMap::identity(2);
+  LayoutAttr a = layout({dim(0, 4), dim(1, 4)}, 16);
+  auto out = rotom::outputLayout(map, /*isMatmul=*/false, a, a, -1, -1);
+  ASSERT_TRUE(out.has_value());
+  EXPECT_EQ(*out, a);
+}
+
+// The whole reference matmul pipeline.
+TEST_F(LayoutAlignmentTest, ReferenceMatmulPipelineYieldsDiagonalResult) {
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  LayoutAttr a = layout({dim(1, 4), dim(0, 4)}, 16);
+  LayoutAttr b = layout({dim(0, 4), dim(1, 4)}, 16);
+  auto rep = rotom::replicateForAlignment(map, a, b, {4, 4}, {4, 4});
+  ASSERT_TRUE(succeeded(rep));
+  auto lhs = rotom::applySumRoll(rep->lhs, /*sumDim=*/1);
+  auto rhs = rotom::applySumRoll(rep->rhs, /*sumDim=*/0);
+  ASSERT_TRUE(lhs.has_value());
+  ASSERT_TRUE(rhs.has_value());
+  EXPECT_FALSE(rotom::isOperatorAligned(map, *lhs, *rhs));
+
+  auto cands = rotom::alignPair(map, *lhs, *rhs);
+  ASSERT_FALSE(cands.empty());
+  for (const rotom::AlignedPair& c : cands) {
+    EXPECT_TRUE(rotom::isOperatorAligned(map, c.lhs, c.rhs));
+  }
+  // The rhs rolled toward the lhs: j takes the replication's place and rolls
+  // by it, on top of the sum roll. The repack candidates share the list, so
+  // the rolled one is found by its shape.
+  const rotom::AlignedPair* rolledPair = nullptr;
+  for (const rotom::AlignedPair& c : cands) {
+    if (fmtRolls(c.rhs) == "(0,1)(1,2)") rolledPair = &c;
+  }
+  ASSERT_NE(rolledPair, nullptr);
+  EXPECT_EQ(fmtDims(rotom::layoutDims(rolledPair->rhs)),
+            "[0:4:1][1:4:1][R:4:1]");
+
+  auto out =
+      rotom::outputLayout(map, true, rolledPair->lhs, rolledPair->rhs, 1, 0);
+  ASSERT_TRUE(out.has_value());
+  // The summation dim sat in the ciphertext region, so the reduction removed
+  // it rather than leaving a gap behind, and the roll's pieces moved down.
+  EXPECT_EQ(fmtDims(rotom::layoutDims(*out)), "[1:4:1][0:4:1]");
+  EXPECT_EQ(fmtRolls(*out), "(0,1)");
+  EXPECT_EQ(rotom::layoutNumCiphertexts(*out), 1);
+}
+
+// The Rotom reference's MNIST layer-1 plan at n = 32768.
+TEST_F(LayoutAlignmentTest, MatchPublicReachesReferenceMnistPlan) {
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  // Weights (i = 0, k = 1) over 16 ciphertexts; image (k = 0, j = 1), one.
+  LayoutAttr lhs = layout({dim(0, 16, 32), dim(0, 32), dim(1, 1024)}, 32768);
+  LayoutAttr rhs =
+      layout({dim(/*dim=*/-1, 32, 1024), dim(0, 1024), dim(1, 1)}, 32768);
+  SmallVector<int64_t> lhsShape = {512, 1024}, rhsShape = {1024, 1};
+  auto rep = rotom::replicateForAlignment(map, lhs, rhs, lhsShape, rhsShape);
+  ASSERT_TRUE(succeeded(rep));
+  std::optional<LayoutAttr> rolled = rotom::applySumRoll(rep->rhs, 0);
+  ASSERT_TRUE(rolled.has_value());
+  // The weights have no ciphertext replication, so they cannot take the roll
+  // themselves; only the repack reaches the aligned pair.
+  EXPECT_FALSE(rotom::applySumRoll(rep->lhs, 1).has_value());
+  auto pairs = rotom::alignPair(map, rep->lhs, *rolled);
+  ASSERT_FALSE(pairs.empty());
+  bool sawRolledPair = false;
+  for (const auto& p : pairs) {
+    if (p.rhs != *rolled) continue;
+    if (!p.lhs.getRolls() || p.lhs.getRolls().empty()) continue;
+    EXPECT_EQ(p.lhs.getRolls(), rolled->getRolls());
+    EXPECT_TRUE(rotom::isOperatorAligned(map, p.lhs, p.rhs));
+    EXPECT_TRUE(rotom::outputLayout(map, /*isMatmul=*/true, p.lhs, p.rhs,
+                                    /*lhsSumDim=*/1, /*rhsSumDim=*/0)
+                    .has_value());
+    sawRolledPair = true;
+  }
+  EXPECT_TRUE(sawRolledPair);
+}
+
+// matchPublicLayout copies the other side's rolls by position, so a
+// whole-axis roll argument has no counterpart and the repack is refused.
+TEST_F(LayoutAlignmentTest, MatchPublicRefusesAxisNamedRolls) {
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  LayoutAttr lhs = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr rhs = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 2, 2), dim(0, 2), dim(1, 4)}),
+      16,
+      DenseI64ArrayAttr::get(&context,
+                             {rotom::encodeRollArg({/*isAxis=*/true, 0}),
+                              rotom::encodeRollArg({/*isAxis=*/false, 2})}));
+  EXPECT_FALSE(
+      rotom::matchPublicLayout(map, lhs, rhs, /*matchLhs=*/true).has_value());
+}
+
+// A replication piece wider than the dim it broadcasts over: the second MNIST
+// layer at n = 32768 replicates the 10x512 weights 4x to reach the aligned
+// fill, and the mirror maps that R:4 onto j, whose extent is 1. The leftover
+// must stay replication or the mirrored layout no longer fills the
+// ciphertext and every candidate dies.
+TEST_F(LayoutAlignmentTest, AlignedDimsKeepsReplicationBeyondUnitDim) {
+  SmallVector<rotom::DimAttr> lhs = {dim(/*dim=*/-1, 4), dim(0, 16),
+                                     dim(1, 512)};
+  SmallVector<rotom::DimAttr> rhs = {dim(/*dim=*/-1, 64, /*stride=*/512),
+                                     dim(0, 512), dim(1, 1)};
+  auto map = rotom::OperatorAlignmentMap::matmul();
+  auto aligned = rotom::alignedDims(map, lhs, rhs, &context);
+  ASSERT_TRUE(aligned.has_value());
+  int64_t capacity = 1;
+  for (rotom::DimAttr d : aligned->forRhs) capacity *= d.getSize();
+  EXPECT_EQ(capacity, 4 * 16 * 512);
+  LayoutAttr lhsLayout =
+      layout({dim(/*dim=*/-1, 4), dim(0, 16), dim(1, 512)}, 32768);
+  LayoutAttr rhsLayout = layout(
+      {dim(/*dim=*/-1, 64, /*stride=*/512), dim(0, 512), dim(1, 1)}, 32768);
+  EXPECT_FALSE(rotom::alignPair(map, lhsLayout, rhsLayout).empty());
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/LayoutConversion.cpp
+++ b/lib/Dialect/Rotom/Utils/LayoutConversion.cpp
@@ -1,0 +1,469 @@
+#include "lib/Dialect/Rotom/Utils/LayoutConversion.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <tuple>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseSet.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"          // from @llvm-project
+#include "llvm/include/llvm/Support/MathExtras.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+namespace {
+// Where a traversal piece lands: in the ciphertext dims or the slot dims,
+// and at what offset. The address is the sum of each piece's dims times its
+// offset.
+struct PiecePlacement {
+  bool inSlots;
+  // The product of the extents of the pieces after this one in its region.
+  // Ciphertext-side offsets count too, so a reorder on the ciphertext side is
+  // free only when the piece stays on that side.
+  int64_t offset;
+  int64_t extent;
+};
+}  // namespace
+
+// Computes the placement of every traversal piece, keyed by (dim, stride).
+// The stride key is 1 for a dim with a single piece. Also returns the product
+// of the slot-side replication extents in `slotReplication`.
+static llvm::DenseMap<std::pair<int64_t, int64_t>, PiecePlacement>
+piecePlacements(LayoutAttr layout, int64_t& slotReplication) {
+  SmallVector<DimAttr> dims;
+  for (Attribute attr : layout.getDims()) dims.push_back(cast<DimAttr>(attr));
+  const size_t ctPrefixLen = inferCtPrefixLen(dims, layout.getN());
+
+  llvm::DenseMap<int64_t, int64_t> pieceCount;
+  for (DimAttr piece : dims) {
+    if (!piece.isGap() && !piece.isReplicate()) ++pieceCount[piece.getDim()];
+  }
+
+  // Suffix offsets within each region, right to left.
+  llvm::DenseMap<std::pair<int64_t, int64_t>, PiecePlacement> placements;
+  slotReplication = 1;
+  int64_t offset = 1;
+  for (size_t p = dims.size(); p-- > 0;) {
+    if (p + 1 == ctPrefixLen) offset = 1;  // entering the ciphertext region
+    DimAttr piece = dims[p];
+    const bool inSlots = p >= ctPrefixLen;
+    if (piece.isReplicate() || piece.isGap()) {
+      // Only replication counts as a fill: a gap's blocks hold nothing, so
+      // producing them is free. A gap is NOT free for the pieces to its
+      // left.
+      if (inSlots && piece.isReplicate() && piece.getSize() > 1) {
+        slotReplication *= piece.getSize();
+      }
+      offset *= piece.getSize();
+      continue;
+    }
+    if (piece.getSize() > 1) {
+      const int64_t strideKey =
+          pieceCount[piece.getDim()] > 1 ? piece.getStride() : 1;
+      placements[{piece.getDim(), strideKey}] =
+          PiecePlacement{inSlots, offset, piece.getSize()};
+    }
+    offset *= piece.getSize();
+  }
+  return placements;
+}
+
+#include "llvm/include/llvm/ADT/DenseSet.h"  // from @llvm-project
+// Shared engine for the address-only conversion and the one-roll alignment.
+namespace {
+struct PositionedPiece {
+  int64_t pos;  // position in the dims list
+  int64_t dim;  // axis, or the R/G sentinel
+  int64_t size;
+  int64_t divisor;  // the piece's stride: index = (axis index / divisor) % size
+  int64_t offset;   // address offset within its region
+  bool inSlots;
+  bool isRepl() const { return dim == -1; }
+  bool isGap() const { return dim == -2; }
+};
+
+SmallVector<PositionedPiece> positionedPieces(LayoutAttr layout) {
+  SmallVector<DimAttr> dims = layoutDims(layout);
+  const size_t ctLen = inferCtPrefixLen(dims, layout.getN());
+  SmallVector<PositionedPiece> out(dims.size());
+  int64_t offset = 1;
+  for (size_t p = dims.size(); p-- > 0;) {
+    if (p + 1 == ctLen) offset = 1;
+    DimAttr d = dims[p];
+    out[p] = PositionedPiece{static_cast<int64_t>(p), d.getDim(), d.getSize(),
+                             d.getStride(),           offset,     p >= ctLen};
+    offset *= d.getSize();
+  }
+  return out;
+}
+
+// An axis this conversion has to move: its pieces on each side. The axis id
+// and its extent both follow from `dst`.
+struct MovingAxis {
+  SmallVector<PositionedPiece> src, dst;
+  int64_t dim() const { return dst.front().dim; }
+  int64_t extent() const {
+    int64_t e = 1;
+    for (const PositionedPiece& p : dst) e *= p.size;
+    return e;
+  }
+};
+}  // namespace
+
+namespace {
+// A roll names its arguments by piece position, so two layouts carry the same
+// rolls when their roll lists match position for position.
+bool sameRollRelation(ArrayRef<RollSpec> fromRolls,
+                      ArrayRef<RollSpec> toRolls) {
+  if (fromRolls.size() != toRolls.size()) return false;
+  for (size_t i = 0; i < fromRolls.size(); ++i) {
+    if (!(fromRolls[i].from == toRolls[i].from &&
+          fromRolls[i].by == toRolls[i].by)) {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
+
+FailureOr<ConversionPlan> planLayoutConversion(LayoutAttr from, LayoutAttr to) {
+  if (!from || !to || from.getN() != to.getN()) return failure();
+  const int64_t n = from.getN();
+  SmallVector<RollSpec> fromRolls = getRollSpecs(from);
+  SmallVector<RollSpec> toRolls = getRollSpecs(to);
+  int64_t rollFromPos = -1, rollByPos = -1;
+  if (toRolls.size() == fromRolls.size() + 1) {
+    const RollSpec& added = toRolls.back();
+    if (added.from.isAxis || added.by.isAxis) return failure();  // TODO: axis
+    rollFromPos = added.from.index;
+    rollByPos = added.by.index;
+    toRolls.pop_back();
+  } else if (toRolls.size() != fromRolls.size()) {
+    return failure();
+  }
+  // The rolls both sides share must be the same relation; a different roll
+  // is a content change that no address plan expresses.
+  if (!sameRollRelation(fromRolls, toRolls)) return failure();
+
+  SmallVector<PositionedPiece> fromP = positionedPieces(from);
+  SmallVector<PositionedPiece> toP = positionedPieces(to);
+  if (rollFromPos >= static_cast<int64_t>(toP.size()) ||
+      rollByPos >= static_cast<int64_t>(toP.size())) {
+    return failure();
+  }
+  // Below every dim id, including the R/G/K sentinels.
+  constexpr int64_t kNoAxis = std::numeric_limits<int64_t>::min();
+  const int64_t rollAxis = rollFromPos >= 0 ? toP[rollFromPos].dim : kNoAxis;
+  const bool byIsRepl = rollByPos >= 0 && toP[rollByPos].isRepl();
+  const int64_t byAxis =
+      (rollByPos >= 0 && !byIsRepl) ? toP[rollByPos].dim : kNoAxis;
+
+  // Group traversal pieces by axis.
+  auto groupAxes = [](ArrayRef<PositionedPiece> pieces) {
+    std::map<int64_t, SmallVector<PositionedPiece>> axes;
+    for (const PositionedPiece& p : pieces) {
+      if (p.isRepl() || p.isGap()) continue;
+      axes[p.dim].push_back(p);
+    }
+    return axes;
+  };
+  auto fromAxes = groupAxes(fromP);
+  auto toAxes = groupAxes(toP);
+  if (fromAxes.size() != toAxes.size()) return failure();
+
+  auto extentOf = [](ArrayRef<PositionedPiece> ps) {
+    int64_t e = 1;
+    for (const PositionedPiece& p : ps) e *= p.size;
+    return e;
+  };
+  auto shape = [](ArrayRef<PositionedPiece> ps) {
+    SmallVector<std::tuple<int64_t, int64_t, int64_t, bool>> s;
+    for (const PositionedPiece& p : ps) {
+      s.push_back({p.divisor, p.size, p.offset, p.inSlots});
+    }
+    llvm::sort(s);
+    return s;
+  };
+
+  SmallVector<MovingAxis> moving;
+  SmallVector<std::pair<int64_t, int64_t>> fixedSpans;  // (offset, extent)
+  for (auto& [dim, dstPieces] : toAxes) {
+    auto it = fromAxes.find(dim);
+    if (it == fromAxes.end()) return failure();
+    const SmallVector<PositionedPiece>& srcPieces = it->second;
+    const int64_t extent = extentOf(dstPieces);
+    if (extentOf(srcPieces) != extent) return failure();
+    bool allSlots = true;
+    for (const PositionedPiece& p : dstPieces) allSlots &= p.inSlots;
+    const bool same = allSlots && shape(srcPieces) == shape(dstPieces) &&
+                      dim != rollAxis && dim != byAxis;
+    if (same) {
+      for (const PositionedPiece& p : dstPieces) {
+        fixedSpans.push_back({p.offset, p.size});
+      }
+      continue;
+    }
+    moving.push_back({srcPieces, dstPieces});
+  }
+
+  // Replication: destination replicas are targets to write, source replicas a
+  // free choice of which copy to read.
+  SmallVector<PositionedPiece> dstReplicas, srcReplicas;
+  SmallVector<ReplicationFill> fills;
+  int byReplicaIdx = -1;
+  // Slot replication the source already holds, by (offset, extent). A cyclic
+  // rotation keeps a period, so a step never disturbs it: the target gets it
+  // for nothing, and filling it again would double every target ciphertext
+  // log2(E) times over.
+  llvm::SmallDenseSet<std::pair<int64_t, int64_t>, 4> srcSlotRepl;
+  for (const PositionedPiece& p : fromP) {
+    if (p.isRepl() && p.size > 1 && p.inSlots) {
+      srcSlotRepl.insert({p.offset, p.size});
+    }
+  }
+  for (const PositionedPiece& p : toP) {
+    if (!p.isRepl() || p.size <= 1) continue;
+    if (p.inSlots && p.pos != rollByPos &&
+        srcSlotRepl.contains({p.offset, p.size})) {
+      // Already there, so neither a fill nor a coordinate -- but the step
+      // still writes every copy: a rotated replicated row is correct in all
+      // of its blocks, so the step covers them and needs no mask.
+      fixedSpans.push_back({p.offset, p.size});
+      continue;
+    }
+    // A slot-side replication is filled by doubling once one copy is in
+    // place, so it is not a target coordinate: enumerating it would cost one
+    // rotation per copy of every value. The roll's BY argument stays a
+    // coordinate, because the roll reads its index.
+    if (p.inSlots && p.pos != rollByPos) {
+      fills.push_back({p.offset, p.size});
+      continue;
+    }
+    if (p.pos == rollByPos) byReplicaIdx = dstReplicas.size();
+    dstReplicas.push_back(p);
+  }
+  if (byIsRepl && byReplicaIdx < 0) return failure();
+  llvm::sort(fixedSpans);
+  for (const PositionedPiece& p : fromP) {
+    if (!p.isRepl() || p.size <= 1) continue;
+    srcReplicas.push_back(p);
+  }
+
+  // The slots a step writes: the target slot plus every combination of the
+  // fixed axes' pieces.
+  SmallVector<int64_t> fixedOffsets = {0};
+  for (auto [offset, extent] : fixedSpans) {
+    SmallVector<int64_t> next;
+    next.reserve(fixedOffsets.size() * extent);
+    for (int64_t off : fixedOffsets) {
+      for (int64_t d = 0; d < extent; ++d) next.push_back(off + d * offset);
+    }
+    fixedOffsets = std::move(next);
+  }
+  llvm::sort(fixedOffsets);
+
+  int64_t targetCombos = 1, replicaCombos = 1;
+  for (const MovingAxis& a : moving) targetCombos *= a.extent();
+  for (const PositionedPiece& r : dstReplicas) targetCombos *= r.size;
+  for (const PositionedPiece& r : srcReplicas) replicaCombos *= r.size;
+
+  std::map<std::tuple<int64_t, int64_t, int64_t>, SmallVector<int64_t>> groups;
+  SmallVector<int64_t> axisValue(moving.size(), 0);
+  SmallVector<int64_t> dstReplValue(dstReplicas.size(), 0);
+  SmallVector<int64_t> srcReplValue(srcReplicas.size(), 0);
+  auto indexOf = [](const PositionedPiece& p, int64_t axisIndex) {
+    return (axisIndex / p.divisor) % p.size;
+  };
+  for (int64_t tc = 0; tc < targetCombos; ++tc) {
+    int64_t rest = tc;
+    for (size_t i = 0; i < moving.size(); ++i) {
+      axisValue[i] = rest % moving[i].extent();
+      rest /= moving[i].extent();
+    }
+    for (size_t i = 0; i < dstReplicas.size(); ++i) {
+      dstReplValue[i] = rest % dstReplicas[i].size;
+      rest /= dstReplicas[i].size;
+    }
+    // The index the applied roll subtracts, if any.
+    int64_t byValue = 0;
+    if (rollByPos >= 0) {
+      if (byIsRepl) {
+        byValue = dstReplValue[byReplicaIdx];
+      } else {
+        for (size_t i = 0; i < moving.size(); ++i) {
+          if (moving[i].dim() == byAxis) {
+            byValue = indexOf(toP[rollByPos], axisValue[i]);
+          }
+        }
+      }
+    }
+    int64_t targetCt = 0, targetSlot = 0;
+    for (size_t i = 0; i < moving.size(); ++i) {
+      for (const PositionedPiece& p : moving[i].dst) {
+        int64_t index = indexOf(p, axisValue[i]);
+        if (p.pos == rollFromPos) {
+          index = ((index - byValue) % p.size + p.size) % p.size;
+        }
+        (p.inSlots ? targetSlot : targetCt) += index * p.offset;
+      }
+    }
+    for (size_t i = 0; i < dstReplicas.size(); ++i) {
+      (dstReplicas[i].inSlots ? targetSlot : targetCt) +=
+          dstReplValue[i] * dstReplicas[i].offset;
+    }
+
+    std::optional<std::tuple<int64_t, int64_t, int64_t>> best;
+    bool bestExisting = false;
+    for (int64_t rc = 0; rc < replicaCombos; ++rc) {
+      int64_t r = rc;
+      for (size_t i = 0; i < srcReplicas.size(); ++i) {
+        srcReplValue[i] = r % srcReplicas[i].size;
+        r /= srcReplicas[i].size;
+      }
+      int64_t sourceCt = 0, sourceSlot = 0;
+      for (size_t i = 0; i < moving.size(); ++i) {
+        for (const PositionedPiece& p : moving[i].src) {
+          (p.inSlots ? sourceSlot : sourceCt) +=
+              indexOf(p, axisValue[i]) * p.offset;
+        }
+      }
+      for (size_t i = 0; i < srcReplicas.size(); ++i) {
+        (srcReplicas[i].inSlots ? sourceSlot : sourceCt) +=
+            srcReplValue[i] * srcReplicas[i].offset;
+      }
+      const int64_t shift = ((sourceSlot - targetSlot) % n + n) % n;
+      std::tuple<int64_t, int64_t, int64_t> key{targetCt, sourceCt, shift};
+      const bool existing = groups.count(key) > 0;
+      auto rank = [](bool existing, const auto& key) {
+        return std::tuple(!existing, std::get<2>(key) != 0, key);
+      };
+      if (!best || rank(existing, key) < rank(bestExisting, *best)) {
+        best = key;
+        bestExisting = existing;
+      }
+    }
+    auto& slots = groups[*best];
+    for (int64_t off : fixedOffsets) slots.push_back(targetSlot + off);
+  }
+
+  SmallVector<LayoutConversionStep> steps;
+  steps.reserve(groups.size());
+  for (auto& [key, slots] : groups) {
+    auto [targetCt, sourceCt, shift] = key;
+    llvm::sort(slots);
+    slots.erase(llvm::unique(slots), slots.end());
+    steps.push_back(
+        LayoutConversionStep{targetCt, sourceCt, shift, std::move(slots)});
+  }
+  llvm::sort(fills, [](const ReplicationFill& x, const ReplicationFill& y) {
+    return std::tuple(x.stride, x.extent) < std::tuple(y.stride, y.extent);
+  });
+  return ConversionPlan{std::move(steps), std::move(fills)};
+}
+
+ConversionEstimate estimateConversionCost(LayoutAttr from, LayoutAttr to) {
+  ConversionEstimate estimate;
+  if (!from || !to) return estimate;
+  // Layouts with the same merged canonical form are the same packing, so the
+  // conversion is free.
+  if (from == to ||
+      mergeAdjacentLayoutDims(from) == mergeAdjacentLayoutDims(to)) {
+    return estimate;
+  }
+
+  // The price is the plan. Anything else lets the search choose a conversion
+  // the lowering cannot emit, or one that costs orders of magnitude more than
+  // it was charged.
+  FailureOr<ConversionPlan> plan = planLayoutConversion(from, to);
+  if (failed(plan)) {
+    estimate.lowerable = false;
+    return estimate;
+  }
+
+  const int64_t n = to.getN();
+  // One rotation per distinct (source ciphertext, shift): the emission reuses
+  // a rotated row across every target it feeds.
+  llvm::DenseSet<std::pair<int64_t, int64_t>> rotations;
+  llvm::DenseSet<int64_t> written;
+  for (const LayoutConversionStep& step : plan->steps) {
+    if (step.shift != 0) rotations.insert({step.sourceCt, step.shift});
+    if (static_cast<int64_t>(step.targetSlots.size()) != n) ++estimate.masks;
+    // The first step of a target ciphertext writes it; the rest add into it.
+    if (!written.insert(step.targetCt).second) ++estimate.accumulates;
+  }
+  estimate.rotations = rotations.size();
+  // A fill doubles: log2(extent) rotate-and-add steps, whatever the extent.
+  for (const ReplicationFill& fill : plan->fills) {
+    const int64_t doublings = llvm::Log2_64_Ceil(fill.extent);
+    estimate.rotations += doublings;
+    estimate.accumulates += doublings;
+  }
+  return estimate;
+}
+
+std::optional<BsgsSchedule> bsgsScheduleOpt(LayoutAttr from, LayoutAttr to) {
+  if (!from || !to || from.getN() != to.getN()) return std::nullopt;
+  const int64_t n = to.getN();
+  SmallVector<RollSpec> fromRolls = getRollSpecs(from);
+  SmallVector<RollSpec> toRolls = getRollSpecs(to);
+  // `to` is `from` plus exactly one roll, the one alignment just built.
+  if (toRolls.size() != fromRolls.size() + 1) return std::nullopt;
+  for (size_t i = 0; i < fromRolls.size(); ++i) {
+    if (!(fromRolls[i].from == toRolls[i].from &&
+          fromRolls[i].by == toRolls[i].by)) {
+      return std::nullopt;
+    }
+  }
+  const RollSpec roll = toRolls.back();
+  if (roll.from.isAxis || roll.by.isAxis) return std::nullopt;
+
+  // The fold reads one source ciphertext, so the source must hold identical
+  // rows: nothing but replication and gaps addresses its ciphertexts.
+  SmallVector<DimAttr> fromDims = layoutDims(from);
+  const size_t fromCtLen = inferCtPrefixLen(fromDims, n);
+  for (size_t p = 0; p < fromCtLen; ++p) {
+    if (!fromDims[p].isReplicate() && !fromDims[p].isGap()) return std::nullopt;
+  }
+
+  SmallVector<DimAttr> toDims = layoutDims(to);
+  const size_t toCtLen = inferCtPrefixLen(toDims, n);
+  const int64_t rolled = roll.from.index;
+  const int64_t by = roll.by.index;
+  if (rolled < 0 || by < 0 || static_cast<size_t>(rolled) >= toCtLen ||
+      static_cast<size_t>(by) < toCtLen ||
+      static_cast<size_t>(by) >= toDims.size()) {
+    return std::nullopt;
+  }
+  // The ciphertext piece traversing the targets, rolled by the replication it
+  // traded places with: same extent, or the shifts would not close.
+  const int64_t targets = toDims[rolled].getSize();
+  if (targets < 2 || toDims[rolled].isReplicate() || toDims[rolled].isGap()) {
+    return std::nullopt;
+  }
+  if (!toDims[by].isReplicate() || toDims[by].getSize() != targets) {
+    return std::nullopt;
+  }
+  // A piece's slot offset is the product of the extents to its right.
+  int64_t stride = 1;
+  for (size_t p = by + 1; p < toDims.size(); ++p) {
+    stride *= toDims[p].getSize();
+  }
+  if (stride <= 0 || stride >= n) return std::nullopt;
+  return BsgsSchedule{stride, targets, /*negative=*/false};
+}
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/LayoutConversion.h
+++ b/lib/Dialect/Rotom/Utils/LayoutConversion.h
@@ -1,0 +1,67 @@
+#ifndef LIB_DIALECT_ROTOM_UTILS_LAYOUTCONVERSION_H_
+#define LIB_DIALECT_ROTOM_UTILS_LAYOUTCONVERSION_H_
+
+#include <cstdint>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+// Estimates the cost of converting `from` to `to`, for the layout search.
+// Computed from the piece and roll structure in O(#pieces).
+struct ConversionEstimate {
+  int64_t rotations = 0;
+  int64_t masks = 0;
+  int64_t accumulates = 0;
+  // False when planLayoutConversion cannot express the conversion. The search
+  // must not choose such a step: the lowering leaves the op in place and the
+  // circuit it belongs to is silently lost.
+  bool lowerable = true;
+};
+ConversionEstimate estimateConversionCost(LayoutAttr from, LayoutAttr to);
+
+// One step of an explicit layout expansion: take ciphertext `sourceCt` of the
+// source, rotate its slots left by `shift`, keep only `targetSlots`, and
+// accumulate into ciphertext `targetCt` of the target. A step whose
+// `targetSlots` cover all n slots needs no mask (a plain copy when the shift
+// is also zero).
+struct LayoutConversionStep {
+  int64_t targetCt;
+  int64_t sourceCt;
+  int64_t shift;
+  llvm::SmallVector<int64_t> targetSlots;
+};
+
+// Computes the rotate/mask/accumulate steps that convert `from` to `to`.
+struct ReplicationFill {
+  int64_t stride;
+  int64_t extent;
+};
+
+// The steps that place one copy of the data, then the replications that fill
+// the rest. Both the emission and the price come from this one plan, so they
+// cannot disagree.
+struct ConversionPlan {
+  llvm::SmallVector<LayoutConversionStep> steps;
+  llvm::SmallVector<ReplicationFill> fills;
+};
+
+FailureOr<ConversionPlan> planLayoutConversion(LayoutAttr from, LayoutAttr to);
+
+// A plan that is a roll by the ciphertext piece.
+struct BsgsSchedule {
+  int64_t stride;
+  int64_t targets;
+  bool negative;
+};
+// The roll read off the layouts, with no plan to materialize.
+std::optional<BsgsSchedule> bsgsScheduleOpt(LayoutAttr from, LayoutAttr to);
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ROTOM_UTILS_LAYOUTCONVERSION_H_

--- a/lib/Dialect/Rotom/Utils/LayoutConversionTest.cpp
+++ b/lib/Dialect/Rotom/Utils/LayoutConversionTest.cpp
@@ -1,0 +1,429 @@
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/Utils/LayoutConversion.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project  // from @googletest
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Location.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using rotom::DimAttr;
+using rotom::LayoutAttr;
+using rotom::RotomDialect;
+
+class LayoutConversionTest : public ::testing::Test {
+ protected:
+  LayoutConversionTest() {
+    context.loadDialect<RotomDialect>();
+    context.loadDialect<tensor_ext::TensorExtDialect>();
+  }
+
+  DimAttr dim(int64_t dim, int64_t size, int64_t stride = 1) {
+    return DimAttr::get(&context, dim, size, stride);
+  }
+
+  LayoutAttr layout(ArrayRef<Attribute> dims, int64_t n) {
+    return LayoutAttr::get(&context, ArrayAttr::get(&context, dims), n);
+  }
+
+  MLIRContext context;
+};
+
+// The estimate is the "is this conversion free?" test: zero for every
+// form of the same packing, in both directions, and nonzero otherwise.
+TEST_F(LayoutConversionTest, EstimateIsZeroForIdenticalLayouts) {
+  LayoutAttr a = layout({dim(0, 4)}, 4);
+  EXPECT_EQ(rotom::estimateConversionCost(a, a).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIsZeroForSplitEquivalentBothWays) {
+  // [0:4:1] packs axis 0 identically to the split [0:2:2][0:2:1].
+  LayoutAttr whole = layout({dim(0, 4)}, 4);
+  LayoutAttr split =
+      layout({dim(0, 2, /*stride=*/2), dim(0, 2, /*stride=*/1)}, 4);
+  EXPECT_EQ(rotom::estimateConversionCost(whole, split).rotations, 0);
+  EXPECT_EQ(rotom::estimateConversionCost(split, whole).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIsZeroAcrossRollFormBothWays) {
+  LayoutAttr whole = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 4), dim(1, 4)}), /*n=*/16,
+      DenseI64ArrayAttr::get(&context, {1, 0}));
+  LayoutAttr split = LayoutAttr::get(
+      &context,
+      ArrayAttr::get(&context, {dim(0, 4), dim(1, 2, /*stride=*/2), dim(1, 2)}),
+      /*n=*/16,
+      DenseI64ArrayAttr::get(&context,
+                             {rotom::encodeRollArg({/*isAxis=*/true, 1}), 0}));
+  EXPECT_EQ(rotom::estimateConversionCost(whole, split).rotations, 0);
+  EXPECT_EQ(rotom::estimateConversionCost(split, whole).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIsZeroForSharedGap) {
+  LayoutAttr gapped = layout({dim(0, 4), dim(/*dim=*/-2, 2)}, 8);
+  EXPECT_EQ(rotom::estimateConversionCost(gapped, gapped).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIgnoresCiphertextOrder) {
+  // The two ciphertext-side axes are merely ordered differently: a free
+  // ciphertext relabel.
+  LayoutAttr a = layout({dim(0, 2), dim(1, 2), dim(2, 2)}, 2);
+  LayoutAttr b = layout({dim(1, 2), dim(0, 2), dim(2, 2)}, 2);
+  EXPECT_EQ(rotom::estimateConversionCost(a, b).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIsNonzeroForSwappedSlots) {
+  LayoutAttr rowMajor = layout({dim(0, 2), dim(1, 2)}, 4);
+  LayoutAttr colMajor = layout({dim(1, 2), dim(0, 2)}, 4);
+  EXPECT_GT(rotom::estimateConversionCost(rowMajor, colMajor).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIsNonzeroForMaterializedRotations) {
+  LayoutAttr plain = layout({dim(/*dim=*/-1, 4), dim(0, 4)}, 16);
+  LayoutAttr rotations = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(/*dim=*/-1, 4), dim(0, 4)}),
+      /*n=*/16, DenseI64ArrayAttr::get(&context, {1, 0}));
+  EXPECT_GT(rotom::estimateConversionCost(plain, rotations).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, EstimateIsNonzeroWhenRollsDiffer) {
+  LayoutAttr plain = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr rolled = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 4), dim(1, 4)}), /*n=*/16,
+      DenseI64ArrayAttr::get(&context, {1, 0}));
+  EXPECT_GT(rotom::estimateConversionCost(plain, rolled).rotations, 0);
+}
+
+// A new gap is free only when it leaves every other piece at its address.
+// A trailing slot gap moves piece 0 from offset 1 to offset 2 (slot i ->
+// slot 2i). That is not rotations alone: the plan rotates 3 times, masks
+// each of the 4 copies (the unrotated one too) down to one slot, and adds
+// them -- 3 rotations, 4 masks, 3 adds, which the estimate reproduces
+// exactly. A leading slot gap leaves piece 0 at offset 1, so it is free.
+TEST_F(LayoutConversionTest, NewGapCostsWhenItShiftsOtherPieces) {
+  LayoutAttr plain = layout({dim(0, 4)}, 8);
+  LayoutAttr gapLast = layout({dim(0, 4), dim(/*dim=*/-2, 2)}, 8);
+  LayoutAttr gapFirst = layout({dim(/*dim=*/-2, 2), dim(0, 4)}, 8);
+
+  auto est = rotom::estimateConversionCost(plain, gapLast);
+  EXPECT_EQ(est.rotations, 3);
+  EXPECT_EQ(est.masks, 4);  // the unrotated copy is masked too
+  EXPECT_EQ(est.accumulates, 3);
+
+  auto plan = rotom::planLayoutConversion(plain, gapLast);
+  ASSERT_TRUE(succeeded(plan));
+  ASSERT_EQ(plan->steps.size(), 4u);
+  int rotations = 0;
+  for (const auto& step : plan->steps) {
+    if (step.shift != 0) ++rotations;
+    EXPECT_EQ(step.targetSlots.size(), 1u);  // every copy is masked
+  }
+  EXPECT_EQ(rotations, 3);
+
+  EXPECT_EQ(rotom::estimateConversionCost(plain, gapFirst).rotations, 0);
+}
+
+// A conversion moves addresses, not content. Two layouts with the same
+// piece order but different rolls hold different values at the same
+// addresses, so no conversion relates them; the planner must refuse rather
+// than return an identity plan. A roll names its arguments by piece position,
+// so the same relation written against a different piece order is a different
+// roll and is refused too.
+TEST_F(LayoutConversionTest, PlanRefusesChangedRollRelation) {
+  auto rolled = [&](ArrayRef<Attribute> dims, ArrayRef<int64_t> rolls) {
+    return LayoutAttr::get(&context, ArrayAttr::get(&context, dims), 16,
+                           DenseI64ArrayAttr::get(&context, rolls));
+  };
+  LayoutAttr zeroByOne = rolled({dim(0, 4), dim(1, 4)}, {0, 1});
+  LayoutAttr oneByZero = rolled({dim(0, 4), dim(1, 4)}, {1, 0});
+  EXPECT_TRUE(failed(rotom::planLayoutConversion(zeroByOne, oneByZero)));
+  EXPECT_TRUE(failed(rotom::planLayoutConversion(oneByZero, zeroByOne)));
+  // Dim 0 rolled by dim 1 again, but written against a swapped piece order:
+  // the arguments no longer name the same positions, so this is refused.
+  LayoutAttr swapped = rolled({dim(1, 4), dim(0, 4)}, {1, 0});
+  EXPECT_TRUE(failed(rotom::planLayoutConversion(zeroByOne, swapped)));
+}
+
+TEST_F(LayoutConversionTest, EstimateIsNonzeroWhenGapPlacementDiffers) {
+  LayoutAttr gapLast = layout({dim(0, 4), dim(/*dim=*/-2, 2)}, 8);
+  LayoutAttr gapFirst = layout({dim(/*dim=*/-2, 2), dim(0, 4)}, 8);
+  EXPECT_GT(rotom::estimateConversionCost(gapLast, gapFirst).rotations, 0);
+}
+
+TEST_F(LayoutConversionTest, ExpansionPureCtReplicationIsFreeCopies) {
+  // 4x4 row-major (1 ct at n=16) expanded to 4 replicated ciphertexts:
+  // every step is a full-row, zero-shift copy -- no rotations, no masks.
+  LayoutAttr source = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr expanded = layout({dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)}, 16);
+  auto steps = rotom::planLayoutConversion(source, expanded);
+  ASSERT_TRUE(succeeded(steps));
+  ASSERT_EQ(steps->steps.size(), 4u);
+  for (const rotom::LayoutConversionStep& step : steps->steps) {
+    EXPECT_EQ(step.sourceCt, 0);
+    EXPECT_EQ(step.shift, 0);
+    EXPECT_EQ(step.targetSlots.size(), 16u);
+  }
+}
+
+// The estimate's mask and accumulate counts are per STEP, so they must
+// match what the plan actually emits: every step masks its target slots,
+// and every step after the first into a given ciphertext is accumulated.
+// This holds exactly whenever the estimate gets the rotation count right.
+TEST_F(LayoutConversionTest, EstimateMatchesThePlansMasksAndAccumulates) {
+  struct Case {
+    const char* name;
+    LayoutAttr from;
+    LayoutAttr to;
+  };
+  const Case cases[] = {
+      // A trailing slot gap moves piece 0 from offset 1 to offset 2.
+      {"new-gap", layout({dim(0, 4)}, 8),
+       layout({dim(0, 4), dim(/*dim=*/-2, 2)}, 8)},
+      // A slot transpose within one ciphertext.
+      {"swap-slots", layout({dim(0, 4), dim(1, 4)}, 16),
+       layout({dim(1, 4), dim(0, 4)}, 16)},
+      // A swap across the ciphertext/slot boundary, four target ciphertexts.
+      {"ct-to-slot", layout({dim(0, 4), dim(1, 4)}, 4),
+       layout({dim(1, 4), dim(0, 4)}, 4)},
+  };
+  for (const Case& c : cases) {
+    SCOPED_TRACE(c.name);
+    auto plan = rotom::planLayoutConversion(c.from, c.to);
+    ASSERT_TRUE(succeeded(plan));
+    int64_t masks = 0;
+    std::set<int64_t> targetCts;
+    for (const rotom::LayoutConversionStep& step : plan->steps) {
+      targetCts.insert(step.targetCt);
+      if (static_cast<int64_t>(step.targetSlots.size()) != c.to.getN()) ++masks;
+    }
+    const int64_t accumulates = static_cast<int64_t>(plan->steps.size()) -
+                                static_cast<int64_t>(targetCts.size());
+
+    auto est = rotom::estimateConversionCost(c.from, c.to);
+    EXPECT_EQ(est.masks, masks);
+    EXPECT_EQ(est.accumulates, accumulates);
+  }
+}
+
+// The price IS the plan: estimateConversionCost counts the steps
+// planLayoutConversion produces, so the two cannot disagree. Expanding into
+// slot replication is where a separate structural model used to go wrong --
+// it priced one row's shifts while the plan writes each replica separately --
+// so this pins the counts against the plan rather than merely bounding them.
+TEST_F(LayoutConversionTest, EstimateCountsTheReplicatedScatterPlan) {
+  LayoutAttr source = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr expanded = layout({dim(0, 4), dim(1, 4), dim(/*dim=*/-1, 4)}, 16);
+  auto plan = rotom::planLayoutConversion(source, expanded);
+  ASSERT_TRUE(succeeded(plan));
+  int64_t masks = 0, accumulates = 0;
+  llvm::DenseSet<std::pair<int64_t, int64_t>> rotations;
+  llvm::DenseSet<int64_t> written;
+  for (const rotom::LayoutConversionStep& step : plan->steps) {
+    if (step.shift != 0) rotations.insert({step.sourceCt, step.shift});
+    if (static_cast<int64_t>(step.targetSlots.size()) != expanded.getN())
+      ++masks;
+    if (!written.insert(step.targetCt).second) ++accumulates;
+  }
+  // A fill is log2(extent) rotate-and-add doublings, whatever the extent.
+  int64_t fillDoublings = 0;
+  for (const rotom::ReplicationFill& fill : plan->fills) {
+    fillDoublings += llvm::Log2_64_Ceil(fill.extent);
+  }
+  auto est = rotom::estimateConversionCost(source, expanded);
+  EXPECT_GT(masks, 0);  // the scatter this case is about
+  EXPECT_EQ(est.masks, masks);
+  EXPECT_EQ(est.rotations,
+            static_cast<int64_t>(rotations.size()) + fillDoublings);
+  EXPECT_EQ(est.accumulates, accumulates + fillDoublings);
+}
+
+TEST_F(LayoutConversionTest, ExpansionScatterNeedsRotationsAndMasks) {
+  // Expanding 4x4 row-major so that ciphertext i holds row i replicated
+  // ([0:4] to ct, [1:4] to slots, replication innermost): each target
+  // ciphertext draws 4 slot-groups from the single source ciphertext, so
+  // steps carry nonzero shifts and partial-row masks.
+  LayoutAttr source = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr expanded = layout({dim(0, 4), dim(1, 4), dim(/*dim=*/-1, 4)}, 16);
+  auto steps = rotom::planLayoutConversion(source, expanded);
+  ASSERT_TRUE(succeeded(steps));
+  EXPECT_GT(steps->steps.size(), 4u);
+  bool sawShift = false;
+  bool sawMask = false;
+  for (const rotom::LayoutConversionStep& step : steps->steps) {
+    if (step.shift != 0) sawShift = true;
+    if (step.targetSlots.size() != 16u) sawMask = true;
+  }
+  EXPECT_TRUE(sawShift);
+  EXPECT_TRUE(sawMask);
+}
+
+// The replicate-then-roll expansion: a column-major operand in one ciphertext
+// expands onto roll(0,1) [k:ct];[R][i], where ciphertext c is the whole matrix
+// with k shifted by c. The roll-by replication sits outermost in the slots and
+// matches the source's outermost piece, so each target is one whole-ciphertext
+// rotation -- no masks, no accumulates.
+TEST_F(LayoutConversionTest, ReplicateThenRollExpansionIsPureRotations) {
+  // Source: lhs (i, k) packed column-major, [1:4][0:4] (slot = 4k + i).
+  LayoutAttr colMajor = layout({dim(1, 4), dim(0, 4)}, 16);
+  // Target: [1:4];[-1:4][0:4] with rolls [(0, 1)] -- k on ct rolled by the
+  // slot-outermost replication.
+  LayoutAttr rolled = LayoutAttr::get(
+      &context,
+      ArrayAttr::get(&context, {dim(1, 4), dim(/*dim=*/-1, 4), dim(0, 4)}),
+      /*n=*/16, DenseI64ArrayAttr::get(&context, {0, 1}));
+  ASSERT_EQ(rotom::layoutNumCiphertexts(colMajor), 1);
+  ASSERT_EQ(rotom::layoutNumCiphertexts(rolled), 4);
+
+  auto steps = rotom::planLayoutConversion(colMajor, rolled);
+  ASSERT_TRUE(succeeded(steps));
+  // One full-row step per target ciphertext: shift 4c, no masks (all 16
+  // slots), no accumulates (one step per target).
+  ASSERT_EQ(steps->steps.size(), 4u);
+  for (const rotom::LayoutConversionStep& step : steps->steps) {
+    EXPECT_EQ(step.sourceCt, 0);
+    EXPECT_EQ(step.shift, 4 * step.targetCt);
+    EXPECT_EQ(step.targetSlots.size(), 16u);
+  }
+}
+
+// Filling a rolled-by-replication placement from a replicated source is one
+// whole-ciphertext rotation per NONZERO block shift: each block of the target
+// holds the source rotated by its block index, and the source's replication
+// lets every block draw from the replica that makes the shift uniform. The
+// step plan expresses this directly, one group per distinct shift.
+TEST_F(LayoutConversionTest, RolledFillPlansOneRotationPerNonzeroBlockShift) {
+  constexpr int64_t kD = 8;
+  constexpr int64_t kN = kD * kD;
+  LayoutAttr source = layout({dim(/*dim=*/-1, kD), dim(0, kD)}, kN);
+  LayoutAttr target = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, kD), dim(-1, kD)}), kN,
+      DenseI64ArrayAttr::get(&context, {0, 1}));
+  auto steps = rotom::planLayoutConversion(source, target);
+  ASSERT_TRUE(succeeded(steps));
+  std::set<int64_t> shifts;
+  for (const rotom::LayoutConversionStep& step : steps->steps) {
+    shifts.insert(step.shift);
+  }
+  shifts.erase(0);
+  EXPECT_EQ(shifts.size(), static_cast<size_t>(kD - 1));
+}
+
+TEST_F(LayoutConversionTest, CompactionOfGappedMatmulResultPlansMaskedGathers) {
+  // Compaction (the ciphertext-count-DECREASING direction): a matmul result
+  // layout [0:4:1];[1:4:1][G:4:1] -- 4 ciphertexts, row i claimed at the k=0
+  // offsets slot 4j, everything else gap garbage -- compacts into one
+  // column-major ciphertext (slot = 4j + i). Each source ciphertext i
+  // contributes one group: shift (-i) mod 16, target slots {4j + i}, masked
+  // (the mask also kills the gap garbage).
+  LayoutAttr source = layout({dim(0, 4), dim(1, 4), dim(/*dim=*/-2, 4)}, 16);
+  LayoutAttr compact = layout({dim(1, 4), dim(0, 4)}, 16);
+  ASSERT_EQ(rotom::layoutNumCiphertexts(source), 4);
+  ASSERT_EQ(rotom::layoutNumCiphertexts(compact), 1);
+
+  auto steps = rotom::planLayoutConversion(source, compact);
+  ASSERT_TRUE(succeeded(steps));
+  ASSERT_EQ(steps->steps.size(), 4u);
+  for (const rotom::LayoutConversionStep& step : steps->steps) {
+    EXPECT_EQ(step.targetCt, 0);
+    const int64_t i = step.sourceCt;
+    EXPECT_EQ(step.shift, (16 - i) % 16);
+    ASSERT_EQ(step.targetSlots.size(), 4u);
+    for (int64_t j = 0; j < 4; ++j) {
+      EXPECT_EQ(step.targetSlots[j], 4 * j + i);
+    }
+  }
+}
+
+// The step counts the retired relation-based planner produced, frozen as
+// expectations: the structural planner reproduced every one of them exactly
+// (same triples, same slot sets) before that planner was deleted.
+TEST_F(LayoutConversionTest, PlansMatchTheRetiredRelationPlannerCounts) {
+  struct Case {
+    const char* name;
+    LayoutAttr from;
+    LayoutAttr to;
+    size_t steps;
+  };
+  SmallVector<Case> cases = {
+      {"ct-replication", layout({dim(0, 4), dim(1, 4)}, 16),
+       layout({dim(/*dim=*/-1, 4), dim(0, 4), dim(1, 4)}, 16), 4},
+      {"rowmajor-to-colmajor", layout({dim(0, 4), dim(1, 4)}, 16),
+       layout({dim(1, 4), dim(0, 4)}, 16), 7},
+      {"gapped-to-compact",
+       layout({dim(0, 4), dim(1, 4), dim(/*dim=*/-2, 4)}, 16),
+       layout({dim(1, 4), dim(0, 4)}, 16), 4},
+      // Large enough that point enumeration and group enumeration diverge:
+      // 63 groups against 1024 tensor points.
+      {"large-transpose", layout({dim(0, 32), dim(1, 32)}, 1024),
+       layout({dim(1, 32), dim(0, 32)}, 1024), 63},
+      {"reslot-split", layout({dim(0, 4), dim(1, 16)}, 64),
+       layout({dim(1, 16), dim(0, 4)}, 64), 31},
+      {"ct-reshuffle", layout({dim(0, 2), dim(1, 2), dim(2, 4)}, 4),
+       layout({dim(1, 2), dim(0, 2), dim(2, 4)}, 4), 4},
+  };
+  for (const Case& c : cases) {
+    auto plan = rotom::planLayoutConversion(c.from, c.to);
+    ASSERT_TRUE(succeeded(plan)) << c.name;
+    EXPECT_EQ(plan->steps.size(), c.steps) << c.name;
+  }
+}
+
+// One added roll is a plan; two at once, or a removed roll, is not.
+TEST_F(LayoutConversionTest, RefusesMoreThanOneRollChange) {
+  LayoutAttr plain = layout({dim(0, 4), dim(1, 4), dim(2, 4)}, 64);
+  LayoutAttr twoRolls = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {dim(0, 4), dim(1, 4), dim(2, 4)}), 64,
+      DenseI64ArrayAttr::get(&context, {1, 0, 2, 0}));
+  EXPECT_TRUE(failed(rotom::planLayoutConversion(plain, twoRolls)));
+  EXPECT_TRUE(failed(rotom::planLayoutConversion(twoRolls, plain)));
+}
+
+TEST_F(LayoutConversionTest, RefusesMismatchedCapacity) {
+  LayoutAttr from = layout({dim(0, 4), dim(1, 4)}, 16);
+  LayoutAttr to = layout({dim(0, 4), dim(1, 4)}, 4);
+  EXPECT_TRUE(failed(rotom::planLayoutConversion(from, to)));
+}
+
+// The MNIST layer-1 roll at n = 32768: 16 targets, each the one source
+// ciphertext rotated by 64 * c, no fills. That is a roll by the ciphertext
+// piece, which a matmul folds into baby-step/giant-step.
+TEST_F(LayoutConversionTest, BsgsScheduleRecognizesTheMnistRoll) {
+  LayoutAttr replicated = layout(
+      {dim(-1, 16, 1), dim(-1, 32, 1024), dim(0, 1024), dim(1, 1)}, 32768);
+  SmallVector<Attribute> rolledDims = {dim(0, 16, 64), dim(-1, 32, 16),
+                                       dim(-1, 16, 1), dim(0, 64), dim(1, 1)};
+  LayoutAttr rolled = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, rolledDims), 32768,
+      DenseI64ArrayAttr::get(&context, {rotom::encodeRollArg({false, 0}),
+                                        rotom::encodeRollArg({false, 2})}));
+  auto roll = rotom::bsgsScheduleOpt(replicated, rolled);
+  ASSERT_TRUE(roll.has_value());
+  EXPECT_EQ(roll->stride, 64);
+  EXPECT_EQ(roll->targets, 16);
+  EXPECT_FALSE(roll->negative);
+  // A conversion that fills is not a pure roll.
+  LayoutAttr image =
+      layout({dim(-1, 32, 1024), dim(0, 1024), dim(1, 1)}, 32768);
+  LayoutAttr gappy = layout({dim(0, 512), dim(-2, 64), dim(1, 1)}, 32768);
+  LayoutAttr filled = layout({dim(0, 512), dim(-1, 64), dim(1, 1)}, 32768);
+  EXPECT_FALSE(rotom::bsgsScheduleOpt(gappy, filled).has_value());
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/RotomLayout.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomLayout.cpp
@@ -1,0 +1,143 @@
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.h"
+#include "llvm/include/llvm/ADT/DenseSet.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Location.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"         // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+SmallVector<DimAttr> layoutDims(LayoutAttr layout) {
+  SmallVector<DimAttr> dims;
+  dims.reserve(layout.getDims().size());
+  for (Attribute attr : layout.getDims()) dims.push_back(cast<DimAttr>(attr));
+  return dims;
+}
+
+int64_t layoutNumCiphertexts(LayoutAttr layout) {
+  SmallVector<DimAttr> dims = layoutDims(layout);
+  size_t ctPrefixLen = inferCtPrefixLen(dims, layout.getN());
+  // A gap that is a roll-by target claims its blocks (one rotation of the
+  // rolled dim per block index), so it counts toward distinct ciphertexts;
+  // plain gaps are unclaimed space.
+  llvm::DenseSet<int64_t> rolledByPositions;
+  if (DenseI64ArrayAttr rolls = layout.getRolls()) {
+    ArrayRef<int64_t> r = rolls.asArrayRef();
+    for (size_t i = 0; i + 1 < r.size(); i += 2) {
+      rolledByPositions.insert(r[i + 1]);
+    }
+  }
+  int64_t numCt = 1;
+  for (size_t i = 0; i < ctPrefixLen; ++i) {
+    if (dims[i].isGap() &&
+        !rolledByPositions.contains(static_cast<int64_t>(i))) {
+      continue;
+    }
+    numCt *= std::max<int64_t>(dims[i].getSize(), 1);
+  }
+  return std::max<int64_t>(numCt, 1);
+}
+
+LayoutAttr mergeAdjacentLayoutDims(LayoutAttr layout) {
+  if (!layout) return layout;
+  MLIRContext* ctx = layout.getContext();
+  SmallVector<DimAttr> dims = layoutDims(layout);
+  const size_t ctPrefixLen = inferCtPrefixLen(dims, layout.getN());
+
+  SmallVector<RollSpec> rolls = getRollSpecs(layout);
+  // A piece argument reads exactly its piece's part of the axis index; joining
+  // that piece with a neighbor would change what the roll rewrites (FROM) or
+  // the part it shifts by (BY), so argument pieces keep their identity.
+  llvm::SmallDenseSet<int64_t> pinned;
+  for (const RollSpec& roll : rolls) {
+    if (!roll.from.isAxis) pinned.insert(roll.from.index);
+    if (!roll.by.isAxis) pinned.insert(roll.by.index);
+  }
+
+  SmallVector<DimAttr> merged;
+  SmallVector<int64_t> mergedIndexOf(dims.size());
+  auto mergeRegion = [&](size_t begin, size_t end) {
+    size_t i = begin;
+    while (i < end) {
+      DimAttr piece = dims[i];
+      // Gap and replication pieces enumerate copies/space in traversal order
+      // regardless of stride; traversal pieces join only when the outer piece
+      // reads the parts directly above the inner one (one contiguous piece).
+      const bool special = piece.isGap() || piece.isReplicate();
+      int64_t size = piece.getSize();
+      int64_t stride = special ? 1 : piece.getStride();
+      mergedIndexOf[i] = merged.size();
+      size_t j = i + 1;
+      for (; j < end && !pinned.contains(static_cast<int64_t>(i)) &&
+             !pinned.contains(static_cast<int64_t>(j));
+           ++j) {
+        DimAttr next = dims[j];
+        if (next.getDim() != piece.getDim()) break;
+        if (!special && stride != next.getSize() * next.getStride()) break;
+        size *= next.getSize();
+        if (!special) stride = next.getStride();
+        mergedIndexOf[j] = mergedIndexOf[i];
+      }
+      merged.push_back(DimAttr::get(ctx, piece.getDim(), size, stride));
+      i = j;
+    }
+  };
+  mergeRegion(0, ctPrefixLen);
+  mergeRegion(ctPrefixLen, dims.size());
+  if (merged.size() == dims.size()) return layout;
+
+  // Re-index piece arguments (pinned, so each survives as its own merged
+  // piece) and restate an axis argument as the piece when its axis is no
+  // longer split (the canonical form of an unsplit axis).
+  auto remapRollArg = [&](RollArg e) -> int64_t {
+    if (!e.isAxis) return mergedIndexOf[e.index];
+    SmallVector<int64_t> positions;
+    for (auto [pos, piece] : llvm::enumerate(merged)) {
+      if (!piece.isGap() && !piece.isReplicate() && piece.getDim() == e.index) {
+        positions.push_back(pos);
+      }
+    }
+    if (positions.size() == 1) return positions.front();
+    return encodeRollArg(e);
+  };
+  SmallVector<int64_t> rollStorage;
+  for (const RollSpec& roll : rolls) {
+    rollStorage.push_back(remapRollArg(roll.from));
+    rollStorage.push_back(remapRollArg(roll.by));
+  }
+
+  canonicalizeLayoutDims(ctx, merged, layout.getN(), rollStorage);
+  SmallVector<Attribute> attrs(merged.begin(), merged.end());
+  auto dimsAttr = ArrayAttr::get(ctx, attrs);
+  auto rollsAttr = DenseI64ArrayAttr::get(ctx, rollStorage);
+  // Defensive: a form whose merge does not verify keys as itself.
+  ScopedDiagnosticHandler silence(ctx, [](Diagnostic&) { return success(); });
+  auto swallow = mlir::detail::getDefaultDiagnosticEmitFn(UnknownLoc::get(ctx));
+  if (failed(LayoutAttr::verify(swallow, dimsAttr, layout.getN(), rollsAttr))) {
+    return layout;
+  }
+  return LayoutAttr::get(ctx, dimsAttr, layout.getN(), rollsAttr);
+}
+
+bool isMaterializableRotomLayout(LayoutAttr layout) {
+  return succeeded(RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout));
+}
+
+bool isLowerableRotomLayout(LayoutAttr layout) {
+  return layout && isMaterializableRotomLayout(layout);
+}
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/RotomLayout.h
+++ b/lib/Dialect/Rotom/Utils/RotomLayout.h
@@ -1,0 +1,43 @@
+#ifndef LIB_DIALECT_ROTOM_UTILS_ROTOMLAYOUT_H_
+#define LIB_DIALECT_ROTOM_UTILS_ROTOMLAYOUT_H_
+
+#include <cstdint>
+
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace rotom {
+
+// A layout's dims as DimAttrs, for the helpers that take a piece list.
+llvm::SmallVector<DimAttr> layoutDims(LayoutAttr layout);
+
+// The number of distinct ciphertexts the layout occupies: the product of the
+// ciphertext-side piece extents. A gap that is a roll's `by` argument claims
+// its blocks (one rotation of the rolled piece per block index) and so counts;
+// a plain gap is unclaimed space and does not.
+int64_t layoutNumCiphertexts(LayoutAttr layout);
+
+// The dimension-merged canonical form of `layout`: adjacent pieces that
+// describe one contiguous piece ([0:2:8][0:8:1] -> [0:16:1]), adjacent
+// replication and adjacent gaps merge, so equivalent forms of the same
+// packing compare equal. The search dedupes candidates on this form. Merging
+// keeps the address map: it never crosses the ct/slot boundary, and a piece a
+// roll names never merges. Roll arguments are re-indexed through the merges.
+LayoutAttr mergeAdjacentLayoutDims(LayoutAttr layout);
+
+// Whether the layout lowers to an ISL relation, i.e. can be materialized as a
+// tensor_ext layout.
+bool isMaterializableRotomLayout(LayoutAttr layout);
+
+// Whether the Rotom lowering can handle the layout at all: it materializes to
+// a relation. A legality gate, not an alignment check -- differing ciphertext
+// counts are fine, planLayoutConversion handles them.
+bool isLowerableRotomLayout(LayoutAttr layout);
+
+}  // namespace rotom
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_ROTOM_UTILS_ROTOMLAYOUT_H_

--- a/lib/Dialect/Rotom/Utils/RotomLayoutTest.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomLayoutTest.cpp
@@ -1,0 +1,142 @@
+#include <cstdint>
+
+#include "gtest/gtest.h"  // from @googletest
+#include "lib/Dialect/Rotom/IR/RotomAttributes.h"
+#include "lib/Dialect/Rotom/IR/RotomDialect.h"
+#include "lib/Dialect/Rotom/Utils/RotomLayout.h"
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"        // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"          // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace {
+
+using rotom::DimAttr;
+using rotom::LayoutAttr;
+using rotom::RotomDialect;
+
+class RotomLayoutTest : public ::testing::Test {
+ protected:
+  RotomLayoutTest() { context.loadDialect<RotomDialect>(); }
+
+  DimAttr dim(int64_t dim, int64_t size, int64_t stride = 1) {
+    return DimAttr::get(&context, dim, size, stride);
+  }
+
+  LayoutAttr layout(ArrayRef<Attribute> dims, int64_t n) {
+    return LayoutAttr::get(&context, ArrayAttr::get(&context, dims), n);
+  }
+
+  MLIRContext context;
+};
+
+TEST_F(RotomLayoutTest, CountsSplitAxisByCiphertextPart) {
+  // A 4x8 layout at n=16 whose row axis (extent 4) is split explicitly into a
+  // high (ciphertext) piece [stride 2] and a low (slot) piece [stride 1] --
+  // the explicit form of an axis spanning the ct/slot boundary. The column
+  // axis (extent 8) and the row's low piece (extent 2) fill the 16 slots (8 * 2
+  // == 16); the row's high piece (extent 2) indexes ciphertexts. The layout
+  // therefore occupies 2 ciphertexts, not 4 (the full row extent).
+  LayoutAttr split = layout({dim(0, 2, /*stride=*/2), dim(1, 8, /*stride=*/1),
+                             dim(0, 2, /*stride=*/1)},
+                            /*n=*/16);
+  EXPECT_EQ(rotom::layoutNumCiphertexts(split), 2);
+}
+
+TEST_F(RotomLayoutTest, MaterializesSplitAxisLayout) {
+  // A repeated dim id is a split of one tensor axis: the two pieces
+  // of axis 0 (strides 2 and 1) and of axis 1 share their axis's domain
+  // variable. This is a valid, materializable 2x2-tiled layout. (An invalid
+  // split -- e.g. two stride-1 pieces -- is rejected by LayoutAttr::verify.)
+  LayoutAttr split = layout({dim(0, 2, /*stride=*/2), dim(1, 2, /*stride=*/2),
+                             dim(0, 2, /*stride=*/1), dim(1, 2, /*stride=*/1)},
+                            /*n=*/8);
+  EXPECT_TRUE(rotom::isMaterializableRotomLayout(split));
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsJoinsContiguousPieces) {
+  // [0:2:8][0:8:1] and [0:16:1] describe the same packing of a 16-vector: the
+  // outer piece reads the index parts directly above the inner one.
+  LayoutAttr split = layout({dim(0, 2, /*stride=*/8), dim(0, 8)}, 16);
+  LayoutAttr whole = layout({dim(0, 16)}, 16);
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(split), whole);
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(whole), whole);
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsJoinsReplicationAndGaps) {
+  LayoutAttr replicated = layout({dim(-1, 2), dim(-1, 2), dim(0, 4)}, 16);
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(replicated),
+            layout({dim(-1, 4), dim(0, 4)}, 16));
+  LayoutAttr gapped = layout({dim(0, 4), dim(-2, 2), dim(-2, 2)}, 16);
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(gapped),
+            layout({dim(0, 4), dim(-2, 4)}, 16));
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsStopsAtCtSlotBoundary) {
+  // The same two contiguous pieces, but the outer piece indexes ciphertexts
+  // (2 * 8 > n = 8): the merged piece would straddle the ct/slot boundary, so
+  // the form is already canonical.
+  LayoutAttr straddling = layout({dim(0, 2, /*stride=*/8), dim(0, 8)}, 8);
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(straddling), straddling);
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsSkipsNonContiguousPieces) {
+  // [0:2:1][0:8:2] traverses the low part then the high parts -- not the
+  // contiguous outer-above-inner order [0:2:8][0:8:1] merges.
+  LayoutAttr interleaved =
+      layout({dim(0, 2, /*stride=*/1), dim(0, 8, /*stride=*/2)}, 16);
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(interleaved), interleaved);
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsPinsPieceRollArgs) {
+  // roll(1, 0) reads piece 1's part of the index; joining pieces 1 and 2
+  // (contiguous pieces of axis 0) would change what the roll rewrites.
+  LayoutAttr rolled = LayoutAttr::getCanonical(
+      &context, {dim(1, 4), dim(0, 2, /*stride=*/8), dim(0, 8)}, 64,
+      /*rolls=*/{1, 0});
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(rolled), rolled);
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsReindexesRollArgs) {
+  // Pieces 0 and 1 merge, shifting the roll's piece arguments (2, 3) -> (1, 2).
+  LayoutAttr split = LayoutAttr::getCanonical(
+      &context, {dim(0, 2, /*stride=*/2), dim(0, 2), dim(1, 4), dim(2, 4)}, 64,
+      /*rolls=*/{2, 3});
+  LayoutAttr merged =
+      LayoutAttr::getCanonical(&context, {dim(0, 4), dim(1, 4), dim(2, 4)}, 64,
+                               /*rolls=*/{1, 2});
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(split), merged);
+}
+
+TEST_F(RotomLayoutTest, MergeAdjacentDimsRestatesAxisArgWhenUnsplit) {
+  // An axis FROM rewrites the whole axis index, so its pieces may merge; once
+  // axis 0 is a single piece the argument restates as that piece (the
+  // canonical form of an unsplit axis).
+  LayoutAttr split = LayoutAttr::getCanonical(
+      &context, {dim(1, 16), dim(0, 2, /*stride=*/8), dim(0, 8)}, 256,
+      /*rolls=*/{rotom::encodeRollArg({/*isAxis=*/true, 0}), 0});
+  LayoutAttr merged = LayoutAttr::getCanonical(
+      &context, {dim(1, 16), dim(0, 16)}, 256, /*rolls=*/{1, 0});
+  EXPECT_EQ(rotom::mergeAdjacentLayoutDims(split), merged);
+}
+
+TEST_F(RotomLayoutTest, LowerableAllowsReplicationStride) {
+  // A replication piece's stride describes replica placement.
+  LayoutAttr replicated =
+      layout({dim(0, 4), dim(/*dim=*/-1, /*size=*/2, /*stride=*/4)}, 8);
+  EXPECT_TRUE(rotom::isLowerableRotomLayout(replicated));
+}
+
+TEST_F(RotomLayoutTest, LowerableAllowsSplitAxis) {
+  // A split axis: the high piece's stride is its offset, which
+  // the verifier requires to be the product of the lower extents. The
+  // matmul pipeline produces such results (a ciphertext piece over a slot
+  // piece), and they lower like any other layout.
+  LayoutAttr split = layout({dim(0, 2, /*stride=*/2), dim(0, 2), dim(1, 4)}, 8);
+  EXPECT_TRUE(rotom::isLowerableRotomLayout(split));
+}
+
+}  // namespace
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLowering.cpp
@@ -18,16 +18,13 @@
 namespace mlir::heir::rotom {
 namespace {
 
-/// Maps a `#rotom.dim` from the layout's `dims` list to its iterator index `i*`
-/// after preprocessing (match logical axis, size, and stride).
-static FailureOr<int64_t> varIndexForRotomDim(const SmallVector<DimAttr>& axes,
-                                              DimAttr want) {
+/// Maps a tensor axis id to its iterator index `i*` after preprocessing.
+/// Preprocessing dedupes traversal pieces per logical axis (a
+/// split contributes one variable), so the axis id identifies the variable.
+static FailureOr<int64_t> varIndexForAxis(const SmallVector<DimAttr>& axes,
+                                          int64_t axis) {
   for (int64_t i = 0; i < static_cast<int64_t>(axes.size()); ++i) {
-    if (axes[i].getDim() == want.getDim() &&
-        axes[i].getSize() == want.getSize() &&
-        axes[i].getStride() == want.getStride()) {
-      return i;
-    }
+    if (axes[i].getDim() == axis) return i;
   }
   return failure();
 }
@@ -89,9 +86,10 @@ static LogicalResult emitSegmentAddress(
     const SmallVector<DimAttr>& axes, int64_t numAxes, size_t segStart,
     size_t segEnd, const llvm::DenseSet<int64_t>& rolledGapIndices,
     ArrayRef<int64_t> rolls, ArrayAttr rotomDims) {
-  // Effective extent of a piece = the range of its mixed-radix digit, which
+  // Effective extent of a piece = the range of the axis-index part it reads,
+  // which
   // is the piece's own extent: a lone piece reads the whole axis index, and
-  // for a valid mixed-radix split each digit ranges over its piece's extent.
+  // for a valid split each part ranges over its piece's extent.
   llvm::SmallVector<int64_t> suffixCoeff(pieces.size(), 0);
   int64_t suffix = 1;
   for (size_t p = segEnd; p > segStart;) {
@@ -133,20 +131,21 @@ static LogicalResult emitSegmentAddress(
     }
   }
 
-  // A tensor dim can contribute several pieces to one segment (a mixed-radix
-  // split places more than one digit of the same index on the same axis), so
-  // collect a list of (coeff, digit descriptor) per dim rather than one entry.
-  struct AxisDigit {
+  // A tensor dim can contribute several pieces to one segment (a split places
+  // more than one part of the same index on the same axis), so collect a list
+  // of terms per dim rather than one entry. Each term reads the part
+  // (i / divBy) mod modBy of the axis variable and scales it by coeff.
+  struct AxisTerm {
     int64_t coeff;
     int64_t divBy;
     int64_t modBy;
   };
-  llvm::DenseMap<int64_t, llvm::SmallVector<AxisDigit>> digitsByAxis;
+  llvm::DenseMap<int64_t, llvm::SmallVector<AxisTerm>> termsByAxis;
   for (size_t p = segStart; p < segEnd; ++p) {
     if (pieces[p].kind != LayoutPieceKind::Traversal) continue;
     const int64_t ti = pieces[p].axisIndex;
     if (axes[ti].getSize() == 1) continue;
-    digitsByAxis[ti].push_back(
+    termsByAxis[ti].push_back(
         {suffixCoeff[p], pieces[p].divBy, pieces[p].modBy});
   }
 
@@ -156,61 +155,118 @@ static LogicalResult emitSegmentAddress(
     axisExprs.push_back("i" + std::to_string(i));
   }
 
-  // Apply roll(a,b) transforms left-to-right:
-  // t_a <- (t_a - t_b) mod extent(a).
+  // Apply rolls left-to-right. A piece FROM rewrites that piece's own
+  // part of the axis index in place, (part - shift) mod extent(piece),
+  // leaving its axis's other pieces untouched; an `axis` FROM rewrites the
+  // whole axis index mod its full extent, so the shift can carry from one
+  // piece into the next (each piece then reads its part of the rolled index).
+  // The shift is the by argument's index: a traversal piece's part (its whole
+  // index when the
+  // axis is unsplit), a whole axis via `axis`, a slot replication's replica
+  // index, or a gap's block index.
   //
-  // The rewrite lands wherever the FROM dimension sits -- the ciphertext
-  // address, the slot address, or both when it straddles the boundary. BY is
-  // another traversal dimension on either axis, or a slot replication/gap
-  // block index, so a roll diagonalizes a ciphertext dimension against a slot
-  // one (one ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup
-  // slot diagonal); a roll within the ciphertext axis is a free ciphertext
+  // The rewrite lands wherever the FROM pieces sit -- the ciphertext
+  // address, the slot address, or both when the axis straddles the boundary.
+  // A roll diagonalizes a ciphertext dimension against a slot one (one
+  // ciphertext per diagonal) or two slot dimensions (a Halevi-Shoup slot
+  // diagonal); a roll within the ciphertext axis is a free ciphertext
   // relabeling that enumeration never generates.
   if (!rolls.empty()) {
     if (!rotomDims || rolls.size() % 2 != 0) return failure();
     for (size_t i = 0; i < rolls.size(); i += 2) {
-      const int64_t fromIdx = rolls[i];
-      const int64_t toIdx = rolls[i + 1];
-      if (fromIdx < 0 || toIdx < 0 ||
-          fromIdx >= static_cast<int64_t>(rotomDims.size()) ||
-          toIdx >= static_cast<int64_t>(rotomDims.size())) {
+      const RollArg from = decodeRollArg(rolls[i]);
+      const RollArg by = decodeRollArg(rolls[i + 1]);
+      if (!from.isAxis && from.index >= static_cast<int64_t>(rotomDims.size()))
         return failure();
-      }
-      auto fromDim = cast<DimAttr>(rotomDims[fromIdx]);
-      auto toDim = cast<DimAttr>(rotomDims[toIdx]);
-      FailureOr<int64_t> maybeFromVar = varIndexForRotomDim(axes, fromDim);
+      if (!by.isAxis && by.index >= static_cast<int64_t>(rotomDims.size()))
+        return failure();
+      DimAttr fromPiece =
+          from.isAxis ? DimAttr() : dyn_cast<DimAttr>(rotomDims[from.index]);
+      if (!from.isAxis && !fromPiece) return failure();
+      const int64_t fromAxis = from.isAxis ? from.index : fromPiece.getDim();
+      FailureOr<int64_t> maybeFromVar = varIndexForAxis(axes, fromAxis);
       if (failed(maybeFromVar)) return failure();
       const int64_t fromVar = *maybeFromVar;
+
       std::string toExpr;
-      if (toDim.isGap()) {
-        // Rolling by a gap dim: the shift is the gap's existential block
-        // index, so block g holds the rolled dim cyclically shifted by g.
-        toExpr = "g" + std::to_string(gapIndexForPosition(rotomDims, toIdx));
-      } else if (toDim.isReplicate()) {
-        // Rolling by a replication dim: the shift is the replica index, whose
-        // existential variable is named after the piece's replication slot.
-        int64_t replicationIndex = 0;
-        for (int64_t k = 0; k < toIdx; ++k) {
-          if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
-        }
-        toExpr = "d" + std::to_string(numAxes + replicationIndex);
-      } else {
-        FailureOr<int64_t> maybeToVar = varIndexForRotomDim(axes, toDim);
+      if (by.isAxis) {
+        // Rolling by a whole axis: the shift is the axis's (possibly
+        // already-rolled) index expression.
+        FailureOr<int64_t> maybeToVar = varIndexForAxis(axes, by.index);
         if (failed(maybeToVar)) return failure();
         toExpr = axisExprs[*maybeToVar];
+      } else {
+        auto toDim = dyn_cast<DimAttr>(rotomDims[by.index]);
+        if (!toDim) return failure();
+        if (toDim.isGap()) {
+          // Rolling by a gap dim: the shift is the gap's existential block
+          // index, so block g holds the rolled index cyclically shifted by g.
+          toExpr =
+              "g" + std::to_string(gapIndexForPosition(rotomDims, by.index));
+        } else if (toDim.isReplicate()) {
+          // Rolling by a replication dim: the shift is the replica index,
+          // whose existential variable is named after the piece's replication
+          // slot.
+          int64_t replicationIndex = 0;
+          for (int64_t k = 0; k < by.index; ++k) {
+            if (cast<DimAttr>(rotomDims[k]).isReplicate()) ++replicationIndex;
+          }
+          toExpr = "d" + std::to_string(numAxes + replicationIndex);
+        } else {
+          FailureOr<int64_t> maybeToVar = varIndexForAxis(axes, toDim.getDim());
+          if (failed(maybeToVar)) return failure();
+          toExpr = axisExprs[*maybeToVar];
+          const AxisPieces toAxis = axisPieces(rotomDims, toDim.getDim());
+          if (toAxis.isSplit()) {
+            // The part the by piece reads: (i / stride) mod extent, with the
+            // modulus redundant on the highest part.
+            const int64_t fullTo = toAxis.extent;
+            if (toDim.getStride() > 1) {
+              toExpr = floorDivExpr(toExpr, toDim.getStride());
+            }
+            if (toDim.getStride() * toDim.getSize() < fullTo) {
+              toExpr = modExpr(toExpr, toDim.getSize());
+            }
+          }
+        }
       }
-      std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
-      axisExprs[fromVar] = modExpr(diffExpr, fromDim.getSize());
+
+      const AxisPieces fromAxisPieces = axisPieces(rotomDims, fromAxis);
+      if (from.isAxis || !fromAxisPieces.isSplit()) {
+        // Whole-axis rewrite (the piece form of an unsplit axis is the
+        // same operation: its one piece reads the whole axis index).
+        std::string diffExpr = "(" + axisExprs[fromVar] + " - " + toExpr + ")";
+        axisExprs[fromVar] = modExpr(diffExpr, fromAxisPieces.extent);
+      } else {
+        // Piece rewrite on a split axis: replace the part this piece reads
+        // with (part - shift) mod extent(piece), i.e. add
+        // stride * (rolled - part) to the axis index. Nothing carries into
+        // the other pieces.
+        const int64_t stride = fromPiece.getStride();
+        const int64_t extent = fromPiece.getSize();
+        const std::string axisExpr = axisExprs[fromVar];
+        std::string part = axisExpr;
+        if (stride > 1) part = floorDivExpr(part, stride);
+        if (stride * extent < fromAxisPieces.extent) {
+          part = modExpr(part, extent);
+        }
+        const std::string rolled =
+            modExpr("(" + part + " - " + toExpr + ")", extent);
+        axisExprs[fromVar] = "(" + axisExpr + " + " + std::to_string(stride) +
+                             " * (" + rolled + ") - " + std::to_string(stride) +
+                             " * (" + part + "))";
+      }
     }
   }
 
   for (int64_t oldIdx = 0; oldIdx < static_cast<int64_t>(axes.size());
        ++oldIdx) {
     if (axes[oldIdx].getSize() == 1) continue;
-    auto it = digitsByAxis.find(oldIdx);
-    if (it == digitsByAxis.end()) continue;
-    for (const AxisDigit& tp : it->second) {
-      // Mixed-radix digit: (i / divBy) mod modBy (modBy 0 => no modulus). A
+    auto it = termsByAxis.find(oldIdx);
+    if (it == termsByAxis.end()) continue;
+    for (const AxisTerm& tp : it->second) {
+      // The part this piece reads: (i / divBy) mod modBy (modBy 0 => no
+      // modulus). A
       // whole-dim piece (divBy 1, modBy 0) leaves the index untouched.
       std::string expr = axisExprs[oldIdx];
       if (tp.divBy > 1) expr = floorDivExpr(expr, tp.divBy);

--- a/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
+++ b/lib/Dialect/Rotom/Utils/RotomTensorExtLayoutLoweringTest.cpp
@@ -113,7 +113,7 @@ TEST(RotomTensorExtLayoutLoweringTest, TiledRowMajor4x4Evaluate) {
       {9, 10, 11, 12},
       {13, 14, 15, 16},
   };
-  // dim ids 0 and 1 are each split mixed-radix into two pieces, so the relation
+  // dim ids 0 and 1 are each split into two pieces, so the relation
   // has one domain variable per tensor axis: i0 = row, i1 = col -- the pieces
   // of an axis share its variable rather than each binding their own. The
   // packing itself is plain 2x2-tiled row-major.
@@ -414,6 +414,147 @@ TEST(RotomTensorExtLayoutLoweringTest, UnequalExtentRollReducesModFromSize) {
   EXPECT_EQ(packed, expected);
 }
 
+// An `axis` FROM argument rewrites the whole dim's index, and each piece
+// takes its part of the rolled index: ciphertext (g, b) at slot a holds the
+// iteration point k = (a + 4g + b) mod 16 -- the diagonal index split across
+// two ciphertext pieces (the carry between pieces is what a piece FROM
+// cannot express).
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollOnSplitDim) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr kHi = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/4);
+  DimAttr kLo = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/1);
+  DimAttr i = DimAttr::get(&context, /*dim=*/0, /*size=*/16, /*stride=*/1);
+  // rolls (axis 1, 2): the whole k index is rewritten to (k - i) mod 16;
+  // k_hi emits its floor part, k_lo its mod part.
+  LayoutAttr layout = LayoutAttr::get(
+      &context, ArrayAttr::get(&context, {kHi, kLo, i}), /*n=*/16,
+      DenseI64ArrayAttr::get(
+          &context,
+          ArrayRef<int64_t>{rotom::encodeRollArg({/*isAxis=*/true, 1}), 2}));
+
+  FailureOr<std::string> isl =
+      RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+  ASSERT_TRUE(succeeded(isl));
+  auto relation = getIntegerRelationFromIslStr(*isl);
+  ASSERT_TRUE(succeeded(relation));
+
+  std::vector<std::vector<int>> packed = evaluateLayout<int>(
+      relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+        // f(i, k) = 16*i + k, distinct per iteration point.
+        return 16 * static_cast<int>(domainPoint[0]) +
+               static_cast<int>(domainPoint[1]);
+      });
+  ASSERT_EQ(packed.size(), 16u);
+  for (int g = 0; g < 4; ++g) {
+    for (int b = 0; b < 4; ++b) {
+      for (int a = 0; a < 16; ++a) {
+        const int k = (a + 4 * g + b) % 16;
+        EXPECT_EQ(packed[4 * g + b][a], 16 * a + k)
+            << "ct (" << g << ", " << b << ") slot " << a;
+      }
+    }
+  }
+}
+
+// A piece FROM on a split dim rewrites only that piece's part of the index --
+// nothing carries into the other pieces. Rolling the high piece shifts the
+// axis in strides of 4; rolling the low piece rotates within each block of 4.
+TEST(RotomTensorExtLayoutLoweringTest, PieceRollOnSplitDimRotatesOnePiece) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr d0Hi = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/4);
+  DimAttr d0Lo = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, d0Hi, d0Lo});
+  std::vector<int> vec(16);
+  for (int i = 0; i < 16; ++i) vec[i] = i + 1;
+  auto evaluate = [&](LayoutAttr layout) {
+    FailureOr<std::string> isl =
+        RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+    EXPECT_TRUE(succeeded(isl));
+    auto relation = getIntegerRelationFromIslStr(*isl);
+    EXPECT_TRUE(succeeded(relation));
+    return evaluateLayout<int>(
+        relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+          return vec[domainPoint[0]];
+        });
+  };
+
+  // roll(1, 0): the high piece shifts by the replica index, so replica d
+  // holds the vector rotated by 4d whole (the low bits ride along
+  // untouched, so no borrow is observable here).
+  LayoutAttr hiRolled = LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0}));
+  std::vector<std::vector<int>> packed = evaluate(hiRolled);
+  ASSERT_EQ(packed.size(), 1u);
+  ASSERT_EQ(packed[0].size(), 64u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      EXPECT_EQ(packed[0][16 * d + a], vec[(a + 4 * d) % 16])
+          << "hi-rolled replica " << d << " slot " << a;
+    }
+  }
+
+  // roll(2, 0): the LOW piece shifts by the replica index -- each block of
+  // 4 rotates independently, with no carry into the high piece (the
+  // whole-axis roll, written `axis 0`, would borrow).
+  LayoutAttr loRolled = LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{2, 0}));
+  packed = evaluate(loRolled);
+  ASSERT_EQ(packed.size(), 1u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      const int block = a / 4;
+      const int within = (a % 4 + d) % 4;
+      EXPECT_EQ(packed[0][16 * d + a], vec[4 * block + within])
+          << "lo-rolled replica " << d << " slot " << a;
+    }
+  }
+}
+
+// Axis arguments: legal only on a split axis (the piece form is
+// canonical when the axis is one piece), and a roll may not shift an axis by
+// one of its own pieces.
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollArgVerifierRules) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr kHi = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/4);
+  DimAttr kLo = DimAttr::get(&context, /*dim=*/1, /*size=*/4, /*stride=*/1);
+  DimAttr i = DimAttr::get(&context, /*dim=*/0, /*size=*/16, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {kHi, kLo, i});
+  ScopedDiagnosticHandler silence(&context,
+                                  [](Diagnostic&) { return success(); });
+  auto swallow =
+      mlir::detail::getDefaultDiagnosticEmitFn(UnknownLoc::get(&context));
+  const int64_t axisK = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  const int64_t axisI = rotom::encodeRollArg({/*isAxis=*/true, 0});
+  const int64_t axisMissing = rotom::encodeRollArg({/*isAxis=*/true, 5});
+
+  // FROM the split axis, BY the unsplit i piece: legal.
+  EXPECT_TRUE(succeeded(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisK, 2}))));
+  // An axis argument on an unsplit axis must use the piece form.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisI, 0}))));
+  // An axis argument must name an axis present in dims.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisMissing, 2}))));
+  // An axis may not be shifted by one of its own pieces.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{axisK, 0}))));
+  // ... nor may a piece be shifted by its own whole axis.
+  EXPECT_TRUE(failed(LayoutAttr::verify(
+      swallow, dims, /*n=*/16,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{0, axisK}))));
+}
+
 TEST(RotomTensorExtLayoutLoweringTest, RollVerifierDimKindRules) {
   MLIRContext context;
   context.loadDialect<RotomDialect>();
@@ -472,6 +613,94 @@ TEST(RotomTensorExtLayoutLoweringTest, RollByGapMaterializesRotations) {
   std::vector<std::vector<int>> expected = {
       {1, 2, 3, 4, 2, 3, 4, 1, 3, 4, 1, 2, 4, 1, 2, 3}};
   EXPECT_EQ(packed, expected);
+}
+
+// The axis argument is not sugar for rolling every piece: rolling both
+// pieces of a split axis by the same partner wraps each piece
+// INDEPENDENTLY, while the axis form rewrites the whole index so the shift
+// carries across pieces. No combination of piece rolls expresses the latter,
+// which is the reason `axis N` exists.
+TEST(RotomTensorExtLayoutLoweringTest, AxisRollDiffersFromRollingEveryPiece) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  DimAttr repl = DimAttr::get(&context, /*dim=*/-1, /*size=*/4, /*stride=*/1);
+  DimAttr hi = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/4);
+  DimAttr lo = DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1);
+  ArrayAttr dims = ArrayAttr::get(&context, {repl, hi, lo});
+  std::vector<int> vec(16);
+  for (int i = 0; i < 16; ++i) vec[i] = i;
+  auto evaluate = [&](LayoutAttr layout) {
+    FailureOr<std::string> isl =
+        RotomTensorExtLayoutLowering::lowerToTensorExtIsl(layout);
+    EXPECT_TRUE(succeeded(isl));
+    auto relation = getIntegerRelationFromIslStr(*isl);
+    EXPECT_TRUE(succeeded(relation));
+    return evaluateLayout<int>(
+        relation.value(), [&](const std::vector<int64_t>& domainPoint) -> int {
+          return vec[domainPoint[0]];
+        });
+  };
+
+  // Whole-axis roll by the replica index: replica d holds (a + d) mod 16.
+  std::vector<std::vector<int>> axisRolled = evaluate(LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(
+          &context,
+          ArrayRef<int64_t>{rotom::encodeRollArg({/*isAxis=*/true, 0}), 0})));
+  // Both pieces rolled by the same replica index.
+  std::vector<std::vector<int>> pieceRolled = evaluate(LayoutAttr::get(
+      &context, dims, /*n=*/64,
+      DenseI64ArrayAttr::get(&context, ArrayRef<int64_t>{1, 0, 2, 0})));
+
+  ASSERT_EQ(axisRolled.size(), 1u);
+  ASSERT_EQ(pieceRolled.size(), 1u);
+  for (int d = 0; d < 4; ++d) {
+    for (int a = 0; a < 16; ++a) {
+      EXPECT_EQ(axisRolled[0][16 * d + a], (a + d) % 16)
+          << "axis-rolled replica " << d << " slot " << a;
+      // Per-piece wrapping: the high piece takes no carry out of the low.
+      EXPECT_EQ(pieceRolled[0][16 * d + a],
+                4 * ((a / 4 + d) % 4) + (a % 4 + d) % 4)
+          << "piece-rolled replica " << d << " slot " << a;
+    }
+  }
+  // Concretely different maps, not just different forms.
+  EXPECT_NE(axisRolled[0], pieceRolled[0]);
+}
+
+// Canonicalization inserts the front gap that fills the slot side, which
+// shifts PIECE arguments at or past the insertion; an axis argument names an
+// axis and must not move. Writing the gap explicitly (with the argument
+// already shifted) must therefore produce the very same attribute.
+TEST(RotomTensorExtLayoutLoweringTest, GapInsertionShiftsOnlyPieceArgs) {
+  MLIRContext context;
+  context.loadDialect<RotomDialect>();
+  // Slot side holds 16 of 32 slots, so canonicalization inserts [G:2:1].
+  SmallVector<DimAttr> dims = {
+      DimAttr::get(&context, /*dim=*/1, /*size=*/2, /*stride=*/2),
+      DimAttr::get(&context, /*dim=*/1, /*size=*/2, /*stride=*/1),
+      DimAttr::get(&context, /*dim=*/0, /*size=*/4, /*stride=*/1)};
+  const int64_t axisK = rotom::encodeRollArg({/*isAxis=*/true, 1});
+  // roll(axis 1, 2): the whole split k rolled by the i piece at position 2.
+  LayoutAttr inserted = LayoutAttr::getCanonical(&context, dims, /*n=*/32,
+                                                 ArrayRef<int64_t>{axisK, 2});
+  ASSERT_TRUE(inserted);
+
+  SmallVector<DimAttr> withUnitAxis = {
+      DimAttr::get(&context, /*dim=*/-2, /*size=*/2, /*stride=*/1)};
+  withUnitAxis.append(dims.begin(), dims.end());
+  // Same packing written out: the gap is explicit and the piece argument
+  // already accounts for it, while the axis argument is unchanged.
+  LayoutAttr explicitGap = LayoutAttr::getCanonical(
+      &context, withUnitAxis, /*n=*/32, ArrayRef<int64_t>{axisK, 3});
+  ASSERT_TRUE(explicitGap);
+
+  EXPECT_EQ(inserted, explicitGap);
+  ArrayRef<int64_t> rolls = inserted.getRolls().asArrayRef();
+  ASSERT_EQ(rolls.size(), 2u);
+  EXPECT_TRUE(rotom::decodeRollArg(rolls[0]).isAxis);
+  EXPECT_EQ(rotom::decodeRollArg(rolls[0]).index, 1);
+  EXPECT_EQ(rolls[1], 3);
 }
 
 }  // namespace

--- a/tests/Dialect/Rotom/IR/layout.mlir
+++ b/tests/Dialect/Rotom/IR/layout.mlir
@@ -24,7 +24,7 @@ func.func private @split_ok(tensor<16xi32> {foo.bar = #split_ok})
 
 // The slot side must fill the ciphertext exactly; a written layout may not
 // leave capacity implicit.
-#underfilled = #rotom.layout<n = 8, dims = [[0:4:1]]> // expected-error {{slot dims must fill the ciphertext exactly (slot extent 4 vs n = 8); spell unused capacity as an explicit gap piece}}
+#underfilled = #rotom.layout<n = 8, dims = [[0:4:1]]> // expected-error {{slot dims must fill the ciphertext exactly (slot extent 4 vs n = 8); state unused capacity as an explicit gap piece}}
 func.func private @underfilled(tensor<16xi32> {foo.bar = #underfilled})
 
 // -----
@@ -61,3 +61,23 @@ func.func private @uneven_roll(tensor<16xi32> {foo.bar = #uneven_roll})
 // blocks would repeat rotations the accounting was not audited for.
 #big_gap_roll = #rotom.layout<n = 8, rolls = [(0, 1)], dims = [#t | #g]> // expected-error {{a rolled-by gap dim must not exceed the rolled dim's extent}}
 func.func private @big_gap_roll(tensor<32xi32> {foo.bar = #big_gap_roll})
+
+// -----
+
+// An `axis` argument rolls the whole split axis: legal when the axis has
+// more than one piece.
+#axis_roll = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+func.func private @axis_roll(tensor<16x16xi32> {foo.bar = #axis_roll})
+
+// -----
+
+// The piece form is canonical for an unsplit axis: the axis form is
+// rejected there.
+#axis_unsplit = #rotom.layout<n = 16, rolls = [(axis 0, 1)], dims = [[0:4:1], [1:4:1]]> // expected-error {{an axis roll argument requires a split axis; write an unsplit axis's argument as its piece position}}
+func.func private @axis_unsplit(tensor<16xi32> {foo.bar = #axis_unsplit})
+
+// -----
+
+// An axis may not be shifted by one of its own pieces.
+#axis_self = #rotom.layout<n = 16, rolls = [(axis 1, 0)], dims = [[1:4:4], [1:4:1] | [0:16:1]]> // expected-error {{a roll may not shift an index by an argument on the same axis}}
+func.func private @axis_self(tensor<16x16xi32> {foo.bar = #axis_self})

--- a/tests/Dialect/Rotom/IR/ops.mlir
+++ b/tests/Dialect/Rotom/IR/ops.mlir
@@ -1,0 +1,74 @@
+// RUN: heir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+#from = #rotom.layout<n = 16, dims = [[0:4:1], [1:4:1]]>
+#to = #rotom.layout<n = 16, dims = [[1:4:1], [0:4:1]]>
+
+// CHECK: rotom.convert_layout
+// CHECK-SAME: from #{{.*}} to #
+func.func @convert(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %0 = rotom.convert_layout %arg0 : tensor<4x4xf32> from #from to #to
+  return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+#from_n8 = #rotom.layout<n = 8, dims = [[0:4:1], [1:2:1]]>
+#to_n16 = #rotom.layout<n = 16, dims = [[0:4:1], [1:4:1]]>
+
+func.func @mismatched_n(%arg0: tensor<4x2xf32>) -> tensor<4x2xf32> {
+  // expected-error@+1 {{the from and to layouts must have the same ciphertext size n; got 8 and 16}}
+  %0 = rotom.convert_layout %arg0 : tensor<4x2xf32> from #from_n8 to #to_n16
+  return %0 : tensor<4x2xf32>
+}
+
+// -----
+
+// apply_roll may swap the rolled piece with its partner: the replicate-then-
+// roll form, where a ciphertext replication trades places with a slot piece
+// that then rolls by it.
+#swap_from = #rotom.layout<n = 16, dims = [[R:4:1] | [1:4:1], [0:4:1]]>
+#swap_to = #rotom.layout<n = 16, rolls = [(0, 1)], dims = [[1:4:1] | [R:4:1], [0:4:1]]>
+// CHECK: rotom.apply_roll
+func.func @apply_roll_swap(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %0 = rotom.apply_roll %arg0 : tensor<4x4xf32> from #swap_from to #swap_to
+  return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+#pieces_from = #rotom.layout<n = 16, dims = [[0:4:1], [1:4:1]]>
+#pieces_to = #rotom.layout<n = 16, rolls = [(0, 1)], dims = [[0:4:1], [1:2:2], [1:2:1]]>
+func.func @apply_roll_pieces_differ(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{the from and to layouts must have the same pieces}}
+  %0 = rotom.apply_roll %arg0 : tensor<4x4xf32> from #pieces_from to #pieces_to
+  return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+// A bsgs_matmul names the operand that arrives unrolled, the layout the roll
+// would have produced, and the baby-step/giant-step split of its targets.
+#bsgs = #rotom.layout<n = 16, dims = [[0:4:1], [1:4:1]]>
+#bsgs_rolled = #rotom.layout<n = 16, rolls = [(0, 1)], dims = [[0:4:1], [1:4:1]]>
+// CHECK: rotom.bsgs_matmul
+// CHECK-SAME: roll_operand = 1
+func.func @bsgs_matmul(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %0 = rotom.bsgs_matmul %arg0, %arg1 : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    {lhs_layout = #bsgs, rhs_layout = #bsgs, rolled = #bsgs_rolled,
+     compute = #bsgs, to = #bsgs, roll_operand = 1 : i64, roll_stride = 4 : i64,
+     roll_targets = 4 : i64, baby = 2 : i64}
+  return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+#bsgs_bad = #rotom.layout<n = 16, dims = [[0:4:1], [1:4:1]]>
+#bsgs_bad_rolled = #rotom.layout<n = 16, rolls = [(0, 1)], dims = [[0:4:1], [1:4:1]]>
+func.func @bsgs_matmul_baby_too_large(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // expected-error@+1 {{baby extent exceeds the target count}}
+  %0 = rotom.bsgs_matmul %arg0, %arg1 : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+    {lhs_layout = #bsgs_bad, rhs_layout = #bsgs_bad, rolled = #bsgs_bad_rolled,
+     compute = #bsgs_bad, to = #bsgs_bad, roll_operand = 1 : i64,
+     roll_stride = 4 : i64, roll_targets = 4 : i64, baby = 8 : i64}
+  return %0 : tensor<4x4xf32>
+}

--- a/tests/Dialect/Rotom/IR/syntax.mlir
+++ b/tests/Dialect/Rotom/IR/syntax.mlir
@@ -2,35 +2,55 @@
 
 #d0 = #rotom.dim<[0:4:1]>
 #d1 = #rotom.dim<[1:4:1]>
-// Unused slot capacity is spelled as an explicit gap piece (the builders
+// Unused slot capacity is written as an explicit gap piece (the builders
 // insert it; written layouts must show it).
 #plain = #rotom.layout<n = 8, dims = [[G:2:1], [0:4:1]]>
 #rolled = #rotom.layout<n = 16, rolls = [(0, 1)], dims = [#d0, #d1]>
-// Replication and gap dims print as R and G; the numeric ids -1 and -2 are
-// accepted on input and round-trip to the letter forms.
+// Replication, gap and contraction dims print as R, G and K; the numeric ids
+// -1, -2 and -3 are accepted on input and round-trip to the letter forms.
 #repl_gap = #rotom.layout<n = 16, dims = [[R:2:1], [-2:2:1], [0:4:1]]>
 // The `|` separates ciphertext dims from slot dims (omitted when every dim
-// is a slot dim): here each of the 8 elements sits in its own ciphertext,
-// and the slot side is all gap.
+// is a slot dim): both k pieces index ciphertexts here, i addresses slots.
+// A roll argument is a dims-list position (bare integer, one piece) or a
+// whole tensor axis (`axis N`, legal only when the axis is split): the axis
+// FROM rewrites the whole split-k index and each piece takes its digit.
+#axis = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = [[1:4:4], [1:4:1] | [0:16:1]]>
+// Each roll is a parenthesized `(from, by)` pair; several apply left to
+// right.
+#mixed = #rotom.layout<n = 16, rolls = [(0, 1), (2, 3)], dims = [[0:2:1], [1:2:1], [2:2:1], [3:2:1]]>
+// An oversized dim spans ciphertexts entirely (ct = i0): here each of the 8
+// elements sits in its own ciphertext, and the slot side is all gap.
 #split = #rotom.layout<n = 4, dims = [[0:8:1] | [G:4:1]]>
+// A K piece is a gap that also says a matmul sums over it. Only a `compute`
+// placement has one; a value's layout carries a plain gap there.
+#contraction = #rotom.layout<n = 8, dims = [[-3:2:1], [0:4:1]]>
 
 // CHECK: #dim = #rotom.dim<[2:8:4]>
-// CHECK: #layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
-// CHECK: #layout1 = #rotom.layout<n = 16, dims = {{\[\[R:2:1\], \[G:2:1\], \[0:4:1\]\]}}>
-// CHECK: #layout2 = #rotom.layout<n = 16, rolls = [(0, 1)], dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
-// CHECK: #layout3 = #rotom.layout<n = 4, dims = {{\[\[0:8:1\] \| \[G:4:1\]\]}}>
+// CHECK: #layout = #rotom.layout<n = 16, rolls = [(axis 1, 2)], dims = {{\[\[1:4:4\], \[1:4:1\] \| \[0:16:1\]\]}}>
+// CHECK: #layout1 = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
+// CHECK: #layout2 = #rotom.layout<n = 16, dims = {{\[\[R:2:1\], \[G:2:1\], \[0:4:1\]\]}}>
+// CHECK: #layout3 = #rotom.layout<n = 16, rolls = [(0, 1)], dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+// CHECK: #layout4 = #rotom.layout<n = 4, dims = {{\[\[0:8:1\] \| \[G:4:1\]\]}}>
+// CHECK: #layout5 = #rotom.layout<n = 16, rolls = [(0, 1), (2, 3)], dims = {{\[\[0:2:1\], \[1:2:1\], \[2:2:1\], \[3:2:1\]\]}}>
+// CHECK: #layout6 = #rotom.layout<n = 8, dims = {{\[\[K:2:1\], \[0:4:1\]\]}}>
 // CHECK: module attributes
+// CHECK-SAME: rotom.axis_layout = #layout
 // CHECK-SAME: rotom.dim_attr = #dim
-// CHECK-SAME: rotom.plain_layout = #layout
-// CHECK-SAME: rotom.repl_gap_layout = #layout1
-// CHECK-SAME: rotom.rolled_layout = #layout2
-// CHECK-SAME: rotom.split_layout = #layout3
+// CHECK-SAME: rotom.plain_layout = #layout1
+// CHECK-SAME: rotom.repl_gap_layout = #layout2
+// CHECK-SAME: rotom.rolled_layout = #layout3
+// CHECK-SAME: rotom.split_layout = #layout4
+// CHECK-SAME: rotom.zmixed_layout = #layout5
+// CHECK-SAME: rotom.zzcontraction_layout = #layout6
 module attributes {
   rotom.dim_attr = #rotom.dim<[2:8:4]>,
   rotom.plain_layout = #plain,
   rotom.repl_gap_layout = #repl_gap,
   rotom.rolled_layout = #rolled,
-  rotom.split_layout = #split
+  rotom.axis_layout = #axis,
+  rotom.split_layout = #split,
+  rotom.zmixed_layout = #mixed,
+  rotom.zzcontraction_layout = #contraction
 } {
   func.func @f(%arg0: tensor<4x4xf32>) {
     return

--- a/tests/Dialect/Rotom/IR/verifier.mlir
+++ b/tests/Dialect/Rotom/IR/verifier.mlir
@@ -10,5 +10,5 @@ func.func private @bad_stride(tensor<16xi32> {foo = #rotom.dim<[0:8:0]>})
 
 // -----
 
-// expected-error @below {{`dim` must be >= -2, got -3}}
-func.func private @bad_dim(tensor<16xi32> {foo = #rotom.dim<[-3:8:1]>})
+// expected-error @below {{`dim` must be >= -3, got -4}}
+func.func private @bad_dim(tensor<16xi32> {foo = #rotom.dim<[-4:8:1]>})

--- a/tests/Dialect/Rotom/Transforms/layout_assignment.mlir
+++ b/tests/Dialect/Rotom/Transforms/layout_assignment.mlir
@@ -1,0 +1,261 @@
+// RUN: heir-opt %s --rotom-seed-layout=n=8 --rotom-assign-layout --mlir-print-local-scope | FileCheck %s
+
+module {
+  // CHECK: func.func @assign_from_seed(
+  // CHECK-SAME: rotom.layout = #rotom.layout
+  // CHECK-SAME: rotom.seed
+  // CHECK-SAME: rotom.layout = #rotom.layout
+  // CHECK-SAME: rotom.seed
+  // CHECK-SAME: -> (!secret.secret<tensor<4x4xf32>> {rotom.layout = #rotom.layout
+  func.func @assign_from_seed(%arg0: !secret.secret<tensor<4x4xf32>>, %arg1: tensor<4x4xf32>) -> !secret.secret<tensor<4x4xf32>> {
+    // CHECK: %[[GENERIC:.*]] = secret.generic(
+    // CHECK-SAME: rotom.layout = #rotom.layout
+    %0 = secret.generic(%arg0 : !secret.secret<tensor<4x4xf32>>) {
+    ^bb0(%arg2: tensor<4x4xf32>):
+      // CHECK: arith.addf
+      // CHECK-SAME: rotom.layout = #rotom.layout
+      %1 = arith.addf %arg2, %arg1 : tensor<4x4xf32>
+      secret.yield %1 : tensor<4x4xf32>
+    } -> !secret.secret<tensor<4x4xf32>>
+    // CHECK: return %[[GENERIC]]
+    return %0 : !secret.secret<tensor<4x4xf32>>
+  }
+}
+
+// -----
+
+#layout_2x4 = #rotom.layout<dims = [#rotom.dim<[0:2:1]>, #rotom.dim<[1:4:1]>], n = 8>
+#seed_2x4 = #rotom.seed<layouts = [#layout_2x4]>
+
+module {
+  // CHECK: func.func @transpose_assign
+  // CHECK-SAME: tensor<4x2xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[1:2:1\], \[0:4:1\]\]}}>}
+  func.func @transpose_assign(%arg0: tensor<2x4xf32> {rotom.seed = #seed_2x4}) -> tensor<4x2xf32> {
+    %empty = tensor.empty() : tensor<4x2xf32>
+    // CHECK: linalg.transpose
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[1:2:1\], \[0:4:1\]\]}}>
+    %0 = linalg.transpose ins(%arg0 : tensor<2x4xf32>) outs(%empty : tensor<4x2xf32>) permutation = [1, 0]
+    return %0 : tensor<4x2xf32>
+  }
+}
+
+// -----
+
+#layout_1x4 = #rotom.layout<dims = [#rotom.dim<[G:2:1]>, #rotom.dim<[0:1:1]>, #rotom.dim<[1:4:1]>], n = 8>
+#layout_4 = #rotom.layout<dims = [#rotom.dim<[G:2:1]>, #rotom.dim<[0:4:1]>], n = 8>
+#seed_1x4 = #rotom.seed<layouts = [#layout_1x4]>
+#seed_4 = #rotom.seed<layouts = [#layout_4]>
+
+module {
+  // CHECK: func.func @collapse_assign
+  // CHECK-SAME: tensor<4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>}
+  func.func @collapse_assign(%arg0: tensor<1x4xf32> {rotom.seed = #seed_1x4}) -> tensor<4xf32> {
+    // CHECK: tensor.collapse_shape
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
+    %0 = tensor.collapse_shape %arg0 [[0, 1]] : tensor<1x4xf32> into tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+
+  // CHECK: func.func @expand_assign
+  // CHECK-SAME: tensor<1x4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[1:4:1\]\]}}>}
+  func.func @expand_assign(%arg0: tensor<4xf32> {rotom.seed = #seed_4}) -> tensor<1x4xf32> {
+    // CHECK: tensor.expand_shape
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[1:4:1\]\]}}>
+    %0 = tensor.expand_shape %arg0 [[0, 1]] output_shape [1, 4] : tensor<4xf32> into tensor<1x4xf32>
+    return %0 : tensor<1x4xf32>
+  }
+}
+
+// -----
+
+#layout_4d_slice = #rotom.layout<dims = [#rotom.dim<[2:4:1]>, #rotom.dim<[3:4:1]>], n = 16>
+#layout_2d_slice = #rotom.layout<dims = [#rotom.dim<[0:4:1]>, #rotom.dim<[1:4:1]>], n = 16>
+#seed_4d_slice = #rotom.seed<layouts = [#layout_4d_slice]>
+#seed_2d_slice = #rotom.seed<layouts = [#layout_2d_slice]>
+
+module {
+  // CHECK: func.func @extract_assign
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>}
+  func.func @extract_assign(%arg0: tensor<1x2x4x4xf32> {rotom.seed = #seed_4d_slice}) -> tensor<4x4xf32> {
+    // CHECK: tensor.extract_slice
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+    %0 = tensor.extract_slice %arg0[0, 1, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : tensor<1x2x4x4xf32> to tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // CHECK: func.func @insert_assign
+  // CHECK-SAME: tensor<1x2x4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[2:4:1\], \[3:4:1\]\]}}>}
+  func.func @insert_assign(%arg0: tensor<4x4xf32> {rotom.seed = #seed_2d_slice}) -> tensor<1x2x4x4xf32> {
+    %empty = tensor.empty() : tensor<1x2x4x4xf32>
+    // CHECK: tensor.insert_slice
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 16, dims = {{\[\[2:4:1\], \[3:4:1\]\]}}>
+    %0 = tensor.insert_slice %arg0 into %empty[0, 1, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : tensor<4x4xf32> into tensor<1x2x4x4xf32>
+    return %0 : tensor<1x2x4x4xf32>
+  }
+}
+
+// -----
+
+#layout_reduce = #rotom.layout<dims = [#rotom.dim<[0:2:1]>, #rotom.dim<[1:4:1]>], n = 8>
+#seed_reduce = #rotom.seed<layouts = [#layout_reduce]>
+
+module {
+  // CHECK: func.func @reduce_assign
+  // CHECK-SAME: tensor<4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>}
+  func.func @reduce_assign(%arg0: tensor<2x4xf32> {rotom.seed = #seed_reduce}) -> tensor<4xf32> {
+    %empty = tensor.empty() : tensor<4xf32>
+    // CHECK: linalg.reduce
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[G:2:1\], \[0:4:1\]\]}}>
+    %0 = linalg.reduce ins(%arg0 : tensor<2x4xf32>) outs(%empty : tensor<4xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %1 = arith.addf %in, %init : f32
+      linalg.yield %1 : f32
+    }
+    return %0 : tensor<4xf32>
+  }
+}
+
+// -----
+
+#layout_generic_a = #rotom.layout<dims = [#rotom.dim<[0:2:1]>, #rotom.dim<[1:4:1]>], n = 8>
+#layout_generic_b = #rotom.layout<dims = [#rotom.dim<[1:4:1]>, #rotom.dim<[0:2:1]>], n = 8>
+#seed_generic_a = #rotom.seed<layouts = [#layout_generic_a]>
+#seed_generic_b = #rotom.seed<layouts = [#layout_generic_b]>
+
+module {
+  // Both operands are sources, so each is packed at the shared compute layout
+  // (the reference's match_public_kernel) instead of converting onto it: the
+  // column-major seed of %arg1 costs nothing to abandon at encode time.
+  // CHECK: func.func @generic_assign
+  // CHECK-SAME: %arg1: tensor<2x4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[0:2:1\], \[1:4:1\]\]}}>
+  func.func @generic_assign(%arg0: tensor<2x4xf32> {rotom.seed = #seed_generic_a}, %arg1: tensor<2x4xf32> {rotom.seed = #seed_generic_b}) -> tensor<2x4xf32> {
+    %empty = tensor.empty() : tensor<2x4xf32>
+    // CHECK: linalg.generic
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[0:2:1\], \[1:4:1\]\]}}>
+    %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0, %arg1 : tensor<2x4xf32>, tensor<2x4xf32>) outs(%empty : tensor<2x4xf32>) {
+    ^bb0(%in0: f32, %in1: f32, %out: f32):
+      %1 = arith.addf %in0, %in1 : f32
+      linalg.yield %1 : f32
+    } -> tensor<2x4xf32>
+    return %0 : tensor<2x4xf32>
+  }
+}
+
+// -----
+
+#layout_cost_good = #rotom.layout<dims = [#rotom.dim<[0:2:2]> | #rotom.dim<[0:2:1]>, #rotom.dim<[1:4:1]>], n = 8>
+#layout_cost_bad = #rotom.layout<dims = [#rotom.dim<[0:4:1]> | #rotom.dim<[G:2:1]>, #rotom.dim<[1:2:2]>, #rotom.dim<[1:2:1]>], n = 8>
+#seed_cost_mixed = #rotom.seed<layouts = [#layout_cost_bad, #layout_cost_good]>
+#seed_cost_good = #rotom.seed<layouts = [#layout_cost_good]>
+
+module {
+  // CHECK: func.func @cost_beats_seed_order
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[0:2:2\] \| \[0:2:1\], \[1:4:1\]\]}}>}
+  func.func @cost_beats_seed_order(%arg0: tensor<4x4xf32> {rotom.seed = #seed_cost_mixed}, %arg1: tensor<4x4xf32> {rotom.seed = #seed_cost_good}) -> tensor<4x4xf32> {
+    // CHECK: arith.addf
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[0:2:2\] \| \[0:2:1\], \[1:4:1\]\]}}>
+    // CHECK-NOT: rotom.elementwise
+    %0 = arith.addf %arg0, %arg1 : tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+// The two seed orderings have the same ciphertext count (so the
+// ciphertext-count carrying cost is a wash) and differ only in slot order;
+// the downstream add's free alignment with %arg1 is what selects %arg0's
+// second seed.
+#layout_chain_a = #rotom.layout<dims = [#rotom.dim<[0:2:2]> | #rotom.dim<[0:2:1]>, #rotom.dim<[1:4:1]>], n = 8>
+#layout_chain_b = #rotom.layout<dims = [#rotom.dim<[1:2:2]> | #rotom.dim<[1:2:1]>, #rotom.dim<[0:4:1]>], n = 8>
+#seed_chain_ab = #rotom.seed<layouts = [#layout_chain_a, #layout_chain_b]>
+#seed_chain_b = #rotom.seed<layouts = [#layout_chain_b]>
+
+module {
+  // CHECK: func.func @downstream_selects_intermediate
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[1:2:2\] \| \[1:2:1\], \[0:4:1\]\]}}>}
+  func.func @downstream_selects_intermediate(%arg0: tensor<4x4xf32> {rotom.seed = #seed_chain_ab}, %arg1: tensor<4x4xf32> {rotom.seed = #seed_chain_b}) -> tensor<4x4xf32> {
+    // CHECK: tensor.extract_slice
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[1:2:2\] \| \[1:2:1\], \[0:4:1\]\]}}>
+    %0 = tensor.extract_slice %arg0[0, 0] [4, 4] [1, 1] : tensor<4x4xf32> to tensor<4x4xf32>
+    // CHECK: arith.addf
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[1:2:2\] \| \[1:2:1\], \[0:4:1\]\]}}>
+    %1 = arith.addf %0, %arg1 : tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+// Row-major vs column-major seeds: both operands are sources, so the
+// column-major one is packed row-major at encode time rather than converted
+// (the reference's match_public_kernel). The elementwise ops get their Rotom
+// kernels at the shared output layout.
+#layout_add_align_a = #rotom.layout<dims = [#rotom.dim<[0:4:1]>, #rotom.dim<[1:4:1]>], n = 16>
+#layout_add_align_b = #rotom.layout<dims = [#rotom.dim<[1:4:1]>, #rotom.dim<[0:4:1]>], n = 16>
+#seed_add_align_a = #rotom.seed<layouts = [#layout_add_align_a]>
+#seed_add_align_b = #rotom.seed<layouts = [#layout_add_align_b]>
+
+module {
+  // CHECK: func.func @add_non_rolled_aligned
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+  func.func @add_non_rolled_aligned(%arg0: tensor<4x4xf32> {rotom.seed = #seed_add_align_a}, %arg1: tensor<4x4xf32> {rotom.seed = #seed_add_align_b}) -> tensor<4x4xf32> {
+    // The repacked operand needs no conversion op at all.
+    // CHECK-NOT: rotom.convert_layout
+    // CHECK: arith.addf %arg0, %arg1
+    // CHECK-SAME: rotom.elementwise
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+    %0 = arith.addf %arg0, %arg1 : tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+
+  // CHECK: func.func @mul_non_rolled_aligned
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+  func.func @mul_non_rolled_aligned(%arg0: tensor<4x4xf32> {rotom.seed = #seed_add_align_a}, %arg1: tensor<4x4xf32> {rotom.seed = #seed_add_align_b}) -> tensor<4x4xf32> {
+    // CHECK: arith.mulf
+    // CHECK-SAME: rotom.elementwise
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+    %0 = arith.mulf %arg0, %arg1 : tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+// Each tensor axis (0 and 1) is split mixed-radix into a stride-2 (high) and
+// stride-1 (low) piece, so the two pieces of an axis share its domain variable.
+#layout_repeated_dim = #rotom.layout<dims = [#rotom.dim<[0:2:2]>, #rotom.dim<[1:2:2]>, #rotom.dim<[0:2:1]>, #rotom.dim<[1:2:1]>], n = 16>
+#seed_repeated_dim = #rotom.seed<layouts = [#layout_repeated_dim]>
+
+module {
+  // CHECK: func.func @add_repeated_logical_dim
+  // CHECK-SAME: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:2:2\], \[1:2:2\], \[0:2:1\], \[1:2:1\]\]}}>}
+  func.func @add_repeated_logical_dim(%arg0: tensor<4x4xf32> {rotom.seed = #seed_repeated_dim}, %arg1: tensor<4x4xf32> {rotom.seed = #seed_repeated_dim}) -> tensor<4x4xf32> {
+    // CHECK: arith.addf
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:2:2\], \[1:2:2\], \[0:2:1\], \[1:2:1\]\]}}>
+    // CHECK-NOT: rotom.elementwise
+    %0 = arith.addf %arg0, %arg1 : tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+#layout_replicated_dim = #rotom.layout<dims = [#rotom.dim<[0:4:1]>, #rotom.dim<[R:2:4]>], n = 8>
+#seed_replicated_dim = #rotom.seed<layouts = [#layout_replicated_dim]>
+
+module {
+  // CHECK: func.func @add_replicated_dim
+  // CHECK-SAME: tensor<4xf32> {rotom.layout = #rotom.layout<n = 8, dims = {{\[\[0:4:1\], \[R:2:4\]\]}}>}
+  func.func @add_replicated_dim(%arg0: tensor<4xf32> {rotom.seed = #seed_replicated_dim}, %arg1: tensor<4xf32> {rotom.seed = #seed_replicated_dim}) -> tensor<4xf32> {
+    // CHECK: arith.addf
+    // CHECK-SAME: rotom.elementwise
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 8, dims = {{\[\[0:4:1\], \[R:2:4\]\]}}>
+    %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+}

--- a/tests/Dialect/Rotom/Transforms/layout_assignment_matmul.mlir
+++ b/tests/Dialect/Rotom/Transforms/layout_assignment_matmul.mlir
@@ -1,0 +1,76 @@
+// RUN: heir-opt %s --rotom-assign-layout --mlir-print-local-scope | FileCheck %s
+
+// Matmul: candidates come from the reference's binop pipeline -- replicate
+// each operand to the aligned shape, apply the sum roll on either side, align
+// the pair by a conversion or a roll, derive the result. The winner becomes
+// IR: a rotom.convert_layout / rotom.apply_roll chain on each operand whose
+// layout differs from its aligned placement, and one rotom.matmul op naming
+// the aligned, compute, and result layouts. The ciphertext lowering reads
+// them from the op.
+//
+// Both operands are seeded sources (data packed at encode time), so the
+// search assigns each one its expanded placement directly -- replication
+// pieces included -- instead of paying ciphertext conversions from the seed.
+//
+// At n=64 the whole 4x4x4 iteration space fits one ciphertext's slots, so
+// the kernel is one multiply and a k rotate-and-reduce. (At n=16 the
+// operands would spread across ciphertexts; see the pipeline execution
+// tests.)
+
+#layout_row = #rotom.layout<dims = [#rotom.dim<[G:4:1]>, #rotom.dim<[0:4:1]>, #rotom.dim<[1:4:1]>], n = 64>
+#seed_row = #rotom.seed<layouts = [#layout_row]>
+
+module {
+  // CHECK: func.func @matmul_assign
+  // CHECK-NOT: secret.kernel
+  // CHECK-SAME: %arg0: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 64, dims = {{\[\[0:4:1\], \[1:4:1\], \[R:4:1\]\]}}>
+  // CHECK-SAME: %arg1: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 64, dims = {{\[\[R:4:1\], \[0:4:1\], \[1:4:1\]\]}}>
+  // CHECK-SAME: -> (tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 64, dims = {{\[\[0:4:1\], \[G:4:1\], \[1:4:1\]\]}}>})
+  func.func @matmul_assign(%a: tensor<4x4xf32> {rotom.seed = #seed_row}, %b: tensor<4x4xf32> {rotom.seed = #seed_row}) -> tensor<4x4xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %empty = tensor.empty() : tensor<4x4xf32>
+    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4x4xf32>) -> tensor<4x4xf32>
+    // The winning compute placement is [i][k][j] in one ciphertext's slots
+    // (operands repacked to it for free, several placements tie on cost);
+    // summing k leaves a slot gap between i and j (the true sums sit at the
+    // k=0 offsets).
+    // CHECK: rotom.matmul
+    // CHECK-SAME: compute = #rotom.layout<n = 64, dims = {{\[\[0:4:1\], \[K:4:1\], \[1:4:1\]\]}}>
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 64, dims = {{\[\[0:4:1\], \[G:4:1\], \[1:4:1\]\]}}>
+    // CHECK-SAME: to = #rotom.layout<n = 64, dims = {{\[\[0:4:1\], \[G:4:1\], \[1:4:1\]\]}}>
+    // CHECK-NOT: linalg.matmul
+    %0 = linalg.matmul ins(%a, %b : tensor<4x4xf32>, tensor<4x4xf32>) outs(%fill : tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %0 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+// Matvec-shaped: the free dim j has extent 1, so no insertion is needed and
+// the whole product stays in one ciphertext. Repacking costs a small epsilon
+// per source, so the winner keeps the matrix at its row-major seed and
+// repacks only the vector (replication where i sits, k innermost); the
+// summed k is an innermost slot gap (true sums at the k=0 offsets).
+
+#seed_mat = #rotom.seed<layouts = [#rotom.layout<dims = [#rotom.dim<[0:4:1]>, #rotom.dim<[1:4:1]>], n = 16>]>
+#seed_col = #rotom.seed<layouts = [#rotom.layout<dims = [#rotom.dim<[G:4:1]>, #rotom.dim<[0:4:1]>], n = 16>]>
+
+module {
+  // CHECK: func.func @matvec_assign
+  // CHECK-NOT: secret.kernel
+  // CHECK-SAME: %arg0: tensor<4x4xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[1:4:1\]\]}}>
+  // CHECK-SAME: %arg1: tensor<4x1xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[R:4:1\], \[0:4:1\]\]}}>
+  // CHECK-SAME: -> (tensor<4x1xf32> {rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[G:4:1\]\]}}>})
+  func.func @matvec_assign(%a: tensor<4x4xf32> {rotom.seed = #seed_mat}, %b: tensor<4x1xf32> {rotom.seed = #seed_col}) -> tensor<4x1xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %empty = tensor.empty() : tensor<4x1xf32>
+    %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<4x1xf32>) -> tensor<4x1xf32>
+    // CHECK: rotom.matmul
+    // CHECK-SAME: compute = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[K:4:1\]\]}}>
+    // CHECK-SAME: rotom.layout = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[G:4:1\]\]}}>
+    // CHECK-SAME: to = #rotom.layout<n = 16, dims = {{\[\[0:4:1\], \[G:4:1\]\]}}>
+    // CHECK-NOT: linalg.matmul
+    %0 = linalg.matmul ins(%a, %b : tensor<4x4xf32>, tensor<4x1xf32>) outs(%fill : tensor<4x1xf32>) -> tensor<4x1xf32>
+    return %0 : tensor<4x1xf32>
+  }
+}

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -386,6 +386,7 @@ int main(int argc, char** argv) {
   polynomial::registerPolynomialPasses();
   preprocessing::registerPreprocessingPasses();
   rns::registerRNSPasses();
+  rotom::registerRotomLayoutAssignmentPasses();
   rotom::registerRotomMaterializePasses();
   rotom::registerRotomSeedPasses();
   secret::registerSecretPasses();


### PR DESCRIPTION
Walks a function bottom up, generating layout candidates for every value and folding them into one function-wide assignment. 

- Layout conversions are directly propagated into public operands. 
- Baby-step giant-step optimizations are added to the matmul operation when a replicated ciphertext piece is rolled by a slot piece. 

Stacks on https://github.com/google/heir/pull/3375.