### PR TITLE
update llvm dep for macos build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,16 +25,7 @@ llvm.configure(
 )
 use_repo(llvm, hermetic_llvm = "llvm-project")
 
-# Apple compilation support.
-# Note this requires full xcode, not just commandline tools
-#
-# Tested with:
-#
-# $ /usr/bin/xcodebuild -version
-#   Xcode 16.2
-#   Build version 16C5032a
-bazel_dep(name = "apple_support", version = "1.24.1", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_apple", version = "3.20.1")
+bazel_dep(name = "apple_support", version = "2.8.1")
 
 # Gazelle puglin for BUILD file autogeneration
 bazel_dep(name = "gazelle", version = "0.51.3")
@@ -209,7 +200,7 @@ git_override(
     remote = "https://github.com/mikael-s-persson/bazel-compile-commands-extractor",
 )
 
-bazel_dep(name = "rules_rust", version = "0.68.1")
+bazel_dep(name = "rules_rust", version = "0.74.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,10 +1,10 @@
 module(name = "heir")
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_cc", version = "0.2.22")
 
 # hermetic LLVM toolchain (for C++ compiler and linker)
-bazel_dep(name = "llvm", version = "0.8.9")
+bazel_dep(name = "llvm", version = "0.8.16")
 
 register_toolchains("@llvm//toolchain:all")
 
@@ -37,7 +37,7 @@ bazel_dep(name = "apple_support", version = "1.24.1", repo_name = "build_bazel_a
 bazel_dep(name = "rules_apple", version = "3.20.1")
 
 # Gazelle puglin for BUILD file autogeneration
-bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "gazelle", version = "0.51.3")
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
 
@@ -46,15 +46,15 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependenc
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cuda", version = "0.3.0")
-bazel_dep(name = "rules_go", version = "0.61.1")
-bazel_dep(name = "rules_python", version = "1.7.0")
+bazel_dep(name = "rules_go", version = "0.62.0")
+bazel_dep(name = "rules_python", version = "1.8.0")
 bazel_dep(name = "googletest", version = "1.17.0")
 bazel_dep(name = "fuzztest", version = "20250805.0")
 bazel_dep(name = "google_benchmark", version = "1.9.1")
 bazel_dep(name = "abseil-cpp", version = "20250512.1", repo_name = "com_google_absl")
 bazel_dep(name = "abseil-py", version = "2.1.0")
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
-bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "re2", version = "2025-08-12")
 bazel_dep(name = "isl", version = "0.27")
 bazel_dep(name = "pocketfft", version = "0.0.2.bcr.1")
@@ -91,8 +91,8 @@ bazel_dep(name = "gawk", version = "5.3.2.bcr.7")
 bazel_dep(name = "sed", version = "4.9.bcr.5")
 
 # LLVM dependency requires us to manually pull in some transitive deps
-bazel_dep(name = "zlib-ng", version = "2.3.3", repo_name = "llvm_zlib")
-bazel_dep(name = "zstd", version = "1.5.7", repo_name = "llvm_zstd")
+bazel_dep(name = "zlib-ng", version = "2.3.3.bcr.2", repo_name = "llvm_zlib")
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1", repo_name = "llvm_zstd")
 
 llvm_extensions = use_extension("//bazel:extensions.bzl", "llvm_deps")
 use_repo(

--- a/lib/Utils/AllocToInPlaceUtils.h
+++ b/lib/Utils/AllocToInPlaceUtils.h
@@ -132,12 +132,17 @@ class CallerProvidedStorageInfo {
   void removeStorage(Value value) { storageToReferringValues.erase(value); }
 
   void mergeStorage(Value from, Value to) {
-    storageToReferringValues[to].reserve(storageToReferringValues[to].size() +
-                                         storageToReferringValues[from].size());
-    storageToReferringValues[to].insert(storageToReferringValues[to].end(),
-                                        storageToReferringValues[from].begin(),
-                                        storageToReferringValues[from].end());
+    if (from == to) {
+      return;
+    }
+    auto it = storageToReferringValues.find(from);
+    if (it == storageToReferringValues.end()) {
+      return;
+    }
+    SmallVector<Value> fromValues = std::move(it->second);
     removeStorage(from);
+    auto& toValues = storageToReferringValues[to];
+    toValues.append(fromValues.begin(), fromValues.end());
   }
 
  public:
@@ -256,12 +261,12 @@ initializeAllocToInPlaceBlockStorage(Operation* op) {
     if (funcOp.isDeclaration()) {
       return;
     }
-    for (auto& block : funcOp.getBody().getBlocks()) {
-      auto& storageInfo = blockToStorageInfo[&block];
+    funcOp.walk([&](Block* block) {
+      auto& storageInfo = blockToStorageInfo[block];
       // Note: We do not add entry block arguments as candidate storages because
       // they may be inserted into tensors/slices and aliased when lowered to
       // pointer slices.
-      for (Operation& op : block.getOperations()) {
+      for (Operation& op : block->getOperations()) {
         // inplace op will not allocate new memory, it produces referring
         // values
         if (auto inplaceOpInterface = mlir::dyn_cast<InPlaceOpInterface>(&op)) {
@@ -287,7 +292,7 @@ initializeAllocToInPlaceBlockStorage(Operation* op) {
           }
         }
       }
-    }
+    });
   });
 
   return blockToStorageInfo;

--- a/tests/Transforms/ilp_bootstrap_placement/ilp_relin_modreduce_placement.mlir
+++ b/tests/Transforms/ilp_bootstrap_placement/ilp_relin_modreduce_placement.mlir
@@ -8,7 +8,7 @@
 // CHECK: secret.generic
 // CHECK: arith.mulf %input0, %input1
 // CHECK-NEXT: mgmt.relinearize
-// CHECK-NEXT: arith.mulf %input1, %input2
+// CHECK: arith.mulf %input1, %input2
 // CHECK: mgmt.modreduce
 // CHECK: mgmt.bootstrap
 // CHECK: secret.yield


### PR DESCRIPTION
Fixes the MacOS build in CI by:

- updating a variety of bazel dependencies
- Fixing some test failures triggered on arm but not x86:
  - Memory corruption and use-after-free in AllocToInPlaceUtils
  - Properly walk blocks in AllocToInPlaceUtils
  - Relax CHECK-NEXT in ilp_relin_modreduce_placement.mlir for test with multiple optimal solutions.

