### PR TITLE
Fix comparison operators being blocked by the arithmetic bitwidth check

### DIFF
--- a/frontend/heir/mlir_emitter.py
+++ b/frontend/heir/mlir_emitter.py
@@ -79,6 +79,18 @@ def getBitwidth(typ: NumbaType | MLIRType) -> int:
       )
 
 
+# Comparison operators always produce a bool result, which is narrower than
+# their operands by design. The bitwidth-matching logic in emit_binop below
+# is meant for arithmetic ops (e.g. widening an i8 to match an i32 result),
+# not comparisons, so it needs to be skipped for these.
+_COMPARISON_OPS = frozenset({
+    operator.lt,
+    operator.ge,
+    operator.eq,
+    operator.ne,
+})
+
+
 def mlirCastOp(
     from_type: NumbaType, to_type: MLIRType, value: str, loc: ir.Loc
 ) -> str:
@@ -653,7 +665,18 @@ class TextualMlirEmitter:
 
     lhs_ssa, rhs_ssa, ext, ty = self.emit_ext_if_needed(binop.lhs, binop.rhs)
 
-    if result_type is not None and isIntegerLike(result_type):
+    if binop.fn in _COMPARISON_OPS:
+      # A comparison's result type is always bool, which says nothing
+      # about whether the operands being compared are float or integer.
+      # The emitted op (arith.cmpf vs arith.cmpi) needs to match the
+      # OPERAND type, not the result type, so recompute the suffix from
+      # `ty` here instead of using the bool-derived one above. The
+      # bitwidth-matching block below is for arithmetic ops whose result
+      # width must match their operand width -- a comparison's 1-bit
+      # bool result is correct by construction, not a narrowing error,
+      # so it's skipped entirely for comparisons.
+      suffix = arithSuffix(ty)
+    elif result_type is not None and isIntegerLike(result_type):
       ty_bw = getBitwidth(ty)
       result_bw = getBitwidth(result_type)
       if result_bw < ty_bw:

--- a/frontend/type_test.py
+++ b/frontend/type_test.py
@@ -1,5 +1,6 @@
 from heir import compile
-from heir.mlir import I64, Secret
+from heir.backends.cleartext import CleartextBackend
+from heir.mlir import F64, I1, I32, I64, Secret
 
 from absl.testing import absltest  # fmt: skip
 
@@ -19,6 +20,28 @@ class TypeTest(absltest.TestCase):
 
     # 2*2 - 2*2 + 3 = 3
     self.assertEqual(3, type_two(2, 3))
+
+  def test_comparison_float(self):
+    # A comparison's result type is always bool (I1), which is narrower
+    # than its operands by design. This used to be misclassified by the
+    # same bitwidth-matching logic meant for arithmetic ops, and crashed
+    # before ever reaching the (correct) comparison-handling code.
+
+    @compile(scheme="ckks", backend=CleartextBackend())
+    def cmp_float(x: Secret[F64], y: F64) -> I1:
+      return x < y
+
+    self.assertEqual(False, cmp_float.original(6.0, 2.0))
+    self.assertEqual(True, cmp_float.original(2.0, 6.0))
+
+  def test_comparison_int(self):
+
+    @compile(scheme="ckks", backend=CleartextBackend())
+    def cmp_int(x: Secret[I32], y: I32) -> I1:
+      return x < y
+
+    self.assertEqual(False, cmp_int.original(6, 2))
+    self.assertEqual(True, cmp_int.original(2, 6))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3384.

`emit_binop` has a bitwidth matching check meant for arithmetic ops, making sure the operand width matches a widened result type. It runs whenever the result type is integer-like. A comparison's result type is always bool, which counts as integer-like, so this check ran for comparisons too and rejected every one of them before the actual comparison handling code further down the same function ever got reached.

Two things were going wrong under that one block:

For integer operands, the check saw a 1-bit bool result next to 32-bit operands and raised "Result type bool is narrower than operands," treating the entire point of a comparison as an error.

For float operands, `getBitwidth(ty)` got called on the operand type before that check even ran, and `getBitwidth` only ever handled integer-like types, so it raised right away regardless of what was actually being compared.

There was a second bug sitting behind the first one too. The suffix used to pick `arith.cmpf` vs `arith.cmpi` was computed from the result type, which is always bool for a comparison, so it always picked the integer suffix. Once the bitwidth check stopped blocking float comparisons, they were still emitting `arith.cmpi` on float operands and failing MLIR verification for a different reason. Fixed that by recomputing the suffix from the operand type specifically for comparison ops, since the operand type is what actually determines whether you want a float or integer compare.

Verified end to end under CKKS, both float and integer comparisons now compile and evaluate correctly. Added `test_comparison_float` and `test_comparison_int` to `type_test.py`.

One thing worth flagging rather than hiding: testing the same fix under BGV surfaced a separate, unrelated failure. Noise analysis rejects some float ops that get inserted for both float and int comparisons alike under BGV, which looks like it comes from a scale or level management pass rather than anything in the frontend. I didn't try to fix that here since it's a different part of the codebase and I wanted to keep this change scoped to what I could actually verify. Happy to file that separately if useful, or if someone more familiar with the BGV lowering side wants to take a look.
