### PR TITLE
cheddar: add destination-style bufferization support

### DIFF
--- a/lib/Dialect/Cheddar/IR/CheddarOps.td
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.td
@@ -22,21 +22,24 @@ class Cheddar_Op<string mnemonic, list<Trait> traits = []> :
 // as a destination-passing-style (DPS) op on builtin tensors: a scalar payload
 // is a rank-0 `tensor<!cheddar.X>`, the trailing `$output` operand is the
 // destination (init), and the result is tied 1:1 to it. The op is valid both
-// in tensor form (one result, pre-bufferization) and in buffer form (operands
-// are `memref<!cheddar.X>`, zero results, post one-shot-bufferize). The shared
+// in tensor form (one or more results, pre-bufferization) and in buffer form
+// (operands are `memref<!cheddar.X>`, zero results, post one-shot-bufferize).
 // `getDpsInitsMutable` points at the init operand named by `initName` (the
 // `$output` of most ops; `decode` writes `$value`, `mad_unsafe` its
 // `$accumulator` for a true in-place update).
 class Cheddar_DpsOp<string mnemonic, list<Trait> traits = [],
-                    string initName = "Output"> :
+                    string initName = "Output", int initCount = 1,
+                    bit readsInit = 0> :
         Cheddar_Op<mnemonic, traits # [DestinationStyleOpInterface,
             DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let extraClassDeclaration = [{
-    // The single init operand as a (length-1) MutableOperandRange.
     ::mlir::MutableOperandRange getDpsInitsMutable() {
       return ::mlir::MutableOperandRange(
-          getOperation(), get}] # initName # [{Mutable().getOperandNumber(), 1);
+          getOperation(), get}] # initName # [{Mutable().getOperandNumber(),
+          }] # !cast<string>(initCount) # [{);
     }
+    static constexpr bool readsDpsInit() { return }] #
+        !if(readsInit, "true", "false") # [{; }
   }];
   // Operand-aware memory effects (linalg-style): only memref operands carry
   // effects, so the tensor form stays value-semantics/side-effect-free (and
@@ -52,16 +55,23 @@ class Cheddar_DpsOp<string mnemonic, list<Trait> traits = [],
       for (::mlir::OpOperand &operand : getOperation()->getOpOperands()) {
         if (!::llvm::isa<::mlir::MemRefType>(operand.get().getType()))
           continue;
-        if (isDpsInit(&operand))
-          effects.emplace_back(::mlir::MemoryEffects::Write::get(), &operand,
-                               ::mlir::SideEffects::DefaultResource::get());
-        else
+        bool isInit = isDpsInit(&operand);
+        if (!isInit || readsDpsInit())
           effects.emplace_back(::mlir::MemoryEffects::Read::get(), &operand,
+                               ::mlir::SideEffects::DefaultResource::get());
+        if (isInit)
+          effects.emplace_back(::mlir::MemoryEffects::Write::get(), &operand,
                                ::mlir::SideEffects::DefaultResource::get());
       }
     }
   }];
 }
+
+class Cheddar_ReadWriteDpsOp<string mnemonic, list<Trait> traits = [],
+                             string initName = "Output",
+                             int initCount = 1> :
+    Cheddar_DpsOp<mnemonic, traits, initName, initCount,
+                  /*readsInit=*/1>;
 
 // Payload operands and results are constrained by their cheddar element type.
 // `*Like` accepts a tensor or memref (valid pre- and post-bufferization);
@@ -80,9 +90,9 @@ def Cheddar_ConstResult : Variadic<RankedTensorOf<[Cheddar_Constant]>>;
 // destination-passing like the payload ops: in tensor form they produce an SSA
 // result (the owning context / user_interface, consumed downstream) and carry a
 // trailing `$output` init operand that is the bufferization destination hint.
-// After one-shot-bufferize + buffer-results-to-out-params the result becomes a
-// `memref<!cheddar.{context,user_interface}>` out-param, which
-// `cheddar-emitc-boundary` re-types to the owning C++ smart-pointer references
+// After bufferization the result is a `memref<!cheddar.{context,user_interface}>`
+// out-param, which `cheddar-emitc-boundary` re-types to the owning C++
+// smart-pointer references
 // (`std::shared_ptr<Context<word>>&` / `std::unique_ptr<UserInterface<word>>&`),
 // distinguishing them from the borrowed raw-pointer handles the
 // compute/encrypt/decrypt funcs take.
