### PR TITLE
setup.py: use @apple_support label after MODULE.bazel dropped the bui…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ class BuildBazelExtension(build_ext.build_ext):
       else:
         target_arch = platform.machine()
       bazel_argv.append(
-          f"--platforms=@build_bazel_apple_support//platforms:darwin_{target_arch}"
+          f"--platforms=@apple_support//platforms:darwin_{target_arch}"
       )
 
     with _maybe_patch_toolchains():


### PR DESCRIPTION
The python setup.py needs its macOS build options updated. Found by @Tuditi