@@ -161,12 +171,14 @@ def Cheddar_CreateBootContextOp : Cheddar_DpsOp<"create_boot_context"> {
   let results = (outs Cheddar_BootContextResult:$result);
 }
 
-def Cheddar_PrepareBootstrapOp : Cheddar_DpsOp<"prepare_bootstrap", [], "Ui"> {
+def Cheddar_PrepareBootstrapOp : Cheddar_ReadWriteDpsOp<
+    "prepare_bootstrap", [SameVariadicResultSize], "Ctx", 2> {
   let summary = "Run the one-time bootstrap precompute and rotation-key setup";
   let description = [{
     Performs the one-time bootstrapping preparation on a `!cheddar.boot_context`
-    and threads the resulting rotation keys into the UserInterface (DPS on
-    `$ui`). Emits the canonical CHEDDAR sequence:
+    and threads the resulting rotation keys into the UserInterface. Both
+    `$ctx` and `$ui` are read-write DPS destinations. Emits the canonical
+    CHEDDAR sequence:
       ctx->PrepareEvalMod();
       ctx->PrepareEvalSpecialFFT(numSlots);
       EvkRequest req; ctx->AddRequiredRotations(req, numSlots);
@@ -181,7 +193,10 @@ def Cheddar_PrepareBootstrapOp : Cheddar_DpsOp<"prepare_bootstrap", [], "Ui"> {
     Cheddar_UserInterfaceLike:$ui,
     Builtin_IntegerAttr:$numSlots
   );
-  let results = (outs Cheddar_UserInterfaceResult:$result);
+  let results = (outs
+    Cheddar_BootContextResult:$ctxResult,
+    Cheddar_UserInterfaceResult:$uiResult
+  );
 }
 
 def Cheddar_GetEncoderOp : Cheddar_Op<"get_encoder", [Pure]> {
@@ -212,7 +227,8 @@ def Cheddar_GetMultKeyOp : Cheddar_Op<"get_mult_key", [Pure]> {
   let results = (outs Cheddar_EvalKey:$key);
 }
 
-def Cheddar_PrepareRotKeyOp : Cheddar_DpsOp<"prepare_rot_key", [], "Ui"> {
+def Cheddar_PrepareRotKeyOp : Cheddar_ReadWriteDpsOp<
+    "prepare_rot_key", [], "Ui"> {
   let summary = "Generate a rotation key for a given distance";
   let description = [{
     Calls `ui->PrepareRotationKey(distance, maxLevel)` to generate a rotation
@@ -270,15 +286,15 @@ def Cheddar_EncodeOp : Cheddar_DpsOp<"encode", [PlaintextEncodeOpInterface]> {
   let summary = "Encode a message vector into a CHEDDAR plaintext";
   let description = [{
     Calls encoder.Encode(pt, level, scale, message). The message is a vector
-    of complex numbers (or reals). `scale` is the C++ `double` value used by
-    CHEDDAR's Encoder. `$output` is the destination plaintext.
+    of complex numbers (or reals). `logScale` preserves HEIR's logarithmic
+    scale metadata for future use. `$output` is the destination plaintext.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
     Cheddar_FloatLike:$message,
     Cheddar_PtLike:$output,
     Builtin_IntegerAttr:$level,
-    F64Attr:$scale
+    OptionalAttr<Builtin_IntegerAttr>:$logScale
   );
   let results = (outs Cheddar_PtResult:$result);
 }
@@ -286,17 +302,17 @@ def Cheddar_EncodeOp : Cheddar_DpsOp<"encode", [PlaintextEncodeOpInterface]> {
 def Cheddar_EncodeConstantOp : Cheddar_DpsOp<"encode_constant"> {
   let summary = "Encode a scalar double into a CHEDDAR constant";
   let description = [{
-    Calls encoder.EncodeConstant(constant, level, scale, number).
+    Calls encoder.EncodeConstant(constant, level, encoder.GetScale(level),
+    number).
     The result is in RNS form for efficient ciphertext-scalar ops.
-    `scale` is the C++ `double` value used by CHEDDAR's Encoder. `$output` is
-    the destination constant.
+    CHEDDAR derives the exact RNS scale from the target level. `$output` is the
+    destination constant.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
     AnyFloat:$value,
     Cheddar_ConstLike:$output,
-    Builtin_IntegerAttr:$level,
-    F64Attr:$scale
+    Builtin_IntegerAttr:$level
   );
   let results = (outs Cheddar_ConstResult:$result);
 }
@@ -604,7 +620,8 @@ def Cheddar_HConjAddOp : Cheddar_DpsOp<"hconj_add"> {
   let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_MadUnsafeOp : Cheddar_DpsOp<"mad_unsafe", [], "Accumulator"> {
+def Cheddar_MadUnsafeOp : Cheddar_ReadWriteDpsOp<
+    "mad_unsafe", [], "Accumulator"> {
   let summary = "Fused multiply-accumulate with constant (no rescale)";
   let description = [{
     Computes res += a * constant (in-place accumulation).

--- a/lib/Dialect/Cheddar/Transforms/BUILD
+++ b/lib/Dialect/Cheddar/Transforms/BUILD
@@ -1,0 +1,33 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CheddarBufferize",
+    srcs = ["CheddarBufferize.cpp"],
+    hdrs = ["CheddarBufferize.h"],
+    deps = [
+        "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "BufferizableOpInterfaceImpl",
+    srcs = ["BufferizableOpInterfaceImpl.cpp"],
+    hdrs = ["BufferizableOpInterfaceImpl.h"],
+    deps = [
+        "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Dialect/Cheddar/IR:ops_inc_gen",
+        "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:BufferizationInterfaces",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)

--- a/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -1,0 +1,116 @@
+#include "lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h"
+
+#include <cassert>
+
+#include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
+#include "lib/Dialect/Cheddar/IR/CheddarOps.h"
+#include "mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Block.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+using namespace mlir;
+using namespace mlir::heir;
+using namespace mlir::heir::cheddar;
+
+namespace {
+
+// Bufferization model shared by all cheddar DPS ops. The stock DPS model
+// supplies the init/result aliasing and write semantics; cheddar refines the
+// read side (most ops fully overwrite their destination) and lets an op pass
+// the same buffer as input and destination, which every scale-snu kernel
+// supports.
+template <typename OpTy>
+struct CheddarDpsModel
+    : public bufferization::DstBufferizableOpInterfaceExternalModel<
+          CheddarDpsModel<OpTy>, OpTy> {
+  bool bufferizesToMemoryRead(Operation* op, OpOperand& opOperand,
+                              const bufferization::AnalysisState& state) const {
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    return !dstOp.isDpsInit(&opOperand) || OpTy::readsDpsInit();
+  }
+
+  // An op may read and write the same (equivalent) buffer without a conflict.
+  bool bufferizesToElementwiseAccess(Operation* op,
+                                     const bufferization::AnalysisState& state,
+                                     ArrayRef<OpOperand*> opOperands) const {
+    return true;
+  }
+
+  // Read-write destinations (user interfaces, accumulators) are move-only and
+  // cannot be copied, so their init must bufferize in place.
+  LogicalResult verifyAnalysis(
+      Operation* op, const bufferization::AnalysisState& state) const {
+    if (!OpTy::readsDpsInit()) return success();
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    for (OpOperand& init : op->getOpOperands()) {
+      if (!dstOp.isDpsInit(&init)) continue;
+      if (isa<TensorType>(init.get().getType()) && !state.isInPlace(init))
+        return op->emitOpError(
+            "move-only read-write destination must bufferize in-place");
+    }
+    return success();
+  }
+
+  // Rebuild the op on buffers with no results; each result is replaced by the
+  // buffer of its tied init.
+  LogicalResult bufferize(Operation* op, RewriterBase& rewriter,
+                          const bufferization::BufferizationOptions& options,
+                          bufferization::BufferizationState& state) const {
+    SmallVector<Value> newOperands;
+    newOperands.reserve(op->getNumOperands());
+    for (OpOperand& operand : op->getOpOperands()) {
+      Value v = operand.get();
+      if (!isa<TensorType>(v.getType())) {
+        newOperands.push_back(v);
+        continue;
+      }
+      FailureOr<Value> buffer = getBuffer(rewriter, v, options, state);
+      if (failed(buffer)) return failure();
+      newOperands.push_back(*buffer);
+    }
+
+    assert(op->getNumRegions() == 0 && op->getNumSuccessors() == 0);
+    rewriter.setInsertionPoint(op);
+    rewriter.insert(Operation::create(
+        op->getLoc(), op->getName(), /*resultTypes=*/TypeRange{}, newOperands,
+        op->getAttrDictionary(), op->getPropertiesStorage(),
+        /*successors=*/BlockRange{}, /*numRegions=*/0));
+
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    SmallVector<Value> replacements;
+    for (OpResult res : op->getResults())
+      replacements.push_back(
+          newOperands[dstOp.getTiedOpOperand(res)->getOperandNumber()]);
+    bufferization::replaceOpWithBufferizedValues(rewriter, op, replacements);
+    return success();
+  }
+};
+
+template <typename OpTy>
+void attachIfDps(MLIRContext* ctx) {
+  if constexpr (OpTy::template hasTrait<DestinationStyleOpInterface::Trait>()) {
+    OpTy::template attachInterface<CheddarDpsModel<OpTy>>(*ctx);
+  }
+}
+
+template <typename... OpTys>
+void attachAllDpsOps(MLIRContext* ctx) {
+  (attachIfDps<OpTys>(ctx), ...);
+}
+
+}  // namespace
+
+void mlir::heir::cheddar::registerBufferizableOpInterfaceExternalModels(
+    DialectRegistry& registry) {
+  registry.addExtension(+[](MLIRContext* ctx, CheddarDialect* dialect) {
+    attachAllDpsOps<
+#define GET_OP_LIST
+#include "lib/Dialect/Cheddar/IR/CheddarOps.cpp.inc"
+        >(ctx);
+  });
+}

--- a/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h
+++ b/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h
@@ -1,0 +1,16 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_BUFFERIZABLEOPINTERFACEIMPL_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_BUFFERIZABLEOPINTERFACEIMPL_H_
+
+#include "mlir/include/mlir/IR/DialectRegistry.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry& registry);
+
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_BUFFERIZABLEOPINTERFACEIMPL_H_

--- a/lib/Dialect/Cheddar/Transforms/CheddarBufferize.cpp
+++ b/lib/Dialect/Cheddar/Transforms/CheddarBufferize.cpp
@@ -1,0 +1,36 @@
+#include "lib/Dialect/Cheddar/Transforms/CheddarBufferize.h"
+
+#include "mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"   // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+void buildCheddarBufferizationPipeline(OpPassManager& pm) {
+  pm.addPass(bufferization::createEmptyTensorEliminationPass());
+  bufferization::OneShotBufferizePassOptions oneShot;
+  oneShot.bufferizeFunctionBoundaries = true;
+  oneShot.functionBoundaryTypeConversion =
+      bufferization::LayoutMapOption::IdentityLayoutMap;
+  pm.addPass(bufferization::createOneShotBufferizePass(oneShot));
+  pm.addPass(memref::createFoldMemRefAliasOpsPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(createCanonicalizerPass());
+  bufferization::DropEquivalentBufferResultsPassOptions dropEquivalent;
+  dropEquivalent.modifyPublicFunctions = true;
+  pm.addPass(
+      bufferization::createDropEquivalentBufferResultsPass(dropEquivalent));
+  bufferization::BufferResultsToOutParamsPassOptions outParams;
+  outParams.hoistStaticAllocs = true;
+  outParams.addResultAttribute = true;
+  outParams.modifyPublicFunctions = true;
+  pm.addPass(bufferization::createBufferResultsToOutParamsPass(outParams));
+  pm.addPass(createCanonicalizerPass());
+}
+
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Cheddar/Transforms/CheddarBufferize.h
+++ b/lib/Dialect/Cheddar/Transforms/CheddarBufferize.h
@@ -1,0 +1,18 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_CHEDDARBUFFERIZE_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_CHEDDARBUFFERIZE_H_
+
+#include "mlir/include/mlir/Pass/PassManager.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+// Bufferizes a cheddar module with the upstream One-Shot pipeline and turns
+// every buffer result into a caller-provided out-param (`bufferize.result`).
+void buildCheddarBufferizationPipeline(OpPassManager& pm);
+
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_CHEDDARBUFFERIZE_H_

--- a/tests/Dialect/Cheddar/IR/roundtrip.mlir
+++ b/tests/Dialect/Cheddar/IR/roundtrip.mlir
@@ -67,8 +67,7 @@ func.func @test_encode(
     %out: tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext> {
   // CHECK: cheddar.encode
   // CHECK-SAME: level = 5
-  // CHECK-SAME: scale = 0x42C0000000000000
-  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
+  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64, logScale = 37 : i64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
   return %pt : tensor<!cheddar.plaintext>
 }
 
@@ -79,8 +78,7 @@ func.func @test_encode_constant(
     %out: tensor<!cheddar.constant>) -> tensor<!cheddar.constant> {
   // CHECK: cheddar.encode_constant
   // CHECK-SAME: level = 3
-  // CHECK-SAME: scale = 0x42C0000000000000
-  %c = cheddar.encode_constant %enc, %val, %out {level = 3 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, f64, tensor<!cheddar.constant>) -> tensor<!cheddar.constant>
+  %c = cheddar.encode_constant %enc, %val, %out {level = 3 : i64} : (!cheddar.encoder, f64, tensor<!cheddar.constant>) -> tensor<!cheddar.constant>
   return %c : tensor<!cheddar.constant>
 }
 

--- a/tests/Dialect/Cheddar/Transforms/BUILD
+++ b/tests/Dialect/Cheddar/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Cheddar/Transforms/bufferize.mlir
+++ b/tests/Dialect/Cheddar/Transforms/bufferize.mlir
@@ -1,0 +1,185 @@
+// RUN: heir-opt --cheddar-bufferize %s | FileCheck %s
+
+// Cheddar DPS ops bufferize like linalg ops: operands become memrefs and the
+// result is folded into its destination. Function results become
+// `bufferize.result` out-params (buffer-results-to-out-params).
+
+// CHECK: func.func @add
+// CHECK: cheddar.add {{.*}} : (!context, memref<!ciphertext>, memref<!ciphertext>, memref<!ciphertext>) -> ()
+// CHECK-NEXT: return
+func.func @add(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>, %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %result = cheddar.add %ctx, %lhs, %rhs, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
+
+// Read-write destinations in a nonstandard operand position.
+// CHECK: func.func @mad_unsafe
+// CHECK: cheddar.mad_unsafe {{.*}} : (!context, memref<!ciphertext>, memref<!ciphertext>, memref<!constant>) -> ()
+// CHECK-NEXT: return
+func.func @mad_unsafe(%ctx: !cheddar.context, %acc: tensor<!cheddar.ciphertext>, %input: tensor<!cheddar.ciphertext>, %constant: tensor<!cheddar.constant>) -> tensor<!cheddar.ciphertext> {
+  %result = cheddar.mad_unsafe %ctx, %acc, %input, %constant : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.constant>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
+
+// A result equivalent to an argument is dropped; the argument is updated in place.
+// CHECK: func.func @prepare_rot_key(%[[UI:.*]]: memref<!user_interface>) {
+// CHECK: cheddar.prepare_rot_key %[[UI]] {distance = 7 : i64, maxLevel = 13 : i64} : (memref<!user_interface>) -> ()
+// CHECK-NEXT: return
+func.func @prepare_rot_key(%ui: tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface> {
+  %result = cheddar.prepare_rot_key %ui {distance = 7 : i64, maxLevel = 13 : i64} : (tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %result : tensor<!cheddar.user_interface>
+}
+
+// CHECK: func.func @prepare_bootstrap(%[[CTX:.*]]: memref<!boot_context>, %[[UI:.*]]: memref<!user_interface>) {
+// CHECK: cheddar.prepare_bootstrap %[[CTX]], %[[UI]] {numSlots = 8 : i64} : (memref<!boot_context>, memref<!user_interface>) -> ()
+// CHECK-NEXT: return
+func.func @prepare_bootstrap(%ctx: tensor<!cheddar.boot_context>, %ui: tensor<!cheddar.user_interface>) -> (tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>) {
+  %new_ctx, %new_ui = cheddar.prepare_bootstrap %ctx, %ui {numSlots = 8 : i64} : (tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>) -> (tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>)
+  return %new_ctx, %new_ui : tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>
+}
+
+// CHECK: func.func @decode
+// CHECK-SAME: %[[DECODED:[a-zA-Z0-9_]+]]: memref<4xf64>
+// CHECK: cheddar.decode %{{.*}}, %{{.*}}, %[[DECODED]] : (!encoder, memref<!plaintext>, memref<4xf64>) -> ()
+func.func @decode(%encoder: !cheddar.encoder, %plaintext: tensor<!cheddar.plaintext>, %value: tensor<4xf64>) -> tensor<4xf64> {
+  %decoded = cheddar.decode %encoder, %plaintext, %value : (!cheddar.encoder, tensor<!cheddar.plaintext>, tensor<4xf64>) -> tensor<4xf64>
+  return %decoded : tensor<4xf64>
+}
+
+// A chain of fully overwriting ops reuses one destination, which becomes the
+// out-param: no allocation, no copy.
+// CHECK: func.func @reuse_sequence
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[OUT]]
+// CHECK: cheddar.neg %{{.*}}, %[[OUT]], %[[OUT]]
+// CHECK-NOT: memref.copy
+func.func @reuse_sequence(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %sum = cheddar.add %ctx, %lhs, %rhs, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %negated = cheddar.neg %ctx, %sum, %sum : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %negated : tensor<!cheddar.ciphertext>
+}
+
+// A distinct tensor.empty destination stays a distinct buffer.
+// CHECK: func.func @rescale_fresh
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK: %[[INPUT:[a-zA-Z0-9_]+]] = memref.alloc(){{.*}} : memref<!ciphertext>
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[INPUT]]
+// CHECK: cheddar.rescale %{{.*}}, %[[INPUT]], %[[OUT]]
+func.func @rescale_fresh(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %inputEmpty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %input = cheddar.add %ctx, %lhs, %rhs, %inputEmpty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %outputEmpty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %output = cheddar.rescale %ctx, %input, %outputEmpty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %output : tensor<!cheddar.ciphertext>
+}
+
+// Passing the same value as input and destination is not a conflict.
+// CHECK: func.func @hrot_add_in_place
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: cheddar.hrot_add %{{.*}}, %{{.*}}, %[[OUT]], %[[OUT]], %[[OUT]]
+// CHECK-NOT: memref.copy
+func.func @hrot_add_in_place(%ctx: !cheddar.context, %ui: !cheddar.user_interface, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %input = cheddar.add %ctx, %lhs, %rhs, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %output = cheddar.hrot_add %ctx, %ui, %input, %input, %input {distance = 2 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %output : tensor<!cheddar.ciphertext>
+}
+
+// A loop carrying a caller-owned input updates it in place; the (equivalent)
+// result is dropped.
+// CHECK: func.func @loop_in_place(%{{.*}}: !context, %[[INIT:.*]]: memref<!ciphertext>, %{{.*}}: index) {
+// CHECK-NOT: memref.copy
+// CHECK: scf.for
+// CHECK-NEXT: cheddar.neg %{{.*}}, %[[INIT]], %[[INIT]]
+func.func @loop_in_place(%ctx: !cheddar.context, %init: tensor<!cheddar.ciphertext>, %upper: index) -> tensor<!cheddar.ciphertext> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %result = scf.for %i = %c0 to %upper step %c1 iter_args(%iter = %init) -> tensor<!cheddar.ciphertext> {
+    %next = cheddar.neg %ctx, %iter, %iter : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+    scf.yield %next : tensor<!cheddar.ciphertext>
+  }
+  return %result : tensor<!cheddar.ciphertext>
+}
+
+// Empty-tensor elimination threads the packed result through the insertion, so
+// the producer writes straight into the out-param slot.
+// CHECK: func.func @packed_encrypt
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<1x!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: %[[SLOT:[a-zA-Z0-9_]+]] = memref.subview %[[OUT]][0] [1] [1]
+// CHECK: cheddar.encrypt %{{.*}}, %{{.*}}, %[[SLOT]]
+// CHECK-NOT: memref.copy
+func.func @packed_encrypt(%ui: !cheddar.user_interface, %plaintext: tensor<!cheddar.plaintext>) -> tensor<1x!cheddar.ciphertext> {
+  %scalarInit = tensor.empty() : tensor<!cheddar.ciphertext>
+  %encrypted = cheddar.encrypt %ui, %plaintext, %scalarInit : (!cheddar.user_interface, tensor<!cheddar.plaintext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %packedInit = tensor.empty() : tensor<1x!cheddar.ciphertext>
+  %packed = tensor.insert_slice %encrypted into %packedInit[0] [1] [1] : tensor<!cheddar.ciphertext> into tensor<1x!cheddar.ciphertext>
+  return %packed : tensor<1x!cheddar.ciphertext>
+}
+
+// CHECK: func.func @loop_packed
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<8x!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: scf.for
+// CHECK: %[[SLOT:[a-zA-Z0-9_]+]] = memref.subview %[[OUT]][%{{.*}}] [1] [1]
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[SLOT]]
+// CHECK-NOT: memref.copy
+func.func @loop_packed(%ctx: !cheddar.context, %input: tensor<!cheddar.ciphertext>) -> tensor<8x!cheddar.ciphertext> {
+  %output = tensor.empty() : tensor<8x!cheddar.ciphertext>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %result = scf.for %i = %c0 to %c8 step %c1 iter_args(%iter = %output) -> tensor<8x!cheddar.ciphertext> {
+    %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+    %value = cheddar.add %ctx, %input, %input, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+    %inserted = tensor.insert_slice %value into %iter[%i] [1] [1] : tensor<!cheddar.ciphertext> into tensor<8x!cheddar.ciphertext>
+    scf.yield %inserted : tensor<8x!cheddar.ciphertext>
+  }
+  return %result : tensor<8x!cheddar.ciphertext>
+}
+
+// A returned call result goes through a temporary and one copy into the
+// out-param; the EmitC lowering turns the copy of a dead temporary into a move.
+func.func private @produce(%ctx: !cheddar.context, %input: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %result = cheddar.neg %ctx, %input, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
+// CHECK: func.func @forward
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK: %[[TMP:.*]] = memref.alloc() : memref<!ciphertext>
+// CHECK: call @produce({{.*}}, %[[TMP]])
+// CHECK: memref.copy %[[TMP]], %[[OUT]]
+// CHECK-NEXT: return
+func.func @forward(%ctx: !cheddar.context, %input: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %result = func.call @produce(%ctx, %input) : (!cheddar.context, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
+
+func.func @setup(%params: !cheddar.parameter) -> tensor<!cheddar.context> {
+  %empty = tensor.empty() : tensor<!cheddar.context>
+  %ctx = cheddar.create_context %params, %empty : (!cheddar.parameter, tensor<!cheddar.context>) -> tensor<!cheddar.context>
+  return %ctx : tensor<!cheddar.context>
+}
+func.func @keygen(%ctx: tensor<!cheddar.context>) -> (tensor<!cheddar.context>, tensor<!cheddar.user_interface>) {
+  %empty = tensor.empty() : tensor<!cheddar.user_interface>
+  %ui = cheddar.create_user_interface %ctx, %empty : (tensor<!cheddar.context>, tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  %ui2 = cheddar.prepare_rot_key %ui {distance = 1 : i64, maxLevel = 1 : i64} : (tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %ctx, %ui2 : tensor<!cheddar.context>, tensor<!cheddar.user_interface>
+}
+// CHECK: func.func @configure(%[[PARAMS:.*]]: !parameter, %[[CTX:.*]]: memref<!context> {bufferize.result}, %[[UI:.*]]: memref<!user_interface> {bufferize.result})
+// CHECK: %[[TMP_CTX:.*]] = memref.alloc() : memref<!context>
+// CHECK: call @setup(%[[PARAMS]], %[[TMP_CTX]])
+// CHECK: %[[TMP_UI:.*]] = memref.alloc() : memref<!user_interface>
+// CHECK: call @keygen(%[[TMP_CTX]], %[[TMP_UI]])
+// CHECK: memref.copy %[[TMP_CTX]], %[[CTX]]
+// CHECK: memref.copy %[[TMP_UI]], %[[UI]]
+// CHECK: return
+func.func @configure(%params: !cheddar.parameter) -> (tensor<!cheddar.context>, tensor<!cheddar.user_interface>) {
+  %ctx = func.call @setup(%params) : (!cheddar.parameter) -> tensor<!cheddar.context>
+  %ctx2, %ui = func.call @keygen(%ctx) : (tensor<!cheddar.context>) -> (tensor<!cheddar.context>, tensor<!cheddar.user_interface>)
+  return %ctx2, %ui : tensor<!cheddar.context>, tensor<!cheddar.user_interface>
+}

--- a/tests/Dialect/Cheddar/Transforms/bufferize_invalid.mlir
+++ b/tests/Dialect/Cheddar/Transforms/bufferize_invalid.mlir
@@ -1,0 +1,24 @@
+// RUN: heir-opt --cheddar-bufferize --split-input-file --verify-diagnostics %s
+
+// A user interface is move-only: a read-write destination that is not writable
+// would need a copy, so it must bufferize in place.
+func.func @borrowed_ui(%ui: tensor<!cheddar.user_interface> {bufferization.writable = false}) -> tensor<!cheddar.user_interface> {
+  // expected-error@+1 {{move-only read-write destination must bufferize in-place}}
+  %updated = cheddar.prepare_rot_key %ui {distance = 7 : i64, maxLevel = 13 : i64} : (tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %updated : tensor<!cheddar.user_interface>
+}
+
+// -----
+
+// A loop must yield the buffer of its iter_arg, not a fresh allocation.
+func.func @fresh_loop_result(%ctx: !cheddar.context, %input: tensor<!cheddar.ciphertext>, %upper: index) -> tensor<!cheddar.ciphertext> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %result = scf.for %i = %c0 to %upper step %c1 iter_args(%iter = %input) -> tensor<!cheddar.ciphertext> {
+    %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+    %next = cheddar.neg %ctx, %iter, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+    // expected-error@+1 {{Yield operand #0 is not equivalent to the corresponding iter bbArg}}
+    scf.yield %next : tensor<!cheddar.ciphertext>
+  }
+  return %result : tensor<!cheddar.ciphertext>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -49,6 +49,8 @@ cc_binary(
         "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/CKKS/Transforms",
         "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Dialect/Cheddar/Transforms:BufferizableOpInterfaceImpl",
+        "@heir//lib/Dialect/Cheddar/Transforms:CheddarBufferize",
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/Debug/IR:Dialect",
         "@heir//lib/Dialect/Debug/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -18,6 +18,8 @@
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 #include "lib/Dialect/CKKS/Transforms/Passes.h"
 #include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
+#include "lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h"
+#include "lib/Dialect/Cheddar/Transforms/CheddarBufferize.h"
 #include "lib/Dialect/Comb/IR/CombDialect.h"
 #include "lib/Dialect/Debug/IR/DebugDialect.h"
 #include "lib/Dialect/Debug/Transforms/Passes.h"
@@ -186,6 +188,7 @@
 #include "mlir/include/mlir/Dialect/Math/IR/Math.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/ValueBoundsOpInterfaceImpl.h"  // from @llvm-project
@@ -323,6 +326,7 @@ int main(int argc, char** argv) {
   registerTransformsPasses();      // canonicalize, cse, etc.
   affine::registerAffinePasses();  // loop unrolling
   registerLinalgPasses();          // linalg to loops
+  memref::registerMemRefPasses();  // fold-memref-alias-ops, etc.
 
   // These are only needed by two tests that build a pass pipeline
   // from the CLI. Those tests can probably eventually be removed.
@@ -360,6 +364,7 @@ int main(int argc, char** argv) {
       registry);
   cf::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::linalg::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::memref::registerAllocationOpInterfaceExternalModels(registry);
   scf::registerBufferizableOpInterfaceExternalModels(registry);
   tensor::registerBufferizableOpInterfaceExternalModels(registry);
   registry.addExtension(+[](MLIRContext* ctx, LLVM::LLVMDialect* dialect) {
@@ -379,6 +384,10 @@ int main(int argc, char** argv) {
   cggi::registerCGGIPasses();
   debug::registerDebugPasses();
   ckks::registerCKKSPasses();
+  PassPipelineRegistration<>(
+      "cheddar-bufferize",
+      "Bufferize cheddar programs into out-params with One-Shot Bufferize",
+      cheddar::buildCheddarBufferizationPipeline);
   lattigo::registerLattigoPasses();
   lwe::registerLWEPasses();
   mgmt::registerMgmtPasses();
@@ -512,6 +521,7 @@ int main(int argc, char** argv) {
   // Interfaces in HEIR
   secret::registerBufferizableOpInterfaceExternalModels(registry);
   lattigo::registerBufferizableOpInterfaceExternalModels(registry);
+  cheddar::registerBufferizableOpInterfaceExternalModels(registry);
   preprocessing::registerBufferizableOpInterfaceExternalModels(registry);
   registerIncreasesMulDepthOpInterface(registry);
   registerLayoutConversionHoistableInterface(registry);


### PR DESCRIPTION
PR 4/? on Cheddar.

This is an attempt to do bufferization for Cheddar with as much of the existing upstream stuff as possible, while still trying to account for the std::move based API of Cheddar and minimising the amount of needless deep copying. 

I'd love a thorough review of this, because I've had to lean heavily on AI here and still don't feel like I _really_ get how a bufferization like this is supposed to happen 😅 